### PR TITLE
fix(core): accept query param for entity search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,132%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,136%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1019,7 +1019,7 @@ List, search, or rank entities. Returns an NDJSON stream.
 curl "http://localhost:8000/api/v1/entities?limit=20"
 
 # Search by name
-curl "http://localhost:8000/api/v1/entities?q=PostgreSQL"
+curl "http://localhost:8000/api/v1/entities?query=PostgreSQL"
 
 # Top entities by mention count
 curl "http://localhost:8000/api/v1/entities?sort=-mentions&limit=10"

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -530,7 +530,7 @@ class RemoteMemexAPI:
         entity_type: str | None = None,
     ) -> list[EntityDTO]:
         """Search for entities by name."""
-        params: dict[str, Any] = {'q': query, 'limit': limit}
+        params: dict[str, Any] = {'query': query, 'limit': limit}
         resolved = resolve_vault_list(vault_id, vault_ids)
         if resolved:
             params['vault_id'] = [str(v) for v in resolved]
@@ -552,7 +552,7 @@ class RemoteMemexAPI:
         """Stream entities ranked by hybrid score."""
         params: dict[str, Any] = {'limit': limit}
         if q:
-            params['q'] = q
+            params['query'] = q
         resolved = resolve_vault_list(vault_id, vault_ids)
         if resolved:
             params['vault_id'] = [str(v) for v in resolved]

--- a/packages/core/src/memex_core/server/entities.py
+++ b/packages/core/src/memex_core/server/entities.py
@@ -47,7 +47,14 @@ router = APIRouter(prefix='/api/v1')
 async def list_entities(
     api: Annotated[MemexAPI, Depends(get_api)],
     limit: Annotated[int, Query(ge=1, le=500)] = 100,
-    q: str | None = None,
+    query: Annotated[
+        str | None,
+        Query(description='Search query for name-based filtering.'),
+    ] = None,
+    q: Annotated[
+        str | None,
+        Query(description='Alias for query (deprecated, use query).', include_in_schema=False),
+    ] = None,
     sort: Literal['-mentions'] | None = Query(
         None, description='Sort option: -mentions for top by mention count'
     ),
@@ -63,17 +70,19 @@ async def list_entities(
 
     Query params:
     - limit: Maximum number of entities to return
-    - q: Optional search query for name-based search
+    - query: Optional search query for name-based search
+    - q: Deprecated alias for query (kept for backward compatibility)
     - sort: Optional sort option. Use '-mentions' for top entities by mention count.
     - vault_id: Optional vault ID(s) or name(s) to filter by. Repeat for multiple vaults.
     - entity_type: Optional entity type filter.
     """
     await check_vault_access(auth, vault_id, api)
     vault_ids = await resolve_vault_ids(api, vault_id)
-    if q:
+    search_query = query or q
+    if search_query:
         try:
             entities = await api.search_entities(
-                query=q, limit=limit, vault_ids=vault_ids, entity_type=entity_type
+                query=search_query, limit=limit, vault_ids=vault_ids, entity_type=entity_type
             )
             return ndjson_response([build_entity_dto(e) for e in entities])
         except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:

--- a/packages/core/tests/integration/test_int_entity_type_filter.py
+++ b/packages/core/tests/integration/test_int_entity_type_filter.py
@@ -239,7 +239,9 @@ async def test_rest_search_with_type_filter(api, metastore, init_global_vault):
         await session.commit()
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
-        response = await ac.get('/api/v1/entities?q=Python&entity_type=Technology&sort=-mentions')
+        response = await ac.get(
+            '/api/v1/entities?query=Python&entity_type=Technology&sort=-mentions'
+        )
         assert response.status_code == 200
         data = [json.loads(line) for line in response.text.splitlines() if line.strip()]
         assert len(data) == 1

--- a/packages/core/tests/unit/test_api_entity_search.py
+++ b/packages/core/tests/unit/test_api_entity_search.py
@@ -83,7 +83,7 @@ async def test_server_entity_search(api, mock_metastore, mock_filestore):
         patch('memex_core.server.run_scheduler_with_leader_election', new_callable=AsyncMock),
     ):
         with TestClient(app) as client:
-            response = client.get('/api/v1/entities?q=match')
+            response = client.get('/api/v1/entities?query=match')
             assert response.status_code == 200
             import json
 
@@ -92,3 +92,162 @@ async def test_server_entity_search(api, mock_metastore, mock_filestore):
             assert data[0]['name'] == 'Search Match'
 
     app.dependency_overrides.clear()
+
+
+def _make_server_test_client(api, mock_metastore, mock_filestore):
+    """Helper to create a TestClient with all required patches for entity endpoint tests."""
+    from memex_core.server import app
+    from memex_core.server.common import get_api
+    from unittest.mock import patch
+
+    mock_config = MagicMock()
+    mock_config.server.memory.extraction.model.model = 'test-model'
+    mock_config.server.default_active_vault = 'global'
+    mock_config.server.default_reader_vault = 'global'
+    mock_config.server.logging.level = 'WARNING'
+    mock_config.server.logging.json_output = False
+    mock_config.server.host = '127.0.0.1'
+    mock_config.server.cache_dir = '/tmp/memex-test-cache'
+    mock_config.server.tracing.enabled = False
+
+    mock_metastore.connect = AsyncMock()
+    mock_metastore.close = AsyncMock()
+    mock_metastore.session.return_value.__aenter__.return_value.get = AsyncMock(return_value=None)
+    mock_metastore.session.return_value.__aenter__.return_value.commit = AsyncMock()
+
+    api.initialize = AsyncMock()
+    app.dependency_overrides[get_api] = lambda: api
+
+    patches = (
+        patch('memex_core.server.get_metastore', return_value=mock_metastore),
+        patch('memex_core.server.get_filestore', return_value=mock_filestore),
+        patch('memex_core.server.parse_memex_config', return_value=mock_config),
+        patch('memex_core.server.setup_auth'),
+        patch('memex_core.server.setup_rate_limiting'),
+        patch('memex_core.server.configure_logging'),
+        patch('memex_core.server.MemexAPI', return_value=api),
+        patch('memex_core.server.get_embedding_model', new_callable=AsyncMock),
+        patch('memex_core.server.get_reranking_model', new_callable=AsyncMock),
+        patch('memex_core.server.get_ner_model', new_callable=AsyncMock),
+        patch('memex_core.server.run_scheduler_with_leader_election', new_callable=AsyncMock),
+    )
+
+    return app, patches, get_api
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: query parameter filtering on GET /api/v1/entities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_entity_search_with_query_param(api, mock_metastore, mock_filestore):
+    """GET /api/v1/entities?query=... must filter entities by name (regression)."""
+    from contextlib import ExitStack
+    from fastapi.testclient import TestClient
+    import json
+
+    e1 = Entity(id=uuid4(), canonical_name='Imagine Dragons')
+    wrapped = EntityWithMetadata(entity=e1, metadata={})
+    api.search_entities = AsyncMock(return_value=[wrapped])
+
+    app, patches, get_api = _make_server_test_client(api, mock_metastore, mock_filestore)
+    try:
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            with TestClient(app) as client:
+                response = client.get('/api/v1/entities?query=Imagine+Dragons')
+                assert response.status_code == 200
+                data = [json.loads(line) for line in response.text.strip().split('\n') if line]
+                assert len(data) == 1
+                assert data[0]['name'] == 'Imagine Dragons'
+                api.search_entities.assert_called_once()
+                call_kwargs = api.search_entities.call_args
+                assert call_kwargs.kwargs['query'] == 'Imagine Dragons'
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_entity_search_with_legacy_q_param(api, mock_metastore, mock_filestore):
+    """GET /api/v1/entities?q=... must still work (backward compatibility)."""
+    from contextlib import ExitStack
+    from fastapi.testclient import TestClient
+    import json
+
+    e1 = Entity(id=uuid4(), canonical_name='Serenity Yoga')
+    wrapped = EntityWithMetadata(entity=e1, metadata={})
+    api.search_entities = AsyncMock(return_value=[wrapped])
+
+    app, patches, get_api = _make_server_test_client(api, mock_metastore, mock_filestore)
+    try:
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            with TestClient(app) as client:
+                response = client.get('/api/v1/entities?q=Serenity')
+                assert response.status_code == 200
+                data = [json.loads(line) for line in response.text.strip().split('\n') if line]
+                assert len(data) == 1
+                assert data[0]['name'] == 'Serenity Yoga'
+                api.search_entities.assert_called_once()
+                call_kwargs = api.search_entities.call_args
+                assert call_kwargs.kwargs['query'] == 'Serenity'
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_entity_search_query_takes_precedence_over_q(api, mock_metastore, mock_filestore):
+    """When both query= and q= are provided, query= takes precedence."""
+    from contextlib import ExitStack
+    from fastapi.testclient import TestClient
+    import json
+
+    e1 = Entity(id=uuid4(), canonical_name='Xfinity Center')
+    wrapped = EntityWithMetadata(entity=e1, metadata={})
+    api.search_entities = AsyncMock(return_value=[wrapped])
+
+    app, patches, get_api = _make_server_test_client(api, mock_metastore, mock_filestore)
+    try:
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            with TestClient(app) as client:
+                response = client.get('/api/v1/entities?query=Xfinity&q=ignored')
+                assert response.status_code == 200
+                data = [json.loads(line) for line in response.text.strip().split('\n') if line]
+                assert len(data) == 1
+                api.search_entities.assert_called_once()
+                call_kwargs = api.search_entities.call_args
+                assert call_kwargs.kwargs['query'] == 'Xfinity'
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_entity_listing_without_query_returns_ranked(api, mock_metastore, mock_filestore):
+    """GET /api/v1/entities without query/q must NOT call search_entities."""
+    from contextlib import ExitStack
+    from fastapi.testclient import TestClient
+
+    api.search_entities = AsyncMock()
+
+    async def _ranked(limit=100, vault_ids=None, entity_type=None):
+        e = Entity(id=uuid4(), canonical_name='User', mention_count=2368)
+        yield EntityWithMetadata(entity=e, metadata={})
+
+    api.list_entities_ranked = _ranked
+
+    app, patches, get_api = _make_server_test_client(api, mock_metastore, mock_filestore)
+    try:
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            with TestClient(app) as client:
+                response = client.get('/api/v1/entities')
+                assert response.status_code == 200
+                api.search_entities.assert_not_called()
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_e2e_entity_resolver_v2.py
+++ b/tests/test_e2e_entity_resolver_v2.py
@@ -100,7 +100,7 @@ def test_entity_type_partitioning_e2e(client: TestClient):
         assert resp.status_code == 200
 
     # Step 3: Verify distinct entities are merged because EntityResolver is type-agnostic
-    resp = client.get(f'/api/v1/entities?q=Java&vault_id={vault_id}')
+    resp = client.get(f'/api/v1/entities?query=Java&vault_id={vault_id}')
     assert resp.status_code == 200
     entities = parse_ndjson(resp.text)
 


### PR DESCRIPTION
## Summary
- The `GET /api/v1/entities` endpoint declared its search parameter as `q`, but all callers (CLI, MCP, REST clients) used `query`. The mismatch caused the query to be silently ignored, always returning entities ranked by mention count regardless of search term.
- Added `query` as the primary parameter with `q` as a deprecated backward-compatible alias.
- Updated `RemoteMemexAPI` client to send `query` instead of `q`.
- Added 4 regression tests for the parameter handling.

## Test plan
- [x] Unit tests: `test_api_entity_search.py` — 4 new tests (query, legacy q, precedence, ranked fallback)
- [x] Integration test updated: `test_int_entity_type_filter.py`
- [x] E2E test updated: `test_e2e_entity_resolver_v2.py`
- [x] All 1794 core unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)