### PR TITLE
feat(core): configurable per-model timeout and num_retries for LLM calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,136%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,152%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -255,6 +255,15 @@ class ModelConfig(BaseModel):
     reasoning_effort: ReasoningEffort | None = Field(
         default=None, description='Reasoning effort of the model (if supported)'
     )
+    timeout: int = Field(
+        default=120,
+        ge=10,
+        description=(
+            'Per-request timeout in seconds for LLM calls. Prevents hanging on '
+            'slow providers. Increase for large models on remote endpoints '
+            '(e.g. ollama.com). Default: 120s.'
+        ),
+    )
 
     @field_serializer('reasoning_effort')
     def serialize_reasoning_effort(self, value: ReasoningEffort | None) -> str | None:

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -264,6 +264,11 @@ class ModelConfig(BaseModel):
             '(e.g. ollama.com). Default: 120s.'
         ),
     )
+    num_retries: int = Field(
+        default=3,
+        ge=1,
+        description='Number of retries for LLM calls on failure (e.g. schema validation errors). Default: 3.',
+    )
 
     @field_serializer('reasoning_effort')
     def serialize_reasoning_effort(self, value: ReasoningEffort | None) -> str | None:

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -377,6 +377,7 @@ class MemexAPI:
                 api_base=str(model_config.base_url) if model_config.base_url else None,
                 api_key=model_config.api_key.get_secret_value() if model_config.api_key else None,
                 timeout=model_config.timeout,
+                num_retries=model_config.num_retries,
             )
             dspy.settings.configure(lm=self.lm)
         else:

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -376,6 +376,7 @@ class MemexAPI:
                 model=model_config.model,
                 api_base=str(model_config.base_url) if model_config.base_url else None,
                 api_key=model_config.api_key.get_secret_value() if model_config.api_key else None,
+                timeout=model_config.timeout,
             )
             dspy.settings.configure(lm=self.lm)
         else:

--- a/packages/core/src/memex_core/llm.py
+++ b/packages/core/src/memex_core/llm.py
@@ -54,6 +54,7 @@ async def run_dspy_operation(
     input_kwargs: dict[str, Any],
     semaphore: asyncio.Semaphore | None = None,
     operation_name: str = 'dspy',
+    timeout: int = 180,
 ) -> Any:
     """
     Executes a DSPy predictor with circuit breaker and metrics.
@@ -105,9 +106,9 @@ async def run_dspy_operation(
     try:
         if semaphore:
             async with semaphore:
-                result = await _execute()
+                result = await asyncio.wait_for(_execute(), timeout=timeout)
         else:
-            result = await _execute()
+            result = await asyncio.wait_for(_execute(), timeout=timeout)
 
         await _circuit_breaker.record_success()
 
@@ -121,6 +122,17 @@ async def run_dspy_operation(
             lm_.history.clear()
 
         return result
+
+    except TimeoutError:
+        await _circuit_breaker.record_failure()
+
+        elapsed = time.monotonic() - start
+        LLM_CALLS_TOTAL.labels(status='timeout').inc()
+        LLM_CALL_DURATION_SECONDS.observe(elapsed)
+        CIRCUIT_BREAKER_STATE.set(_STATE_VALUES.get(str(_circuit_breaker.state), 0))
+
+        logger.error('DSPy operation timed out after %ds: %s', timeout, operation_name)
+        raise RuntimeError(f'LLM call timed out after {timeout}s ({operation_name})') from None
 
     except (ValueError, RuntimeError, OSError, KeyError) as e:
         await _circuit_breaker.record_failure()

--- a/packages/core/src/memex_core/memory/extraction/core.py
+++ b/packages/core/src/memex_core/memory/extraction/core.py
@@ -1408,9 +1408,15 @@ async def index_document(
 
     # Full PageIndex
     indexer = AsyncMarkdownPageIndex(lm=lm)
-    return await indexer.aforward(
-        full_text,
-        max_scan_tokens=max_scan_tokens,
-        max_node_length=max_node_length,
-        block_size=block_token_target,
+    # Wrap in timeout — individual LLM calls have their own timeout via dspy.LM,
+    # but the full page-index pipeline (multiple sequential LLM calls) can hang
+    # if any single call stalls silently.
+    return await asyncio.wait_for(
+        indexer.aforward(
+            full_text,
+            max_scan_tokens=max_scan_tokens,
+            max_node_length=max_node_length,
+            block_size=block_token_target,
+        ),
+        timeout=600,  # 10 min max for full page index pipeline
     )

--- a/packages/core/tests/unit/memory/extraction/test_utils.py
+++ b/packages/core/tests/unit/memory/extraction/test_utils.py
@@ -1,5 +1,7 @@
 import datetime as dt
 
+import pytest
+
 from memex_core.memory.extraction.utils import parse_iso_datetime, sanitize_text
 
 
@@ -70,3 +72,103 @@ class TestNormalizeTimestamp:
         aware = dt.datetime(2024, 1, 1, 10, 0, 0, tzinfo=dt.timezone.utc)
         res = normalize_timestamp(aware)
         assert res == aware
+
+
+class TestNormalizeTimestampFallback:
+    """Test normalize_timestamp fallback chain."""
+
+    def test_uses_fallback_when_none(self) -> None:
+        from memex_core.memory.extraction.utils import normalize_timestamp
+
+        fallback = dt.datetime(2023, 6, 1, tzinfo=dt.timezone.utc)
+        res = normalize_timestamp(None, fallback=fallback)
+        assert res == fallback
+
+    def test_uses_value_over_fallback(self) -> None:
+        from memex_core.memory.extraction.utils import normalize_timestamp
+
+        value = dt.datetime(2024, 3, 15, tzinfo=dt.timezone.utc)
+        fallback = dt.datetime(2023, 6, 1, tzinfo=dt.timezone.utc)
+        res = normalize_timestamp(value, fallback=fallback)
+        assert res == value
+
+    def test_no_fallback_uses_now(self) -> None:
+        from memex_core.memory.extraction.utils import normalize_timestamp
+
+        res = normalize_timestamp(None)
+        assert res.year >= 2020
+        assert res.tzinfo is not None
+
+
+class TestExtremeDateHandling:
+    """Regression tests: extreme dates must not crash the extraction pipeline."""
+
+    def test_timedelta_overflow_guarded_for_datetime_min(self) -> None:
+        """datetime.min - timedelta(hours=12) overflows; the guard catches it."""
+        from datetime import timedelta
+
+        target = dt.datetime(1, 1, 1, tzinfo=dt.timezone.utc)
+        delta = timedelta(hours=12)
+
+        # Without guard, this crashes:
+        with pytest.raises(OverflowError):
+            _ = target - delta
+
+        # The guard in check_duplicates_in_window catches it:
+        try:
+            start = target - delta
+        except OverflowError:
+            start = dt.datetime.min.replace(tzinfo=target.tzinfo)
+        assert start.year == 1
+
+    def test_timedelta_overflow_guarded_for_datetime_max(self) -> None:
+        """datetime.max + timedelta(hours=12) overflows; the guard catches it."""
+        from datetime import timedelta
+
+        target = dt.datetime(9999, 12, 31, 23, 0, 0, tzinfo=dt.timezone.utc)
+        delta = timedelta(hours=12)
+
+        with pytest.raises(OverflowError):
+            _ = target + delta
+
+        try:
+            end = target + delta
+        except OverflowError:
+            end = dt.datetime.max.replace(tzinfo=target.tzinfo)
+        assert end.year == 9999
+
+    def test_parse_iso_datetime_accepts_year_one(self) -> None:
+        """parse_iso_datetime should accept '0001-01-01' — valid ISO 8601."""
+        result = parse_iso_datetime('0001-01-01')
+        assert result is not None
+        assert result.year == 1
+
+    def test_parse_iso_datetime_accepts_historical(self) -> None:
+        """Historical dates like Battle of Hastings should parse."""
+        result = parse_iso_datetime('1066-10-14')
+        assert result is not None
+        assert result.year == 1066
+
+    def test_parse_iso_datetime_accepts_far_future(self) -> None:
+        """Far future dates should parse."""
+        result = parse_iso_datetime('9999-01-01')
+        assert result is not None
+        assert result.year == 9999
+
+    def test_dedup_batch_uses_event_date_fallback(self) -> None:
+        """When fact has no dates, dedup uses event_date, not now()."""
+        from memex_core.memory.extraction.models import ProcessedFact
+        from memex_common.types import FactTypes
+
+        event_date = dt.datetime(2023, 6, 1, tzinfo=dt.timezone.utc)
+        fact = ProcessedFact(
+            fact_text='test',
+            fact_type=FactTypes.WORLD,
+            embedding=[0.1] * 384,
+            mentioned_at=event_date,
+            occurred_start=None,
+        )
+        # The dedup function should use mentioned_at (which is event_date),
+        # not crash or produce datetime.min
+        fact_date = fact.occurred_start or fact.mentioned_at
+        assert fact_date == event_date


### PR DESCRIPTION
## Summary

LLM calls via dspy/litellm had no timeout — calls could hang forever on slow or unresponsive providers (e.g. ollama.com, Gemma models on Google API).

## Changes

- Add `timeout: int = 120` and `num_retries: int = 3` to `ModelConfig`
- Wire both to `dspy.LM()` constructor in `api.py`
- Add `asyncio.wait_for(timeout)` wrapper in `run_dspy_operation` — catches hanging LLM calls
- Add `asyncio.wait_for(timeout=600)` on full page index pipeline — prevents entire extraction from hanging
- `TimeoutError` triggers circuit breaker failure recording + Prometheus metric

## Configuration

```yaml
server:
  default_model:
    model: ollama/gemma4:31b-cloud
    timeout: 300  # 5 min for slow providers
    num_retries: 1  # reduce for faster fail
```

Or via env: `MEMEX_SERVER__DEFAULT_MODEL__TIMEOUT=300`

## Found during

LongMemEval ingestion with Gemma models on ollama.com — calls hung indefinitely, blocking the entire batch processor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)