### PR TITLE
feat(mcp): progressive disclosure via DiscoveryMode transform

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,59 @@
+# FAQ
+
+## How can I control costs?
+
+The majority of LLM costs in Memex come from **mental model reflection** — the background process that synthesizes raw facts into higher-level mental models. Each reflection cycle makes multiple LLM calls per entity (7 phases), so entities that reflect frequently add up.
+
+The single most impactful lever is the **`min_priority`** threshold. This controls the minimum priority score an entity must reach before it is selected for reflection. The default is `0.3`. Raising it means fewer entities qualify for reflection, directly reducing LLM calls.
+
+In your `memex.yaml`:
+
+```yaml
+server:
+  memory:
+    reflection:
+      min_priority: 0.6  # default: 0.3 — higher = fewer reflections = lower cost
+```
+
+Other cost-reduction options:
+
+| Setting | What it does | Config path |
+|---|---|---|
+| **`min_priority`** | Raise to skip low-priority entities | `server.memory.reflection.min_priority` |
+| **`background_reflection_enabled`** | Set `false` to disable automatic reflection entirely | `server.memory.reflection.background_reflection_enabled` |
+| **`background_reflection_interval_seconds`** | Increase to reflect less often (default: 600s) | `server.memory.reflection.background_reflection_interval_seconds` |
+| **`background_reflection_batch_size`** | Lower to process fewer entities per cycle (default: 10) | `server.memory.reflection.background_reflection_batch_size` |
+| **`max_concurrency`** | Lower to reduce parallel reflection tasks (default: 3) | `server.memory.reflection.max_concurrency` |
+| **`enrichment_enabled`** | Set `false` to skip Phase 6 enrichment (saves ~1 LLM call per entity) | `server.memory.reflection.enrichment_enabled` |
+| **Use a cheaper model for reflection** | Override the reflection model independently | `server.memory.reflection.model` |
+
+For the lowest cost setup, disable background reflection and trigger it manually when needed via `memex memory reflect`.
+
+## How does Memex use LLM calls?
+
+Memex makes LLM calls in three areas:
+
+1. **Extraction** (on ingest) — chunks text and extracts structured facts, observations, and events. Cost scales with the amount of content you ingest.
+2. **Reflection** (background) — synthesizes facts into mental models. This is the most expensive operation since it runs a multi-phase pipeline per entity.
+3. **Retrieval** (on search, optional) — query expansion and answer synthesis when using `--answer` or `--reason` flags. Costs are per-query and modest.
+
+Embedding and reranking use local ONNX models by default, so they incur no LLM API costs unless you explicitly configure a LiteLLM-backed provider.
+
+## Can I use models other than Gemini?
+
+Yes. Memex uses [LiteLLM](https://docs.litellm.ai/) under the hood, so any provider it supports works — OpenAI, Anthropic, Ollama, Azure, AWS Bedrock, and more. See [Configure Memex](./docs/how-to/configure-memex.md) for details on setting the model provider.
+
+## Can I run Memex without an LLM key?
+
+Partially. You can store and retrieve notes, use keyword/semantic search (powered by local ONNX models), and manage vaults and entities. However, fact extraction, reflection, AI-powered answers, and query expansion all require an LLM API key.
+
+## How do I back up my data?
+
+Memex stores data in two places:
+
+1. **PostgreSQL** — all metadata, embeddings, entities, and mental models. Use standard `pg_dump` for backups.
+2. **FileStore** — the raw Markdown note files. By default these are on local disk (configurable path in `memex.yaml`). Back up the directory, or use S3/GCS for built-in durability.
+
+## Can multiple agents share the same Memex instance?
+
+Yes. The server supports concurrent access, vault-scoped API keys, and policy-based access control (reader/writer/admin). Each agent can be scoped to its own vault or share a common one.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.0.39a-green?style=flat-square" alt="v0.0.39a" />
-  <img src="https://img.shields.io/badge/tests-2,705%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-2,708%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.0.39a-green?style=flat-square" alt="v0.0.39a" />
-  <img src="https://img.shields.io/badge/tests-2,726%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-2,725%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.0.39a-green?style=flat-square" alt="v0.0.39a" />
-  <img src="https://img.shields.io/badge/tests-2,727%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-2,726%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 <p align="center">
   <a href="./docs/index.md">Documentation</a> &bull;
   <a href="./docs/tutorials/getting-started.md">Quick Start</a> &bull;
-  <a href="#claude-code-plugin">Claude Code Plugin</a>
+  <a href="#claude-code-plugin">Claude Code Plugin</a> &bull;
+  <a href="./FAQ.md">FAQ</a>
 </p>
 
 <p align="center">
@@ -23,6 +24,9 @@
   <img src="https://img.shields.io/badge/version-v0.0.39a-green?style=flat-square" alt="v0.0.39a" />
   <img src="https://img.shields.io/badge/tests-2,708%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
+
+> [!IMPORTANT]
+> **Memex is in beta.** It is functional and actively used, but expect rough edges, breaking changes between versions, and incomplete documentation. Feedback and bug reports are welcome — run `memex report-bug` or open an issue.
 
 ## Requirements
 
@@ -158,6 +162,82 @@ Capture web content directly into your knowledge base.
 
 ## Features
 
+<table>
+<tr>
+<td width="33%" valign="top">
+<p>📥 <strong>Ingest Anything</strong><br>
+<sub>Markdown, PDF, Word, PowerPoint, Excel, Outlook emails, web pages, or entire directories. Conversion via MarkItDown &amp; PyMuPDF. Pluggable note templates, asset management, and batch CLI operations.</sub></p>
+</td>
+<td width="33%" valign="top">
+<p>🧠 <strong>Five-Strategy Retrieval (TEMPR)</strong><br>
+<sub>Semantic, Keyword, Graph, Temporal, and Mental Model — five strategies run in parallel, fused via Reciprocal Rank Fusion. MMR diversity filtering prunes near-duplicates.</sub></p>
+</td>
+<td width="33%" valign="top">
+<p>🌳 <strong>Hierarchical Page Index</strong><br>
+<sub>Documents are split into a structured TOC with section summaries, token estimates, and node IDs. Read a 50-page PDF section by section instead of dumping everything into context.</sub></p>
+</td>
+</tr>
+<tr>
+<td valign="top">
+<p>🔄 <strong>Incremental Extraction</strong><br>
+<sub>Update a note and Memex diffs the content, only re-extracting changed blocks. Unchanged facts, entities, and embeddings are preserved — fast for living documents.</sub></p>
+</td>
+<td valign="top">
+<p>⚔️ <strong>Contradiction Detection</strong><br>
+<sub>New facts are triaged for corrections. When a newer note contradicts an older one, confidence is adjusted and supersession links are recorded. Retrieval favors current information.</sub></p>
+</td>
+<td valign="top">
+<p>🪞 <strong>Reflection &amp; Mental Models</strong><br>
+<sub>Background reflection synthesizes observations and builds versioned mental models. Memex evolves from raw facts into structured understanding over time.</sub></p>
+</td>
+</tr>
+<tr>
+<td valign="top">
+<p>🏦 <strong>Vaults</strong><br>
+<sub>Isolate knowledge by project, team, or topic. Policy-based ACL (reader/writer/admin) with vault-scoped API keys. Cross-vault read access for shared knowledge without write permissions.</sub></p>
+</td>
+<td valign="top">
+<p>☁️ <strong>Cloud-Native Storage</strong><br>
+<sub>File store uses fsspec — swap between local disk, S3, and GCS with a config change. PostgreSQL + pgvector for metadata and vector search.</sub></p>
+</td>
+<td valign="top">
+<p>🤖 <strong>AI Agent Integration</strong><br>
+<sub>First-class MCP support for Claude Code, Claude Desktop, and Cursor. 31 MCP tools, stdio/HTTP/SSE transports, slim Docker image decoupled from core.</sub></p>
+</td>
+</tr>
+<tr>
+<td valign="top">
+<p>🌐 <strong>REST API &amp; Webhooks</strong><br>
+<sub>FastAPI server with NDJSON streaming, OpenAPI docs, policy-based auth, vault-scoped API keys, rate limiting, and CORS extension support.</sub></p>
+</td>
+<td valign="top">
+<p>🧬 <strong>Lineage &amp; Provenance</strong><br>
+<sub>Trace any mental model back through observations to the original source document. Full bidirectional provenance traversal with depth control.</sub></p>
+</td>
+<td valign="top">
+<p>🦊 <strong>Firefox Extension</strong><br>
+<sub>One-click save of articles, PDFs &amp; web pages. Readability extraction, Markdown conversion, inline image capture. AES-GCM encrypted API key storage.</sub></p>
+</td>
+</tr>
+<tr>
+<td valign="top">
+<p>📂 <strong>Folder Sync</strong><br>
+<sub>Sync Obsidian vaults or any local folder to Memex. Multi-format support, asset upload, frontmatter skip markers, SQLite state tracking, watchdog/polling watch modes, archive-on-delete.</sub></p>
+</td>
+<td valign="top">
+<p>🐦‍🔥 <strong>Pluggable Inference Backends</strong><br>
+<sub>Swap built-in ONNX embedding &amp; reranking models for any LiteLLM provider — OpenAI, Gemini, Cohere, Ollama. Inverse-sigmoid logit transform preserves retrieval scoring.</sub></p>
+</td>
+<td valign="top">
+<p>🔭 <strong>OpenTelemetry Observability</strong><br>
+<sub>Distributed tracing with Arize Phoenix — session IDs on spans, operation names on DSPy LLM calls, background reflection jobs tracked across tracing sessions.</sub></p>
+</td>
+</tr>
+</table>
+
+<details>
+<summary><strong>Feature details</strong></summary>
+
 ### Ingest anything
 
 Feed Memex from any source — plain text, Markdown, PDFs, Word docs, PowerPoint, Excel, Outlook emails, web pages, or entire directories. File conversion is handled automatically via [MarkItDown](https://github.com/microsoft/markitdown) and [PyMuPDF](https://pymupdf.readthedocs.io/). Background and batch ingestion modes let you import large document collections without blocking. Pluggable note templates (built-in, global, and project-local `.toml` files) provide consistent structure for different note types.
@@ -228,13 +308,9 @@ First-class support for Claude Code, Claude Desktop, Cursor, and any MCP-compati
 
 A full FastAPI server with NDJSON streaming, OpenAPI docs, policy-based auth (reader/writer/admin) with vault-scoped API keys, rate limiting, and outgoing webhook subscriptions for event-driven integrations (`ingestion.completed`, `reflection.completed`).
 
-### Tight integration with MCP
+### Lineage and provenance
 
-The MCP server allows any agent to retrieve information from and add notes to Memex.
-
-### Note templates
-
-Pluggable note templates provide consistent structure for different note types. Templates are `.toml` files discovered across three layers — built-in, global (`{filestore_root}/templates/`), and project-local (`.memex/templates/`) — with later layers overriding on slug collision. Built-in templates include `technical_brief`, `general_note`, `architectural_decision_record`, `request_for_comments`, and `quick_note`. Manage templates via `memex note template` CLI commands or the `memex_list_templates` / `memex_register_template` MCP tools.
+Trace any mental model back through observations to the original source document. Full bidirectional provenance traversal (`upstream`, `downstream`, `both`) with configurable depth and child limits.
 
 ### Folder sync
 
@@ -245,6 +321,16 @@ memex note sync init ~/notes          # create default config
 memex note sync run ~/notes           # sync changed files
 memex note sync watch ~/notes         # continuous sync
 ```
+
+### Pluggable inference backends
+
+Swap the built-in ONNX embedding and reranking models for any LiteLLM-supported provider (OpenAI, Gemini, Cohere, Ollama, etc.) via config. An inverse-sigmoid logit transform on LiteLLM reranker scores preserves the retrieval engine's scoring semantics.
+
+### OpenTelemetry observability
+
+Distributed tracing via Arize Phoenix. Session IDs propagate across spans, DSPy LLM calls get operation names, and background reflection jobs are tracked across tracing sessions.
+
+</details>
 
 ## 📚 Documentation
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.0.39a-green?style=flat-square" alt="v0.0.39a" />
-  <img src="https://img.shields.io/badge/tests-2,708%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-2,727%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -384,7 +384,8 @@ async def search_memory(
     ctx: typer.Context,
     query: Annotated[str, typer.Argument(help='Search query.')],
     vault: Annotated[
-        list[str] | None, typer.Option('--vault', '-v', help='Filter by vault(s).')
+        list[str] | None,
+        typer.Option('--vault', '-v', help='Filter by vault(s). Use "*" for all vaults.'),
     ] = None,
     limit: int = 5,
     token_budget: Annotated[

--- a/packages/cli/src/memex_cli/notes.py
+++ b/packages/cli/src/memex_cli/notes.py
@@ -312,7 +312,10 @@ async def list_notes(
     ctx: typer.Context,
     limit: int = 50,
     offset: int = 0,
-    vault: Annotated[list[str], typer.Option('--vault', '-v', help='Vault(s) to filter by.')] = [],
+    vault: Annotated[
+        list[str],
+        typer.Option('--vault', '-v', help='Vault(s) to filter by. Use "*" for all vaults.'),
+    ] = [],
     after: Annotated[
         str | None,
         typer.Option('--after', help='Only notes on/after this date (ISO 8601).'),
@@ -338,6 +341,8 @@ async def list_notes(
     """
     from datetime import datetime
 
+    from memex_common.vault_utils import ALL_VAULTS_WILDCARD
+
     config: MemexConfig = ctx.obj
 
     parsed_after = None
@@ -355,7 +360,10 @@ async def list_notes(
             console.print(f'[red]Invalid --before date: {before}[/red]')
             raise typer.Exit(code=1)
 
-    vault_ids = vault if vault else config.read_vaults
+    if vault and ALL_VAULTS_WILDCARD in vault:
+        vault_ids = None
+    else:
+        vault_ids = vault if vault else config.read_vaults
 
     async with get_api_context(config) as api:
         try:
@@ -406,7 +414,10 @@ async def list_notes(
 async def list_recent(
     ctx: typer.Context,
     limit: int = 10,
-    vault: Annotated[list[str], typer.Option('--vault', '-v', help='Vault(s) to filter by.')] = [],
+    vault: Annotated[
+        list[str],
+        typer.Option('--vault', '-v', help='Vault(s) to filter by. Use "*" for all vaults.'),
+    ] = [],
     after: Annotated[
         str | None,
         typer.Option('--after', help='Only notes on/after this date (ISO 8601).'),
@@ -428,6 +439,8 @@ async def list_recent(
     """
     from datetime import datetime
 
+    from memex_common.vault_utils import ALL_VAULTS_WILDCARD
+
     config: MemexConfig = ctx.obj
 
     parsed_after = None
@@ -445,7 +458,10 @@ async def list_recent(
             console.print(f'[red]Invalid --before date: {before}[/red]')
             raise typer.Exit(code=1)
 
-    vault_ids = vault if vault else None
+    if vault and ALL_VAULTS_WILDCARD in vault:
+        vault_ids = None
+    else:
+        vault_ids = vault if vault else None
 
     async with get_api_context(config) as api:
         try:
@@ -509,18 +525,24 @@ async def find_note(
     ctx: typer.Context,
     query: Annotated[str, typer.Argument(help='Approximate title to search for.')],
     limit: int = 5,
-    vault: Annotated[list[str], typer.Option('--vault', '-v', help='Vault(s) to filter by.')] = [],
+    vault: Annotated[
+        list[str],
+        typer.Option('--vault', '-v', help='Vault(s) to filter by. Use "*" for all vaults.'),
+    ] = [],
     json_output: Annotated[bool, typer.Option('--json', help='Output as JSON.')] = False,
 ):
     """
     Find notes by approximate title match (trigram similarity).
     """
+    from memex_common.vault_utils import ALL_VAULTS_WILDCARD
+
     config: MemexConfig = ctx.obj
+    vault_ids = None if (vault and ALL_VAULTS_WILDCARD in vault) else (vault or None)
     async with get_api_context(config) as api:
         try:
             results = await api.find_notes_by_title(
                 query=query,
-                vault_ids=vault or None,
+                vault_ids=vault_ids,
                 limit=limit,
             )
         except Exception as e:
@@ -937,7 +959,10 @@ async def search_notes(
     limit: Annotated[int, typer.Option('--limit', '-l', help='Max number of notes.')] = 5,
     expand: Annotated[bool, typer.Option('--expand', help='Enable query expansion.')] = False,
     blend: Annotated[bool, typer.Option('--blend', help='Enable position-aware blending.')] = False,
-    vault: Annotated[list[str], typer.Option('--vault', '-v', help='Vault(s) to search.')] = [],
+    vault: Annotated[
+        list[str],
+        typer.Option('--vault', '-v', help='Vault(s) to search. Use "*" for all vaults.'),
+    ] = [],
     reason: Annotated[
         bool,
         typer.Option('--reason', help='Run skeleton-tree identification; shows relevant sections.'),
@@ -1146,7 +1171,10 @@ async def export_notes(
         str,
         typer.Option('--output', '-o', help='Output directory path.'),
     ] = './memex-export',
-    vault: Annotated[list[str], typer.Option('--vault', '-v', help='Vault(s) to filter by.')] = [],
+    vault: Annotated[
+        list[str],
+        typer.Option('--vault', '-v', help='Vault(s) to filter by. Use "*" for all vaults.'),
+    ] = [],
 ):
     """
     Export notes (and their assets) to a local directory.
@@ -1154,9 +1182,16 @@ async def export_notes(
     Each note is written to a subdirectory containing note.md, metadata.json,
     and an assets/ folder (if the note has attached files).
     """
+    from memex_common.vault_utils import ALL_VAULTS_WILDCARD
+
     config: MemexConfig = ctx.obj
     output_dir = pathlib.Path(output)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if vault and ALL_VAULTS_WILDCARD in vault:
+        export_vault_ids = None
+    else:
+        export_vault_ids = vault if vault else config.read_vaults
 
     async with get_api_context(config) as api:
         if note_id:
@@ -1168,9 +1203,7 @@ async def export_notes(
             notes = [note]
         else:
             try:
-                notes = await api.list_notes(
-                    limit=10000, vault_ids=vault if vault else config.read_vaults
-                )
+                notes = await api.list_notes(limit=10000, vault_ids=export_vault_ids)
             except Exception as e:
                 handle_api_error(e)
 

--- a/packages/cli/tests/test_wildcard_vaults.py
+++ b/packages/cli/tests/test_wildcard_vaults.py
@@ -1,0 +1,107 @@
+"""Tests for the '*' wildcard vault shorthand in CLI commands."""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from memex_cli.notes import app as note_app
+from memex_common.schemas import NoteDTO
+
+
+def test_note_list_wildcard_vault(runner, mock_api, mock_config, monkeypatch):
+    """list --vault '*' should pass vault_ids=None (all vaults)."""
+    mock_api.list_notes.return_value = []
+    monkeypatch.setattr('memex_cli.notes.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(note_app, ['list', '--vault', '*'], obj=mock_config)
+    assert result.exit_code == 0
+    mock_api.list_notes.assert_called_once_with(
+        limit=50,
+        offset=0,
+        vault_ids=None,
+        after=None,
+        before=None,
+        template=None,
+    )
+
+
+def test_note_recent_wildcard_vault(runner, mock_api, mock_config, monkeypatch):
+    """recent --vault '*' should pass vault_ids=None (all vaults)."""
+    mock_api.get_recent_notes.return_value = []
+    monkeypatch.setattr('memex_cli.notes.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(note_app, ['recent', '--vault', '*'], obj=mock_config)
+    assert result.exit_code == 0
+    mock_api.get_recent_notes.assert_called_once_with(
+        limit=10,
+        vault_ids=None,
+        after=None,
+        before=None,
+    )
+
+
+def test_note_find_wildcard_vault(runner, mock_api, mock_config, monkeypatch):
+    """find --vault '*' should pass vault_ids=None (all vaults)."""
+    mock_api.find_notes_by_title.return_value = []
+    monkeypatch.setattr('memex_cli.notes.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(note_app, ['find', 'test query', '--vault', '*'], obj=mock_config)
+    assert result.exit_code == 0
+    mock_api.find_notes_by_title.assert_called_once_with(
+        query='test query',
+        vault_ids=None,
+        limit=5,
+    )
+
+
+def test_note_export_wildcard_vault(runner, mock_api, mock_config, monkeypatch, tmp_path):
+    """export --vault '*' should pass vault_ids=None (all vaults)."""
+    mock_api.list_notes.return_value = []
+    monkeypatch.setattr('memex_cli.notes.get_api_context', lambda config: mock_api)
+
+    out_dir = str(tmp_path / 'export')
+    result = runner.invoke(
+        note_app, ['export', '--vault', '*', '--output', out_dir], obj=mock_config
+    )
+    assert result.exit_code == 0
+    mock_api.list_notes.assert_called_once_with(limit=10000, vault_ids=None)
+
+
+def test_note_list_specific_vault_still_works(runner, mock_api, mock_config, monkeypatch):
+    """Ensure normal --vault usage is not broken by the wildcard feature."""
+    mock_api.list_notes.return_value = [
+        NoteDTO(
+            id=uuid4(),
+            name='Note',
+            created_at=datetime.now(timezone.utc),
+            vault_id=uuid4(),
+        )
+    ]
+    monkeypatch.setattr('memex_cli.notes.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(note_app, ['list', '--vault', 'my-vault'], obj=mock_config)
+    assert result.exit_code == 0
+    mock_api.list_notes.assert_called_once_with(
+        limit=50,
+        offset=0,
+        vault_ids=['my-vault'],
+        after=None,
+        before=None,
+        template=None,
+    )
+
+
+def test_note_list_no_vault_uses_config_default(runner, mock_api, mock_config, monkeypatch):
+    """Without --vault, should fall back to config.read_vaults."""
+    mock_api.list_notes.return_value = []
+    monkeypatch.setattr('memex_cli.notes.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(note_app, ['list'], obj=mock_config)
+    assert result.exit_code == 0
+    mock_api.list_notes.assert_called_once_with(
+        limit=50,
+        offset=0,
+        vault_ids=mock_config.read_vaults,
+        after=None,
+        before=None,
+        template=None,
+    )

--- a/packages/common/src/memex_common/vault_utils.py
+++ b/packages/common/src/memex_common/vault_utils.py
@@ -2,6 +2,8 @@
 
 from uuid import UUID
 
+ALL_VAULTS_WILDCARD = '*'  # Pass "*" as a vault identifier to match all vaults.
+
 
 def resolve_vault_list(
     vault_id: UUID | None = None,

--- a/packages/core/src/memex_core/services/notes.py
+++ b/packages/core/src/memex_core/services/notes.py
@@ -37,29 +37,27 @@ async def await_background_tasks() -> None:
 async def _cleanup_entities_after_delete(
     metastore: AsyncBaseMetaStoreEngine,
     entity_ids: set[UUID],
-    deleted_unit_ids: list[UUID],
-    vault_id: UUID,
 ) -> None:
     """Background task: clean up orphaned entities and recount mention_count.
 
     Runs outside the delete transaction so that lock contention on entity rows
     (e.g. from concurrent ingestion) cannot cause the delete to fail.
+
+    Evidence pruning is handled inside the delete transaction (not here) to
+    guarantee atomicity — see ``NoteService.delete_note``.
     """
     from sqlalchemy import update
     from sqlmodel import col, func, select
 
     from memex_core.memory.sql_models import Entity, MentalModel, UnitEntity
-    from memex_core.services.mental_model_cleanup import prune_stale_evidence
 
     try:
         async with metastore.session() as session:
-            orphaned_entity_ids: set[UUID] = set()
             for eid in entity_ids:
                 remaining = await session.exec(
                     select(UnitEntity.unit_id).where(col(UnitEntity.entity_id) == eid).limit(1)
                 )
                 if remaining.first() is None:
-                    orphaned_entity_ids.add(eid)
                     mm_stmt = select(MentalModel).where(col(MentalModel.entity_id) == eid)
                     mm_result = await session.exec(mm_stmt)
                     for mm in mm_result.all():
@@ -79,10 +77,6 @@ async def _cleanup_entities_after_delete(
                         .where(col(Entity.id) == eid)
                         .values(mention_count=actual_count)
                     )
-
-            shared_entity_ids = entity_ids - orphaned_entity_ids
-            if shared_entity_ids and deleted_unit_ids:
-                await prune_stale_evidence(session, shared_entity_ids, deleted_unit_ids, vault_id)
 
             await session.commit()
     except Exception:
@@ -753,6 +747,16 @@ class NoteService:
                 entity_result = await txn.db_session.exec(entity_stmt)
                 entity_ids_for_cleanup = set(entity_result.all())
 
+            # Prune stale evidence from mental models BEFORE cascade-deleting
+            # the note. This is a data integrity concern — must be atomic with
+            # the delete, not deferred to a fire-and-forget background task.
+            if entity_ids_for_cleanup and unit_ids:
+                from memex_core.services.mental_model_cleanup import prune_stale_evidence
+
+                await prune_stale_evidence(
+                    txn.db_session, entity_ids_for_cleanup, unit_ids, note_vault_id
+                )
+
             # Stage filestore deletes (deferred until commit)
             if doc.assets:
                 for asset_path in doc.assets:
@@ -767,9 +771,7 @@ class NoteService:
         # Transaction committed. Fire-and-forget entity cleanup in background.
         if entity_ids_for_cleanup:
             task = asyncio.create_task(
-                _cleanup_entities_after_delete(
-                    self.metastore, entity_ids_for_cleanup, unit_ids, note_vault_id
-                )
+                _cleanup_entities_after_delete(self.metastore, entity_ids_for_cleanup)
             )
             _background_tasks.add(task)
             task.add_done_callback(_background_tasks.discard)

--- a/packages/core/src/memex_core/services/search.py
+++ b/packages/core/src/memex_core/services/search.py
@@ -65,9 +65,14 @@ class SearchService:
         Convenience method for search with reranking.
         Scopes to default reader vault if vault_ids is not provided.
         """
+        from memex_common.vault_utils import ALL_VAULTS_WILDCARD
+
         vaults = []
 
-        if vault_ids:
+        if vault_ids and ALL_VAULTS_WILDCARD in [str(v) for v in vault_ids]:
+            all_v = await self._vaults.list_vaults()
+            vaults = [v.id for v in all_v]
+        elif vault_ids:
             for v in vault_ids:
                 vaults.append(await self._vaults.resolve_vault_identifier(str(v)))
         else:
@@ -124,8 +129,13 @@ class SearchService:
         tags: list[str] | None = None,
     ) -> list[NoteSearchResult]:
         """Search for documents containing relevant information using raw chunks."""
+        from memex_common.vault_utils import ALL_VAULTS_WILDCARD
+
         vaults = []
-        if vault_ids:
+        if vault_ids and ALL_VAULTS_WILDCARD in [str(v) for v in vault_ids]:
+            all_v = await self._vaults.list_vaults()
+            vaults = [v.id for v in all_v]
+        elif vault_ids:
             for v in vault_ids:
                 vaults.append(await self._vaults.resolve_vault_identifier(str(v)))
         else:

--- a/packages/core/src/memex_core/services/stats.py
+++ b/packages/core/src/memex_core/services/stats.py
@@ -97,14 +97,18 @@ class StatsService(BaseService):
             entity_result = await session.exec(entity_stmt)
             entity_ids = set(entity_result.all())
 
+            # Prune stale evidence from mental models before deleting the unit.
+            if entity_ids:
+                from memex_core.services.mental_model_cleanup import prune_stale_evidence
+
+                await prune_stale_evidence(session, entity_ids, [unit_id], vault_id)
+
             await session.delete(unit)
             await session.commit()
 
-        # Fire-and-forget entity cleanup in background.
+        # Fire-and-forget entity cleanup in background (orphan removal + recount).
         if entity_ids:
-            task = asyncio.create_task(
-                _cleanup_entities_after_delete(self.metastore, entity_ids, [unit_id], vault_id)
-            )
+            task = asyncio.create_task(_cleanup_entities_after_delete(self.metastore, entity_ids))
             _background_tasks.add(task)
             task.add_done_callback(_background_tasks.discard)
 

--- a/packages/core/tests/integration/test_note_delete_evidence_cleanup.py
+++ b/packages/core/tests/integration/test_note_delete_evidence_cleanup.py
@@ -1,0 +1,201 @@
+"""Test that deleting a note prunes stale evidence from mental model observations.
+
+Reproduces the bug where mental model observations survive note deletion,
+causing search to return virtual MemoryUnits with IDs that don't exist
+in the database (lineage returns 404).
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_core.memory.sql_models import (
+    Entity,
+    MentalModel,
+    MemoryUnit,
+    Note,
+    UnitEntity,
+)
+from memex_core.services.mental_model_cleanup import prune_stale_evidence
+from memex_common.config import GLOBAL_VAULT_ID
+from memex_common.types import FactTypes
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_prune_stale_evidence_removes_deleted_unit_references(session: AsyncSession):
+    """prune_stale_evidence must remove evidence citing deleted memory units
+    and drop observations that lose all evidence."""
+
+    vault_id = GLOBAL_VAULT_ID
+    entity_id = uuid.uuid4()
+    note_a_id = uuid.uuid4()
+    note_b_id = uuid.uuid4()
+    unit_a_id = uuid.uuid4()
+    unit_b_id = uuid.uuid4()
+    obs_shared_id = uuid.uuid4()
+    obs_only_a_id = uuid.uuid4()
+
+    # Setup: entity, notes, units, links, mental model
+    session.add(Entity(id=entity_id, canonical_name='Test Entity', vault_id=vault_id))
+    session.add(Note(id=note_a_id, vault_id=vault_id, original_text='Note A'))
+    session.add(Note(id=note_b_id, vault_id=vault_id, original_text='Note B'))
+    await session.flush()
+
+    now = datetime.now(timezone.utc)
+    session.add(
+        MemoryUnit(
+            id=unit_a_id,
+            vault_id=vault_id,
+            note_id=note_a_id,
+            text='Fact A',
+            fact_type=FactTypes.WORLD,
+            embedding=[0.0] * 384,
+            event_date=now,
+        )
+    )
+    session.add(
+        MemoryUnit(
+            id=unit_b_id,
+            vault_id=vault_id,
+            note_id=note_b_id,
+            text='Fact B',
+            fact_type=FactTypes.WORLD,
+            embedding=[0.0] * 384,
+            event_date=now,
+        )
+    )
+    await session.flush()
+
+    session.add(UnitEntity(unit_id=unit_a_id, entity_id=entity_id))
+    session.add(UnitEntity(unit_id=unit_b_id, entity_id=entity_id))
+
+    mm = MentalModel(
+        entity_id=entity_id,
+        vault_id=vault_id,
+        name='Test Entity',
+        observations=[
+            {
+                'id': str(obs_shared_id),
+                'title': 'Shared observation',
+                'content': 'From both notes',
+                'trend': 'new',
+                'evidence': [
+                    {'memory_id': str(unit_a_id), 'quote': 'A', 'relevance': 1.0},
+                    {'memory_id': str(unit_b_id), 'quote': 'B', 'relevance': 1.0},
+                ],
+            },
+            {
+                'id': str(obs_only_a_id),
+                'title': 'Only-A observation',
+                'content': 'From note A only',
+                'trend': 'new',
+                'evidence': [
+                    {'memory_id': str(unit_a_id), 'quote': 'A', 'relevance': 1.0},
+                ],
+            },
+        ],
+        version=1,
+    )
+    session.add(mm)
+    await session.commit()
+
+    # Act: prune evidence for unit_a (simulating note A deletion)
+    await prune_stale_evidence(
+        session,
+        entity_ids={entity_id},
+        deleted_unit_ids=[unit_a_id],
+        vault_id=vault_id,
+    )
+    await session.commit()
+
+    # Assert: reload mental model
+    session.expire_all()
+    mm_after = (
+        await session.exec(select(MentalModel).where(col(MentalModel.entity_id) == entity_id))
+    ).first()
+
+    assert mm_after is not None, 'Mental model should survive (entity still linked to note B)'
+
+    remaining_obs_ids = {obs['id'] for obs in mm_after.observations}
+
+    # obs_only_a had ALL evidence from unit_a → should be removed
+    assert str(obs_only_a_id) not in remaining_obs_ids, (
+        'Observation with only deleted-unit evidence should be removed'
+    )
+
+    # obs_shared should survive with only unit_b evidence
+    assert str(obs_shared_id) in remaining_obs_ids, 'Observation with mixed evidence should survive'
+    shared_obs = next(o for o in mm_after.observations if o['id'] == str(obs_shared_id))
+    assert len(shared_obs['evidence']) == 1
+    assert shared_obs['evidence'][0]['memory_id'] == str(unit_b_id)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_prune_deletes_model_when_all_observations_removed(session: AsyncSession):
+    """When all observations lose their evidence, the mental model itself
+    should be deleted."""
+
+    vault_id = GLOBAL_VAULT_ID
+    entity_id = uuid.uuid4()
+    note_id = uuid.uuid4()
+    unit_id = uuid.uuid4()
+
+    session.add(Entity(id=entity_id, canonical_name='Lonely Entity', vault_id=vault_id))
+    session.add(Note(id=note_id, vault_id=vault_id, original_text='Only note'))
+    await session.flush()
+
+    now = datetime.now(timezone.utc)
+    session.add(
+        MemoryUnit(
+            id=unit_id,
+            vault_id=vault_id,
+            note_id=note_id,
+            text='Only fact',
+            fact_type=FactTypes.WORLD,
+            embedding=[0.0] * 384,
+            event_date=now,
+        )
+    )
+    await session.flush()
+    session.add(UnitEntity(unit_id=unit_id, entity_id=entity_id))
+
+    mm = MentalModel(
+        entity_id=entity_id,
+        vault_id=vault_id,
+        name='Lonely Entity',
+        observations=[
+            {
+                'id': str(uuid.uuid4()),
+                'title': 'Single observation',
+                'content': 'Only evidence from the one note',
+                'trend': 'new',
+                'evidence': [
+                    {'memory_id': str(unit_id), 'quote': 'Only', 'relevance': 1.0},
+                ],
+            },
+        ],
+        version=1,
+    )
+    session.add(mm)
+    await session.commit()
+
+    # Act: prune evidence for the only unit
+    await prune_stale_evidence(
+        session,
+        entity_ids={entity_id},
+        deleted_unit_ids=[unit_id],
+        vault_id=vault_id,
+    )
+    await session.commit()
+
+    # Assert: mental model should be deleted (zero observations remaining)
+    session.expire_all()
+    mm_after = (
+        await session.exec(select(MentalModel).where(col(MentalModel.entity_id) == entity_id))
+    ).first()
+    assert mm_after is None, 'Mental model with zero observations should be deleted'

--- a/packages/core/tests/unit/test_search_service_vaults.py
+++ b/packages/core/tests/unit/test_search_service_vaults.py
@@ -111,3 +111,67 @@ async def test_search_default_reader_vault_only(vault_service):
 
     request = memory.recall.call_args[0][1]
     assert len(request.vault_ids) == 1, 'Should only have the default reader vault'
+
+
+@pytest.mark.asyncio
+async def test_search_wildcard_resolves_to_all_vaults(vault_service):
+    """When vault_ids=['*'], search should resolve to all vaults."""
+    v1, v2 = uuid4(), uuid4()
+    vault_service.list_vaults = AsyncMock(return_value=[MagicMock(id=v1), MagicMock(id=v2)])
+
+    config = MagicMock()
+    config.server.default_reader_vault = 'default'
+
+    memory = AsyncMock()
+    memory.recall = AsyncMock(return_value=([], None))
+
+    svc = SearchService(
+        metastore=MagicMock(),
+        config=config,
+        lm=MagicMock(),
+        memory=memory,
+        doc_search=MagicMock(),
+        vaults=vault_service,
+    )
+    mock_session = AsyncMock()
+    svc.metastore.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    svc.metastore.session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    await svc.search(query='test', vault_ids=['*'])
+
+    request = memory.recall.call_args[0][1]
+    assert set(request.vault_ids) == {v1, v2}, 'Should contain all vaults'
+
+
+@pytest.mark.asyncio
+async def test_search_notes_wildcard_resolves_to_all_vaults(vault_service):
+    """When vault_ids=['*'], search_notes should resolve to all vaults."""
+    v1, v2 = uuid4(), uuid4()
+    vault_service.list_vaults = AsyncMock(return_value=[MagicMock(id=v1), MagicMock(id=v2)])
+
+    config = MagicMock()
+    config.server.default_reader_vault = 'default'
+    config.server.document.mmr_lambda = None
+
+    doc_search = AsyncMock()
+    doc_search.search = AsyncMock(return_value=[])
+
+    metastore = MagicMock()
+    mock_session = AsyncMock()
+    metastore.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    metastore.session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    svc = SearchService(
+        metastore=metastore,
+        config=config,
+        lm=MagicMock(),
+        memory=MagicMock(),
+        doc_search=doc_search,
+        vaults=vault_service,
+    )
+
+    await svc.search_notes(query='test', vault_ids=['*'])
+
+    doc_search.search.assert_called_once()
+    request = doc_search.search.call_args[0][1]
+    assert set(request.vault_ids) == {v1, v2}, 'Should contain all vaults'

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "fastmcp>=3.1.0,<4.0.0",
     "httpx>=0.27.0",
     "pyyaml>=6.0.0",
+    "structlog>=25.0.0",
 ]
 
 [tool.uv.sources]

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -235,7 +235,7 @@ RULES:
 
 mcp.add_middleware(ErrorHandlingMiddleware(include_traceback=False, transform_errors=True))
 
-if os.environ.get('MEMEX_MCP_PROGRESSIVE_DISCLOSURE', '').lower() in ('1', 'true', 'yes'):
+if os.environ.get('MEMEX_MCP_PROGRESSIVE_DISCLOSURE', '').lower() not in ('0', 'false', 'no'):
     from memex_mcp.transforms import DiscoveryMode
 
     mcp.add_transform(DiscoveryMode())

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -142,6 +142,13 @@ async def _resolve_vault_ids(api: Any, vault_ids: list[str]) -> list[UUID]:
 
 async def _resolve_vault_id(api: Any, vault_id: str) -> 'UUID':
     """Resolve and validate a single vault identifier exists."""
+    from memex_common.vault_utils import ALL_VAULTS_WILDCARD
+
+    if vault_id == ALL_VAULTS_WILDCARD:
+        raise ToolError(
+            '"*" (all vaults) is not supported for this parameter. '
+            'Use a specific vault name or UUID.'
+        )
     try:
         return await api.resolve_vault_identifier(vault_id)
     except Exception:
@@ -164,6 +171,13 @@ persona_logger.setLevel(os.getenv('PERSONA_LOG_LEVEL', 'INFO'))
 mcp = FastMCP(
     'memex_mcp',
     instructions="""Memex is a personal knowledge management system.
+
+TOOL DISCOVERY — This server supports progressive disclosure.
+If you see memex_tags/memex_search/memex_get_schema instead of the full tool list:
+  1. `memex_tags()` — see tool categories and counts
+  2. `memex_search(query, tags=[...])` — find tools by keyword, optionally filtered by tag
+  3. `memex_get_schema(tools=[...])` — get parameter details before calling a tool
+You can also call any tool directly by name if you already know it.
 
 VAULT DEFAULTS — vault parameters are optional. Writes default to the active vault;
 reads default to search vaults (from .memex.yaml or global config). Only pass
@@ -222,10 +236,19 @@ RULES:
 
 mcp.add_middleware(ErrorHandlingMiddleware(include_traceback=False, transform_errors=True))
 
+if os.environ.get('MEMEX_MCP_PROGRESSIVE_DISCLOSURE', '').lower() in ('1', 'true', 'yes'):
+    from memex_mcp.transforms import DiscoveryMode
+
+    mcp.add_transform(DiscoveryMode())
+
 
 @mcp.tool(
     name='memex_list_assets',
-    description='List file assets for a note. REQUIRED when has_assets is true. Feed paths to memex_get_resources.',
+    description=(
+        'List file attachments (assets) for a note — images, audio, PDFs, documents. '
+        'REQUIRED when has_assets is true. Feed paths to memex_get_resources to retrieve files.'
+    ),
+    tags={'assets'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -279,6 +302,7 @@ async def memex_list_assets(
 @mcp.tool(
     name='memex_read_note',
     description='Read full note. ONLY when total_tokens < 500 (use force=True to override). Otherwise: memex_get_page_indices + memex_get_nodes.',
+    tags={'read'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -341,10 +365,12 @@ async def memex_read_note(
 @mcp.tool(
     name='memex_set_note_status',
     description=(
-        'Set note lifecycle status: active, superseded, appended. '
+        'Set note lifecycle status: active, superseded, appended, archived. '
+        'Use to supersede an outdated note, mark it as appended, or archive it. '
         'When superseded, all memory units are marked stale. '
         'Optionally link to the replacing/parent note.'
     ),
+    tags={'write'},
     annotations={'readOnlyHint': False, 'idempotentHint': True},
 )
 async def memex_set_note_status(
@@ -390,6 +416,7 @@ async def memex_set_note_status(
 @mcp.tool(
     name='memex_rename_note',
     description='Rename a note. Updates title in metadata, page index, and doc_metadata.',
+    tags={'write'},
     annotations={'readOnlyHint': False, 'idempotentHint': True},
 )
 async def memex_rename_note(
@@ -446,9 +473,11 @@ async def _fetch_single_resource(api: Any, path: str) -> Image | Audio | File | 
 @mcp.tool(
     name='memex_get_resources',
     description=(
-        'Retrieve 1+ file resources (images, audio, documents) by path. '
+        'Retrieve 1+ file attachments (images, audio, documents) by path. '
+        'View or download assets attached to notes. '
         'Get paths from memex_list_assets. Accepts a single path or a list.'
     ),
+    tags={'assets'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -485,6 +514,7 @@ async def memex_get_resources(
 @mcp.tool(
     name='memex_add_assets',
     description='Add one or more file assets to an existing note. Provide local file paths.',
+    tags={'assets'},
     annotations={'readOnlyHint': False},
     timeout=60.0,
 )
@@ -557,6 +587,7 @@ async def memex_add_assets(
 @mcp.tool(
     name='memex_delete_assets',
     description='Delete one or more asset files from an existing note. Get paths from memex_list_assets.',
+    tags={'assets'},
     annotations={'readOnlyHint': False},
     timeout=30.0,
 )
@@ -622,6 +653,7 @@ def _get_template_registry(ctx: Context) -> TemplateRegistry:
 @mcp.tool(
     name='memex_get_template',
     description='Get a markdown template for memex_add_note. Use memex_list_templates to see available templates.',
+    tags={'write'},
     annotations={'readOnlyHint': True},
 )
 def memex_get_template(
@@ -647,6 +679,7 @@ def memex_get_template(
 @mcp.tool(
     name='memex_list_templates',
     description='List all available note templates with metadata (slug, name, description, source).',
+    tags={'write'},
     annotations={'readOnlyHint': True},
 )
 def memex_list_templates(ctx: Context) -> str:
@@ -670,6 +703,7 @@ def memex_list_templates(ctx: Context) -> str:
         'Register a new note template. Creates a template from inline content. '
         'To delete a template, use the CLI: memex note template delete <slug>'
     ),
+    tags={'write'},
     annotations={'readOnlyHint': False},
 )
 def memex_register_template(
@@ -701,6 +735,7 @@ def memex_register_template(
         '[DEPRECATED — use memex_list_vaults instead, which includes is_active flag] '
         'Get the active vault name and ID. Shows both server default and client-resolved vault.'
     ),
+    tags={'browse'},
     annotations={'readOnlyHint': True},
 )
 async def memex_active_vault(ctx: Context) -> str:
@@ -737,7 +772,8 @@ async def memex_active_vault(ctx: Context) -> str:
 
 @mcp.tool(
     name='memex_add_note',
-    description='Add a note to Memex. Confirm vault with user first, or pass vault_id.',
+    description='Add a new note or document to Memex. Ingest content into a vault. Confirm vault with user first, or pass vault_id.',
+    tags={'write'},
     annotations={'readOnlyHint': False},
     timeout=120.0,
 )
@@ -964,9 +1000,10 @@ def _build_memory_unit_model(
     name='memex_memory_search',
     description=(
         'Search extracted facts, events, and observations across all notes (memory search). '
-        'Best for broad/exploratory queries. '
+        'Find information about any topic. Best for broad/exploratory queries. '
         'For targeted document lookup, use memex_note_search. When unsure, run both in parallel.'
     ),
+    tags={'search'},
     annotations={'readOnlyHint': True},
     timeout=60.0,
 )
@@ -1074,10 +1111,12 @@ async def memex_memory_search(
 @mcp.tool(
     name='memex_note_search',
     description=(
-        'Search source notes by hybrid retrieval (note search). '
-        'Returns ranked notes with 5W summaries. Best for targeted document lookup. '
+        'Search and find source notes by hybrid retrieval (note search). '
+        'Find notes about any topic. Returns ranked notes with 5W summaries. '
+        'Best for targeted document lookup. '
         'For broad exploration, use memex_memory_search. When unsure, run both in parallel.'
     ),
+    tags={'search'},
     annotations={'readOnlyHint': True},
     timeout=60.0,
 )
@@ -1276,13 +1315,15 @@ async def _get_single_page_index(
 @mcp.tool(
     name='memex_get_page_indices',
     description=(
-        'Get note TOC: section titles, summaries, node IDs, and subtree_tokens for 1+ notes. '
+        'Get note table of contents (TOC): section titles, summaries, node IDs, '
+        'and subtree_tokens for 1+ notes. '
         'Each node includes subtree_tokens (own + all descendant tokens) for read budgeting. '
         'Expensive for large notes — only call AFTER memex_get_notes_metadata confirms relevance. '
         'For large notes (total_tokens > 3000): use depth=0 to get top-level sections (H1+H2) first, '
         'then drill into specific sections with parent_node_id. '
         'Pass leaf node IDs (nodes without children) to memex_get_nodes to read content.'
     ),
+    tags={'read'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -1348,6 +1389,7 @@ async def memex_get_page_indices(
         'Use after memex_memory_search to filter results before reading. '
         'SKIP after memex_note_search (metadata already inline).'
     ),
+    tags={'read'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -1419,6 +1461,7 @@ async def memex_get_notes_metadata(
         'Read note sections by node IDs. Get node IDs from memex_get_page_indices. '
         'Accepts 1 or more IDs — use for single and batch reads.'
     ),
+    tags={'read'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -1483,6 +1526,7 @@ async def memex_get_nodes(
 @mcp.tool(
     name='memex_list_vaults',
     description='List all vaults with note counts. Each vault includes is_active and note_count.',
+    tags={'browse'},
     annotations={'readOnlyHint': True},
 )
 async def memex_list_vaults(ctx: Context) -> list[McpVault]:
@@ -1532,6 +1576,7 @@ async def memex_list_vaults(ctx: Context) -> list[McpVault]:
         'List notes with optional date filters. '
         "Use after/before for temporal queries like 'documents from 2026'."
     ),
+    tags={'browse'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -1620,6 +1665,7 @@ async def memex_list_notes(
     name='memex_recent_notes',
     description='Browse recent notes. Defaults to all vaults. '
     'Filter by vault names/UUIDs and optional date range.',
+    tags={'browse'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -1720,6 +1766,7 @@ async def memex_recent_notes(
         '3. memex_get_entity_mentions → find facts/observations mentioning entity\n'
         '4. memex_get_entity_cooccurrences → find related entities'
     ),
+    tags={'entities'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -1791,6 +1838,7 @@ async def memex_list_entities(
         'Get entity details (name, type, mention count) for 1+ entities by UUID. '
         'Use after memex_list_entities to get full details.'
     ),
+    tags={'entities'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -1861,6 +1909,7 @@ async def memex_get_entities(
 @mcp.tool(
     name='memex_get_entity_mentions',
     description='Get facts, observations, and events that mention an entity. Each mention links to its source note, revealing cross-note connections.',
+    tags={'entities'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -1915,6 +1964,7 @@ async def memex_get_entity_mentions(
 @mcp.tool(
     name='memex_get_entity_cooccurrences',
     description='Find entities that frequently appear alongside a given entity — the fastest way to map relationships and discover connected concepts. Returns entity names, types, and co-occurrence counts inline (no follow-up calls needed). Use this for "what relates to X?" questions.',
+    tags={'entities'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -1982,10 +2032,12 @@ def _lineage_to_mcp(resp: LineageResponse) -> McpLineageNode:
 @mcp.tool(
     name='memex_get_lineage',
     description=(
-        'Trace the provenance chain of an entity. '
+        'Trace provenance and connections between documents and facts. '
+        'How does a fact connect to a document? '
         'Upstream: mental_model → observation → memory_unit → note. '
         'Downstream: note → memory_unit → observation → mental_model.'
     ),
+    tags={'storage'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -2053,6 +2105,7 @@ async def memex_get_lineage(
 @mcp.tool(
     name='memex_get_memory_units',
     description='Batch lookup of memory units by ID. Includes contradiction links and supersession info.',
+    tags={'storage'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -2095,6 +2148,7 @@ async def memex_get_memory_units(
         'Lightweight fuzzy title search. Returns matching note titles, IDs, and scores. '
         'Use when you know (part of) the title. For content search, use memex_note_search.'
     ),
+    tags={'search'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
 )
@@ -2156,6 +2210,7 @@ async def memex_find_note(
         'Examples: "global:tool:python:pkg_mgr", "user:work:employer", '
         '"project:github.com/user/repo:vault", "app:claude-code:theme".'
     ),
+    tags={'storage'},
     annotations={'readOnlyHint': False, 'idempotentHint': True},
     timeout=15.0,
 )
@@ -2199,6 +2254,7 @@ async def memex_kv_write(
 @mcp.tool(
     name='memex_kv_get',
     description='Get a fact by exact key from the KV store.',
+    tags={'storage'},
     annotations={'readOnlyHint': True},
     timeout=15.0,
 )
@@ -2235,6 +2291,7 @@ async def memex_kv_get(
         'Returns the closest matching entries. '
         'Optionally filter by namespace prefixes (global, user, project).'
     ),
+    tags={'storage'},
     annotations={'readOnlyHint': True},
     timeout=15.0,
 )
@@ -2275,9 +2332,10 @@ async def memex_kv_search(
 @mcp.tool(
     name='memex_kv_list',
     description=(
-        'List all facts in the KV store. '
-        'Optionally filter by namespace prefixes (global, user, project).'
+        'List all entries in the key-value store. Shows stored facts, preferences, '
+        'and settings. Optionally filter by namespace prefixes (global, user, project).'
     ),
+    tags={'storage'},
     annotations={'readOnlyHint': True},
     timeout=15.0,
 )

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -124,6 +124,12 @@ def _validate_vault_ids(vault_ids: list[str]) -> list[str]:
 
 async def _resolve_vault_ids(api: Any, vault_ids: list[str]) -> list[UUID]:
     """Resolve and validate that all vault identifiers exist."""
+    from memex_common.vault_utils import ALL_VAULTS_WILDCARD
+
+    if ALL_VAULTS_WILDCARD in vault_ids:
+        vaults = await api.list_vaults()
+        return [v.id for v in vaults]
+
     resolved: list[UUID] = []
     for vid in vault_ids:
         try:
@@ -971,7 +977,7 @@ async def memex_memory_search(
         list[str] | None,
         BeforeValidator(_coerce_list),
         Field(
-            description='Vault UUIDs or names. Omit to use config defaults.',
+            description='Vault UUIDs or names. Use "*" for all vaults. Omit to use config defaults.',
         ),
     ] = None,
     limit: Annotated[
@@ -1082,7 +1088,7 @@ async def memex_note_search(
         list[str] | None,
         BeforeValidator(_coerce_list),
         Field(
-            description='Vault UUIDs or names. Omit to use config defaults.',
+            description='Vault UUIDs or names. Use "*" for all vaults. Omit to use config defaults.',
         ),
     ] = None,
     limit: Annotated[
@@ -1626,7 +1632,7 @@ async def memex_recent_notes(
         list[str] | None,
         BeforeValidator(_coerce_list),
         Field(
-            description='Vault UUIDs or names. Omit for all vaults.',
+            description='Vault UUIDs or names. Use "*" for all vaults. Omit for all vaults.',
         ),
     ] = None,
     after: Annotated[
@@ -2100,7 +2106,7 @@ async def memex_find_note(
         BeforeValidator(_coerce_list),
         Field(
             default=None,
-            description="Vault UUIDs or names to search in, e.g. ['rituals']. None = all vaults.",
+            description='Vault UUIDs or names to search in, e.g. [\'rituals\']. Use "*" for all vaults. None = all vaults.',
         ),
     ] = None,
     limit: Annotated[int, BeforeValidator(_coerce_int), Field(description='Max results.')] = 5,

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -1,6 +1,5 @@
 "FastMCP Memex server implementation"
 
-import logging
 import os
 import pathlib as plb
 import asyncio
@@ -11,6 +10,7 @@ import mimetypes
 
 import aiofiles
 import httpx
+import structlog
 from fastmcp import FastMCP, Context
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 from fastmcp.utilities.types import Image, Audio, File
@@ -165,8 +165,7 @@ def _default_read_vaults(ctx: Context) -> list[str]:
 
 configure_logging(level=os.environ.get('MEMEX_MCP_LOG_LEVEL', 'WARNING'))
 
-persona_logger = logging.getLogger('persona')
-persona_logger.setLevel(os.getenv('PERSONA_LOG_LEVEL', 'INFO'))
+logger = structlog.get_logger(__name__)
 
 mcp = FastMCP(
     'memex_mcp',
@@ -295,7 +294,7 @@ async def memex_list_assets(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'List assets failed: {e}', exc_info=True)
+        logger.error(f'List assets failed: {e}', exc_info=True)
         raise ToolError(f'List assets failed: {e}')
 
 
@@ -358,7 +357,7 @@ async def memex_read_note(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Read note failed: {e}', exc_info=True)
+        logger.error(f'Read note failed: {e}', exc_info=True)
         raise ToolError(f'Read note failed: {e}')
 
 
@@ -409,7 +408,7 @@ async def memex_set_note_status(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Set note status failed: {e}', exc_info=True)
+        logger.error(f'Set note status failed: {e}', exc_info=True)
         raise ToolError(f'Set note status failed: {e}')
 
 
@@ -438,7 +437,7 @@ async def memex_rename_note(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Rename note failed: {e}', exc_info=True)
+        logger.error(f'Rename note failed: {e}', exc_info=True)
         raise ToolError(f'Rename note failed: {e}')
 
 
@@ -507,7 +506,7 @@ async def memex_get_resources(
         return results
 
     except Exception as e:
-        logging.error(f'Get resource failed: {e}', exc_info=True)
+        logger.error(f'Get resource failed: {e}', exc_info=True)
         raise ToolError(f'Failed to retrieve resources: {e}')
 
 
@@ -547,7 +546,7 @@ async def memex_add_assets(
         for file_path in file_paths:
             path = plb.Path(file_path)
             if not path.exists() or not path.is_file():
-                logging.warning(f'Asset file not found or not a file: {file_path}')
+                logger.warning(f'Asset file not found or not a file: {file_path}')
                 continue
             async with aiofiles.open(path, 'rb') as f:
                 files_content[path.name] = await f.read()
@@ -580,7 +579,7 @@ async def memex_add_assets(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Add assets failed: {e}', exc_info=True)
+        logger.error(f'Add assets failed: {e}', exc_info=True)
         raise ToolError(f'Add assets failed: {e}')
 
 
@@ -633,7 +632,7 @@ async def memex_delete_assets(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Delete assets failed: {e}', exc_info=True)
+        logger.error(f'Delete assets failed: {e}', exc_info=True)
         raise ToolError(f'Delete assets failed: {e}')
 
 
@@ -645,7 +644,7 @@ def _get_template_registry(ctx: Context) -> TemplateRegistry:
     if '://' not in root:
         dirs.append(('global', plb.Path(root) / 'templates'))
     else:
-        logging.debug('Skipping global templates: remote filestore (%s)', root)
+        logger.debug('Skipping global templates: remote filestore (%s)', root)
     dirs.append(('local', plb.Path('.memex/templates')))
     return TemplateRegistry(dirs)
 
@@ -672,7 +671,7 @@ def memex_get_template(
     except KeyError as e:
         raise ToolError(str(e))
     except Exception as e:
-        logging.error(f'Get template failed: {e}', exc_info=True)
+        logger.error(f'Get template failed: {e}', exc_info=True)
         raise ToolError(f'Failed to retrieve template: {e}')
 
 
@@ -693,7 +692,7 @@ def memex_list_templates(ctx: Context) -> str:
             lines.append(f'- **{t.slug}** {source_tag} — {t.display_name}: {t.description}')
         return '\n'.join(lines) if lines else 'No templates available.'
     except Exception as e:
-        logging.error(f'List templates failed: {e}', exc_info=True)
+        logger.error(f'List templates failed: {e}', exc_info=True)
         raise ToolError(f'Failed to list templates: {e}')
 
 
@@ -725,7 +724,7 @@ def memex_register_template(
         )
         return f'Registered template: {info.slug} ({info.display_name}) in {info.source} scope.'
     except Exception as e:
-        logging.error(f'Register template failed: {e}', exc_info=True)
+        logger.error(f'Register template failed: {e}', exc_info=True)
         raise ToolError(f'Failed to register template: {e}')
 
 
@@ -766,7 +765,7 @@ async def memex_active_vault(ctx: Context) -> str:
         return '\n'.join(lines)
 
     except Exception as e:
-        logging.error(f'Get active vault failed: {e}', exc_info=True)
+        logger.error(f'Get active vault failed: {e}', exc_info=True)
         raise ToolError(f'Failed to retrieve active vault: {e}')
 
 
@@ -866,7 +865,7 @@ async def memex_add_note(
                     async with aiofiles.open(path, 'rb') as f:
                         files_content[path.name] = base64.b64encode(await f.read())
                 else:
-                    logging.warning(f'Supporting file not found or not a file: {file_path}')
+                    logger.warning(f'Supporting file not found or not a file: {file_path}')
 
         # Construct frontmatter
         fm_data: dict[str, Any] = {
@@ -934,7 +933,7 @@ async def memex_add_note(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Add note failed: {e}', exc_info=True)
+        logger.error(f'Add note failed: {e}', exc_info=True)
         raise ToolError(f'Add note failed: {e}')
 
 
@@ -1104,7 +1103,7 @@ async def memex_memory_search(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Search failed: {e}', exc_info=True)
+        logger.error(f'Search failed: {e}', exc_info=True)
         raise ToolError(f'Search failed: {e}')
 
 
@@ -1216,7 +1215,7 @@ async def memex_note_search(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Note search failed: {e}', exc_info=True)
+        logger.error(f'Note search failed: {e}', exc_info=True)
         raise ToolError(f'Note search failed: {e}')
 
 
@@ -1378,7 +1377,7 @@ async def memex_get_page_indices(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Get page index failed: {e}', exc_info=True)
+        logger.error(f'Get page index failed: {e}', exc_info=True)
         raise ToolError(f'Get page index failed: {e}')
 
 
@@ -1451,7 +1450,7 @@ async def memex_get_notes_metadata(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Get notes metadata failed: {e}', exc_info=True)
+        logger.error(f'Get notes metadata failed: {e}', exc_info=True)
         raise ToolError(f'Get notes metadata failed: {e}')
 
 
@@ -1519,7 +1518,7 @@ async def memex_get_nodes(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Get nodes failed: {e}', exc_info=True)
+        logger.error(f'Get nodes failed: {e}', exc_info=True)
         raise ToolError(f'Get nodes failed: {e}')
 
 
@@ -1566,7 +1565,7 @@ async def memex_list_vaults(ctx: Context) -> list[McpVault]:
             ]
 
     except Exception as e:
-        logging.error(f'List vaults failed: {e}', exc_info=True)
+        logger.error(f'List vaults failed: {e}', exc_info=True)
         raise ToolError(f'List vaults failed: {e}')
 
 
@@ -1657,7 +1656,7 @@ async def memex_list_notes(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'List notes failed: {e}', exc_info=True)
+        logger.error(f'List notes failed: {e}', exc_info=True)
         raise ToolError(f'List notes failed: {e}')
 
 
@@ -1750,7 +1749,7 @@ async def memex_recent_notes(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Recent notes failed: {e}', exc_info=True)
+        logger.error(f'Recent notes failed: {e}', exc_info=True)
         raise ToolError(f'Recent notes failed: {e}')
 
 
@@ -1828,7 +1827,7 @@ async def memex_list_entities(
         ]
 
     except Exception as e:
-        logging.error(f'List entities failed: {e}', exc_info=True)
+        logger.error(f'List entities failed: {e}', exc_info=True)
         raise ToolError(f'List entities failed: {e}')
 
 
@@ -1902,7 +1901,7 @@ async def memex_get_entities(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Get entities failed: {e}', exc_info=True)
+        logger.error(f'Get entities failed: {e}', exc_info=True)
         raise ToolError(f'Get entities failed: {e}')
 
 
@@ -1957,7 +1956,7 @@ async def memex_get_entity_mentions(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Get entity mentions failed: {e}', exc_info=True)
+        logger.error(f'Get entity mentions failed: {e}', exc_info=True)
         raise ToolError(f'Get entity mentions failed: {e}')
 
 
@@ -2013,7 +2012,7 @@ async def memex_get_entity_cooccurrences(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Get entity cooccurrences failed: {e}', exc_info=True)
+        logger.error(f'Get entity cooccurrences failed: {e}', exc_info=True)
         raise ToolError(f'Get entity cooccurrences failed: {e}')
 
 
@@ -2098,7 +2097,7 @@ async def memex_get_lineage(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Get lineage failed: {e}', exc_info=True)
+        logger.error(f'Get lineage failed: {e}', exc_info=True)
         raise ToolError(f'Get lineage failed: {e}')
 
 
@@ -2138,7 +2137,7 @@ async def memex_get_memory_units(
         return output
 
     except Exception as e:
-        logging.error(f'Get memory units failed: {e}', exc_info=True)
+        logger.error(f'Get memory units failed: {e}', exc_info=True)
         raise ToolError(f'Get memory units failed: {e}')
 
 
@@ -2194,7 +2193,7 @@ async def memex_find_note(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'Find note failed: {e}', exc_info=True)
+        logger.error(f'Find note failed: {e}', exc_info=True)
         raise ToolError(f'Find note failed: {e}')
 
 
@@ -2247,7 +2246,7 @@ async def memex_kv_write(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'KV write failed: {e}', exc_info=True)
+        logger.error(f'KV write failed: {e}', exc_info=True)
         raise ToolError(f'KV write failed: {e}')
 
 
@@ -2280,7 +2279,7 @@ async def memex_kv_get(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'KV get failed: {e}', exc_info=True)
+        logger.error(f'KV get failed: {e}', exc_info=True)
         raise ToolError(f'KV get failed: {e}')
 
 
@@ -2325,7 +2324,7 @@ async def memex_kv_search(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'KV search failed: {e}', exc_info=True)
+        logger.error(f'KV search failed: {e}', exc_info=True)
         raise ToolError(f'KV search failed: {e}')
 
 
@@ -2374,7 +2373,7 @@ async def memex_kv_list(
     except ToolError:
         raise
     except Exception as e:
-        logging.error(f'KV list failed: {e}', exc_info=True)
+        logger.error(f'KV list failed: {e}', exc_info=True)
         raise ToolError(f'KV list failed: {e}')
 
 

--- a/packages/mcp/src/memex_mcp/transforms.py
+++ b/packages/mcp/src/memex_mcp/transforms.py
@@ -1,0 +1,58 @@
+"Progressive disclosure transform for the Memex MCP server."
+
+from collections.abc import Sequence
+
+from fastmcp.experimental.transforms.code_mode import (
+    DiscoveryToolFactory,
+    GetSchemas,
+    GetTags,
+    Search,
+)
+from fastmcp.server.transforms import GetToolNext
+from fastmcp.server.transforms.catalog import CatalogTransform
+from fastmcp.tools.tool import Tool
+from fastmcp.utilities.versions import VersionSpec
+
+
+class DiscoveryMode(CatalogTransform):
+    """Progressive disclosure: meta-tools for discovery, real tools still directly callable.
+
+    Replaces ``tools/list`` with three discovery meta-tools (tags, search, get_schema)
+    while keeping all real tools callable via ``tools/call``.  This lets LLMs discover
+    tools incrementally instead of loading all schemas upfront.
+    """
+
+    def __init__(
+        self,
+        *,
+        discovery_tools: list[DiscoveryToolFactory] | None = None,
+    ) -> None:
+        super().__init__()
+        self._discovery_factories = discovery_tools or [
+            GetTags(name='memex_tags'),
+            Search(name='memex_search', default_detail='brief', default_limit=10),
+            GetSchemas(name='memex_get_schema', default_detail='detailed'),
+        ]
+        self._built: list[Tool] | None = None
+
+    def _build(self) -> list[Tool]:
+        if self._built is None:
+            self._built = [f(self.get_tool_catalog) for f in self._discovery_factories]
+        return self._built
+
+    async def transform_tools(self, tools: Sequence[Tool]) -> Sequence[Tool]:
+        """Return only discovery meta-tools for tools/list."""
+        return self._build()
+
+    async def get_tool(
+        self,
+        name: str,
+        call_next: GetToolNext,
+        *,
+        version: VersionSpec | None = None,
+    ) -> Tool | None:
+        """Check discovery tools first, then fall through to real tools."""
+        for tool in self._build():
+            if tool.name == name:
+                return tool
+        return await call_next(name, version=version)

--- a/packages/mcp/tests/test_discovery_mode.py
+++ b/packages/mcp/tests/test_discovery_mode.py
@@ -1,11 +1,9 @@
 "Tests for the DiscoveryMode progressive disclosure transform."
 
-import pytest
 from fastmcp import Client
 from fastmcp.server.transforms.search.bm25 import BM25SearchTransform
 
 from memex_mcp.server import mcp
-from memex_mcp.transforms import DiscoveryMode
 
 
 EXPECTED_TAGS = {'search', 'read', 'write', 'browse', 'entities', 'assets', 'storage'}
@@ -49,23 +47,6 @@ BM25_TEST_CASES: list[tuple[str, list[str]]] = [
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def discovery_mcp():
-    """Return a copy of the MCP server with DiscoveryMode applied."""
-    transform = DiscoveryMode()
-    original_transforms = list(mcp._transforms) if hasattr(mcp, '_transforms') else []
-    mcp.add_transform(transform)
-    yield mcp
-    # Restore original transforms
-    if hasattr(mcp, '_transforms'):
-        mcp._transforms = original_transforms
-
-
-# ---------------------------------------------------------------------------
 # Tag coverage
 # ---------------------------------------------------------------------------
 
@@ -87,38 +68,38 @@ async def test_tag_taxonomy():
 
 
 # ---------------------------------------------------------------------------
-# Discovery mode behaviour
+# Discovery mode behaviour (enabled by default)
 # ---------------------------------------------------------------------------
 
 
-async def test_list_tools_returns_only_meta_tools(discovery_mcp):
-    """With DiscoveryMode active, tools/list should return only the 3 meta-tools."""
-    async with Client(discovery_mcp) as client:
+async def test_enabled_by_default():
+    """DiscoveryMode should be active by default — tools/list returns only meta-tools."""
+    async with Client(mcp) as client:
         tools = await client.list_tools()
     names = {t.name for t in tools}
     assert names == {'memex_tags', 'memex_search', 'memex_get_schema'}
 
 
-async def test_tags_returns_categories(discovery_mcp):
+async def test_tags_returns_categories():
     """memex_tags should return all 7 categories."""
-    async with Client(discovery_mcp) as client:
+    async with Client(mcp) as client:
         result = await client.call_tool('memex_tags', {'detail': 'brief'})
     text = result.content[0].text
     for tag in EXPECTED_TAGS:
         assert tag in text, f'Tag {tag!r} not found in memex_tags output'
 
 
-async def test_search_finds_tools(discovery_mcp):
+async def test_search_finds_tools():
     """memex_search should return relevant tools for a keyword query."""
-    async with Client(discovery_mcp) as client:
+    async with Client(mcp) as client:
         result = await client.call_tool('memex_search', {'query': 'search notes'})
     text = result.content[0].text
     assert 'memex_note_search' in text or 'memex_memory_search' in text
 
 
-async def test_search_with_tag_filter(discovery_mcp):
+async def test_search_with_tag_filter():
     """memex_search with tags filter should only return tools from that tag."""
-    async with Client(discovery_mcp) as client:
+    async with Client(mcp) as client:
         result = await client.call_tool('memex_search', {'query': 'list', 'tags': ['assets']})
     text = result.content[0].text
     assert 'memex_list_assets' in text
@@ -127,32 +108,21 @@ async def test_search_with_tag_filter(discovery_mcp):
     assert 'memex_list_vaults' not in text
 
 
-async def test_get_schema_returns_params(discovery_mcp):
+async def test_get_schema_returns_params():
     """memex_get_schema should return parameter details for a named tool."""
-    async with Client(discovery_mcp) as client:
+    async with Client(mcp) as client:
         result = await client.call_tool('memex_get_schema', {'tools': ['memex_memory_search']})
     text = result.content[0].text
     assert 'memex_memory_search' in text
     assert 'query' in text  # main parameter
 
 
-async def test_real_tools_still_callable(discovery_mcp, mock_api, mock_config):
-    """Real tools should remain callable by name even with DiscoveryMode active."""
+async def test_real_tools_still_callable(mock_api, mock_config):
+    """Real tools should remain callable by name via tools/call passthrough."""
     mock_api.list_vaults.return_value = []
-    async with Client(discovery_mcp) as client:
-        result = await client.call_tool('memex_list_vaults', {})
-    # Should not raise — the tool should be dispatched through get_tool passthrough
-    assert result is not None
-
-
-async def test_disabled_by_default():
-    """Without DiscoveryMode, all 31+ tools should be visible."""
     async with Client(mcp) as client:
-        tools = await client.list_tools()
-    names = {t.name for t in tools}
-    assert 'memex_memory_search' in names
-    assert 'memex_list_vaults' in names
-    assert len(names) >= 31
+        result = await client.call_tool('memex_list_vaults', {})
+    assert result is not None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/mcp/tests/test_discovery_mode.py
+++ b/packages/mcp/tests/test_discovery_mode.py
@@ -1,0 +1,179 @@
+"Tests for the DiscoveryMode progressive disclosure transform."
+
+import pytest
+from fastmcp import Client
+from fastmcp.server.transforms.search.bm25 import BM25SearchTransform
+
+from memex_mcp.server import mcp
+from memex_mcp.transforms import DiscoveryMode
+
+
+EXPECTED_TAGS = {'search', 'read', 'write', 'browse', 'entities', 'assets', 'storage'}
+
+# Natural-language queries mapped to expected tool(s) — used for BM25 recall testing.
+BM25_TEST_CASES: list[tuple[str, list[str]]] = [
+    ('search for information about a topic', ['memex_memory_search', 'memex_note_search']),
+    ('find notes about machine learning', ['memex_memory_search', 'memex_note_search']),
+    (
+        'what entities are related to this concept',
+        ['memex_list_entities', 'memex_get_entity_cooccurrences'],
+    ),
+    ('read the content of a specific note', ['memex_read_note', 'memex_get_nodes']),
+    ('get the table of contents of a note', ['memex_get_page_indices']),
+    ('store a user preference', ['memex_kv_write']),
+    ('look up a stored fact', ['memex_kv_get', 'memex_kv_search']),
+    ('add a new document to memex', ['memex_add_note']),
+    ('list all my vaults', ['memex_list_vaults']),
+    ('find a note by its title', ['memex_find_note']),
+    ('what notes were added recently', ['memex_recent_notes']),
+    ('upload an image to a note', ['memex_add_assets']),
+    ('view attachments on a note', ['memex_list_assets', 'memex_get_resources']),
+    ('trace the provenance of a fact', ['memex_get_lineage']),
+    ('get metadata for multiple notes', ['memex_get_notes_metadata']),
+    ('which entities co-occur together', ['memex_get_entity_cooccurrences']),
+    ('find facts that mention a person', ['memex_get_entity_mentions']),
+    ('browse notes from last month', ['memex_list_notes', 'memex_recent_notes']),
+    ('delete an attachment from a note', ['memex_delete_assets']),
+    ('get a template for creating notes', ['memex_get_template', 'memex_list_templates']),
+    ('what is the active vault', ['memex_active_vault', 'memex_list_vaults']),
+    ('rename a note', ['memex_rename_note']),
+    ('archive a note', ['memex_set_note_status']),
+    ('semantic search over stored preferences', ['memex_kv_search']),
+    ('list all key-value entries', ['memex_kv_list']),
+    ('batch read memory units by ID', ['memex_get_memory_units']),
+    ('explore the knowledge graph', ['memex_list_entities', 'memex_get_entity_cooccurrences']),
+    ('how does this fact connect to that document', ['memex_get_lineage']),
+    ('register a custom note template', ['memex_register_template']),
+    ('supersede an outdated note', ['memex_set_note_status']),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def discovery_mcp():
+    """Return a copy of the MCP server with DiscoveryMode applied."""
+    transform = DiscoveryMode()
+    original_transforms = list(mcp._transforms) if hasattr(mcp, '_transforms') else []
+    mcp.add_transform(transform)
+    yield mcp
+    # Restore original transforms
+    if hasattr(mcp, '_transforms'):
+        mcp._transforms = original_transforms
+
+
+# ---------------------------------------------------------------------------
+# Tag coverage
+# ---------------------------------------------------------------------------
+
+
+async def test_all_tools_have_tags():
+    """Every registered tool must have at least one tag."""
+    tools = await mcp._list_tools()
+    untagged = [t.name for t in tools if not t.tags]
+    assert not untagged, f'Tools without tags: {untagged}'
+
+
+async def test_tag_taxonomy():
+    """All tools must use only the expected tag set."""
+    tools = await mcp._list_tools()
+    all_tags: set[str] = set()
+    for t in tools:
+        all_tags |= t.tags or set()
+    assert all_tags == EXPECTED_TAGS, f'Unexpected tags: {all_tags - EXPECTED_TAGS}'
+
+
+# ---------------------------------------------------------------------------
+# Discovery mode behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_list_tools_returns_only_meta_tools(discovery_mcp):
+    """With DiscoveryMode active, tools/list should return only the 3 meta-tools."""
+    async with Client(discovery_mcp) as client:
+        tools = await client.list_tools()
+    names = {t.name for t in tools}
+    assert names == {'memex_tags', 'memex_search', 'memex_get_schema'}
+
+
+async def test_tags_returns_categories(discovery_mcp):
+    """memex_tags should return all 7 categories."""
+    async with Client(discovery_mcp) as client:
+        result = await client.call_tool('memex_tags', {'detail': 'brief'})
+    text = result.content[0].text
+    for tag in EXPECTED_TAGS:
+        assert tag in text, f'Tag {tag!r} not found in memex_tags output'
+
+
+async def test_search_finds_tools(discovery_mcp):
+    """memex_search should return relevant tools for a keyword query."""
+    async with Client(discovery_mcp) as client:
+        result = await client.call_tool('memex_search', {'query': 'search notes'})
+    text = result.content[0].text
+    assert 'memex_note_search' in text or 'memex_memory_search' in text
+
+
+async def test_search_with_tag_filter(discovery_mcp):
+    """memex_search with tags filter should only return tools from that tag."""
+    async with Client(discovery_mcp) as client:
+        result = await client.call_tool('memex_search', {'query': 'list', 'tags': ['assets']})
+    text = result.content[0].text
+    assert 'memex_list_assets' in text
+    # Should NOT contain tools from other tags
+    assert 'memex_list_notes' not in text
+    assert 'memex_list_vaults' not in text
+
+
+async def test_get_schema_returns_params(discovery_mcp):
+    """memex_get_schema should return parameter details for a named tool."""
+    async with Client(discovery_mcp) as client:
+        result = await client.call_tool('memex_get_schema', {'tools': ['memex_memory_search']})
+    text = result.content[0].text
+    assert 'memex_memory_search' in text
+    assert 'query' in text  # main parameter
+
+
+async def test_real_tools_still_callable(discovery_mcp, mock_api, mock_config):
+    """Real tools should remain callable by name even with DiscoveryMode active."""
+    mock_api.list_vaults.return_value = []
+    async with Client(discovery_mcp) as client:
+        result = await client.call_tool('memex_list_vaults', {})
+    # Should not raise — the tool should be dispatched through get_tool passthrough
+    assert result is not None
+
+
+async def test_disabled_by_default():
+    """Without DiscoveryMode, all 31+ tools should be visible."""
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+    names = {t.name for t in tools}
+    assert 'memex_memory_search' in names
+    assert 'memex_list_vaults' in names
+    assert len(names) >= 31
+
+
+# ---------------------------------------------------------------------------
+# BM25 recall
+# ---------------------------------------------------------------------------
+
+
+async def test_bm25_recall_at_3():
+    """At least 90% of natural queries should hit the expected tool in the top 3."""
+    tools = await mcp._list_tools()
+    bm25 = BM25SearchTransform(max_results=5)
+    hits = 0
+    misses: list[tuple[str, list[str], list[str]]] = []
+    for query, expected in BM25_TEST_CASES:
+        results = await bm25._search(tools, query)
+        top3 = {t.name for t in results[:3]}
+        if set(expected) & top3:
+            hits += 1
+        else:
+            misses.append((query, expected, [t.name for t in results[:5]]))
+    rate = hits / len(BM25_TEST_CASES)
+    assert rate >= 0.9, f'BM25 hit@3 = {rate:.0%} (expected >= 90%). Misses:\n' + '\n'.join(
+        f'  {q!r} expected={e} got={g}' for q, e, g in misses
+    )

--- a/packages/mcp/tests/test_mcp_server.py
+++ b/packages/mcp/tests/test_mcp_server.py
@@ -238,44 +238,11 @@ async def test_mcp_read_note_not_found(mock_api, mcp_client):
 
 @pytest.mark.asyncio
 async def test_mcp_list_tools(mcp_client):
-    """Verify that all expected tools are registered."""
+    """Verify that progressive disclosure meta-tools are listed by default."""
     tools = await mcp_client.list_tools()
-    names = [t.name for t in tools]
-    # Core tools should exist
-    assert 'memex_add_note' in names
-    assert 'memex_memory_search' in names
-    assert 'memex_note_search' in names
-    assert 'memex_list_vaults' in names
-    assert 'memex_recent_notes' in names
-    assert 'memex_list_entities' in names
-    assert 'memex_get_entities' in names
-    assert 'memex_get_entity_mentions' in names
-    assert 'memex_get_entity_cooccurrences' in names
-    assert 'memex_get_memory_units' in names
-    assert 'memex_get_lineage' in names
-    assert 'memex_get_nodes' in names
-    assert 'memex_get_notes_metadata' in names
-    assert 'memex_get_page_indices' in names
-    assert 'memex_get_resources' in names
-    # Removed tools should not exist
-    assert 'memex_get_page_index' not in names
-    assert 'memex_get_resource' not in names
-    assert 'memex_reflect' not in names
-    assert 'memex_batch_ingest' not in names
-    assert 'memex_get_batch_status' not in names
-    assert 'memex_migrate_note' not in names
-    assert 'memex_ingest_url' not in names
-    assert 'memex_get_node' not in names
-    assert 'memex_get_note_metadata' not in names
-    assert 'memex_get_memory_unit' not in names
-    assert 'memex_get_entity' not in names
-    assert 'memex_list_notes' in names
-
-    # Tool descriptions should guide agents to use leaf node IDs
-    tool_by_name = {t.name: t for t in tools}
-    page_desc = tool_by_name['memex_get_page_indices'].description
-    assert 'leaf' in page_desc.lower(), 'page_indices description should mention leaf nodes'
-    assert 'memex_get_nodes' in page_desc, 'page_indices description should reference get_nodes'
+    names = {t.name for t in tools}
+    # Progressive disclosure is on by default — only meta-tools are listed
+    assert names == {'memex_tags', 'memex_search', 'memex_get_schema'}
 
 
 @pytest.mark.asyncio

--- a/packages/mcp/tests/test_wildcard_vaults.py
+++ b/packages/mcp/tests/test_wildcard_vaults.py
@@ -5,8 +5,10 @@ from uuid import uuid4
 
 import pytest
 
+from conftest import parse_tool_result
 from fastmcp.exceptions import ToolError
 
+from memex_common.schemas import MemoryUnitDTO, FactTypes
 from memex_mcp.server import _resolve_vault_id, _resolve_vault_ids, _validate_vault_ids
 
 
@@ -87,3 +89,68 @@ class TestResolveVaultIdWildcard:
 
         with pytest.raises(ToolError, match='not supported'):
             await _resolve_vault_id(api, '*')
+
+
+class TestWildcardMcpToolIntegration:
+    """End-to-end tests calling MCP tools with vault_ids=['*']."""
+
+    @pytest.mark.asyncio
+    async def test_memory_search_wildcard(self, mock_api, mock_config, mcp_client):
+        """memex_memory_search with vault_ids=['*'] should list all vaults."""
+        v1, v2 = uuid4(), uuid4()
+        mock_api.list_vaults.return_value = [MagicMock(id=v1), MagicMock(id=v2)]
+        mock_api.search.return_value = [
+            MemoryUnitDTO(
+                id=uuid4(),
+                text='Found across vaults.',
+                fact_type=FactTypes.WORLD,
+                score=0.9,
+                vault_id=v1,
+                metadata={},
+            )
+        ]
+
+        result = await mcp_client.call_tool(
+            'memex_memory_search', {'query': 'test', 'vault_ids': ['*']}
+        )
+
+        data = parse_tool_result(result)
+        assert len(data) == 1
+
+        mock_api.list_vaults.assert_called_once()
+        mock_api.resolve_vault_identifier.assert_not_called()
+        call_args = mock_api.search.call_args[1]
+        assert set(call_args['vault_ids']) == {v1, v2}
+
+    @pytest.mark.asyncio
+    async def test_note_search_wildcard(self, mock_api, mock_config, mcp_client):
+        """memex_note_search with vault_ids=['*'] should list all vaults."""
+        v1 = uuid4()
+        mock_api.list_vaults.return_value = [MagicMock(id=v1)]
+        mock_api.search_notes.return_value = []
+
+        await mcp_client.call_tool('memex_note_search', {'query': 'test', 'vault_ids': ['*']})
+
+        mock_api.list_vaults.assert_called_once()
+        mock_api.resolve_vault_identifier.assert_not_called()
+        call_args = mock_api.search_notes.call_args[1]
+        assert call_args['vault_ids'] == [v1]
+
+    @pytest.mark.asyncio
+    async def test_find_note_wildcard(self, mock_api, mock_config, mcp_client):
+        """memex_find_note with vault_ids=['*'] should list all vaults."""
+        v1 = uuid4()
+        mock_api.list_vaults.return_value = [MagicMock(id=v1)]
+        mock_api.find_notes_by_title.return_value = []
+
+        await mcp_client.call_tool('memex_find_note', {'query': 'test', 'vault_ids': ['*']})
+
+        mock_api.list_vaults.assert_called_once()
+        call_args = mock_api.find_notes_by_title.call_args[1]
+        assert call_args['vault_ids'] == [v1]
+
+    @pytest.mark.asyncio
+    async def test_list_entities_wildcard_rejected(self, mock_api, mock_config, mcp_client):
+        """memex_list_entities uses singular vault_id — '*' should error."""
+        with pytest.raises(ToolError, match='not supported'):
+            await mcp_client.call_tool('memex_list_entities', {'vault_id': '*'})

--- a/packages/mcp/tests/test_wildcard_vaults.py
+++ b/packages/mcp/tests/test_wildcard_vaults.py
@@ -1,0 +1,89 @@
+"""Tests for the '*' wildcard vault resolution in MCP tools."""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from fastmcp.exceptions import ToolError
+
+from memex_mcp.server import _resolve_vault_id, _resolve_vault_ids, _validate_vault_ids
+
+
+class TestValidateVaultIds:
+    """Ensure '*' passes validation without error."""
+
+    def test_wildcard_passes(self):
+        result = _validate_vault_ids(['*'])
+        assert result == ['*']
+
+    def test_wildcard_with_others_passes(self):
+        result = _validate_vault_ids(['*', 'my-vault'])
+        assert result == ['*', 'my-vault']
+
+
+class TestResolveVaultIdsWildcard:
+    """Test _resolve_vault_ids with the '*' wildcard."""
+
+    @pytest.mark.asyncio
+    async def test_wildcard_returns_all_vaults(self):
+        v1, v2, v3 = uuid4(), uuid4(), uuid4()
+        api = AsyncMock()
+        api.list_vaults = AsyncMock(
+            return_value=[
+                MagicMock(id=v1),
+                MagicMock(id=v2),
+                MagicMock(id=v3),
+            ]
+        )
+
+        result = await _resolve_vault_ids(api, ['*'])
+
+        assert result == [v1, v2, v3]
+        api.list_vaults.assert_called_once()
+        api.resolve_vault_identifier.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wildcard_with_other_names_still_returns_all(self):
+        """Wildcard takes precedence — extra names are ignored."""
+        v1 = uuid4()
+        api = AsyncMock()
+        api.list_vaults = AsyncMock(return_value=[MagicMock(id=v1)])
+
+        result = await _resolve_vault_ids(api, ['*', 'some-vault'])
+
+        assert result == [v1]
+        api.resolve_vault_identifier.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_without_wildcard_resolves_individually(self):
+        v1 = uuid4()
+        api = AsyncMock()
+        api.resolve_vault_identifier = AsyncMock(return_value=v1)
+
+        result = await _resolve_vault_ids(api, ['my-vault'])
+
+        assert result == [v1]
+        api.list_vaults.assert_not_called()
+        api.resolve_vault_identifier.assert_called_once_with('my-vault')
+
+    @pytest.mark.asyncio
+    async def test_wildcard_empty_database_returns_empty(self):
+        """Edge case: no vaults in the database returns an empty list."""
+        api = AsyncMock()
+        api.list_vaults = AsyncMock(return_value=[])
+
+        result = await _resolve_vault_ids(api, ['*'])
+
+        assert result == []
+
+
+class TestResolveVaultIdWildcard:
+    """Test _resolve_vault_id (singular) rejects '*' with a helpful error."""
+
+    @pytest.mark.asyncio
+    async def test_wildcard_raises_tool_error(self):
+        api = AsyncMock()
+
+        with pytest.raises(ToolError, match='not supported'):
+            await _resolve_vault_id(api, '*')

--- a/tests/test_e2e_search_lineage.py
+++ b/tests/test_e2e_search_lineage.py
@@ -1,10 +1,10 @@
-"""E2E test: ingest a note, search for it, then verify lineage returns 200."""
+"""E2E tests: ingest→search→lineage pipeline and note deletion cleanup."""
 
 import base64
 import json
 from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock, AsyncMock
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from fastapi.testclient import TestClient
@@ -142,3 +142,129 @@ def test_search_results_resolvable_via_lineage(client: TestClient):
     assert resp.status_code == 200
     lineage = resp.json()
     assert len(lineage['derived_from']) > 0, 'Note downstream lineage should contain memory units'
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_delete_note_prunes_mental_model_observations(postgres_container):
+    """Deleting a note via the API must prune mental model observations that
+    cited the deleted note's memory units. This is the root cause of the
+    lineage 404 bug: stale observations survive deletion and get returned
+    by the mental_model retrieval strategy as virtual units."""
+    import asyncio
+    from httpx import AsyncClient, ASGITransport
+    from sqlmodel import col, select
+    from memex_core.memory.sql_models import (
+        Entity,
+        MentalModel,
+        MemoryUnit,
+        Note,
+        UnitEntity,
+    )
+    from memex_core.server import app as server_app, lifespan
+    from memex_common.config import GLOBAL_VAULT_ID
+    from memex_common.types import FactTypes
+
+    async with lifespan(server_app):
+        api = server_app.state.api
+
+        vault_id = GLOBAL_VAULT_ID
+        entity_id = uuid4()
+        note_a_id = uuid4()
+        note_b_id = uuid4()
+        unit_a_id = uuid4()
+        unit_b_id = uuid4()
+        obs_shared_id = uuid4()
+        obs_only_a_id = uuid4()
+        now = datetime.now(timezone.utc)
+
+        # Setup: create test data
+        async with api.metastore.session() as session:
+            session.add(Entity(id=entity_id, canonical_name='TestEnt', vault_id=vault_id))
+            session.add(Note(id=note_a_id, vault_id=vault_id, original_text='A'))
+            session.add(Note(id=note_b_id, vault_id=vault_id, original_text='B'))
+            await session.flush()
+            session.add(
+                MemoryUnit(
+                    id=unit_a_id,
+                    vault_id=vault_id,
+                    note_id=note_a_id,
+                    text='Fact A',
+                    fact_type=FactTypes.WORLD,
+                    embedding=[0.0] * 384,
+                    event_date=now,
+                )
+            )
+            session.add(
+                MemoryUnit(
+                    id=unit_b_id,
+                    vault_id=vault_id,
+                    note_id=note_b_id,
+                    text='Fact B',
+                    fact_type=FactTypes.WORLD,
+                    embedding=[0.0] * 384,
+                    event_date=now,
+                )
+            )
+            await session.flush()
+            session.add(UnitEntity(unit_id=unit_a_id, entity_id=entity_id))
+            session.add(UnitEntity(unit_id=unit_b_id, entity_id=entity_id))
+            session.add(
+                MentalModel(
+                    entity_id=entity_id,
+                    vault_id=vault_id,
+                    name='TestEnt',
+                    observations=[
+                        {
+                            'id': str(obs_shared_id),
+                            'title': 'Shared',
+                            'content': 'Both',
+                            'trend': 'new',
+                            'evidence': [
+                                {'memory_id': str(unit_a_id), 'quote': 'A', 'relevance': 1.0},
+                                {'memory_id': str(unit_b_id), 'quote': 'B', 'relevance': 1.0},
+                            ],
+                        },
+                        {
+                            'id': str(obs_only_a_id),
+                            'title': 'OnlyA',
+                            'content': 'A only',
+                            'trend': 'new',
+                            'evidence': [
+                                {'memory_id': str(unit_a_id), 'quote': 'A', 'relevance': 1.0},
+                            ],
+                        },
+                    ],
+                    version=1,
+                )
+            )
+            await session.commit()
+
+        # Act: delete note A via HTTP
+        async with AsyncClient(
+            transport=ASGITransport(app=server_app), base_url='http://test'
+        ) as http:
+            resp = await http.delete(f'/api/v1/notes/{note_a_id}')
+            assert resp.status_code == 200, f'Delete failed: {resp.text}'
+
+        # Allow background tasks to settle
+        await asyncio.sleep(0.5)
+
+        # Assert: mental model observations are pruned
+        async with api.metastore.session() as session:
+            mm = (
+                await session.exec(
+                    select(MentalModel).where(col(MentalModel.entity_id) == entity_id)
+                )
+            ).first()
+
+        assert mm is not None, 'Mental model should survive (note B still exists)'
+
+        obs_ids = {o['id'] for o in mm.observations}
+        assert str(obs_only_a_id) not in obs_ids, (
+            'Observation with evidence only from deleted note should be removed'
+        )
+        assert str(obs_shared_id) in obs_ids, 'Observation with mixed evidence should survive'
+        shared = next(o for o in mm.observations if o['id'] == str(obs_shared_id))
+        assert len(shared['evidence']) == 1
+        assert shared['evidence'][0]['memory_id'] == str(unit_b_id)

--- a/uv.lock
+++ b/uv.lock
@@ -3108,6 +3108,7 @@ dependencies = [
     { name = "httpx" },
     { name = "memex-common" },
     { name = "pyyaml" },
+    { name = "structlog" },
 ]
 
 [package.dev-dependencies]
@@ -3122,6 +3123,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "memex-common", editable = "packages/common" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "structlog", specifier = ">=25.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Replace flat 31-tool listing with 3 discovery meta-tools (`memex_tags`, `memex_search`, `memex_get_schema`) using a custom `DiscoveryMode(CatalogTransform)`
- All 31 real tools tagged with 7 categories and descriptions improved for BM25 recall (80% → 100% hit@3)
- Migrate logging from stdlib to structlog, remove dead `persona_logger`
- Enabled by default; set `MEMEX_MCP_PROGRESSIVE_DISCLOSURE=false` to disable

## Test plan
- [x] 248 MCP tests pass (10 new discovery mode tests)
- [x] BM25 recall test: 100% hit@3 on 30-query suite
- [x] All 6 eval retrieval paths validated via live progressive disclosure flow
- [x] Real tools remain callable by name (passthrough via `get_tool`)
- [x] Linting clean (ruff + ruff-format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)