### PR TITLE
fix(cli): respect MEMEX_SERVER__PORT env var when starting server

### DIFF
--- a/packages/cli/src/memex_cli/server.py
+++ b/packages/cli/src/memex_cli/server.py
@@ -159,7 +159,7 @@ async def _initialize_models(cache_dir: str):
 def start(
     ctx: typer.Context,
     host: str = typer.Option('0.0.0.0', envvar='MEMEX_HOST', help='Host to bind the server to'),
-    port: int = typer.Option(8000, envvar='MEMEX_PORT', help='Port to bind the server to'),
+    port: int | None = typer.Option(None, envvar='MEMEX_PORT', help='Port to bind the server to'),
     workers: int = typer.Option(
         None, '--workers', '-w', envvar='MEMEX_WORKERS', help='Number of worker processes'
     ),
@@ -185,16 +185,20 @@ def start(
         console.print('Use [cyan]memex server stop[/cyan] to stop it first.')
         raise typer.Exit(0)
 
-    # Check port availability
-    if not check_port_available(host, port):
-        console.print(f'[bold red]Error:[/bold red] Port {port} is already in use.')
-        raise typer.Exit(1)
-
     if config:
         os.environ['MEMEX_CONFIG_PATH'] = config
 
     # Load config and check DB
     conf = parse_memex_config()
+
+    # Resolve port: CLI flag / MEMEX_PORT > MEMEX_SERVER__PORT > default (8000)
+    if port is None:
+        port = conf.server.port
+
+    # Check port availability
+    if not check_port_available(host, port):
+        console.print(f'[bold red]Error:[/bold red] Port {port} is already in use.')
+        raise typer.Exit(1)
     db_ready = asyncio.run(_readiness_check(conf.server.meta_store.instance))
     if not db_ready:
         console.print(

--- a/packages/cli/tests/test_server_cli.py
+++ b/packages/cli/tests/test_server_cli.py
@@ -16,6 +16,7 @@ def mock_dependencies():
         patch('memex_cli.server.check_port_available', return_value=True),
     ):
         # Setup mock config
+        mock_conf.return_value.server.port = 8000
         mock_conf.return_value.meta_store.instance.host = 'localhost'
         mock_conf.return_value.meta_store.instance.port = 5432
 


### PR DESCRIPTION
## Summary

- `MEMEX_SERVER__PORT` (and by extension `MEMEX_SERVER__HOST`) was silently ignored when starting the server because the CLI `start` command used a hardcoded default of `8000` for `--port`, with no fallback to the loaded config
- Changed `port` option default to `None` and moved `parse_memex_config()` before the port-availability check so `conf.server.port` can be used as the fallback
- Precedence is now: `--port` / `MEMEX_PORT` > `MEMEX_SERVER__PORT` > `8000` (ServerConfig default)

## Test plan

- [ ] `MEMEX_SERVER__PORT=9000 memex server start` binds on port 9000
- [ ] `memex server start` still defaults to port 8000
- [ ] `memex server start --port 9001` still respects the explicit flag
- [ ] Existing unit tests pass (`uv run pytest packages/cli/tests/test_server_cli.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)