### PR TITLE
feat(hermes-plugin): add standalone Memex memory provider plugin for Hermes Agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,19 +47,20 @@ Always use `uv`, never `pip`.
 
 ## Architecture
 
-Python monorepo managed by `uv` with 7 packages.
+Python monorepo managed by `uv` with 8 packages.
 
 ### Packages
 
 | Package | Import | Purpose |
 |---------|--------|---------|
 | `packages/core` | `memex_core` | Core library: storage, memory engine (extraction/retrieval/reflection), services layer, MemexAPI facade, FastAPI server |
-| `packages/cli` | `memex_cli` | Typer CLI (`memex` command) — 12 command groups: note, vault, memory, entity, kv, server, mcp, config, system, database, setup, report-bug |
+| `packages/cli` | `memex_cli` | Typer CLI (`memex` command) — 13 command groups: note, vault, memory, entity, kv, server, mcp, config, system, database, setup, hermes, report-bug |
 | `packages/mcp` | `memex_mcp` | FastMCP server — 35 tools for LLM integration (progressive disclosure by default) |
 | `packages/common` | `memex_common` | Shared Pydantic models, config (hierarchical YAML), HTTP client, exceptions |
 | `packages/eval` | `memex_eval` | Evaluation: internal synthetic benchmarks + external LoCoMo benchmark with LLM-as-judge |
 | `packages/firefox-extension` | — | TypeScript/WebExtension for saving pages to Memex |
 | `packages/claude-code-plugin` | — | Claude Code plugin: `/remember` and `/recall` skills, session hooks, MCP server config |
+| `packages/hermes-plugin` | `memex_hermes_plugin` | Hermes Agent memory provider plugin — 7 tools (recall, retrieve_notes, survey, retain, list_entities, get_entity_mentions, get_entity_cooccurrences), session briefings, per-project vault binding |
 
 ### Dependency graph
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,205%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,278%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -22,12 +22,14 @@ dependencies = [
 [project.optional-dependencies]
 server = ["memex-core"]
 mcp = ["memex-mcp"]
+hermes = ["memex-hermes-plugin"]
 sync = ["watchdog>=4.0.0", "sqlmodel>=0.0.22", "structlog>=25.0.0"]
 
 [tool.uv.sources]
 memex-common = { workspace = true }
 memex-core = { workspace = true }
 memex-mcp = { workspace = true }
+memex-hermes-plugin = { workspace = true }
 
 [project.scripts]
 memex = "memex_cli:app"

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -22,14 +22,12 @@ dependencies = [
 [project.optional-dependencies]
 server = ["memex-core"]
 mcp = ["memex-mcp"]
-hermes = ["memex-hermes-plugin"]
 sync = ["watchdog>=4.0.0", "sqlmodel>=0.0.22", "structlog>=25.0.0"]
 
 [tool.uv.sources]
 memex-common = { workspace = true }
 memex-core = { workspace = true }
 memex-mcp = { workspace = true }
-memex-hermes-plugin = { workspace = true }
 
 [project.scripts]
 memex = "memex_cli:app"

--- a/packages/cli/src/memex_cli/hermes.py
+++ b/packages/cli/src/memex_cli/hermes.py
@@ -1,0 +1,297 @@
+"""Hermes Agent integration commands.
+
+Installs and manages the Memex memory-provider plugin for
+https://hermes-agent.nousresearch.com under ``$HERMES_HOME/plugins/memex/``.
+
+Requires the ``hermes`` optional extra: ``uv tool install 'memex-cli[hermes]'``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Annotated, Literal
+
+import httpx
+import typer
+import yaml
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from memex_common.config import MemexConfig
+
+logger = logging.getLogger('memex_cli.hermes')
+console = Console()
+
+app = typer.Typer(
+    name='hermes',
+    help='Manage the Memex plugin for Hermes Agent.',
+    no_args_is_help=True,
+)
+
+
+def _default_hermes_home() -> Path:
+    raw = os.environ.get('HERMES_HOME')
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / '.hermes'
+
+
+def _plugin_source() -> Path:
+    try:
+        from memex_hermes_plugin import PLUGIN_DIR
+    except ImportError as exc:
+        raise typer.BadParameter(
+            'memex-hermes-plugin is not installed. Install with: '
+            "uv tool install 'memex-cli[hermes] @ git+https://github.com/JasperHG90/memex.git@latest#subdirectory=packages/cli'"
+        ) from exc
+    return PLUGIN_DIR
+
+
+def _plugin_destination(hermes_home: Path) -> Path:
+    return hermes_home / 'plugins' / 'memex'
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.exists():
+        shutil.rmtree(path)
+
+
+def _set_provider_in_hermes_config(hermes_home: Path) -> bool:
+    """Set ``memory.provider: memex`` in ``$HERMES_HOME/config.yaml``.
+
+    Returns True if the file was modified. Creates the file if missing.
+    """
+    cfg_path = hermes_home / 'config.yaml'
+    if cfg_path.exists():
+        try:
+            data = yaml.safe_load(cfg_path.read_text(encoding='utf-8')) or {}
+        except yaml.YAMLError:
+            console.print(f'[yellow]Could not parse {cfg_path}; leaving it untouched.[/]')
+            return False
+    else:
+        data = {}
+
+    memory = data.setdefault('memory', {}) if isinstance(data, dict) else None
+    if memory is None or not isinstance(memory, dict):
+        return False
+    if memory.get('provider') == 'memex':
+        return False
+    memory['provider'] = 'memex'
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding='utf-8')
+    return True
+
+
+@app.command('install')
+def install(
+    hermes_home: Annotated[
+        Path | None,
+        typer.Option(
+            '--hermes-home',
+            help='Hermes home directory. Defaults to $HERMES_HOME or ~/.hermes.',
+        ),
+    ] = None,
+    mode: Annotated[
+        str,
+        typer.Option(
+            '--mode',
+            help='symlink (default, for dev) or copy (for distribution).',
+        ),
+    ] = 'symlink',
+    force: Annotated[
+        bool,
+        typer.Option('--force', '-f', help='Replace an existing installation.'),
+    ] = False,
+    set_provider: Annotated[
+        bool,
+        typer.Option(
+            '--set-provider/--no-set-provider',
+            help='Set memory.provider: memex in $HERMES_HOME/config.yaml.',
+        ),
+    ] = True,
+) -> None:
+    """Install the Memex plugin into ``$HERMES_HOME/plugins/memex/``."""
+    mode_literal: Literal['symlink', 'copy']
+    if mode == 'symlink':
+        mode_literal = 'symlink'
+    elif mode == 'copy':
+        mode_literal = 'copy'
+    else:
+        raise typer.BadParameter("--mode must be 'symlink' or 'copy'")
+
+    source = _plugin_source()
+    if not source.exists():
+        raise typer.Exit(f'Plugin source directory not found: {source}')
+
+    home = (hermes_home or _default_hermes_home()).expanduser()
+    dest = _plugin_destination(home)
+
+    if dest.exists() or dest.is_symlink():
+        if not force:
+            console.print(f'[yellow]Plugin already installed at {dest}. Use --force to replace.[/]')
+            raise typer.Exit(1)
+        _remove_path(dest)
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    if mode_literal == 'symlink':
+        dest.symlink_to(source.resolve(), target_is_directory=True)
+        console.print(f'[green]✓[/] Symlinked {source} → {dest}')
+    else:
+        shutil.copytree(source, dest)
+        console.print(f'[green]✓[/] Copied {source} → {dest}')
+
+    if set_provider:
+        if _set_provider_in_hermes_config(home):
+            console.print(f'[green]✓[/] Set memory.provider: memex in {home / "config.yaml"}')
+        else:
+            console.print(f'memory.provider already set or unchanged in {home / "config.yaml"}')
+
+    console.print(
+        Panel.fit(
+            'Next steps:\n'
+            '  1. Start the Memex server:   [cyan]memex server start -d[/]\n'
+            '  2. Configure the plugin:     [cyan]hermes memory setup[/]\n'
+            '  3. Start a session:          [cyan]hermes chat[/]',
+            title='Memex Hermes plugin installed',
+        )
+    )
+
+
+@app.command('uninstall')
+def uninstall(
+    hermes_home: Annotated[
+        Path | None,
+        typer.Option('--hermes-home', help='Hermes home directory.'),
+    ] = None,
+    purge_config: Annotated[
+        bool,
+        typer.Option('--purge-config', help='Also remove $HERMES_HOME/memex/config.json.'),
+    ] = False,
+) -> None:
+    """Remove the plugin directory from ``$HERMES_HOME/plugins/memex/``."""
+    home = (hermes_home or _default_hermes_home()).expanduser()
+    dest = _plugin_destination(home)
+
+    if not (dest.exists() or dest.is_symlink()):
+        console.print(f'[yellow]Plugin is not installed at {dest}.[/]')
+        raise typer.Exit(0)
+
+    _remove_path(dest)
+    console.print(f'[green]✓[/] Removed {dest}')
+
+    if purge_config:
+        cfg_path = home / 'memex' / 'config.json'
+        if cfg_path.exists():
+            cfg_path.unlink()
+            console.print(f'[green]✓[/] Removed {cfg_path}')
+
+
+@app.command('status')
+def status(
+    hermes_home: Annotated[
+        Path | None,
+        typer.Option('--hermes-home', help='Hermes home directory.'),
+    ] = None,
+) -> None:
+    """Show install state, config, active provider, and server reachability."""
+    home = (hermes_home or _default_hermes_home()).expanduser()
+    dest = _plugin_destination(home)
+    cfg_path = home / 'memex' / 'config.json'
+    hermes_cfg_path = home / 'config.yaml'
+
+    table = Table(title='Memex plugin for Hermes', show_header=False, expand=False)
+    table.add_column('Check')
+    table.add_column('Result')
+
+    table.add_row('Hermes home', str(home))
+
+    if dest.is_symlink():
+        table.add_row('Plugin dir', f'[green]symlink[/] → {dest.resolve()}')
+    elif dest.is_dir():
+        table.add_row('Plugin dir', f'[green]directory[/] {dest}')
+    else:
+        table.add_row('Plugin dir', '[red]not installed[/]')
+
+    active = _active_provider(hermes_cfg_path)
+    if active == 'memex':
+        table.add_row('memory.provider', '[green]memex[/]')
+    elif active:
+        table.add_row('memory.provider', f'[yellow]{active}[/] (not memex)')
+    else:
+        table.add_row('memory.provider', '[yellow]unset[/]')
+
+    if cfg_path.exists():
+        table.add_row('Plugin config', f'[green]{cfg_path}[/]')
+    else:
+        table.add_row(
+            'Plugin config',
+            f'[yellow]missing[/] — will fall back to env + {_memex_config_hint()}',
+        )
+
+    server_url = _resolve_server_url(cfg_path)
+    reachable, detail = _check_server(server_url)
+    if reachable:
+        table.add_row('Server', f'[green]reachable[/] {server_url}')
+    else:
+        table.add_row('Server', f'[red]unreachable[/] {server_url} ({detail})')
+
+    console.print(table)
+
+
+def _active_provider(hermes_cfg_path: Path) -> str | None:
+    if not hermes_cfg_path.exists():
+        return None
+    try:
+        data = yaml.safe_load(hermes_cfg_path.read_text(encoding='utf-8')) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    memory = data.get('memory') or {}
+    if not isinstance(memory, dict):
+        return None
+    provider = memory.get('provider')
+    return provider if isinstance(provider, str) else None
+
+
+def _memex_config_hint() -> str:
+    try:
+        return str(Path(MemexConfig().server_url))
+    except Exception:
+        return 'MemexConfig()'
+
+
+def _resolve_server_url(cfg_path: Path) -> str:
+    if 'MEMEX_SERVER_URL' in os.environ:
+        return os.environ['MEMEX_SERVER_URL']
+    if cfg_path.exists():
+        import json
+
+        try:
+            data = json.loads(cfg_path.read_text(encoding='utf-8'))
+            if isinstance(data, dict) and isinstance(data.get('server_url'), str):
+                return data['server_url']
+        except json.JSONDecodeError:
+            pass
+    try:
+        return MemexConfig().server_url or 'http://127.0.0.1:8000'
+    except Exception:
+        return 'http://127.0.0.1:8000'
+
+
+def _check_server(url: str) -> tuple[bool, str]:
+    base = url.rstrip('/')
+    try:
+        response = httpx.get(f'{base}/health', timeout=3.0)
+        if response.status_code == 200:
+            return True, 'ok'
+        return False, f'HTTP {response.status_code}'
+    except httpx.HTTPError as e:
+        return False, str(e)

--- a/packages/cli/src/memex_cli/utils.py
+++ b/packages/cli/src/memex_cli/utils.py
@@ -39,7 +39,6 @@ LAZY_SUBCOMMANDS: dict[str, str] = {
     'mcp': 'memex_cli.mcp:app',
     'briefing': 'memex_cli.session:app',
     'setup': 'memex_cli.setup_claude_code:app',
-    'hermes': 'memex_cli.hermes:app',
     'report-bug': 'memex_cli.report_bug:app',
 }
 

--- a/packages/cli/src/memex_cli/utils.py
+++ b/packages/cli/src/memex_cli/utils.py
@@ -39,6 +39,7 @@ LAZY_SUBCOMMANDS: dict[str, str] = {
     'mcp': 'memex_cli.mcp:app',
     'briefing': 'memex_cli.session:app',
     'setup': 'memex_cli.setup_claude_code:app',
+    'hermes': 'memex_cli.hermes:app',
     'report-bug': 'memex_cli.report_bug:app',
 }
 

--- a/packages/hermes-plugin/README.md
+++ b/packages/hermes-plugin/README.md
@@ -1,0 +1,208 @@
+# Memex — Hermes Agent Plugin
+
+Long-term memory for [Hermes Agent](https://hermes-agent.nousresearch.com), powered by [Memex](https://github.com/JasperHG90/memex).
+
+See `memex/README.md` for the plugin-local documentation shown by `hermes memory setup`.
+
+> Full user-facing documentation is in this README. If you're looking for the install instructions, skip to [Installation](#installation).
+
+## Why Memex?
+
+Most agent memory backends are opaque: a SaaS vendor decides what gets stored, how it is indexed, and when it is surfaced. Memex takes the opposite approach. You own the Postgres database, the markdown files, the vault structure. You can inspect, export, or migrate at any time.
+
+Inside Hermes, Memex exposes more than just search: five tools cover memory-unit recall (facts/observations/events), whole-note retrieval, query-decomposing surveys, explicit ingestion, and the knowledge graph. A session briefing is injected into the system prompt at startup; the full transcript is ingested at session end. Per-project vault binding mirrors the pattern used by Memex's Claude Code plugin.
+
+## Prerequisites
+
+1. Install the Memex CLI:
+
+   ```bash
+   uv tool install "memex-cli[mcp,server] @ git+https://github.com/JasperHG90/memex.git@latest#subdirectory=packages/cli"
+   ```
+
+2. Initialize Memex and create a vault:
+
+   ```bash
+   memex config init
+   memex vault create my-vault --description "My notes"
+   ```
+
+3. Start the Memex server (the plugin warns if unreachable):
+
+   ```bash
+   memex server start -d
+   ```
+
+## Installation
+
+From this repo:
+
+```bash
+memex hermes install
+```
+
+Or manually copy the plugin directory:
+
+```bash
+cp -r packages/hermes-plugin/src/memex_hermes_plugin/memex "$HERMES_HOME/plugins/memex"
+```
+
+Then activate in Hermes:
+
+```bash
+hermes memory setup    # select "memex"
+```
+
+This writes `memory.provider: memex` to `$HERMES_HOME/config.yaml` and walks you through the config keys.
+
+## Per-project vault binding
+
+The plugin resolves which vault to use per project via the Memex KV store — the same pattern used by the Claude Code plugin. The project identifier is derived from the git remote origin URL (portable across team members' machines), falling back to the directory path for non-git projects.
+
+On session start, it looks up the KV key `project:<project_id>:vault` — for example, `project:github.com/acme/myapp:vault`.
+
+To bind a project to a vault, ask Hermes:
+
+> Set this project's vault to "my-vault"
+
+Or call Memex directly:
+
+```bash
+memex kv put "project:github.com/acme/myapp:vault" my-vault
+```
+
+If no per-project vault is set, writes go to the vault in `$HERMES_HOME/memex/config.json`, then to the Memex global vault.
+
+## Configuration
+
+### Config file
+
+The plugin writes non-secret config to `$HERMES_HOME/memex/config.json`. Secrets go to `$HERMES_HOME/.env`.
+
+| Key | Default | Description |
+|---|---|---|
+| `server_url` | `http://127.0.0.1:8000` | Memex server base URL |
+| `vault_id` | _(unset)_ | Fallback vault when per-project lookup misses |
+| `memory_mode` | `hybrid` | `hybrid` / `context` / `tools` (see below) |
+| `create_vaults_on_init` | `true` | Auto-create a missing vault at session start |
+| `briefing_budget` | `2000` | Token budget for the startup briefing |
+| `briefing_refresh_cadence` | `0` | Refresh briefing every N turns (0 = never) |
+| `recall.facts_limit` | `5` | Prefetch memory-unit count |
+| `recall.notes_limit` | `3` | Prefetch note count |
+| `recall.strategies` | `[semantic, keyword, temporal, graph, mental_model]` | TEMPR strategies to fuse |
+| `recall.token_budget` | `2048` | Token budget per recall |
+| `recall.include_stale` | `false` | Include stale memory units |
+| `recall.include_superseded` | `false` | Include superseded memory units |
+| `recall.expand_query` | `false` | LLM query expansion for prefetch |
+| `retain.session_template` | `hermes-session` | Template name for session notes |
+
+### Environment variables
+
+Env vars override the config file. Useful for CI, containerized setups, or per-shell tweaks:
+
+- `MEMEX_SERVER_URL` — server base URL
+- `MEMEX_API_KEY` — API key (secret; goes to `$HERMES_HOME/.env`)
+- `MEMEX_VAULT` — alias for `vault_id`
+- `MEMEX_HERMES_MODE` — alias for `memory_mode`
+
+### Fallback to Memex's own config
+
+If `$HERMES_HOME/memex/config.json` is absent, the plugin reads `MemexConfig()` (which in turn reads `~/.config/memex/config.yaml` and local `.memex.yaml`). Users who already run Memex locally can skip the Hermes-side config file entirely.
+
+## Tools
+
+Seven tools. The granularity mirrors Memex's MCP server — separate tools so the LLM can usefully dispatch in parallel, consolidated only when operations are genuinely sequential. Tool descriptions describe *what each tool does*; routing (when to pair tools vs. call them solo) is injected once per session via `system_prompt_block` rather than repeated in every schema.
+
+| Tool | Purpose |
+|---|---|
+| `memex_recall` | Search memory units (facts/observations/events). TEMPR fusion. |
+| `memex_retrieve_notes` | Search whole notes ranked by relevance. |
+| `memex_survey` | Decompose a broad query into sub-questions; server fans out. |
+| `memex_retain` | Ingest a note; append to the session note via `note_key`. |
+| `memex_list_entities` | Search entities by name/type. |
+| `memex_get_entity_mentions` | Source facts mentioning a specific entity. |
+| `memex_get_entity_cooccurrences` | Related entities with co-occurrence counts. |
+
+### Routing (delivered via the system prompt)
+
+- **Content lookup** — `memex_recall` + `memex_retrieve_notes` in parallel (same assistant message).
+- **Broad / panoramic query** — `memex_survey` (single call).
+- **Entity graph** — `memex_list_entities` first; then `memex_get_entity_mentions` and/or `memex_get_entity_cooccurrences` (safe to parallelise if both are needed).
+- **Title known** — `memex_retrieve_notes` with a title fragment.
+- **Capturing work** — `memex_retain` with the session note key for incremental captures; a fresh note otherwise.
+
+## Memory modes
+
+| Mode | Briefing | Prefetch | Tools |
+|---|---|---|---|
+| `hybrid` (default) | injected | yes | exposed |
+| `context` | injected | yes | hidden |
+| `tools` | skipped | skipped | exposed |
+
+Set via `memory_mode` in the config file or `MEMEX_HERMES_MODE=tools`.
+
+## What gets captured automatically
+
+- **Session briefing** on startup — fetched from Memex via the `get_session_briefing` endpoint and injected into the system prompt.
+- **Session transcript** on exit — `on_session_end` ingests the full conversation as a single note keyed `hermes:session:<ISO-timestamp>` with template `hermes-session`. Idempotent via the note key.
+- **Pre-compression chunks** — `on_pre_compress` appends messages about to be discarded to the session note so nothing is lost.
+- **Built-in memory writes** — Hermes' built-in MEMORY.md / USER.md writes are mirrored to the Memex KV store under `hermes:<target>:<hash>`.
+
+## Troubleshooting
+
+**"Memex server is not reachable"** — start it: `memex server start -d`. Check `$MEMEX_SERVER_URL` or `server_url` in the config file.
+
+**"No vault configured"** — the plugin resolves `project:<project_id>:vault` from KV. Bind one: `memex kv put "project:<your_project_id>:vault" my-vault`. Run `memex hermes status` to see the derived project ID.
+
+**Tools missing in chat** — check `memory_mode`. If set to `context`, tools are intentionally hidden. Use `hybrid` or `tools`.
+
+**Permission errors under `$HERMES_HOME/plugins/memex/`** — the install step may have used `--mode copy` when a symlink was expected. Re-run: `memex hermes install --mode symlink`.
+
+## Updating
+
+```bash
+memex hermes install --mode copy --force    # refresh copied plugin
+# or for a symlinked install:
+cd /path/to/memex-repo && git pull
+```
+
+## Uninstall
+
+```bash
+memex hermes uninstall
+```
+
+Removes `$HERMES_HOME/plugins/memex/` and (with `--purge-config`) `$HERMES_HOME/memex/config.json`.
+
+## Development
+
+Two test suites:
+
+### Unit tests (fast; no external deps)
+
+```bash
+cd packages/hermes-plugin
+just test                  # pytest -v, excludes hermes_integration marker
+uv run ruff check . && uv run mypy src
+```
+
+Stubs Hermes' `MemoryProvider` ABC via `tests/_stubs/memory_provider.py`. Refresh when upstream changes by copying from https://github.com/NousResearch/hermes-agent/blob/main/agent/memory_provider.py — the drift-detection test `test_default_strategies_match_server` will flag other breaking changes at test time.
+
+### Integration tests (live Hermes loader + live Memex via uvicorn + testcontainers Postgres)
+
+```bash
+just test-integration       # full end-to-end
+```
+
+What it does:
+1. `uv sync --all-packages --dev --group hermes-integration` — installs `hermes-agent` from GitHub
+2. Spins up `pgvector/pgvector:pg18-trixie` via testcontainers
+3. Boots the Memex FastAPI app via `uvicorn` on a free port in a background thread
+4. Discovers + loads the plugin through Hermes' real `plugins.memory.load_memory_provider`
+5. Exercises every lifecycle hook against real HTTP + real Postgres
+
+Skipped automatically if Docker or hermes-agent is unavailable. Assumes no LLM credentials — tests that rely on LLM output (survey decomposition, fact extraction on recall) are deliberately scoped to return-empty-on-empty-graph cases.
+
+## Upstreaming
+
+This plugin ships from the Memex monorepo. After the plugin has user traction, we'll propose contributing a bundled copy to `NousResearch/hermes-agent/plugins/memory/memex/` so it's discoverable without the `memex hermes install` step.

--- a/packages/hermes-plugin/README.md
+++ b/packages/hermes-plugin/README.md
@@ -35,25 +35,31 @@ Inside Hermes, Memex exposes more than just search: five tools cover memory-unit
 
 ## Installation
 
-From this repo:
+The plugin is a standalone package — no Memex CLI required.
 
 ```bash
-memex hermes install
-```
-
-Or manually copy the plugin directory:
-
-```bash
-cp -r packages/hermes-plugin/src/memex_hermes_plugin/memex "$HERMES_HOME/plugins/memex"
-```
-
-Then activate in Hermes:
-
-```bash
+uv tool install 'memex-hermes-plugin @ git+https://github.com/JasperHG90/memex.git@latest#subdirectory=packages/hermes-plugin'
+memex-hermes install
 hermes memory setup    # select "memex"
 ```
 
-This writes `memory.provider: memex` to `$HERMES_HOME/config.yaml` and walks you through the config keys.
+Or install from a GitHub release wheel (attached to every Memex `v*` release):
+
+```bash
+uv tool install https://github.com/JasperHG90/memex/releases/download/<tag>/memex_hermes_plugin-<version>-py3-none-any.whl
+memex-hermes install
+```
+
+Manual install (no Python tooling):
+
+```bash
+git clone https://github.com/JasperHG90/memex.git
+cp -r memex/packages/hermes-plugin/src/memex_hermes_plugin/memex "$HERMES_HOME/plugins/memex"
+```
+
+`memex-hermes install` writes `memory.provider: memex` to `$HERMES_HOME/config.yaml` and symlinks the plugin directory into `$HERMES_HOME/plugins/memex/`. Use `--mode copy` for a real copy instead of a symlink, and `--force` to replace an existing install.
+
+Commands: `memex-hermes install`, `memex-hermes status`, `memex-hermes uninstall`.
 
 ## Per-project vault binding
 
@@ -161,15 +167,15 @@ Set via `memory_mode` in the config file or `MEMEX_HERMES_MODE=tools`.
 ## Updating
 
 ```bash
-memex hermes install --mode copy --force    # refresh copied plugin
-# or for a symlinked install:
-cd /path/to/memex-repo && git pull
+uv tool upgrade memex-hermes-plugin
+memex-hermes install --mode copy --force    # refresh the copy in $HERMES_HOME
 ```
 
 ## Uninstall
 
 ```bash
-memex hermes uninstall
+memex-hermes uninstall
+uv tool uninstall memex-hermes-plugin
 ```
 
 Removes `$HERMES_HOME/plugins/memex/` and (with `--purge-config`) `$HERMES_HOME/memex/config.json`.

--- a/packages/hermes-plugin/justfile
+++ b/packages/hermes-plugin/justfile
@@ -3,11 +3,11 @@ default:
 
 # Install plugin into $HERMES_HOME/plugins/memex via symlink (dev default)
 install mode="symlink":
-    uv run memex hermes install --mode {{mode}}
+    uv run --no-sync memex-hermes install --mode {{mode}}
 
 # Remove plugin from $HERMES_HOME/plugins/memex
 uninstall:
-    uv run memex hermes uninstall
+    uv run --no-sync memex-hermes uninstall
 
 # Run unit tests (fast; excludes hermes_integration)
 test:

--- a/packages/hermes-plugin/justfile
+++ b/packages/hermes-plugin/justfile
@@ -1,0 +1,40 @@
+default:
+    @just --list
+
+# Install plugin into $HERMES_HOME/plugins/memex via symlink (dev default)
+install mode="symlink":
+    uv run memex hermes install --mode {{mode}}
+
+# Remove plugin from $HERMES_HOME/plugins/memex
+uninstall:
+    uv run memex hermes uninstall
+
+# Run unit tests (fast; excludes hermes_integration)
+test:
+    uv run --no-sync pytest -v
+
+# Install hermes-agent + dev deps for the integration suite
+integration-setup:
+    cd ../.. && uv sync --all-packages --dev --group hermes-integration
+
+# Run the hermes_integration suite (testcontainers Postgres + real Hermes loader + uvicorn)
+test-integration: integration-setup
+    uv run --no-sync pytest -v -m hermes_integration
+
+# Run EVERYTHING — unit + integration
+test-all: integration-setup
+    uv run --no-sync pytest -v -m "hermes_integration or not hermes_integration"
+
+# Run a specific test file or pattern
+test-one pattern:
+    uv run pytest -v -k "{{pattern}}"
+
+# Lint + format + type-check
+lint:
+    uv run ruff check .
+    uv run ruff format --check .
+    uv run mypy src
+
+# Format in place
+fmt:
+    uv run ruff format .

--- a/packages/hermes-plugin/pyproject.toml
+++ b/packages/hermes-plugin/pyproject.toml
@@ -12,7 +12,12 @@ dependencies = [
     "memex-common",
     "httpx>=0.27.0",
     "pyyaml>=6.0.0",
+    "typer>=0.12.0",
+    "rich>=13.7.0",
 ]
+
+[project.scripts]
+memex-hermes = "memex_hermes_plugin.install:app"
 
 [tool.uv.sources]
 memex-common = { workspace = true }

--- a/packages/hermes-plugin/pyproject.toml
+++ b/packages/hermes-plugin/pyproject.toml
@@ -1,0 +1,51 @@
+[project]
+name = "memex-hermes-plugin"
+dynamic = ["version"]
+description = "Memex memory provider plugin for Hermes Agent."
+authors = [
+  {name="Jasper Ginn", email="jasperginn@gmail.com"}
+]
+requires-python = ">=3.12"
+readme = "README.md"
+license = "Apache-2.0"
+dependencies = [
+    "memex-common",
+    "httpx>=0.27.0",
+    "pyyaml>=6.0.0",
+]
+
+[tool.uv.sources]
+memex-common = { workspace = true }
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/memex_hermes_plugin"]
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/memex_hermes_plugin/__about__.py"
+
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+raw-options.root = "../.."
+raw-options.git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "v*"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.2",
+    "pytest-asyncio>=1.2.0",
+    "pytest-httpx>=0.27.0",
+    "respx>=0.22.0",
+]
+
+[tool.pytest.ini_options]
+# Fast unit suite by default; integration suite is opt-in.
+addopts = "-m 'not hermes_integration'"
+markers = [
+  "hermes_integration: tests that clone + install hermes-agent and exercise the real plugin loader (slow; opt-in)",
+]

--- a/packages/hermes-plugin/src/memex_hermes_plugin/__init__.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/__init__.py
@@ -1,0 +1,15 @@
+"""memex-hermes-plugin — Memex memory provider for Hermes Agent.
+
+The actual plugin directory lives at ``memex_hermes_plugin/memex``. It is copied
+or symlinked into ``$HERMES_HOME/plugins/memex/`` by ``memex hermes install``.
+"""
+
+from pathlib import Path
+
+try:
+    from .__about__ import __version__ as __version__
+except ModuleNotFoundError:
+    __version__ = '0.0.0.dev0'
+
+# Filesystem path to the bundled Hermes plugin directory.
+PLUGIN_DIR: Path = Path(__file__).parent / 'memex'

--- a/packages/hermes-plugin/src/memex_hermes_plugin/install.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/install.py
@@ -1,13 +1,21 @@
-"""Hermes Agent integration commands.
+"""Standalone installer for the Memex Hermes plugin.
 
-Installs and manages the Memex memory-provider plugin for
-https://hermes-agent.nousresearch.com under ``$HERMES_HOME/plugins/memex/``.
+Exposed as the ``memex-hermes`` console script (see ``[project.scripts]`` in
+``pyproject.toml``). Intended to be used WITHOUT the Memex CLI:
 
-Requires the ``hermes`` optional extra: ``uv tool install 'memex-cli[hermes]'``.
+    uv tool install 'memex-hermes-plugin @ git+https://github.com/JasperHG90/memex.git@latest#subdirectory=packages/hermes-plugin'
+    memex-hermes install
+    memex-hermes status
+    memex-hermes uninstall
+
+The command walks the bundled ``memex_hermes_plugin.memex`` package to find
+the plugin directory, then symlinks (dev) or copies (distribution) it into
+``$HERMES_HOME/plugins/memex/`` so Hermes' real loader can discover it.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -23,11 +31,11 @@ from rich.table import Table
 
 from memex_common.config import MemexConfig
 
-logger = logging.getLogger('memex_cli.hermes')
+logger = logging.getLogger('memex_hermes_plugin.install')
 console = Console()
 
 app = typer.Typer(
-    name='hermes',
+    name='memex-hermes',
     help='Manage the Memex plugin for Hermes Agent.',
     no_args_is_help=True,
 )
@@ -41,13 +49,8 @@ def _default_hermes_home() -> Path:
 
 
 def _plugin_source() -> Path:
-    try:
-        from memex_hermes_plugin import PLUGIN_DIR
-    except ImportError as exc:
-        raise typer.BadParameter(
-            'memex-hermes-plugin is not installed. Install with: '
-            "uv tool install 'memex-cli[hermes] @ git+https://github.com/JasperHG90/memex.git@latest#subdirectory=packages/cli'"
-        ) from exc
+    from memex_hermes_plugin import PLUGIN_DIR
+
     return PLUGIN_DIR
 
 
@@ -63,10 +66,7 @@ def _remove_path(path: Path) -> None:
 
 
 def _set_provider_in_hermes_config(hermes_home: Path) -> bool:
-    """Set ``memory.provider: memex`` in ``$HERMES_HOME/config.yaml``.
-
-    Returns True if the file was modified. Creates the file if missing.
-    """
+    """Set ``memory.provider: memex`` in ``$HERMES_HOME/config.yaml``."""
     cfg_path = hermes_home / 'config.yaml'
     if cfg_path.exists():
         try:
@@ -272,8 +272,6 @@ def _resolve_server_url(cfg_path: Path) -> str:
     if 'MEMEX_SERVER_URL' in os.environ:
         return os.environ['MEMEX_SERVER_URL']
     if cfg_path.exists():
-        import json
-
         try:
             data = json.loads(cfg_path.read_text(encoding='utf-8'))
             if isinstance(data, dict) and isinstance(data.get('server_url'), str):
@@ -295,3 +293,7 @@ def _check_server(url: str) -> tuple[bool, str]:
         return False, f'HTTP {response.status_code}'
     except httpx.HTTPError as e:
         return False, str(e)
+
+
+if __name__ == '__main__':
+    app()

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/README.md
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/README.md
@@ -1,0 +1,44 @@
+# Memex Memory Provider
+
+Long-term memory with knowledge graph, entity resolution, multi-strategy retrieval (TEMPR), survey decomposition, and session briefings.
+
+## Requirements
+
+- Running Memex server (`memex server start -d`, default `http://127.0.0.1:8000`)
+- Memex CLI with an initialized vault (`memex config init` + `memex vault create`)
+
+## Setup
+
+```bash
+hermes memory setup    # select "memex"
+```
+
+Or manually:
+
+```bash
+hermes config set memory.provider memex
+```
+
+Config lives at `$HERMES_HOME/memex/config.json`. Secrets (API key) go to `$HERMES_HOME/.env`.
+
+## Tools
+
+- `memex_recall` — memory-unit search (facts, observations, events)
+- `memex_retrieve_notes` — whole-note search
+- `memex_survey` — broad query decomposition (server-side parallel fan-out)
+- `memex_retain` — explicit ingest (supports session-note append)
+- `memex_list_entities` — entity-graph search
+- `memex_get_entity_mentions` — source facts for an entity
+- `memex_get_entity_cooccurrences` — related entities
+
+The plugin injects routing guidance into the system prompt — when to pair
+recall with retrieve_notes, when to use survey, how to chain entity tools.
+Tool descriptions themselves stay neutral.
+
+## Memory modes
+
+- `hybrid` (default) — briefing + prefetch + tools
+- `context` — briefing + prefetch, no tools
+- `tools` — tools only, no auto-inject
+
+See the full README at https://github.com/JasperHG90/memex/blob/main/packages/hermes-plugin/README.md.

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/__init__.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/__init__.py
@@ -1,0 +1,16 @@
+"""Memex memory provider — Hermes plugin entry point.
+
+Hermes discovers plugins by importing ``__init__.py`` and calling ``register``.
+"""
+
+from __future__ import annotations
+
+from .provider import MemexMemoryProvider
+
+
+def register(ctx: object) -> None:
+    """Register Memex as the active memory provider."""
+    ctx.register_memory_provider(MemexMemoryProvider())  # type: ignore[attr-defined]
+
+
+__all__ = ['MemexMemoryProvider', 'register']

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/async_bridge.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/async_bridge.py
@@ -1,0 +1,86 @@
+"""Synchronous bridge to ``RemoteMemexAPI`` (which is async-only).
+
+Hermes calls memory provider methods synchronously, so we run a single
+long-lived asyncio loop on a daemon thread and marshal coroutines onto it
+with ``asyncio.run_coroutine_threadsafe``. One loop per process, reused.
+
+Adapted from the Hindsight plugin's approach. Using ``asyncio.run()`` per
+call is ~10x slower and leaks aiohttp sessions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Awaitable, TypeVar
+
+T = TypeVar('T')
+
+_loop: asyncio.AbstractEventLoop | None = None
+_loop_thread: threading.Thread | None = None
+_loop_lock = threading.Lock()
+
+
+def get_loop() -> asyncio.AbstractEventLoop:
+    """Return the process-wide event loop, starting it on first call."""
+    global _loop, _loop_thread
+    with _loop_lock:
+        if _loop is not None and _loop.is_running():
+            return _loop
+        _loop = asyncio.new_event_loop()
+
+        def _run() -> None:
+            asyncio.set_event_loop(_loop)
+            assert _loop is not None
+            _loop.run_forever()
+
+        _loop_thread = threading.Thread(target=_run, daemon=True, name='memex-hermes-loop')
+        _loop_thread.start()
+        return _loop
+
+
+def run_sync(coro: Awaitable[T], timeout: float = 120.0) -> T:
+    """Schedule ``coro`` on the shared loop and block until it completes."""
+    future = asyncio.run_coroutine_threadsafe(coro, get_loop())  # type: ignore[arg-type]
+    return future.result(timeout=timeout)
+
+
+def shutdown_loop(thread_join_timeout: float = 5.0) -> None:
+    """Stop the shared loop, join its thread, and close the loop. Idempotent."""
+    global _loop, _loop_thread
+    with _loop_lock:
+        loop = _loop
+        thread = _loop_thread
+        _loop = None
+        _loop_thread = None
+
+    if loop is not None and loop.is_running():
+        loop.call_soon_threadsafe(loop.stop)
+    if thread is not None and thread.is_alive():
+        thread.join(timeout=thread_join_timeout)
+    if loop is not None and not loop.is_closed():
+        try:
+            loop.close()
+        except Exception:
+            pass
+
+
+def is_loop_running() -> bool:
+    """Return True iff the shared loop is active. For tests / diagnostics."""
+    with _loop_lock:
+        return _loop is not None and _loop.is_running()
+
+
+def _reset_for_tests() -> None:
+    """Test helper — forcibly clear module-level state without a clean stop.
+
+    Never call from production code.
+    """
+    global _loop, _loop_thread
+    shutdown_loop()
+    with _loop_lock:
+        _loop = None
+        _loop_thread = None
+
+
+__all__ = ['get_loop', 'run_sync', 'shutdown_loop', 'is_loop_running']

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -1,0 +1,156 @@
+"""Session briefing fetch.
+
+The briefing is a token-budgeted markdown summary produced by Memex's
+``/vaults/{vault_id}/session-briefing`` endpoint. We fetch it once per session,
+in the background so ``initialize()`` returns quickly, and cache the result
+for ``system_prompt_block()`` to consume.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+from uuid import UUID
+
+from .async_bridge import run_sync
+
+logger = logging.getLogger(__name__)
+
+
+class BriefingCache:
+    """Thread-safe cache with a single in-flight fetch."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._result: str = ''
+        self._ready = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._error: str | None = None
+
+    def start_fetch(
+        self,
+        api: Any,
+        vault_id: UUID,
+        budget: int,
+        project_id: str | None,
+    ) -> None:
+        """Fire the background briefing fetch. Safe to call multiple times."""
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._ready.clear()
+            self._result = ''
+            self._error = None
+
+            def _run() -> None:
+                try:
+                    text = run_sync(
+                        api.get_session_briefing(
+                            vault_id=vault_id,
+                            budget=budget,
+                            project_id=project_id,
+                        ),
+                        timeout=30.0,
+                    )
+                    with self._lock:
+                        self._result = text or ''
+                except Exception as e:
+                    logger.debug('Briefing fetch failed: %s', e)
+                    with self._lock:
+                        self._error = str(e)
+                finally:
+                    self._ready.set()
+
+            self._thread = threading.Thread(
+                target=_run,
+                daemon=True,
+                name='memex-briefing',
+            )
+            self._thread.start()
+
+    def get(self, timeout: float = 5.0) -> str:
+        """Block up to ``timeout`` seconds for the briefing; return it or ''."""
+        if not self._ready.wait(timeout=timeout):
+            return ''
+        with self._lock:
+            return self._result
+
+    def get_error(self) -> str | None:
+        with self._lock:
+            return self._error
+
+    def reset(self) -> None:
+        """Clear the cached result. For session refresh or tests."""
+        with self._lock:
+            self._result = ''
+            self._error = None
+            self._ready.clear()
+
+
+_ROUTING_GUIDE = """### How to use Memex tools
+
+Match the tool to the query type:
+
+- **Title known** → `memex_retrieve_notes(query="title fragment")`.
+- **Content / document lookup** → call `memex_recall` AND `memex_retrieve_notes`
+  in the same assistant message. Recall returns distilled facts; retrieve_notes
+  returns source documents. Use both only when the query genuinely benefits —
+  a simple title lookup doesn't.
+- **Broad / panoramic** ("what do you know about X?", "overview of X") →
+  `memex_survey(query)` as a single call. The server decomposes into
+  sub-questions and fans out in parallel.
+- **Relationships / entities** → `memex_list_entities` first, then
+  `memex_get_entity_mentions` and/or `memex_get_entity_cooccurrences` with the
+  returned entity_id. The latter two are safe to call in parallel if both are
+  needed; otherwise pick the one that fits the question.
+- **Capturing work** → `memex_retain`. Pass the session note key below for
+  incremental progress captures; omit it for a standalone note."""
+
+
+def format_briefing_block(
+    briefing: str,
+    *,
+    vault_id: str | None,
+    project_id: str,
+    session_note_key: str,
+    kv_instructions_if_no_vault: bool,
+) -> str:
+    """Compose the Memex system-prompt block.
+
+    Includes vault/project metadata, the session note key, routing guidance
+    for tool selection, and the fetched briefing markdown. If no vault is
+    resolved, appends guidance on how to bind one via the KV store.
+    """
+    lines = ['## Memex Memory']
+    if vault_id:
+        lines.append(f'Active vault: `{vault_id}` · Project: `{project_id}`')
+    else:
+        lines.append(f'Project: `{project_id}` · **No vault bound to this project.**')
+
+    lines.append(
+        f'\nSession note key: `{session_note_key}`. Call '
+        '`memex_retain(note_key="...", background=true)` with this key when '
+        'you complete meaningful work — the note accumulates across the '
+        'session and is finalized at exit.'
+    )
+
+    if kv_instructions_if_no_vault:
+        from .project import project_vault_kv_key
+
+        lines.append(
+            f'\nTo bind this project to a vault, set the KV key '
+            f'`{project_vault_kv_key(project_id)}` to the vault name. Ask the '
+            'user which vault to use.'
+        )
+
+    lines.append('\n' + _ROUTING_GUIDE)
+
+    if briefing:
+        lines.append('\n---\n')
+        lines.append(briefing)
+
+    return '\n'.join(lines)
+
+
+__all__ = ['BriefingCache', 'format_briefing_block']

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/config.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/config.py
@@ -1,0 +1,170 @@
+"""Hermes-side config for the Memex memory provider.
+
+Resolution order (highest precedence first):
+1. Environment variables (``MEMEX_SERVER_URL``, ``MEMEX_API_KEY``, ``MEMEX_VAULT``,
+   ``MEMEX_HERMES_MODE``)
+2. ``$HERMES_HOME/memex/config.json``
+3. Memex's own ``MemexConfig`` — reads ``~/.config/memex/config.yaml`` and any
+   local ``.memex.yaml``. Frictionless for users who already run Memex locally.
+
+Secrets (api_key) belong in ``$HERMES_HOME/.env`` and load via env vars.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+MemoryMode = Literal['hybrid', 'context', 'tools']
+
+
+# Retrieval strategies accepted by the Memex server.
+# Keep in sync with ``memex_core.memory.retrieval.models.VALID_STRATEGIES``.
+# ``test_default_strategies_match_server`` asserts parity.
+VALID_STRATEGIES = frozenset({'semantic', 'keyword', 'graph', 'temporal', 'mental_model'})
+
+
+class RecallConfig(BaseModel):
+    facts_limit: int = 5
+    notes_limit: int = 3
+    strategies: list[str] = Field(
+        default_factory=lambda: ['semantic', 'keyword', 'temporal', 'graph', 'mental_model']
+    )
+    token_budget: int = 2048
+    include_stale: bool = False
+    include_superseded: bool = False
+    expand_query: bool = False
+
+    @field_validator('strategies')
+    @classmethod
+    def _validate_strategies(cls, v: list[str]) -> list[str]:
+        invalid = set(v) - VALID_STRATEGIES
+        if invalid:
+            raise ValueError(
+                f'Invalid strategies: {sorted(invalid)}. Valid: {sorted(VALID_STRATEGIES)}'
+            )
+        return v
+
+
+class RetainConfig(BaseModel):
+    session_template: str = 'hermes-session'
+
+
+class HermesMemexConfig(BaseModel):
+    """Plugin configuration resolved from file + env + MemexConfig fallback."""
+
+    server_url: str = 'http://127.0.0.1:8000'
+    api_key: str | None = None
+    vault_id: str | None = None
+    memory_mode: MemoryMode = 'hybrid'
+    create_vaults_on_init: bool = True
+    briefing_budget: int = 2000
+    briefing_refresh_cadence: int = 0
+    recall: RecallConfig = Field(default_factory=RecallConfig)
+    retain: RetainConfig = Field(default_factory=RetainConfig)
+
+    @field_validator('server_url')
+    @classmethod
+    def _strip_trailing_slash(cls, v: str) -> str:
+        return v.rstrip('/')
+
+    @field_validator('briefing_budget')
+    @classmethod
+    def _validate_budget(cls, v: int) -> int:
+        # Memex server currently accepts 1000 or 2000 only (see memex_cli/session.py).
+        if v not in (1000, 2000):
+            raise ValueError('briefing_budget must be 1000 or 2000')
+        return v
+
+
+def _config_path(hermes_home: Path) -> Path:
+    return hermes_home / 'memex' / 'config.json'
+
+
+def _load_file(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError:
+        return {}
+
+
+def _apply_env(data: dict[str, Any]) -> dict[str, Any]:
+    """Layer env vars on top of file data."""
+    if 'MEMEX_SERVER_URL' in os.environ:
+        data['server_url'] = os.environ['MEMEX_SERVER_URL']
+    if 'MEMEX_API_KEY' in os.environ:
+        data['api_key'] = os.environ['MEMEX_API_KEY']
+    if 'MEMEX_VAULT' in os.environ:
+        data['vault_id'] = os.environ['MEMEX_VAULT']
+    if 'MEMEX_HERMES_MODE' in os.environ:
+        data['memory_mode'] = os.environ['MEMEX_HERMES_MODE']
+    return data
+
+
+def _apply_memex_fallback(data: dict[str, Any]) -> dict[str, Any]:
+    """If server_url or api_key are missing, try MemexConfig.
+
+    This makes users who already run Memex locally frictionless: no
+    Hermes-side config file needed.
+    """
+    need_server = 'server_url' not in data
+    need_api_key = 'api_key' not in data
+    need_vault = 'vault_id' not in data
+    if not (need_server or need_api_key or need_vault):
+        return data
+    try:
+        from memex_common.config import MemexConfig
+
+        mc = MemexConfig()
+        if need_server and mc.server_url:
+            data['server_url'] = mc.server_url
+        if need_api_key and mc.api_key is not None:
+            data['api_key'] = mc.api_key.get_secret_value()
+        if need_vault and mc.vault.active:
+            data['vault_id'] = mc.vault.active
+    except Exception:
+        # MemexConfig can fail on malformed local config — ignore, use defaults.
+        pass
+    return data
+
+
+def load_config(hermes_home: Path) -> HermesMemexConfig:
+    """Resolve the plugin's config from file, env, and MemexConfig fallback."""
+    path = _config_path(hermes_home)
+    data = _load_file(path)
+    data = _apply_env(data)
+    data = _apply_memex_fallback(data)
+    return HermesMemexConfig.model_validate(data)
+
+
+def save_config(
+    values: dict[str, Any],
+    hermes_home: Path,
+) -> Path:
+    """Merge ``values`` into ``$HERMES_HOME/memex/config.json``.
+
+    Only non-secret keys should arrive here — secrets go to ``.env`` via
+    Hermes' setup flow. Returns the path written.
+    """
+    path = _config_path(hermes_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = _load_file(path)
+    existing.update({k: v for k, v in values.items() if v is not None})
+    path.write_text(json.dumps(existing, indent=2) + '\n', encoding='utf-8')
+    return path
+
+
+__all__ = [
+    'HermesMemexConfig',
+    'MemoryMode',
+    'RecallConfig',
+    'RetainConfig',
+    'load_config',
+    'save_config',
+]

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/plugin.yaml
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/plugin.yaml
@@ -1,0 +1,17 @@
+name: memex
+version: 1.0.0
+description: "Memex — long-term memory with knowledge graph, multi-strategy TEMPR retrieval, session briefings, surveys, and multi-vault scoping."
+pip_dependencies:
+  - "memex-common>=0.1.11"
+requires_env:
+  - name: MEMEX_API_KEY
+    description: "Memex server API key (optional for local/unsecured deployments)."
+    secret: true
+  - name: MEMEX_SERVER_URL
+    description: "Memex server base URL. Defaults to http://127.0.0.1:8000."
+    secret: false
+hooks:
+  - on_session_end
+  - on_pre_compress
+  - on_memory_write
+  - on_turn_start

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/prefetch.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/prefetch.py
@@ -1,0 +1,159 @@
+"""Two-layer prefetch: memory units + whole notes.
+
+Fires on ``queue_prefetch`` after each turn, joined on the next turn's
+``prefetch`` with a short timeout. Cache is overwritten on each fire — we
+deliberately don't accumulate, because user queries drift.
+
+Returns a formatted markdown block with two sections for injection into the
+next user message.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+from uuid import UUID
+
+from .async_bridge import run_sync
+from .config import HermesMemexConfig
+
+logger = logging.getLogger(__name__)
+
+
+class PrefetchCache:
+    """Holds the most recent prefetch result pair.
+
+    Uses a generation counter so ``queue`` is non-blocking: stale threads
+    from a prior generation silently drop their results on the way to
+    writing. The previous approach joined prior threads (up to ~1s each),
+    which blocked the main thread between turns — a problem for agent UX.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._facts: list[Any] = []
+        self._notes: list[Any] = []
+        self._generation: int = 0
+        self._pending: set[int] = set()
+
+    def queue(
+        self,
+        query: str,
+        *,
+        api: Any,
+        config: HermesMemexConfig,
+        vault_id: UUID | None,
+    ) -> None:
+        """Fire background fetches for ``query``. Non-blocking (<1ms)."""
+        with self._lock:
+            self._generation += 1
+            gen = self._generation
+            self._facts = []
+            self._notes = []
+            self._pending = {gen}
+
+        vault_ids: list[Any] | None = [vault_id] if vault_id else None
+
+        def _fetch_facts() -> None:
+            try:
+                result = run_sync(
+                    api.search(
+                        query=query,
+                        limit=config.recall.facts_limit,
+                        vault_ids=vault_ids,
+                        token_budget=config.recall.token_budget,
+                        strategies=config.recall.strategies,
+                        include_stale=config.recall.include_stale,
+                        include_superseded=config.recall.include_superseded,
+                    ),
+                    timeout=30.0,
+                )
+                with self._lock:
+                    if gen == self._generation:
+                        self._facts = list(result or [])
+            except Exception as e:
+                logger.debug('Prefetch facts failed: %s', e)
+
+        def _fetch_notes() -> None:
+            try:
+                result = run_sync(
+                    api.search_notes(
+                        query=query,
+                        limit=config.recall.notes_limit,
+                        vault_ids=vault_ids,
+                        expand_query=config.recall.expand_query,
+                        strategies=config.recall.strategies,
+                    ),
+                    timeout=30.0,
+                )
+                with self._lock:
+                    if gen == self._generation:
+                        self._notes = list(result or [])
+            except Exception as e:
+                logger.debug('Prefetch notes failed: %s', e)
+
+        threading.Thread(
+            target=_fetch_facts, daemon=True, name=f'memex-prefetch-facts-{gen}'
+        ).start()
+        threading.Thread(
+            target=_fetch_notes, daemon=True, name=f'memex-prefetch-notes-{gen}'
+        ).start()
+
+    def consume(self, timeout: float = 3.0) -> str:
+        """Wait up to ``timeout`` for the current generation's results, then format.
+
+        Polls at 50ms intervals until both layers have landed or until the
+        deadline passes. Returns '' if nothing arrived. After consumption the
+        buffers are cleared so the next turn starts fresh.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                if self._facts or self._notes:
+                    break
+            time.sleep(0.05)
+
+        with self._lock:
+            facts = list(self._facts)
+            notes = list(self._notes)
+            self._facts = []
+            self._notes = []
+
+        if not facts and not notes:
+            return ''
+
+        blocks: list[str] = []
+
+        if facts:
+            blocks.append('## Memex — Facts')
+            for u in facts:
+                text = getattr(u, 'text', None) or ''
+                if not text:
+                    continue
+                note_id = getattr(u, 'note_id', None)
+                suffix = f' _(note: {note_id})_' if note_id else ''
+                blocks.append(f'- {text}{suffix}')
+
+        if notes:
+            if blocks:
+                blocks.append('')
+            blocks.append('## Memex — Related Notes')
+            for r in notes:
+                metadata = getattr(r, 'metadata', None) or {}
+                title = metadata.get('name') or metadata.get('title') or '(untitled)'
+                note_id = getattr(r, 'note_id', None)
+                blocks.append(f'- **{title}** _(id: {note_id})_')
+                summaries = getattr(r, 'summaries', None) or []
+                first = next(
+                    (getattr(s, 'summary', None) or getattr(s, 'text', None) for s in summaries),
+                    None,
+                )
+                if first:
+                    blocks.append(f'  - {first}')
+
+        return '\n'.join(blocks).strip()
+
+
+__all__ = ['PrefetchCache']

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/project.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/project.py
@@ -1,0 +1,165 @@
+"""Per-project vault resolution.
+
+Ports the pattern from Memex's Claude Code plugin (``scripts/on_session_start.sh``):
+1. Derive a portable ``project_id`` from git remote origin or the CWD.
+2. Look up ``project:<project_id>:vault`` in the Memex KV store.
+3. Fall back in order: gateway ``user_id`` / ``agent_identity`` vault → config
+   ``vault_id`` → Memex default.
+
+Keeping the same KV namespace as the Claude Code plugin means users bind a
+project once and both plugins resolve the same vault.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .async_bridge import run_sync
+
+
+def derive_project_id(cwd: Path | None = None, home: Path | None = None) -> str:
+    """Derive a project identifier portable across machines.
+
+    Prefers the git remote origin URL (normalized: no .git, no scheme, no
+    basic-auth prefix). Falls back to ``$HOME``-relative CWD or absolute CWD.
+    """
+    cwd = cwd or Path.cwd()
+    home = home or Path(os.environ.get('HOME', str(Path.home())))
+
+    remote = _git_remote_origin(cwd)
+    if remote:
+        return _normalize_remote(remote)
+
+    try:
+        relative = cwd.resolve().relative_to(home.resolve())
+        return str(relative)
+    except ValueError:
+        return str(cwd.resolve())
+
+
+def _git_remote_origin(cwd: Path) -> str | None:
+    """Return the git remote origin URL for ``cwd`` or None if unavailable."""
+    try:
+        result = subprocess.run(
+            ['git', 'remote', 'get-url', 'origin'],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    return url or None
+
+
+def _normalize_remote(url: str) -> str:
+    """Normalize a git remote URL to match the claude-code-plugin shell script.
+
+    Steps (in order):
+    - Strip trailing ``.git``
+    - Strip basic-auth prefix from ``https://user:pass@host/path``
+    - Strip the URL scheme (``https://`` etc.)
+
+    Note: SSH URLs (``git@host:path``) are returned as-is minus the ``.git``
+    suffix — matching the shell script's behavior so KV keys are interchangeable
+    between the Claude Code and Hermes plugins.
+    """
+    url = re.sub(r'\.git$', '', url)
+    url = re.sub(r'^https://[^@]*@', 'https://', url)
+    url = re.sub(r'^[a-zA-Z][a-zA-Z0-9+.\-]*://', '', url)
+    return url
+
+
+def project_vault_kv_key(project_id: str) -> str:
+    """Return the KV key under which the per-project vault is stored."""
+    return f'project:{project_id}:vault'
+
+
+async def _kv_lookup(api: Any, key: str) -> str | None:
+    """Look up a KV value. Returns None on miss or error.
+
+    ``RemoteMemexAPI.kv_get`` returns a ``KVEntryDTO`` (pydantic model with a
+    ``value: str`` attribute) or None. Handles dict/str returns too for
+    robustness against client-shape changes.
+    """
+    try:
+        result = await api.kv_get(key)
+    except Exception:
+        return None
+    if result is None:
+        return None
+    # KVEntryDTO / similar pydantic model.
+    value = getattr(result, 'value', None)
+    if isinstance(value, str):
+        return value
+    # Defensive fallbacks in case the client evolves.
+    if isinstance(result, dict):
+        dict_value = result.get('value')
+        return dict_value if isinstance(dict_value, str) else None
+    if isinstance(result, str):
+        return result
+    return None
+
+
+async def _vault_exists(api: Any, identifier: str) -> bool:
+    """Return True if a vault with ``identifier`` (name or UUID) exists."""
+    try:
+        await api.resolve_vault_identifier(identifier)
+        return True
+    except Exception:
+        return False
+
+
+def resolve_vault(
+    api: Any,
+    *,
+    project_id: str,
+    agent_identity: str | None,
+    user_id: str | None,
+    config_vault: str | None,
+) -> str | None:
+    """Resolve the active vault, returning its name or None if nothing found.
+
+    Synchronous wrapper over async KV + vault checks; runs on the shared loop.
+    Priority order:
+    1. ``project:<project_id>:vault`` in KV
+    2. ``hermes:user:<user_id>`` if a vault with that name exists
+    3. ``hermes:agent:<agent_identity>`` if a vault with that name exists
+    4. Plugin config ``vault_id``
+    5. None (caller uses Memex default)
+    """
+    candidates: list[str] = []
+
+    kv_key = project_vault_kv_key(project_id)
+    kv_vault = run_sync(_kv_lookup(api, kv_key), timeout=5.0)
+    if kv_vault:
+        return kv_vault
+
+    if user_id:
+        candidates.append(f'hermes:user:{user_id}')
+    if agent_identity:
+        candidates.append(f'hermes:agent:{agent_identity}')
+
+    for candidate in candidates:
+        if run_sync(_vault_exists(api, candidate), timeout=3.0):
+            return candidate
+
+    if config_vault:
+        return config_vault
+
+    return None
+
+
+__all__ = [
+    'derive_project_id',
+    'project_vault_kv_key',
+    'resolve_vault',
+]

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -1,0 +1,408 @@
+"""``MemexMemoryProvider`` — Hermes Agent memory provider backed by Memex.
+
+Lifecycle: Hermes calls ``initialize`` once at session start → ``get_tool_schemas``
+at prompt assembly → ``system_prompt_block`` (which blocks for the briefing) →
+``queue_prefetch``/``prefetch`` each turn → ``handle_tool_call`` when the model
+uses a Memex tool → ``on_session_end``/``on_pre_compress``/``on_memory_write``
+hooks as they fire → ``shutdown`` at exit.
+
+The plugin talks to a running Memex server over HTTP via ``RemoteMemexAPI``.
+All async calls are marshalled onto the shared event loop in ``async_bridge``.
+"""
+
+from __future__ import annotations
+
+import atexit
+import base64
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import httpx
+from agent.memory_provider import MemoryProvider  # type: ignore[import-not-found]
+
+from .async_bridge import run_sync, shutdown_loop
+from .briefing import BriefingCache, format_briefing_block
+from .config import HermesMemexConfig, load_config, save_config
+from .prefetch import PrefetchCache
+from .project import derive_project_id, resolve_vault
+from .session import make_session_note_key
+from .templates import HERMES_SESSION_TEMPLATE
+from .tools import ALL_SCHEMAS, dispatch
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_hermes_home(kwargs: dict[str, Any]) -> Path:
+    raw = kwargs.get('hermes_home') or os.environ.get('HERMES_HOME')
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / '.hermes'
+
+
+class MemexMemoryProvider(MemoryProvider):
+    """Memex-backed memory provider."""
+
+    def __init__(self) -> None:
+        self._config: HermesMemexConfig | None = None
+        self._hermes_home: Path | None = None
+        self._client: httpx.AsyncClient | None = None
+        self._api: Any | None = None
+        self._vault_name: str | None = None
+        self._vault_id: UUID | None = None
+        self._project_id: str = ''
+        self._session_note_key: str = ''
+        self._session_id: str = ''
+        self._agent_identity: str = ''
+        self._user_id: str | None = None
+        self._briefing = BriefingCache()
+        self._prefetch = PrefetchCache()
+        self._turn_buffer: list[dict[str, str]] = []
+        self._turn_count = 0
+        self._shutdown_registered = False
+        self._state_lock = threading.Lock()
+        self._atexit_lock = threading.Lock()
+
+    # -- Identity ------------------------------------------------------------
+
+    @property
+    def name(self) -> str:  # type: ignore[override]
+        return 'memex'
+
+    # -- Availability --------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """True when we have enough config to talk to a Memex server.
+
+        Checks env vars first, then the plugin config file. No network calls.
+        """
+        if os.environ.get('MEMEX_SERVER_URL'):
+            return True
+        try:
+            hermes_home = Path(os.environ.get('HERMES_HOME') or str(Path.home() / '.hermes'))
+            cfg_path = hermes_home / 'memex' / 'config.json'
+            if cfg_path.exists():
+                return True
+            # Fall back to Memex's own config — if it has a server_url the
+            # user already runs Memex locally and we can use it.
+            from memex_common.config import MemexConfig
+
+            mc = MemexConfig()
+            return bool(mc.server_url)
+        except Exception:
+            return False
+
+    # -- Config schema for ``hermes memory setup`` --------------------------
+
+    def get_config_schema(self) -> list[dict[str, Any]]:
+        return [
+            {
+                'key': 'server_url',
+                'description': 'Memex server URL',
+                'default': 'http://127.0.0.1:8000',
+            },
+            {
+                'key': 'api_key',
+                'description': 'Memex API key (optional; only for secured deployments)',
+                'secret': True,
+                'env_var': 'MEMEX_API_KEY',
+            },
+            {
+                'key': 'vault_id',
+                'description': 'Fallback vault name when no per-project binding is set',
+            },
+            {
+                'key': 'memory_mode',
+                'description': 'hybrid / context / tools',
+                'default': 'hybrid',
+                'choices': ['hybrid', 'context', 'tools'],
+            },
+        ]
+
+    def save_config(self, values: dict[str, Any], hermes_home: str) -> None:  # type: ignore[override]
+        save_config(values, Path(hermes_home).expanduser())
+
+    # -- Initialization ------------------------------------------------------
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:  # type: ignore[override]
+        self._session_id = session_id
+        self._hermes_home = _resolve_hermes_home(kwargs)
+        self._agent_identity = kwargs.get('agent_identity') or ''
+        self._user_id = kwargs.get('user_id')
+
+        self._config = load_config(self._hermes_home)
+        self._session_note_key = make_session_note_key()
+        self._project_id = derive_project_id()
+
+        headers: dict[str, str] = {}
+        if self._config.api_key:
+            headers['X-API-Key'] = self._config.api_key
+
+        base_url = f'{self._config.server_url.rstrip("/")}/api/v1/'
+        self._client = httpx.AsyncClient(base_url=base_url, timeout=240.0, headers=headers)
+
+        from memex_common.client import RemoteMemexAPI
+
+        self._api = RemoteMemexAPI(self._client)
+
+        try:
+            self._vault_name = resolve_vault(
+                self._api,
+                project_id=self._project_id,
+                agent_identity=self._agent_identity or None,
+                user_id=self._user_id,
+                config_vault=self._config.vault_id,
+            )
+        except Exception as e:
+            logger.debug('Vault resolution failed: %s', e)
+            self._vault_name = self._config.vault_id
+
+        if self._vault_name:
+            self._vault_id = self._resolve_or_create_vault_id(self._vault_name)
+
+        if self._vault_id is not None and self._config.memory_mode != 'tools':
+            self._briefing.start_fetch(
+                self._api,
+                vault_id=self._vault_id,
+                budget=self._config.briefing_budget,
+                project_id=self._project_id,
+            )
+
+        with self._atexit_lock:
+            if not self._shutdown_registered:
+                atexit.register(self._atexit_shutdown)
+                self._shutdown_registered = True
+
+        logger.debug(
+            'Memex provider initialized: session=%s vault=%s project=%s',
+            session_id,
+            self._vault_name,
+            self._project_id,
+        )
+
+    def _resolve_or_create_vault_id(self, name: str) -> UUID | None:
+        """Resolve ``name`` to a UUID; optionally create if missing."""
+        assert self._api is not None
+        try:
+            return run_sync(self._api.resolve_vault_identifier(name), timeout=5.0)
+        except Exception as e:
+            logger.debug('Vault %s does not exist: %s', name, e)
+
+        if self._config is None or not self._config.create_vaults_on_init:
+            return None
+
+        from memex_common.schemas import CreateVaultRequest
+
+        try:
+            vault = run_sync(
+                self._api.create_vault(CreateVaultRequest(name=name)),
+                timeout=10.0,
+            )
+            return UUID(str(vault.id))
+        except Exception as e:
+            logger.warning('Failed to auto-create vault %s: %s', name, e)
+            return None
+
+    # -- System prompt block ------------------------------------------------
+
+    def system_prompt_block(self) -> str:  # type: ignore[override]
+        if self._config is None or self._config.memory_mode == 'tools':
+            return ''
+        briefing = self._briefing.get(timeout=5.0)
+        return format_briefing_block(
+            briefing,
+            vault_id=self._vault_name,
+            project_id=self._project_id,
+            session_note_key=self._session_note_key,
+            kv_instructions_if_no_vault=self._vault_name is None,
+        )
+
+    # -- Tools ---------------------------------------------------------------
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:  # type: ignore[override]
+        if self._config is None or self._config.memory_mode == 'context':
+            return []
+        return list(ALL_SCHEMAS)
+
+    def handle_tool_call(self, tool_name: str, args: dict[str, Any], **kwargs: Any) -> str:  # type: ignore[override]
+        if self._api is None or self._config is None:
+            from tools.registry import tool_error  # type: ignore[import-not-found]
+
+            return tool_error('Memex provider is not initialized.')
+        return dispatch(
+            tool_name,
+            args,
+            api=self._api,
+            config=self._config,
+            vault_id=self._vault_id,
+        )
+
+    # -- Prefetch ------------------------------------------------------------
+
+    def queue_prefetch(self, query: str, *, session_id: str = '') -> None:  # type: ignore[override]
+        if self._config is None or self._config.memory_mode == 'tools':
+            return
+        if self._api is None or self._vault_id is None:
+            return
+        self._prefetch.queue(
+            query,
+            api=self._api,
+            config=self._config,
+            vault_id=self._vault_id,
+        )
+
+    def prefetch(self, query: str, *, session_id: str = '') -> str:  # type: ignore[override]
+        if self._config is None or self._config.memory_mode == 'tools':
+            return ''
+        return self._prefetch.consume(timeout=3.0)
+
+    # -- Turn / session hooks ------------------------------------------------
+
+    def on_turn_start(self, turn_number: int, message: str, **kwargs: Any) -> None:  # type: ignore[override]
+        self._turn_count = turn_number
+        if (
+            self._config is not None
+            and self._config.briefing_refresh_cadence > 0
+            and turn_number > 0
+            and turn_number % self._config.briefing_refresh_cadence == 0
+            and self._vault_id is not None
+            and self._api is not None
+        ):
+            self._briefing.reset()
+            self._briefing.start_fetch(
+                self._api,
+                vault_id=self._vault_id,
+                budget=self._config.briefing_budget,
+                project_id=self._project_id,
+            )
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = '') -> None:  # type: ignore[override]
+        """Buffer the turn; we ingest the full transcript in ``on_session_end``."""
+        with self._state_lock:
+            self._turn_buffer.append({'user': user_content, 'assistant': assistant_content})
+
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:  # type: ignore[override]
+        if self._api is None or self._config is None:
+            return
+        transcript = _format_transcript(messages or self._turn_buffer)
+        if not transcript.strip():
+            return
+        self._ingest_session_note(transcript, title='Hermes session')
+
+    def on_pre_compress(self, messages: list[dict[str, Any]]) -> str:  # type: ignore[override]
+        """Append soon-to-be-compressed messages to the session note so nothing is lost.
+
+        Returns a short summary that Hermes includes in the compression prompt.
+        """
+        if self._api is None or self._config is None or not messages:
+            return ''
+        chunk = _format_transcript(messages)
+        if chunk.strip():
+            self._ingest_session_note(chunk, title='Hermes session (pre-compress fragment)')
+        return (
+            f'Memex captured {len(messages)} pre-compression messages into '
+            f'session note `{self._session_note_key}`.'
+        )
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:  # type: ignore[override]
+        """Mirror built-in MEMORY.md/USER.md writes to the Memex KV store.
+
+        Keys are namespaced per Memex's ``VALID_NAMESPACES`` contract:
+        ``app:hermes:<target>:<hash>``. The ``app:`` prefix is Memex's
+        app-scoped namespace; ``hermes`` scopes within it; ``<target>`` is
+        'memory' or 'user' (from Hermes' built-in memory); hash dedupes.
+        """
+        if self._api is None or action == 'remove' or not content:
+            return
+        import hashlib
+
+        digest = hashlib.sha256(content.encode('utf-8')).hexdigest()[:12]
+        key = f'app:hermes:{target}:{digest}'
+        try:
+            run_sync(self._api.kv_put(value=content, key=key), timeout=10.0)
+        except Exception as e:
+            logger.debug('KV mirror failed for %s: %s', key, e)
+
+    # -- Shutdown ------------------------------------------------------------
+
+    def shutdown(self) -> None:  # type: ignore[override]
+        """Flush pending buffers and close the client."""
+        if self._api is not None and self._turn_buffer:
+            transcript = _format_transcript(self._turn_buffer)
+            if transcript.strip():
+                try:
+                    self._ingest_session_note(transcript, title='Hermes session')
+                except Exception as e:
+                    logger.debug('Shutdown ingest failed: %s', e)
+        client = self._client
+        self._client = None
+        self._api = None
+        if client is not None:
+            try:
+                run_sync(client.aclose(), timeout=5.0)
+            except Exception:
+                pass
+        shutdown_loop(thread_join_timeout=5.0)
+
+    def _atexit_shutdown(self) -> None:
+        """atexit callback — best-effort cleanup if ``shutdown`` was skipped."""
+        try:
+            self.shutdown()
+        except Exception:
+            pass
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _ingest_session_note(self, content: str, *, title: str) -> None:
+        assert self._api is not None and self._config is not None
+
+        from memex_common.schemas import NoteCreateDTO
+
+        dto = NoteCreateDTO(
+            name=title,
+            description=f'Hermes session transcript ({self._session_id})',
+            content=base64.b64encode(content.encode('utf-8')),
+            note_key=self._session_note_key,
+            vault_id=str(self._vault_id) if self._vault_id else None,
+            tags=['hermes', self._agent_identity] if self._agent_identity else ['hermes'],
+            author='hermes',
+            template=self._config.retain.session_template or HERMES_SESSION_TEMPLATE,
+        )
+        try:
+            run_sync(self._api.ingest(dto, background=True), timeout=30.0)
+            with self._state_lock:
+                self._turn_buffer = []
+        except Exception as e:
+            logger.warning('Session note ingest failed: %s', e)
+
+
+def _format_transcript(messages: list[dict[str, Any]]) -> str:
+    """Render a list of turn dicts as a flat markdown transcript.
+
+    Accepts both ``{user, assistant}`` pairs (our sync_turn buffer format) and
+    Hermes' own ``{role, content}`` message objects.
+    """
+    lines: list[str] = []
+    for m in messages:
+        if 'user' in m or 'assistant' in m:
+            if m.get('user'):
+                lines.append(f'**User:** {m["user"]}')
+            if m.get('assistant'):
+                lines.append(f'**Assistant:** {m["assistant"]}')
+        else:
+            role = str(m.get('role', 'user')).strip() or 'user'
+            content = m.get('content', '')
+            if isinstance(content, list):
+                content = '\n'.join(
+                    c.get('text', '') if isinstance(c, dict) else str(c) for c in content
+                )
+            if content:
+                lines.append(f'**{role.capitalize()}:** {content}')
+        lines.append('')
+    return '\n'.join(lines).strip()
+
+
+__all__ = ['MemexMemoryProvider']

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/session.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/session.py
@@ -1,0 +1,33 @@
+"""Session note key lifecycle.
+
+Each Hermes session gets a unique ``note_key`` that the plugin exposes to the
+model via ``system_prompt_block``. The model calls ``memex_retain(note_key=...)``
+to append meaningful progress; ``on_session_end`` finalizes the note with the
+full transcript. Memex's note-key upsert semantics handle idempotency.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+SESSION_KEY_PREFIX = 'hermes:session:'
+
+
+def make_session_note_key(now: datetime | None = None) -> str:
+    """Return a unique session note key.
+
+    Format: ``hermes:session:<ISO-UTC-timestamp>``. The timestamp includes
+    milliseconds to disambiguate sessions started within the same second.
+    """
+    now = now or datetime.now(timezone.utc)
+    # Milliseconds to 3 decimals, trailing Z to mark UTC.
+    iso = now.strftime('%Y-%m-%dT%H:%M:%S') + f'.{now.microsecond // 1000:03d}Z'
+    return f'{SESSION_KEY_PREFIX}{iso}'
+
+
+def is_session_note_key(key: str) -> bool:
+    """True if ``key`` looks like a session key this plugin issued."""
+    return key.startswith(SESSION_KEY_PREFIX)
+
+
+__all__ = ['SESSION_KEY_PREFIX', 'is_session_note_key', 'make_session_note_key']

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
@@ -1,0 +1,18 @@
+"""Template name constants for Hermes-originated notes."""
+
+from __future__ import annotations
+
+# Template used for the per-session transcript note ingested on exit.
+HERMES_SESSION_TEMPLATE = 'hermes-session'
+
+# Template used for explicit ``memex_retain`` captures with no other template.
+HERMES_USER_NOTE_TEMPLATE = 'hermes-user-note'
+
+# Template for future ``memex_retro`` structured postmortems (v2).
+AGENT_REFLECTION_TEMPLATE = 'agent_reflection'
+
+__all__ = [
+    'AGENT_REFLECTION_TEMPLATE',
+    'HERMES_SESSION_TEMPLATE',
+    'HERMES_USER_NOTE_TEMPLATE',
+]

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -1,0 +1,664 @@
+"""Memex tool schemas and handlers for Hermes.
+
+Seven tools are exposed (in ``hybrid`` and ``tools`` memory modes):
+
+- ``memex_recall`` — memory-unit search (TEMPR)
+- ``memex_retrieve_notes`` — whole-note search
+- ``memex_survey`` — broad query decomposition
+- ``memex_retain`` — explicit ingest (supports session-note append)
+- ``memex_list_entities`` — entity-graph search
+- ``memex_get_entity_mentions`` — source facts for an entity
+- ``memex_get_entity_cooccurrences`` — related entities
+
+Tool descriptions describe *what the tool does*, not *when to combine it with
+others*. Routing guidance (parallel dispatch for content lookup, sequential
+for graph exploration, survey for broad queries) lives in the plugin's
+``system_prompt_block`` so it's injected once per session rather than inflating
+every tool description — mirroring how Memex's MCP server and Claude Code
+plugin handle routing.
+
+Handlers are synchronous wrappers that bridge to the async ``RemoteMemexAPI``
+via ``async_bridge.run_sync``. All return JSON strings.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import Any
+from uuid import UUID
+
+from tools.registry import tool_error  # type: ignore[import-not-found]
+
+from .async_bridge import run_sync
+from .config import HermesMemexConfig
+from .templates import HERMES_USER_NOTE_TEMPLATE
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+RECALL_SCHEMA: dict[str, Any] = {
+    'name': 'memex_recall',
+    'description': (
+        'Search memory units — individual facts, observations, and events '
+        'extracted from stored notes. Uses TEMPR: temporal + entity + '
+        'mental-model + keyword + semantic strategies fused via Reciprocal '
+        'Rank Fusion. Returns distilled claims, not raw text.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'query': {
+                'type': 'string',
+                'description': 'Natural-language query. Preserve proper nouns, dates, and qualifiers.',
+            },
+            'limit': {
+                'type': 'integer',
+                'description': 'Max results (default: 10, max: 50).',
+            },
+            'tags': {
+                'type': 'array',
+                'items': {'type': 'string'},
+                'description': 'Filter by note tags (optional).',
+            },
+            'after': {
+                'type': 'string',
+                'description': 'ISO 8601 date. Only return memory units dated after this.',
+            },
+            'before': {
+                'type': 'string',
+                'description': 'ISO 8601 date. Only return memory units dated before this.',
+            },
+            'include_stale': {
+                'type': 'boolean',
+                'description': 'Include stale/lower-confidence memory units (default: false).',
+            },
+        },
+        'required': ['query'],
+    },
+}
+
+RETRIEVE_NOTES_SCHEMA: dict[str, Any] = {
+    'name': 'memex_retrieve_notes',
+    'description': (
+        'Search whole notes ranked by relevance. Returns note metadata plus '
+        'section summaries (topic + key points). Returns source documents, '
+        'not distilled facts.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'query': {
+                'type': 'string',
+                'description': 'Natural-language query.',
+            },
+            'limit': {
+                'type': 'integer',
+                'description': 'Max results (default: 10).',
+            },
+            'expand_query': {
+                'type': 'boolean',
+                'description': 'Use LLM to generate query variations. Higher recall, higher cost (default: false).',
+            },
+        },
+        'required': ['query'],
+    },
+}
+
+SURVEY_SCHEMA: dict[str, Any] = {
+    'name': 'memex_survey',
+    'description': (
+        'Broad / panoramic knowledge query. Memex decomposes your question into '
+        'sub-questions, runs parallel retrievals, and returns facts grouped by '
+        'source note. Use for "what do you know about X?" queries, project '
+        'overviews, or when you need a landscape view rather than specific facts.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'query': {
+                'type': 'string',
+                'description': 'Broad natural-language question.',
+            },
+            'limit_per_query': {
+                'type': 'integer',
+                'description': 'Max results per decomposed sub-question (default: 10).',
+            },
+        },
+        'required': ['query'],
+    },
+}
+
+RETAIN_SCHEMA: dict[str, Any] = {
+    'name': 'memex_retain',
+    'description': (
+        'Ingest a note into Memex. If note_key is provided and matches an existing '
+        'note, the content is upserted (enables incremental session capture). Pass '
+        'the session note key from the system prompt to append meaningful progress '
+        'to the running session note.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'name': {
+                'type': 'string',
+                'description': 'Short title for the note.',
+            },
+            'description': {
+                'type': 'string',
+                'description': "One-sentence summary of the note's contents.",
+            },
+            'content': {
+                'type': 'string',
+                'description': 'Full markdown body of the note.',
+            },
+            'tags': {
+                'type': 'array',
+                'items': {'type': 'string'},
+                'description': 'Topic/category tags (optional).',
+            },
+            'note_key': {
+                'type': 'string',
+                'description': (
+                    'Stable key for upsert. Use the session note key to append to the '
+                    'running session note. Omit for a fresh note.'
+                ),
+            },
+        },
+        'required': ['name', 'description', 'content'],
+    },
+}
+
+LIST_ENTITIES_SCHEMA: dict[str, Any] = {
+    'name': 'memex_list_entities',
+    'description': (
+        'Search entities in the knowledge graph by name or type. Returns '
+        'entity IDs, canonical names, and mention counts. Entity IDs from '
+        'this tool feed into memex_get_entity_mentions and '
+        'memex_get_entity_cooccurrences.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'query': {
+                'type': 'string',
+                'description': 'Entity name or substring (e.g. "Rust", "Alice", "Q3 launch").',
+            },
+            'entity_type': {
+                'type': 'string',
+                'description': 'Filter by type (person/org/topic/event/etc). Optional.',
+            },
+            'limit': {
+                'type': 'integer',
+                'description': 'Max results (default: 20).',
+            },
+        },
+        'required': ['query'],
+    },
+}
+
+GET_ENTITY_MENTIONS_SCHEMA: dict[str, Any] = {
+    'name': 'memex_get_entity_mentions',
+    'description': (
+        'Return memory units (facts/observations/events) that mention a '
+        'specific entity, plus the source note for each. Requires an '
+        'entity_id from memex_list_entities.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'entity_id': {
+                'type': 'string',
+                'description': 'Entity UUID from a prior memex_list_entities call.',
+            },
+            'limit': {
+                'type': 'integer',
+                'description': 'Max mentions to return (default: 20).',
+            },
+        },
+        'required': ['entity_id'],
+    },
+}
+
+GET_ENTITY_COOCCURRENCES_SCHEMA: dict[str, Any] = {
+    'name': 'memex_get_entity_cooccurrences',
+    'description': (
+        'Return entities that co-occur with a given entity, with '
+        'co-occurrence counts. Surfaces related concepts, people, or '
+        'projects. Requires an entity_id from memex_list_entities.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'entity_id': {
+                'type': 'string',
+                'description': 'Entity UUID from a prior memex_list_entities call.',
+            },
+            'limit': {
+                'type': 'integer',
+                'description': 'Max co-occurring entities (default: 20).',
+            },
+        },
+        'required': ['entity_id'],
+    },
+}
+
+ALL_SCHEMAS: list[dict[str, Any]] = [
+    RECALL_SCHEMA,
+    RETRIEVE_NOTES_SCHEMA,
+    SURVEY_SCHEMA,
+    RETAIN_SCHEMA,
+    LIST_ENTITIES_SCHEMA,
+    GET_ENTITY_MENTIONS_SCHEMA,
+    GET_ENTITY_COOCCURRENCES_SCHEMA,
+]
+
+
+# ---------------------------------------------------------------------------
+# Handler helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(value: str | None) -> Any:
+    if not value:
+        return None
+    from datetime import datetime
+
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+
+
+def _require(args: dict[str, Any], name: str) -> Any:
+    value = args.get(name)
+    if value in (None, ''):
+        raise ValueError(f'Missing required parameter: {name}')
+    return value
+
+
+def _serialize_memory_unit(unit: Any) -> dict[str, Any]:
+    """Trim a MemoryUnitDTO to the fields useful to the model."""
+    return {
+        'id': str(getattr(unit, 'id', '')),
+        'text': getattr(unit, 'text', ''),
+        'type': getattr(unit, 'fact_type', None),
+        'status': getattr(unit, 'status', None),
+        'note_id': str(u) if (u := getattr(unit, 'note_id', None)) else None,
+        'mentioned_at': (m.isoformat() if (m := getattr(unit, 'mentioned_at', None)) else None),
+    }
+
+
+def _serialize_note_result(result: Any) -> dict[str, Any]:
+    """Flatten a ``NoteSearchResult`` into a dict for the model.
+
+    ``metadata`` is populated server-side with ``name``, ``title``,
+    ``description``, ``tags``, ``publish_date``, ``source_uri``, ``has_assets``,
+    ``vault_id`` (see ``document_search.py``). ``summaries`` is
+    ``list[BlockSummaryDTO]`` — each with ``topic: str`` and
+    ``key_points: list[str]``.
+    """
+    metadata = getattr(result, 'metadata', None) or {}
+    summaries = getattr(result, 'summaries', None) or []
+    return {
+        'note_id': str(getattr(result, 'note_id', '')),
+        'name': metadata.get('name') or metadata.get('title'),
+        'description': metadata.get('description'),
+        'tags': metadata.get('tags') or [],
+        'score': getattr(result, 'score', 0.0),
+        'note_status': getattr(result, 'note_status', None),
+        'vault_name': getattr(result, 'vault_name', None),
+        'answer': getattr(result, 'answer', None),
+        'summaries': [
+            {
+                'topic': getattr(s, 'topic', None),
+                'key_points': list(getattr(s, 'key_points', []) or []),
+            }
+            for s in summaries
+        ],
+    }
+
+
+def _serialize_entity(entity: Any) -> dict[str, Any]:
+    return {
+        'id': str(getattr(entity, 'id', '')),
+        'name': getattr(entity, 'name', ''),
+        'mention_count': getattr(entity, 'mention_count', 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_recall(
+    api: Any, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
+) -> str:
+    try:
+        query = _require(args, 'query')
+    except ValueError as e:
+        return tool_error(str(e))
+
+    limit = min(int(args.get('limit') or 10), 50)
+    tags = args.get('tags') or None
+    vault_ids: list[Any] | None = [vault_id] if vault_id else None
+
+    try:
+        results = run_sync(
+            api.search(
+                query=query,
+                limit=limit,
+                vault_ids=vault_ids,
+                token_budget=config.recall.token_budget,
+                strategies=config.recall.strategies,
+                include_stale=bool(args.get('include_stale', config.recall.include_stale)),
+                include_superseded=config.recall.include_superseded,
+                after=_parse_iso(args.get('after')),
+                before=_parse_iso(args.get('before')),
+                tags=tags,
+            ),
+            timeout=60.0,
+        )
+    except Exception as e:
+        logger.warning('memex_recall failed: %s', e)
+        return tool_error(f'Recall failed: {e}')
+
+    items = [_serialize_memory_unit(u) for u in (results or [])]
+    return json.dumps({'count': len(items), 'results': items})
+
+
+def handle_retrieve_notes(
+    api: Any, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
+) -> str:
+    try:
+        query = _require(args, 'query')
+    except ValueError as e:
+        return tool_error(str(e))
+
+    limit = min(int(args.get('limit') or 10), 50)
+    expand_query = bool(args.get('expand_query', config.recall.expand_query))
+    vault_ids: list[Any] | None = [vault_id] if vault_id else None
+
+    try:
+        results = run_sync(
+            api.search_notes(
+                query=query,
+                limit=limit,
+                vault_ids=vault_ids,
+                expand_query=expand_query,
+                strategies=config.recall.strategies,
+            ),
+            timeout=60.0,
+        )
+    except Exception as e:
+        logger.warning('memex_retrieve_notes failed: %s', e)
+        return tool_error(f'Note search failed: {e}')
+
+    items = [_serialize_note_result(r) for r in (results or [])]
+    return json.dumps({'count': len(items), 'results': items})
+
+
+def handle_survey(
+    api: Any, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
+) -> str:
+    try:
+        query = _require(args, 'query')
+    except ValueError as e:
+        return tool_error(str(e))
+
+    limit_per_query = min(int(args.get('limit_per_query') or 10), 25)
+    vault_ids: list[Any] | None = [vault_id] if vault_id else None
+
+    try:
+        response = run_sync(
+            api.survey(
+                query=query,
+                vault_ids=vault_ids,
+                limit_per_query=limit_per_query,
+                token_budget=config.recall.token_budget,
+            ),
+            timeout=120.0,
+        )
+    except Exception as e:
+        logger.warning('memex_survey failed: %s', e)
+        return tool_error(f'Survey failed: {e}')
+
+    topics = []
+    for t in getattr(response, 'topics', []) or []:
+        topics.append(
+            {
+                'note_id': str(getattr(t, 'note_id', '')),
+                'title': getattr(t, 'title', None),
+                'fact_count': getattr(t, 'fact_count', 0),
+                'facts': [
+                    {
+                        'id': str(getattr(f, 'id', '')),
+                        'text': getattr(f, 'text', ''),
+                        'fact_type': getattr(f, 'fact_type', None),
+                        'score': getattr(f, 'score', None),
+                    }
+                    for f in getattr(t, 'facts', []) or []
+                ],
+            }
+        )
+    return json.dumps(
+        {
+            'query': getattr(response, 'query', query),
+            'sub_queries': getattr(response, 'sub_queries', []) or [],
+            'total_notes': getattr(response, 'total_notes', 0),
+            'total_facts': getattr(response, 'total_facts', 0),
+            'truncated': getattr(response, 'truncated', False),
+            'topics': topics,
+        }
+    )
+
+
+def handle_retain(
+    api: Any,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+    args: dict[str, Any],
+) -> str:
+    try:
+        name = _require(args, 'name')
+        description = _require(args, 'description')
+        content = _require(args, 'content')
+    except ValueError as e:
+        return tool_error(str(e))
+
+    tags = args.get('tags') or []
+    note_key = args.get('note_key') or None
+
+    from memex_common.schemas import NoteCreateDTO
+
+    dto = NoteCreateDTO(
+        name=name,
+        description=description,
+        content=base64.b64encode(content.encode('utf-8')),
+        tags=tags,
+        note_key=note_key,
+        vault_id=str(vault_id) if vault_id else None,
+        author='hermes',
+        template=HERMES_USER_NOTE_TEMPLATE,
+    )
+
+    try:
+        result = run_sync(api.ingest(dto, background=True), timeout=30.0)
+    except Exception as e:
+        logger.warning('memex_retain failed: %s', e)
+        return tool_error(f'Retain failed: {e}')
+
+    return json.dumps(
+        {
+            'status': getattr(result, 'status', 'ok'),
+            'note_id': getattr(result, 'note_id', None),
+            'note_key': note_key,
+        }
+    )
+
+
+def handle_list_entities(
+    api: Any, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
+) -> str:
+    try:
+        query = _require(args, 'query')
+    except ValueError as e:
+        return tool_error(str(e))
+
+    limit = min(int(args.get('limit') or 20), 100)
+
+    try:
+        entities = run_sync(
+            api.search_entities(
+                query=query,
+                limit=limit,
+                vault_id=vault_id,
+                entity_type=args.get('entity_type') or None,
+            ),
+            timeout=30.0,
+        )
+    except Exception as e:
+        logger.warning('memex_list_entities failed: %s', e)
+        return tool_error(f'Entity list failed: {e}')
+
+    return json.dumps({'results': [_serialize_entity(e) for e in entities or []]})
+
+
+def handle_get_entity_mentions(
+    api: Any, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
+) -> str:
+    try:
+        entity_id = _require(args, 'entity_id')
+    except ValueError as e:
+        return tool_error(str(e))
+
+    limit = min(int(args.get('limit') or 20), 100)
+
+    try:
+        mentions = run_sync(
+            api.get_entity_mentions(
+                entity_id=entity_id,
+                limit=limit,
+                vault_id=vault_id,
+            ),
+            timeout=30.0,
+        )
+    except Exception as e:
+        logger.warning('memex_get_entity_mentions failed: %s', e)
+        return tool_error(f'Entity mentions failed: {e}')
+
+    items: list[dict[str, Any]] = []
+    for m in mentions or []:
+        if isinstance(m, dict):
+            unit = m.get('unit')
+            note = m.get('note')
+            items.append(
+                {
+                    'unit': _serialize_memory_unit(unit) if unit else None,
+                    'note_id': str(getattr(note, 'id', '')) if note is not None else None,
+                }
+            )
+        else:
+            items.append({'unit': _serialize_memory_unit(m), 'note_id': None})
+    return json.dumps({'results': items})
+
+
+def handle_get_entity_cooccurrences(
+    api: Any, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
+) -> str:
+    try:
+        entity_id = _require(args, 'entity_id')
+    except ValueError as e:
+        return tool_error(str(e))
+
+    limit = min(int(args.get('limit') or 20), 100)
+
+    try:
+        cooccurrences = run_sync(
+            api.get_entity_cooccurrences(
+                entity_id=entity_id,
+                limit=limit,
+                vault_id=vault_id,
+            ),
+            timeout=30.0,
+        )
+    except Exception as e:
+        logger.warning('memex_get_entity_cooccurrences failed: %s', e)
+        return tool_error(f'Entity cooccurrences failed: {e}')
+
+    # Server returns dicts with keys: entity_id_1, entity_id_2, entity_1_name,
+    # entity_1_type, entity_2_name, entity_2_type, cooccurrence_count, vault_id.
+    # Pivot onto the "other" entity relative to the queried one.
+    queried_id = str(entity_id)
+    pairs: list[dict[str, Any]] = []
+    for c in cooccurrences or []:
+        if not isinstance(c, dict):
+            continue
+        id_1 = str(c.get('entity_id_1') or '')
+        id_2 = str(c.get('entity_id_2') or '')
+        if queried_id == id_1:
+            other_id, other_name, other_type = (
+                id_2,
+                c.get('entity_2_name'),
+                c.get('entity_2_type'),
+            )
+        else:
+            other_id, other_name, other_type = (
+                id_1,
+                c.get('entity_1_name'),
+                c.get('entity_1_type'),
+            )
+        pairs.append(
+            {
+                'entity_id': other_id,
+                'name': other_name,
+                'type': other_type,
+                'count': c.get('cooccurrence_count', 0),
+            }
+        )
+    return json.dumps({'results': pairs})
+
+
+HANDLERS = {
+    'memex_recall': handle_recall,
+    'memex_retrieve_notes': handle_retrieve_notes,
+    'memex_survey': handle_survey,
+    'memex_retain': handle_retain,
+    'memex_list_entities': handle_list_entities,
+    'memex_get_entity_mentions': handle_get_entity_mentions,
+    'memex_get_entity_cooccurrences': handle_get_entity_cooccurrences,
+}
+
+
+def dispatch(
+    tool_name: str,
+    args: dict[str, Any],
+    *,
+    api: Any,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+) -> str:
+    handler = HANDLERS.get(tool_name)
+    if handler is None:
+        return tool_error(f'Unknown tool: {tool_name}')
+    return handler(api, config, vault_id, args)
+
+
+__all__ = [
+    'ALL_SCHEMAS',
+    'GET_ENTITY_COOCCURRENCES_SCHEMA',
+    'GET_ENTITY_MENTIONS_SCHEMA',
+    'HANDLERS',
+    'LIST_ENTITIES_SCHEMA',
+    'RECALL_SCHEMA',
+    'RETAIN_SCHEMA',
+    'RETRIEVE_NOTES_SCHEMA',
+    'SURVEY_SCHEMA',
+    'dispatch',
+]

--- a/packages/hermes-plugin/tests/_stubs/memory_provider.py
+++ b/packages/hermes-plugin/tests/_stubs/memory_provider.py
@@ -1,0 +1,232 @@
+"""Abstract base class for pluggable memory providers.
+
+Memory providers give the agent persistent recall across sessions. One
+external provider is active at a time alongside the always-on built-in
+memory (MEMORY.md / USER.md). The MemoryManager enforces this limit.
+
+Built-in memory is always active as the first provider and cannot be removed.
+External providers (Honcho, Hindsight, Mem0, etc.) are additive — they never
+disable the built-in store. Only one external provider runs at a time to
+prevent tool schema bloat and conflicting memory backends.
+
+Registration:
+  1. Built-in: BuiltinMemoryProvider — always present, not removable.
+  2. Plugins: Ship in plugins/memory/<name>/, activated by memory.provider config.
+
+Lifecycle (called by MemoryManager, wired in run_agent.py):
+  initialize()          — connect, create resources, warm up
+  system_prompt_block()  — static text for the system prompt
+  prefetch(query)        — background recall before each turn
+  sync_turn(user, asst)  — async write after each turn
+  get_tool_schemas()     — tool schemas to expose to the model
+  handle_tool_call()     — dispatch a tool call
+  shutdown()             — clean exit
+
+Optional hooks (override to opt in):
+  on_turn_start(turn, message, **kwargs) — per-turn tick with runtime context
+  on_session_end(messages)               — end-of-session extraction
+  on_pre_compress(messages) -> str       — extract before context compression
+  on_memory_write(action, target, content) — mirror built-in memory writes
+  on_delegation(task, result, **kwargs)  — parent-side observation of subagent work
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryProvider(ABC):
+    """Abstract base class for memory providers."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Short identifier for this provider (e.g. 'builtin', 'honcho', 'hindsight')."""
+
+    # -- Core lifecycle (implement these) ------------------------------------
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Return True if this provider is configured, has credentials, and is ready.
+
+        Called during agent init to decide whether to activate the provider.
+        Should not make network calls — just check config and installed deps.
+        """
+
+    @abstractmethod
+    def initialize(self, session_id: str, **kwargs) -> None:
+        """Initialize for a session.
+
+        Called once at agent startup. May create resources (banks, tables),
+        establish connections, start background threads, etc.
+
+        kwargs always include:
+          - hermes_home (str): The active HERMES_HOME directory path. Use this
+            for profile-scoped storage instead of hardcoding ``~/.hermes``.
+          - platform (str): "cli", "telegram", "discord", "cron", etc.
+
+        kwargs may also include:
+          - agent_context (str): "primary", "subagent", "cron", or "flush".
+            Providers should skip writes for non-primary contexts (cron system
+            prompts would corrupt user representations).
+          - agent_identity (str): Profile name (e.g. "coder"). Use for
+            per-profile provider identity scoping.
+          - agent_workspace (str): Shared workspace name (e.g. "hermes").
+          - parent_session_id (str): For subagents, the parent's session_id.
+          - user_id (str): Platform user identifier (gateway sessions).
+        """
+
+    def system_prompt_block(self) -> str:
+        """Return text to include in the system prompt.
+
+        Called during system prompt assembly. Return empty string to skip.
+        This is for STATIC provider info (instructions, status). Prefetched
+        recall context is injected separately via prefetch().
+        """
+        return ''
+
+    def prefetch(self, query: str, *, session_id: str = '') -> str:
+        """Recall relevant context for the upcoming turn.
+
+        Called before each API call. Return formatted text to inject as
+        context, or empty string if nothing relevant. Implementations
+        should be fast — use background threads for the actual recall
+        and return cached results here.
+
+        session_id is provided for providers serving concurrent sessions
+        (gateway group chats, cached agents). Providers that don't need
+        per-session scoping can ignore it.
+        """
+        return ''
+
+    def queue_prefetch(self, query: str, *, session_id: str = '') -> None:
+        """Queue a background recall for the NEXT turn.
+
+        Called after each turn completes. The result will be consumed
+        by prefetch() on the next turn. Default is no-op — providers
+        that do background prefetching should override this.
+        """
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = '') -> None:
+        """Persist a completed turn to the backend.
+
+        Called after each turn. Should be non-blocking — queue for
+        background processing if the backend has latency.
+        """
+
+    @abstractmethod
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        """Return tool schemas this provider exposes.
+
+        Each schema follows the OpenAI function calling format:
+        {"name": "...", "description": "...", "parameters": {...}}
+
+        Return empty list if this provider has no tools (context-only).
+        """
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        """Handle a tool call for one of this provider's tools.
+
+        Must return a JSON string (the tool result).
+        Only called for tool names returned by get_tool_schemas().
+        """
+        raise NotImplementedError(f'Provider {self.name} does not handle tool {tool_name}')
+
+    def shutdown(self) -> None:
+        """Clean shutdown — flush queues, close connections."""
+
+    # -- Optional hooks (override to opt in) ---------------------------------
+
+    def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
+        """Called at the start of each turn with the user message.
+
+        Use for turn-counting, scope management, periodic maintenance.
+
+        kwargs may include: remaining_tokens, model, platform, tool_count.
+        Providers use what they need; extras are ignored.
+        """
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        """Called when a session ends (explicit exit or timeout).
+
+        Use for end-of-session fact extraction, summarization, etc.
+        messages is the full conversation history.
+
+        NOT called after every turn — only at actual session boundaries
+        (CLI exit, /reset, gateway session expiry).
+        """
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        """Called before context compression discards old messages.
+
+        Use to extract insights from messages about to be compressed.
+        messages is the list that will be summarized/discarded.
+
+        Return text to include in the compression summary prompt so the
+        compressor preserves provider-extracted insights. Return empty
+        string for no contribution (backwards-compatible default).
+        """
+        return ''
+
+    def on_delegation(
+        self, task: str, result: str, *, child_session_id: str = '', **kwargs
+    ) -> None:
+        """Called on the PARENT agent when a subagent completes.
+
+        The parent's memory provider gets the task+result pair as an
+        observation of what was delegated and what came back. The subagent
+        itself has no provider session (skip_memory=True).
+
+        task: the delegation prompt
+        result: the subagent's final response
+        child_session_id: the subagent's session_id
+        """
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        """Return config fields this provider needs for setup.
+
+        Used by 'hermes memory setup' to walk the user through configuration.
+        Each field is a dict with:
+          key:         config key name (e.g. 'api_key', 'mode')
+          description: human-readable description
+          secret:      True if this should go to .env (default: False)
+          required:    True if required (default: False)
+          default:     default value (optional)
+          choices:     list of valid values (optional)
+          url:         URL where user can get this credential (optional)
+          env_var:     explicit env var name for secrets (default: auto-generated)
+
+        Return empty list if no config needed (e.g. local-only providers).
+        """
+        return []
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        """Write non-secret config to the provider's native location.
+
+        Called by 'hermes memory setup' after collecting user inputs.
+        ``values`` contains only non-secret fields (secrets go to .env).
+        ``hermes_home`` is the active HERMES_HOME directory path.
+
+        Providers with native config files (JSON, YAML) should override
+        this to write to their expected location. Providers that use only
+        env vars can leave the default (no-op).
+
+        All new memory provider plugins MUST implement either:
+        - save_config() for native config file formats, OR
+        - use only env vars (in which case get_config_schema() fields
+          should all have ``env_var`` set and this method stays no-op).
+        """
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Called when the built-in memory tool writes an entry.
+
+        action: 'add', 'replace', or 'remove'
+        target: 'memory' or 'user'
+        content: the entry content
+
+        Use to mirror built-in memory writes to your backend.
+        """

--- a/packages/hermes-plugin/tests/_stubs/tools_registry.py
+++ b/packages/hermes-plugin/tests/_stubs/tools_registry.py
@@ -1,0 +1,22 @@
+"""Stub for hermes-agent's ``tools.registry`` module.
+
+Provides ``tool_error`` used by the plugin at import time.
+Refresh from https://github.com/NousResearch/hermes-agent/blob/main/tools/registry.py
+if the upstream signature changes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def tool_error(message: str, **extra: Any) -> str:
+    """Format a tool error as a JSON string.
+
+    Mirrors the upstream Hermes helper. The real implementation includes more
+    structure; we keep the minimum surface the plugin relies on.
+    """
+    payload: dict[str, Any] = {'error': message}
+    payload.update(extra)
+    return json.dumps(payload)

--- a/packages/hermes-plugin/tests/conftest.py
+++ b/packages/hermes-plugin/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Shared test fixtures and Hermes stub injection.
+
+Hermes plugin modules import from ``agent.memory_provider`` and ``tools.registry``.
+Neither is pip-installable — they live inside the hermes-agent repo. We inject
+the vendored stubs in ``tests/_stubs/`` into ``sys.modules`` before any plugin
+code is imported so tests run without a Hermes checkout.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+# Make the vendored stubs importable.
+_STUBS_DIR = Path(__file__).parent / '_stubs'
+if str(_STUBS_DIR) not in sys.path:
+    sys.path.insert(0, str(_STUBS_DIR))
+
+
+def _install_hermes_stubs() -> None:
+    """Install ``agent.memory_provider`` and ``tools.registry`` into ``sys.modules``."""
+    import importlib
+
+    if 'agent.memory_provider' not in sys.modules:
+        agent_mod = sys.modules.get('agent') or ModuleType('agent')
+        mp_mod = importlib.import_module('memory_provider')
+        agent_mod.memory_provider = mp_mod  # type: ignore[attr-defined]
+        sys.modules['agent'] = agent_mod
+        sys.modules['agent.memory_provider'] = mp_mod
+
+    if 'tools.registry' not in sys.modules:
+        tools_mod = sys.modules.get('tools') or ModuleType('tools')
+        reg_mod = importlib.import_module('tools_registry')
+        tools_mod.registry = reg_mod  # type: ignore[attr-defined]
+        sys.modules['tools'] = tools_mod
+        sys.modules['tools.registry'] = reg_mod
+
+
+_install_hermes_stubs()
+
+
+import pytest  # noqa: E402
+
+from memex_hermes_plugin.memex import async_bridge  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_async_bridge():
+    """Ensure the shared event loop is torn down between tests."""
+    yield
+    try:
+        async_bridge._reset_for_tests()
+    except Exception:
+        pass

--- a/packages/hermes-plugin/tests/integration/conftest.py
+++ b/packages/hermes-plugin/tests/integration/conftest.py
@@ -1,0 +1,335 @@
+"""Hermes integration fixtures — real Hermes loader × live Memex server × Postgres.
+
+The suite starts Memex's FastAPI app under ``uvicorn`` on a free port in a
+background thread, backed by a testcontainers-managed
+``pgvector/pgvector:pg18-trixie`` Postgres. The plugin talks to the server
+over real HTTP — matching production — which also keeps the plugin's async
+bridge loop isolated from pytest-asyncio's loop (asyncpg connections are
+bound to the loop they're created on).
+
+Requirements:
+- Docker daemon running (for testcontainers)
+- ``hermes-agent`` installed (``uv sync --group hermes-integration``)
+
+Run with:
+
+    just test-integration
+
+Suite is gated by the ``hermes_integration`` pytest marker and excluded from
+the default run so unit tests stay fast.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, AsyncGenerator, Generator, Iterator
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+
+_HERMES_INSTALL_HINT = (
+    'hermes-agent is not installed. Integration tests need it. Install with:\n'
+    '    uv sync --group hermes-integration\n'
+    'then run ``just test-integration``.'
+)
+
+
+# ---------------------------------------------------------------------------
+# Skip the entire suite early if Docker or hermes-agent are missing
+# ---------------------------------------------------------------------------
+
+
+def _hermes_is_importable() -> bool:
+    import importlib.util
+
+    return all(
+        importlib.util.find_spec(m) is not None
+        for m in ('hermes_constants', 'agent.memory_provider', 'tools.registry', 'plugins.memory')
+    )
+
+
+def _docker_is_available() -> bool:
+    try:
+        import docker  # type: ignore[import-not-found,attr-defined]
+
+        docker.from_env().ping()  # type: ignore[attr-defined]
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope='session', autouse=True)
+def _require_prerequisites() -> None:
+    if not _hermes_is_importable():
+        pytest.skip(_HERMES_INSTALL_HINT, allow_module_level=False)
+    if not _docker_is_available():
+        pytest.skip(
+            'Docker daemon not reachable. Integration tests need Docker for '
+            'testcontainers Postgres.',
+            allow_module_level=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Postgres + Memex app (mirrors tests/conftest.py patterns)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='session')
+def postgres_container() -> Generator[Any, None, None]:
+    from testcontainers.postgres import PostgresContainer
+
+    pg = PostgresContainer('pgvector/pgvector:pg18-trixie')
+    pg.start()
+    try:
+        yield pg
+    finally:
+        pg.stop()
+
+
+def _set_memex_env_vars(pg: Any) -> None:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(pg.get_connection_url())
+    os.environ['MEMEX_LOAD_LOCAL_CONFIG'] = 'false'
+    os.environ['MEMEX_LOAD_GLOBAL_CONFIG'] = 'false'
+    os.environ['MEMEX_SERVER__META_STORE__TYPE'] = 'postgres'
+    os.environ['MEMEX_SERVER__META_STORE__INSTANCE__HOST'] = parsed.hostname or 'localhost'
+    os.environ['MEMEX_SERVER__META_STORE__INSTANCE__PORT'] = str(parsed.port or 5432)
+    os.environ['MEMEX_SERVER__META_STORE__INSTANCE__DATABASE'] = parsed.path.lstrip('/')
+    os.environ['MEMEX_SERVER__META_STORE__INSTANCE__USER'] = parsed.username or 'test'
+    os.environ['MEMEX_SERVER__META_STORE__INSTANCE__PASSWORD'] = parsed.password or 'test'
+    os.environ['MEMEX_SERVER__MEMORY__REFLECTION__BACKGROUND_REFLECTION_ENABLED'] = 'false'
+
+
+@pytest_asyncio.fixture(scope='session')
+async def _schema_ready(postgres_container: Any) -> AsyncGenerator[None, None]:
+    """Initialize the DB schema + seed the global vault (session-scoped)."""
+    _set_memex_env_vars(postgres_container)
+
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlmodel import SQLModel
+
+    from memex_core.config import GLOBAL_VAULT_ID, GLOBAL_VAULT_NAME
+    from memex_core.memory.sql_models import Vault
+    from memex_core.migration import get_expected_head
+
+    dsn = postgres_container.get_connection_url().replace('psycopg2', 'asyncpg')
+    engine = create_async_engine(dsn)
+    async with engine.begin() as conn:
+        await conn.execute(text('CREATE EXTENSION IF NOT EXISTS vector'))
+        await conn.execute(text('CREATE EXTENSION IF NOT EXISTS pg_trgm'))
+        await conn.run_sync(SQLModel.metadata.create_all)
+        await conn.execute(
+            text(
+                'CREATE TABLE IF NOT EXISTS alembic_version ('
+                '  version_num VARCHAR(32) NOT NULL PRIMARY KEY)'
+            )
+        )
+        await conn.execute(text('DELETE FROM alembic_version'))
+        await conn.execute(
+            text('INSERT INTO alembic_version (version_num) VALUES (:rev)'),
+            {'rev': get_expected_head()},
+        )
+
+    session_maker = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with session_maker() as s:
+        s.add(
+            Vault(
+                id=GLOBAL_VAULT_ID,
+                name=GLOBAL_VAULT_NAME,
+                description='Hermes integration global vault',
+            )
+        )
+        await s.commit()
+    await engine.dispose()
+    yield
+
+
+@pytest.fixture(scope='session')
+def memex_server_url(
+    postgres_container: Any,
+    _schema_ready: None,
+) -> Generator[str, None, None]:
+    """Run Memex FastAPI in a background thread with uvicorn. Yield base URL.
+
+    We can't use ``ASGITransport`` because the plugin's ``async_bridge`` runs
+    on its own event loop; asyncpg connections created on the server loop can't
+    be reused across loops. A real HTTP server isolates the two.
+    """
+    import socket
+    import threading
+    import time
+
+    import uvicorn
+
+    from memex_core.server import app
+
+    # Patch the background scheduler so it doesn't contend for Postgres locks.
+    import asyncio as _asyncio
+
+    async def _noop(*_a: Any, **_kw: Any) -> None:
+        await _asyncio.Event().wait()
+
+    scheduler_patch = patch(
+        'memex_core.server.run_scheduler_with_leader_election', side_effect=_noop
+    )
+    scheduler_patch.start()
+
+    # Find a free port.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        port = s.getsockname()[1]
+
+    class _Server(uvicorn.Server):
+        def install_signal_handlers(self) -> None:  # type: ignore[override]
+            pass
+
+    config = uvicorn.Config(
+        app=app, host='127.0.0.1', port=port, log_level='warning', lifespan='on'
+    )
+    server = _Server(config=config)
+    thread = threading.Thread(target=server.run, daemon=True, name='memex-test-uvicorn')
+    thread.start()
+
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        if server.started:
+            break
+        time.sleep(0.05)
+    if not server.started:
+        scheduler_patch.stop()
+        raise RuntimeError('Memex test server failed to start')
+
+    url = f'http://127.0.0.1:{port}'
+    try:
+        yield url
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10.0)
+        scheduler_patch.stop()
+
+
+@pytest_asyncio.fixture(scope='function')
+async def _fresh_db(postgres_container: Any) -> AsyncGenerator[None, None]:
+    """Per-test marker fixture; no-op.
+
+    We don't TRUNCATE between tests: the prior test's background batch jobs
+    may still hold row locks, which deadlock against TRUNCATE's
+    AccessExclusiveLock. Each test uses a uuid-based vault and unique query
+    strings, so cross-test data is harmless.
+    """
+    yield
+
+
+# ---------------------------------------------------------------------------
+# RemoteMemexAPI wired to the in-process app via ASGITransport
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(scope='function')
+async def live_api(memex_server_url: str, _fresh_db: None) -> AsyncGenerator[Any, None]:
+    """``RemoteMemexAPI`` connected to the uvicorn test server over HTTP."""
+    import httpx
+
+    from memex_common.client import RemoteMemexAPI
+
+    async with httpx.AsyncClient(base_url=f'{memex_server_url}/api/v1/', timeout=30.0) as client:
+        yield RemoteMemexAPI(client)
+
+
+@pytest.fixture(scope='function')
+def server_url_env(memex_server_url: str, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Set ``MEMEX_SERVER_URL`` so the plugin connects to our test server."""
+    monkeypatch.setenv('MEMEX_SERVER_URL', memex_server_url)
+    return memex_server_url
+
+
+# ---------------------------------------------------------------------------
+# HERMES_HOME + symlinked plugin
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='session')
+def hermes_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return tmp_path_factory.mktemp('hermes-home')
+
+
+@pytest.fixture(scope='session')
+def installed_plugin(hermes_home: Path) -> Path:
+    source = Path(__file__).resolve().parents[2] / 'src' / 'memex_hermes_plugin' / 'memex'
+    assert source.exists(), f'plugin source not found at {source}'
+    plugin_dir = hermes_home / 'plugins' / 'memex'
+    plugin_dir.parent.mkdir(parents=True, exist_ok=True)
+    if plugin_dir.exists() or plugin_dir.is_symlink():
+        if plugin_dir.is_symlink() or plugin_dir.is_file():
+            plugin_dir.unlink()
+        else:
+            import shutil
+
+            shutil.rmtree(plugin_dir)
+    plugin_dir.symlink_to(source.resolve(), target_is_directory=True)
+    return plugin_dir
+
+
+@pytest.fixture(autouse=True)
+def _hermes_env(hermes_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('HERMES_HOME', str(hermes_home))
+
+
+# ---------------------------------------------------------------------------
+# Plugin lifecycle helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vault_name() -> str:
+    return f'hermes-int-{uuid4().hex[:8]}'
+
+
+@pytest_asyncio.fixture
+async def live_vault(live_api: Any, vault_name: str) -> UUID:
+    from memex_common.schemas import CreateVaultRequest
+
+    vault = await live_api.create_vault(CreateVaultRequest(name=vault_name))
+    return UUID(str(vault.id))
+
+
+@pytest.fixture
+def loaded_provider(
+    installed_plugin: Path,  # noqa: ARG001 — ensures symlink
+    server_url_env: str,  # noqa: ARG001 — MEMEX_SERVER_URL set
+    live_vault: UUID,  # noqa: ARG001 — vault must exist
+    vault_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> Iterator[Any]:
+    monkeypatch.setenv('MEMEX_VAULT', vault_name)
+    from plugins.memory import load_memory_provider  # type: ignore[import-not-found]
+
+    caplog.set_level(logging.WARNING, logger='memex_hermes_plugin')
+    provider = load_memory_provider('memex')
+    if provider is None:
+        pytest.fail('Hermes loader returned None for "memex"')
+    yield provider
+    try:
+        provider.shutdown()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def initialized_provider(loaded_provider: Any, hermes_home: Path) -> Any:
+    loaded_provider.initialize(
+        'integration-session',
+        hermes_home=str(hermes_home),
+        platform='cli',
+        agent_identity='integration',
+        user_id='tester',
+    )
+    return loaded_provider

--- a/packages/hermes-plugin/tests/integration/test_live_hermes.py
+++ b/packages/hermes-plugin/tests/integration/test_live_hermes.py
@@ -1,0 +1,172 @@
+"""Live end-to-end: real Hermes loader × real Memex FastAPI app × real Postgres.
+
+The Memex server runs under uvicorn in a background thread, backed by a
+testcontainers Postgres. The plugin talks over real HTTP and goes through
+Hermes' own ``plugins.memory`` discovery + registration machinery.
+
+No API mocks. Only LLM-bound behaviour (DSPy extraction, survey decomposition,
+reranker) is avoided; the rest of the round-trip is real.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+pytestmark = pytest.mark.hermes_integration
+
+
+def test_discovery_lists_memex(installed_plugin: Path):
+    from plugins.memory import discover_memory_providers  # type: ignore[import-not-found]
+
+    providers = {name: (desc, available) for name, desc, available in discover_memory_providers()}
+    assert 'memex' in providers
+    assert providers['memex'][1] is True  # available
+    assert 'Memex' in providers['memex'][0]
+
+
+def test_loaded_provider_subclasses_memory_provider_abc(loaded_provider):
+    from agent.memory_provider import MemoryProvider  # type: ignore[import-not-found]
+
+    assert isinstance(loaded_provider, MemoryProvider)
+    assert loaded_provider.name == 'memex'
+
+
+def test_initialize_resolves_vault_and_fetches_real_briefing(
+    initialized_provider, live_vault: UUID
+):
+    assert initialized_provider._vault_id == live_vault
+    assert initialized_provider._session_note_key.startswith('hermes:session:')
+    block = initialized_provider.system_prompt_block()
+    # The real briefing endpoint returns markdown with vault listings.
+    assert '## Memex Memory' in block
+    assert initialized_provider._session_note_key in block
+
+
+def test_get_tool_schemas_exposes_7_tools(initialized_provider):
+    names = {s['name'] for s in initialized_provider.get_tool_schemas()}
+    assert names == {
+        'memex_recall',
+        'memex_retrieve_notes',
+        'memex_survey',
+        'memex_retain',
+        'memex_list_entities',
+        'memex_get_entity_mentions',
+        'memex_get_entity_cooccurrences',
+    }
+
+
+@pytest.mark.asyncio
+async def test_retain_roundtrip_via_real_server(initialized_provider, live_api, live_vault: UUID):
+    """memex_retain → note lands in Postgres; verified by listing server-side."""
+    marker = f'integration-marker-{UUID(int=0).hex}'
+    result = initialized_provider.handle_tool_call(
+        'memex_retain',
+        {
+            'name': 'integration-note',
+            'description': 'integration test capture',
+            'content': f'The marker is {marker}. The answer is 42.',
+            'tags': ['integration'],
+        },
+    )
+    data = json.loads(result)
+    assert 'error' not in data, f'retain failed: {data}'
+
+    # Wait a bit for the background batch job to persist the note.
+    import asyncio
+
+    for _ in range(20):
+        await asyncio.sleep(0.5)
+        response = await live_api.client.get(
+            'notes', params={'vault_id': str(live_vault), 'limit': 10}
+        )
+        if response.status_code == 200:
+            body = response.text
+            if 'integration-note' in body:
+                return
+    pytest.fail(
+        f'retained note did not appear in /notes listing; last status={response.status_code}'
+    )
+
+
+def test_on_session_end_persists_transcript(initialized_provider, loaded_provider):
+    initialized_provider.sync_turn('hello', 'hi there')
+    initialized_provider.sync_turn('what did I say?', 'you said hello')
+    initialized_provider.on_session_end([])
+    # Transcript was buffered, then cleared after ingest.
+    assert initialized_provider._turn_buffer == []
+
+
+def test_on_memory_write_kv_roundtrip(initialized_provider, memex_server_url: str):
+    """KV mirror must satisfy Memex's VALID_NAMESPACES contract end-to-end.
+
+    Uses sync ``httpx.Client`` against the uvicorn-in-thread server so we stay
+    off pytest-asyncio's loop (the plugin already spins up its own loop).
+    """
+    import hashlib
+
+    import httpx
+
+    from memex_core.services.kv import VALID_NAMESPACES
+
+    initialized_provider.on_memory_write('add', 'user', 'Prefers Rust for systems code')
+
+    digest = hashlib.sha256(b'Prefers Rust for systems code').hexdigest()[:12]
+    expected_key = f'app:hermes:user:{digest}'
+    with httpx.Client(base_url=f'{memex_server_url}/api/v1/', timeout=10.0) as client:
+        response = client.get('kv/get', params={'key': expected_key})
+    assert response.status_code == 200, f'KV lookup failed: {response.status_code} {response.text}'
+    payload = response.json()
+    assert payload['key'] == expected_key
+    prefix = payload['key'].split(':', 1)[0]
+    assert prefix in VALID_NAMESPACES
+    assert payload['value'] == 'Prefers Rust for systems code'
+
+
+def test_list_entities_on_empty_graph_returns_empty(initialized_provider):
+    """No notes → no entities — should not error."""
+    result = initialized_provider.handle_tool_call(
+        'memex_list_entities', {'query': 'nonexistent-entity-xyz'}
+    )
+    data = json.loads(result)
+    assert 'error' not in data
+    assert data['results'] == []
+
+
+def test_recall_with_no_matches_returns_empty(initialized_provider):
+    result = initialized_provider.handle_tool_call(
+        'memex_recall', {'query': 'zyxwvutsrq-no-match-hermes-integration'}
+    )
+    data = json.loads(result)
+    assert 'error' not in data
+    assert data['count'] == 0
+
+
+def test_shutdown_is_idempotent(loaded_provider, hermes_home: Path):
+    loaded_provider.initialize('shutdown-test', hermes_home=str(hermes_home), platform='cli')
+    loaded_provider.shutdown()
+    loaded_provider.shutdown()  # must not raise
+
+
+def test_memory_mode_tools_hides_briefing_and_prefetch(
+    installed_plugin,  # noqa: ARG001
+    server_url_env: str,  # noqa: ARG001 — MEMEX_SERVER_URL set
+    live_vault: UUID,  # noqa: ARG001 — vault exists
+    vault_name: str,
+    hermes_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv('MEMEX_HERMES_MODE', 'tools')
+    monkeypatch.setenv('MEMEX_VAULT', vault_name)
+    from plugins.memory import load_memory_provider  # type: ignore[import-not-found]
+
+    provider = load_memory_provider('memex')
+    try:
+        provider.initialize('mode-tools', hermes_home=str(hermes_home), platform='cli')
+        assert provider.system_prompt_block() == ''
+        assert len(provider.get_tool_schemas()) == 7
+    finally:
+        provider.shutdown()

--- a/packages/hermes-plugin/tests/test_async_bridge.py
+++ b/packages/hermes-plugin/tests/test_async_bridge.py
@@ -1,0 +1,46 @@
+"""Tests for the synchronous asyncio bridge."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from memex_hermes_plugin.memex import async_bridge
+
+
+def test_run_sync_executes_coroutine():
+    async def double(x: int) -> int:
+        return x * 2
+
+    assert async_bridge.run_sync(double(21)) == 42
+
+
+def test_run_sync_respects_timeout():
+    async def slow() -> None:
+        await asyncio.sleep(2)
+
+    with pytest.raises(Exception):
+        async_bridge.run_sync(slow(), timeout=0.05)
+
+
+def test_loop_is_reused():
+    async def noop() -> int:
+        return 1
+
+    async_bridge.run_sync(noop())
+    loop_before = async_bridge.get_loop()
+    async_bridge.run_sync(noop())
+    loop_after = async_bridge.get_loop()
+    assert loop_before is loop_after
+
+
+def test_shutdown_is_idempotent():
+    async def noop() -> int:
+        return 1
+
+    async_bridge.run_sync(noop())
+    async_bridge.shutdown_loop()
+    # Calling twice should not raise.
+    async_bridge.shutdown_loop()
+    assert not async_bridge.is_loop_running()

--- a/packages/hermes-plugin/tests/test_briefing.py
+++ b/packages/hermes-plugin/tests/test_briefing.py
@@ -1,0 +1,103 @@
+"""Tests for briefing cache + block formatting."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+from memex_hermes_plugin.memex.briefing import BriefingCache, format_briefing_block
+
+
+def test_cache_returns_empty_on_timeout():
+    cache = BriefingCache()
+    api = Mock()
+
+    async def slow(*args, **kwargs):
+        await asyncio.sleep(5)
+        return 'late'
+
+    api.get_session_briefing = slow
+    cache.start_fetch(api, vault_id=uuid4(), budget=2000, project_id='p')
+    assert cache.get(timeout=0.1) == ''
+
+
+def test_cache_returns_result():
+    cache = BriefingCache()
+    api = Mock()
+    api.get_session_briefing = AsyncMock(return_value='# Briefing\nRecent work: X.')
+    cache.start_fetch(api, vault_id=uuid4(), budget=2000, project_id='p')
+    # Block up to 5s for the single-call coroutine to finish.
+    assert 'Briefing' in cache.get(timeout=5.0)
+
+
+def test_cache_records_error():
+    cache = BriefingCache()
+    api = Mock()
+    api.get_session_briefing = AsyncMock(side_effect=RuntimeError('boom'))
+    cache.start_fetch(api, vault_id=uuid4(), budget=2000, project_id='p')
+    cache.get(timeout=5.0)
+    assert 'boom' in (cache.get_error() or '')
+
+
+def test_cache_reset_clears_state():
+    cache = BriefingCache()
+    api = Mock()
+    api.get_session_briefing = AsyncMock(return_value='hello')
+    cache.start_fetch(api, vault_id=uuid4(), budget=2000, project_id='p')
+    cache.get(timeout=5.0)
+    cache.reset()
+    assert cache.get(timeout=0.01) == ''
+
+
+def test_format_block_with_vault_and_briefing():
+    block = format_briefing_block(
+        '# Recent activity\n- Did X',
+        vault_id='my-vault',
+        project_id='github.com/acme/x',
+        session_note_key='hermes:session:2026-01-01T00:00:00.000Z',
+        kv_instructions_if_no_vault=False,
+    )
+    assert 'Memex Memory' in block
+    assert '`my-vault`' in block
+    assert 'github.com/acme/x' in block
+    assert 'hermes:session:2026-01-01T00:00:00.000Z' in block
+    assert '# Recent activity' in block
+
+
+def test_format_block_contains_routing_guidance():
+    """Routing advice (parallel for content lookup, survey for broad, etc.) lives here,
+    not in per-tool descriptions."""
+    block = format_briefing_block(
+        '',
+        vault_id='v',
+        project_id='p',
+        session_note_key='k',
+        kv_instructions_if_no_vault=False,
+    )
+    assert 'How to use Memex tools' in block
+    assert 'memex_survey' in block
+    assert 'memex_list_entities' in block
+
+
+def test_format_block_without_vault_adds_kv_guidance():
+    block = format_briefing_block(
+        '',
+        vault_id=None,
+        project_id='p',
+        session_note_key='hermes:session:abc',
+        kv_instructions_if_no_vault=True,
+    )
+    assert 'No vault bound' in block
+    assert 'project:p:vault' in block
+
+
+def test_format_block_skips_briefing_section_when_empty():
+    block = format_briefing_block(
+        '',
+        vault_id='v',
+        project_id='p',
+        session_note_key='k',
+        kv_instructions_if_no_vault=False,
+    )
+    assert '---' not in block

--- a/packages/hermes-plugin/tests/test_config.py
+++ b/packages/hermes-plugin/tests/test_config.py
@@ -1,0 +1,124 @@
+"""Tests for the Hermes-side config loader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from memex_hermes_plugin.memex.config import (
+    HermesMemexConfig,
+    load_config,
+    save_config,
+)
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def test_defaults_when_no_config_or_env(tmp_home: Path, monkeypatch: pytest.MonkeyPatch):
+    for k in ('MEMEX_SERVER_URL', 'MEMEX_API_KEY', 'MEMEX_VAULT', 'MEMEX_HERMES_MODE'):
+        monkeypatch.delenv(k, raising=False)
+    with patch('memex_hermes_plugin.memex.config._apply_memex_fallback', side_effect=lambda d: d):
+        cfg = load_config(tmp_home)
+    assert cfg.server_url == 'http://127.0.0.1:8000'
+    assert cfg.memory_mode == 'hybrid'
+    assert cfg.vault_id is None
+
+
+def test_env_overrides_file(tmp_home: Path, monkeypatch: pytest.MonkeyPatch):
+    cfg_path = tmp_home / 'memex' / 'config.json'
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text(
+        json.dumps({'server_url': 'http://file-host:8000', 'vault_id': 'file-vault'})
+    )
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://env-host:8000')
+    monkeypatch.setenv('MEMEX_VAULT', 'env-vault')
+    monkeypatch.setenv('MEMEX_HERMES_MODE', 'tools')
+
+    cfg = load_config(tmp_home)
+
+    assert cfg.server_url == 'http://env-host:8000'
+    assert cfg.vault_id == 'env-vault'
+    assert cfg.memory_mode == 'tools'
+
+
+def test_save_config_writes_non_secret_keys(tmp_home: Path):
+    save_config(
+        {'server_url': 'http://x:9000', 'vault_id': 'v', 'api_key': None},
+        tmp_home,
+    )
+    cfg_path = tmp_home / 'memex' / 'config.json'
+    assert cfg_path.exists()
+    data = json.loads(cfg_path.read_text())
+    assert data['server_url'] == 'http://x:9000'
+    assert data['vault_id'] == 'v'
+    assert 'api_key' not in data
+
+
+def test_save_config_merges(tmp_home: Path):
+    save_config({'server_url': 'http://a'}, tmp_home)
+    save_config({'vault_id': 'v'}, tmp_home)
+    data = json.loads((tmp_home / 'memex' / 'config.json').read_text())
+    assert data['server_url'] == 'http://a'
+    assert data['vault_id'] == 'v'
+
+
+def test_invalid_briefing_budget_rejected():
+    with pytest.raises(Exception):
+        HermesMemexConfig(briefing_budget=1500)
+
+
+def test_server_url_trailing_slash_stripped():
+    cfg = HermesMemexConfig(server_url='http://x:8000/')
+    assert cfg.server_url == 'http://x:8000'
+
+
+def test_invalid_strategy_rejected():
+    """Strategies must match the server-side ``VALID_STRATEGIES`` frozenset."""
+    from memex_hermes_plugin.memex.config import RecallConfig
+
+    with pytest.raises(Exception):
+        RecallConfig(strategies=['not-a-strategy'])
+    # 'entity' was the old incorrect name — it must be 'graph'.
+    with pytest.raises(Exception):
+        RecallConfig(strategies=['entity'])
+
+
+def test_default_strategies_match_server():
+    """Server's ``VALID_STRATEGIES`` is mirrored in the plugin — keep them in sync."""
+    from memex_core.memory.retrieval.models import VALID_STRATEGIES as SERVER_VALID
+
+    from memex_hermes_plugin.memex.config import VALID_STRATEGIES, RecallConfig
+
+    assert VALID_STRATEGIES == SERVER_VALID
+    assert set(RecallConfig().strategies) <= SERVER_VALID
+
+
+def test_memex_fallback_applied_when_file_and_env_miss(
+    tmp_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    for k in ('MEMEX_SERVER_URL', 'MEMEX_API_KEY', 'MEMEX_VAULT'):
+        monkeypatch.delenv(k, raising=False)
+
+    class FakeSecret:
+        def get_secret_value(self) -> str:
+            return 'fallback-key'
+
+    class FakeVault:
+        active = 'fallback-vault'
+
+    class FakeConfig:
+        server_url = 'http://fallback:8000'
+        api_key = FakeSecret()
+        vault = FakeVault()
+
+    with patch('memex_common.config.MemexConfig', return_value=FakeConfig()):
+        cfg = load_config(tmp_home)
+    assert cfg.server_url == 'http://fallback:8000'
+    assert cfg.api_key == 'fallback-key'
+    assert cfg.vault_id == 'fallback-vault'

--- a/packages/hermes-plugin/tests/test_prefetch.py
+++ b/packages/hermes-plugin/tests/test_prefetch.py
@@ -1,0 +1,89 @@
+"""Tests for the two-layer prefetch cache."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+from memex_common.schemas import BlockSummaryDTO, MemoryUnitDTO, NoteSearchResult
+
+from memex_hermes_plugin.memex.config import HermesMemexConfig
+from memex_hermes_plugin.memex.prefetch import PrefetchCache
+
+
+def _fact(text: str) -> MemoryUnitDTO:
+    return MemoryUnitDTO(
+        id=uuid4(),
+        note_id=uuid4(),
+        text=text,
+        fact_type='world',
+        status='active',
+    )
+
+
+def _note_result(title: str) -> NoteSearchResult:
+    return NoteSearchResult(
+        note_id=uuid4(),
+        metadata={'name': title},
+        summaries=[BlockSummaryDTO(topic='preview', key_points=[])],
+    )
+
+
+def test_consume_returns_empty_when_no_data():
+    cache = PrefetchCache()
+    assert cache.consume(timeout=0.1) == ''
+
+
+def test_formats_both_sections_when_results_present():
+    cache = PrefetchCache()
+    config = HermesMemexConfig()
+    api = Mock()
+    api.search = AsyncMock(return_value=[_fact('foo'), _fact('bar')])
+    api.search_notes = AsyncMock(return_value=[_note_result('Doc A')])
+    cache.queue('q', api=api, config=config, vault_id=uuid4())
+    text = cache.consume(timeout=5.0)
+    assert 'Memex — Facts' in text
+    assert '- foo' in text
+    assert 'Memex — Related Notes' in text
+    assert 'Doc A' in text
+
+
+def test_consume_clears_cache():
+    cache = PrefetchCache()
+    config = HermesMemexConfig()
+    api = Mock()
+    api.search = AsyncMock(return_value=[_fact('foo')])
+    api.search_notes = AsyncMock(return_value=[])
+    cache.queue('q', api=api, config=config, vault_id=uuid4())
+    first = cache.consume(timeout=5.0)
+    assert 'foo' in first
+    # second consume: nothing new queued → empty.
+    assert cache.consume(timeout=0.1) == ''
+
+
+def test_facts_only_when_notes_empty():
+    cache = PrefetchCache()
+    config = HermesMemexConfig()
+    api = Mock()
+    api.search = AsyncMock(return_value=[_fact('only')])
+    api.search_notes = AsyncMock(return_value=[])
+    cache.queue('q', api=api, config=config, vault_id=uuid4())
+    text = cache.consume(timeout=5.0)
+    assert 'Memex — Facts' in text
+    assert 'Related Notes' not in text
+
+
+def test_slow_fetch_respects_timeout():
+    cache = PrefetchCache()
+    config = HermesMemexConfig()
+    api = Mock()
+
+    async def slow_search(*args, **kwargs):
+        await asyncio.sleep(5)
+        return []
+
+    api.search = slow_search
+    api.search_notes = slow_search
+    cache.queue('q', api=api, config=config, vault_id=uuid4())
+    assert cache.consume(timeout=0.1) == ''

--- a/packages/hermes-plugin/tests/test_project.py
+++ b/packages/hermes-plugin/tests/test_project.py
@@ -1,0 +1,160 @@
+"""Tests for project_id derivation and vault resolution."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+
+from memex_hermes_plugin.memex.project import (
+    _normalize_remote,
+    derive_project_id,
+    project_vault_kv_key,
+    resolve_vault,
+)
+
+
+class TestNormalizeRemote:
+    def test_https_with_git_suffix(self):
+        assert _normalize_remote('https://github.com/acme/myapp.git') == 'github.com/acme/myapp'
+
+    def test_https_with_basic_auth(self):
+        assert (
+            _normalize_remote('https://user:pass@github.com/acme/myapp.git')
+            == 'github.com/acme/myapp'
+        )
+
+    def test_https_without_git_suffix(self):
+        assert _normalize_remote('https://github.com/acme/myapp') == 'github.com/acme/myapp'
+
+    def test_ssh_url_keeps_user_prefix(self):
+        # Matches claude-code-plugin's shell normalization.
+        assert _normalize_remote('git@github.com:acme/myapp.git') == 'git@github.com:acme/myapp'
+
+
+class TestDeriveProjectId:
+    def test_falls_back_to_cwd_relative_to_home(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv('HOME', str(tmp_path))
+        sub = tmp_path / 'proj' / 'sub'
+        sub.mkdir(parents=True)
+        with patch('subprocess.run', side_effect=FileNotFoundError):
+            assert derive_project_id(cwd=sub, home=tmp_path) == 'proj/sub'
+
+    def test_falls_back_to_absolute_when_not_under_home(self, tmp_path: Path):
+        home = tmp_path / 'home'
+        elsewhere = tmp_path / 'elsewhere'
+        home.mkdir()
+        elsewhere.mkdir()
+        with patch('subprocess.run', side_effect=FileNotFoundError):
+            result = derive_project_id(cwd=elsewhere, home=home)
+        assert result == str(elsewhere.resolve())
+
+    def test_uses_git_remote_when_available(self, tmp_path: Path):
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='https://github.com/acme/myapp.git\n', stderr=''
+        )
+        with patch('subprocess.run', return_value=completed):
+            assert derive_project_id(cwd=tmp_path, home=tmp_path) == 'github.com/acme/myapp'
+
+    def test_falls_back_when_git_errors(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv('HOME', str(tmp_path))
+        failed = subprocess.CompletedProcess(args=[], returncode=128, stdout='', stderr='')
+        with patch('subprocess.run', return_value=failed):
+            assert derive_project_id(cwd=tmp_path, home=tmp_path) == '.'
+
+
+def test_project_vault_kv_key():
+    assert project_vault_kv_key('github.com/acme/x') == 'project:github.com/acme/x:vault'
+
+
+def _fake_kv_entry(value: str) -> object:
+    """Build a real ``KVEntryDTO`` so tests catch DTO-shape drift."""
+    from datetime import datetime, timezone
+    from uuid import uuid4
+
+    from memex_common.schemas import KVEntryDTO
+
+    now = datetime.now(timezone.utc)
+    return KVEntryDTO(
+        id=uuid4(),
+        key='irrelevant',
+        value=value,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestResolveVault:
+    def test_kv_hit_wins(self):
+        api = Mock()
+        api.kv_get = AsyncMock(return_value=_fake_kv_entry('kv-vault'))
+        api.resolve_vault_identifier = AsyncMock()
+        result = resolve_vault(
+            api,
+            project_id='p',
+            agent_identity='coder',
+            user_id='u',
+            config_vault='cfg',
+        )
+        assert result == 'kv-vault'
+        api.resolve_vault_identifier.assert_not_called()
+
+    def test_kv_dict_return_still_handled(self):
+        """Defensive fallback: if the client ever returns a dict, still works."""
+        api = Mock()
+        api.kv_get = AsyncMock(return_value={'value': 'dict-vault'})
+        api.resolve_vault_identifier = AsyncMock()
+        result = resolve_vault(
+            api,
+            project_id='p',
+            agent_identity=None,
+            user_id=None,
+            config_vault='cfg',
+        )
+        assert result == 'dict-vault'
+
+    def test_user_id_vault_used_when_kv_misses(self):
+        api = Mock()
+        api.kv_get = AsyncMock(return_value=None)
+
+        async def _resolve(name: str) -> object:
+            if name == 'hermes:user:alice':
+                return object()
+            raise ValueError('not found')
+
+        api.resolve_vault_identifier = AsyncMock(side_effect=_resolve)
+        result = resolve_vault(
+            api,
+            project_id='p',
+            agent_identity='coder',
+            user_id='alice',
+            config_vault='cfg',
+        )
+        assert result == 'hermes:user:alice'
+
+    def test_config_vault_when_everything_else_misses(self):
+        api = Mock()
+        api.kv_get = AsyncMock(return_value=None)
+        api.resolve_vault_identifier = AsyncMock(side_effect=ValueError('not found'))
+        result = resolve_vault(
+            api,
+            project_id='p',
+            agent_identity=None,
+            user_id=None,
+            config_vault='fallback',
+        )
+        assert result == 'fallback'
+
+    def test_returns_none_when_no_candidates(self):
+        api = Mock()
+        api.kv_get = AsyncMock(return_value=None)
+        api.resolve_vault_identifier = AsyncMock(side_effect=ValueError('not found'))
+        result = resolve_vault(
+            api,
+            project_id='p',
+            agent_identity=None,
+            user_id=None,
+            config_vault=None,
+        )
+        assert result is None

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -1,0 +1,141 @@
+"""Smoke tests for MemexMemoryProvider lifecycle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+
+from memex_hermes_plugin.memex.provider import MemexMemoryProvider
+
+
+@pytest.fixture
+def provider_with_stubbed_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
+    monkeypatch.setenv('MEMEX_VAULT', 'test-vault')
+
+    fake_api = Mock()
+    vault_uuid = uuid4()
+    fake_api.kv_get = AsyncMock(return_value=None)
+    fake_api.resolve_vault_identifier = AsyncMock(return_value=vault_uuid)
+    fake_api.get_session_briefing = AsyncMock(return_value='# Briefing')
+    fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(uuid4())))
+    fake_api.kv_put = AsyncMock()
+
+    with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
+        provider = MemexMemoryProvider()
+        provider.initialize('session-abc', hermes_home=str(tmp_path), platform='cli')
+        yield provider, fake_api, vault_uuid
+    provider.shutdown()
+
+
+def test_name_is_memex():
+    p = MemexMemoryProvider()
+    assert p.name == 'memex'
+
+
+def test_is_available_with_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://x')
+    assert MemexMemoryProvider().is_available() is True
+
+
+def test_initialize_fetches_briefing_and_sets_vault(provider_with_stubbed_api):
+    provider, api, vault_uuid = provider_with_stubbed_api
+    assert provider._vault_name == 'test-vault'
+    assert provider._vault_id == vault_uuid
+    # Session note key format.
+    assert provider._session_note_key.startswith('hermes:session:')
+    # system_prompt_block includes the briefing text.
+    block = provider.system_prompt_block()
+    assert 'Memex Memory' in block
+    assert '# Briefing' in block
+
+
+def test_get_tool_schemas_respects_memory_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
+    monkeypatch.setenv('MEMEX_HERMES_MODE', 'context')
+
+    fake_api = Mock()
+    fake_api.kv_get = AsyncMock(return_value=None)
+    fake_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+    fake_api.get_session_briefing = AsyncMock(return_value='')
+
+    with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
+        provider = MemexMemoryProvider()
+        provider.initialize('s', hermes_home=str(tmp_path), platform='cli')
+        try:
+            assert provider.get_tool_schemas() == []
+        finally:
+            provider.shutdown()
+
+
+def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
+    provider, *_ = provider_with_stubbed_api
+    schemas = provider.get_tool_schemas()
+    names = {s['name'] for s in schemas}
+    assert names == {
+        'memex_recall',
+        'memex_retrieve_notes',
+        'memex_survey',
+        'memex_retain',
+        'memex_list_entities',
+        'memex_get_entity_mentions',
+        'memex_get_entity_cooccurrences',
+    }
+
+
+def test_sync_turn_buffers(provider_with_stubbed_api):
+    provider, *_ = provider_with_stubbed_api
+    provider.sync_turn('hi', 'hello', session_id='s')
+    assert len(provider._turn_buffer) == 1
+    assert provider._turn_buffer[0]['user'] == 'hi'
+
+
+def test_on_session_end_ingests_transcript(provider_with_stubbed_api):
+    provider, api, _ = provider_with_stubbed_api
+    provider.sync_turn('ping', 'pong', session_id='s')
+    provider.on_session_end([])
+    api.ingest.assert_awaited()
+    dto = api.ingest.call_args.args[0]
+    assert dto.note_key == provider._session_note_key
+    # Transcript should contain the buffered content.
+    import base64
+
+    body = base64.b64decode(dto.content).decode('utf-8')
+    assert 'ping' in body
+    assert 'pong' in body
+
+
+def test_on_memory_write_mirrors_to_kv(provider_with_stubbed_api):
+    provider, api, _ = provider_with_stubbed_api
+    provider.on_memory_write('add', 'user', 'Prefers Rust')
+    api.kv_put.assert_awaited()
+    kwargs = api.kv_put.call_args.kwargs
+    assert kwargs['value'] == 'Prefers Rust'
+    # Key must start with a Memex VALID_NAMESPACES prefix (app/user/project/global).
+    from memex_core.services.kv import VALID_NAMESPACES
+
+    prefix = kwargs['key'].split(':', 1)[0]
+    assert prefix in VALID_NAMESPACES, (
+        f'KV key {kwargs["key"]!r} prefix {prefix!r} not in VALID_NAMESPACES={VALID_NAMESPACES}'
+    )
+    assert kwargs['key'].startswith('app:hermes:user:')
+
+
+def test_on_memory_write_remove_is_noop(provider_with_stubbed_api):
+    provider, api, _ = provider_with_stubbed_api
+    api.kv_put.reset_mock()
+    provider.on_memory_write('remove', 'user', 'Prefers Rust')
+    api.kv_put.assert_not_called()
+
+
+def test_shutdown_is_safe_to_call_twice(provider_with_stubbed_api):
+    provider, *_ = provider_with_stubbed_api
+    provider.shutdown()
+    # Second call is a no-op.
+    provider.shutdown()

--- a/packages/hermes-plugin/tests/test_session.py
+++ b/packages/hermes-plugin/tests/test_session.py
@@ -1,0 +1,35 @@
+"""Tests for session note key generation."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from memex_hermes_plugin.memex.session import (
+    SESSION_KEY_PREFIX,
+    is_session_note_key,
+    make_session_note_key,
+)
+
+
+def test_key_is_prefixed():
+    key = make_session_note_key()
+    assert key.startswith(SESSION_KEY_PREFIX)
+
+
+def test_key_is_deterministic_for_fixed_time():
+    t = datetime(2026, 4, 21, 12, 0, 0, 123000, tzinfo=timezone.utc)
+    key = make_session_note_key(t)
+    assert key == 'hermes:session:2026-04-21T12:00:00.123Z'
+
+
+def test_is_session_note_key():
+    key = make_session_note_key()
+    assert is_session_note_key(key)
+    assert not is_session_note_key('some-other-key')
+    assert not is_session_note_key('hermes:user:foo')
+
+
+def test_keys_in_same_second_differ_by_ms():
+    t1 = datetime(2026, 4, 21, 12, 0, 0, 100000, tzinfo=timezone.utc)
+    t2 = datetime(2026, 4, 21, 12, 0, 0, 200000, tzinfo=timezone.utc)
+    assert make_session_note_key(t1) != make_session_note_key(t2)

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -1,0 +1,334 @@
+"""Tests for Memex tool schemas + handlers.
+
+The handlers wrap ``RemoteMemexAPI`` methods; we mock the API and verify
+dispatch, arg handling, and error paths. Fixtures build real ``memex_common``
+DTOs so a schema drift in the client is caught here, not in production.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from memex_common.schemas import (
+    BlockSummaryDTO,
+    EntityDTO,
+    IngestResponse,
+    MemoryUnitDTO,
+    NoteSearchResult,
+    SurveyFact,
+    SurveyResponse,
+    SurveyTopic,
+)
+
+from memex_hermes_plugin.memex.config import HermesMemexConfig
+from memex_hermes_plugin.memex.tools import ALL_SCHEMAS, dispatch
+
+
+@pytest.fixture
+def config() -> HermesMemexConfig:
+    return HermesMemexConfig()
+
+
+@pytest.fixture
+def vault_id():
+    return uuid4()
+
+
+def _fake_memory_unit(text: str = 'a fact') -> MemoryUnitDTO:
+    # ``FactTypes`` accepts 'world', 'event', or 'observation' only.
+    return MemoryUnitDTO(
+        id=uuid4(),
+        note_id=uuid4(),
+        text=text,
+        fact_type='world',
+        status='active',
+    )
+
+
+def _fake_note_result(name: str = 'note') -> NoteSearchResult:
+    return NoteSearchResult(
+        note_id=uuid4(),
+        metadata={'name': name, 'title': name, 'description': 'd', 'tags': ['x']},
+        summaries=[BlockSummaryDTO(topic='Intro about note', key_points=['pt1'])],
+        score=0.9,
+        note_status='active',
+        vault_name='v',
+    )
+
+
+def _fake_entity(name: str = 'Rust') -> EntityDTO:
+    return EntityDTO(id=uuid4(), name=name, mention_count=5)
+
+
+def test_all_schemas_have_required_fields():
+    names = {s['name'] for s in ALL_SCHEMAS}
+    assert names == {
+        'memex_recall',
+        'memex_retrieve_notes',
+        'memex_survey',
+        'memex_retain',
+        'memex_list_entities',
+        'memex_get_entity_mentions',
+        'memex_get_entity_cooccurrences',
+    }
+    for s in ALL_SCHEMAS:
+        assert 'description' in s
+        assert s['parameters']['type'] == 'object'
+
+
+def test_tool_descriptions_are_neutral():
+    """Descriptions describe what the tool does, not when to combine it.
+
+    Routing (parallel/sequential dispatch) lives in the system prompt block,
+    not per-tool — matches MCP's convention and keeps tool schemas compact.
+    """
+    for schema in ALL_SCHEMAS:
+        desc = schema['description'].lower()
+        assert 'in parallel' not in desc, (
+            f'{schema["name"]} leaked a "parallel" hint into its description; '
+            'routing belongs in the system prompt block (briefing.py).'
+        )
+
+
+def test_recall_returns_serialized_results(config, vault_id):
+    api = Mock()
+    api.search = AsyncMock(return_value=[_fake_memory_unit('X is Y')])
+    out = dispatch('memex_recall', {'query': 'X'}, api=api, config=config, vault_id=vault_id)
+    data = json.loads(out)
+    assert data['count'] == 1
+    assert data['results'][0]['text'] == 'X is Y'
+    api.search.assert_awaited_once()
+
+
+def test_recall_missing_query_returns_error(config, vault_id):
+    api = Mock()
+    out = dispatch('memex_recall', {}, api=api, config=config, vault_id=vault_id)
+    assert 'error' in json.loads(out)
+
+
+def test_retrieve_notes(config, vault_id):
+    api = Mock()
+    api.search_notes = AsyncMock(return_value=[_fake_note_result('doc')])
+    out = dispatch(
+        'memex_retrieve_notes',
+        {'query': 'doc'},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert data['count'] == 1
+    result = data['results'][0]
+    assert result['name'] == 'doc'
+    # BlockSummaryDTO fields surface.
+    assert result['summaries'][0]['topic'] == 'Intro about note'
+    assert result['summaries'][0]['key_points'] == ['pt1']
+
+
+def test_survey(config, vault_id):
+    api = Mock()
+    note_id = uuid4()
+    topic = SurveyTopic(
+        note_id=note_id,
+        title='Source doc',
+        fact_count=1,
+        facts=[
+            SurveyFact(id=uuid4(), text='fact a', fact_type='world', score=0.9),
+        ],
+    )
+    response = SurveyResponse(
+        query='broad',
+        sub_queries=['sub1'],
+        topics=[topic],
+        total_notes=1,
+        total_facts=1,
+        truncated=False,
+    )
+    api.survey = AsyncMock(return_value=response)
+    out = dispatch('memex_survey', {'query': 'broad'}, api=api, config=config, vault_id=vault_id)
+    data = json.loads(out)
+    assert data['total_facts'] == 1
+    assert data['sub_queries'] == ['sub1']
+    assert data['topics'][0]['title'] == 'Source doc'
+    assert data['topics'][0]['facts'][0]['text'] == 'fact a'
+    assert data['topics'][0]['facts'][0]['fact_type'] == 'world'
+
+
+def test_retain_ingests_note(config, vault_id):
+    api = Mock()
+    api.ingest = AsyncMock(return_value=IngestResponse(status='success', note_id=str(uuid4())))
+    out = dispatch(
+        'memex_retain',
+        {
+            'name': 'decision',
+            'description': 'short',
+            'content': 'user prefers X',
+            'note_key': 'hermes:session:abc',
+        },
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert data['status'] == 'success'
+    api.ingest.assert_awaited_once()
+    dto = api.ingest.call_args.args[0]
+    # vault_id and author propagate to the DTO.
+    assert str(dto.vault_id) == str(vault_id)
+    assert dto.author == 'hermes'
+    assert dto.note_key == 'hermes:session:abc'
+
+
+def test_retain_missing_required_params(config, vault_id):
+    api = Mock()
+    out = dispatch(
+        'memex_retain',
+        {'name': 'x'},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    assert 'error' in json.loads(out)
+
+
+def test_list_entities(config, vault_id):
+    api = Mock()
+    api.search_entities = AsyncMock(return_value=[_fake_entity('Rust')])
+    out = dispatch(
+        'memex_list_entities',
+        {'query': 'Rust'},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert data['results'][0]['name'] == 'Rust'
+    assert data['results'][0]['mention_count'] == 5
+
+
+def test_list_entities_missing_query(config, vault_id):
+    api = Mock()
+    out = dispatch('memex_list_entities', {}, api=api, config=config, vault_id=vault_id)
+    assert 'error' in json.loads(out)
+
+
+def test_get_entity_mentions(config, vault_id):
+    from datetime import datetime, timezone
+
+    from memex_common.schemas import NoteDTO
+
+    api = Mock()
+    note_uuid = uuid4()
+    note_vault = uuid4()
+    note = NoteDTO(
+        id=note_uuid,
+        title='a note',
+        vault_id=note_vault,
+        created_at=datetime.now(timezone.utc),
+    )
+    api.get_entity_mentions = AsyncMock(
+        return_value=[{'unit': _fake_memory_unit('mention'), 'note': note}]
+    )
+    out = dispatch(
+        'memex_get_entity_mentions',
+        {'entity_id': str(uuid4())},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert data['results'][0]['unit']['text'] == 'mention'
+    assert data['results'][0]['note_id'] == str(note_uuid)
+
+
+def test_get_entity_mentions_missing_entity_id(config, vault_id):
+    api = Mock()
+    out = dispatch('memex_get_entity_mentions', {}, api=api, config=config, vault_id=vault_id)
+    assert 'error' in json.loads(out)
+
+
+def test_get_entity_cooccurrences(config, vault_id):
+    """Matches the real server response shape in ``entities.py``."""
+    api = Mock()
+    queried = uuid4()
+    other = uuid4()
+    api.get_entity_cooccurrences = AsyncMock(
+        return_value=[
+            {
+                'entity_id_1': queried,
+                'entity_id_2': other,
+                'entity_1_name': 'Rust',
+                'entity_1_type': 'tool',
+                'entity_2_name': 'Python',
+                'entity_2_type': 'tool',
+                'cooccurrence_count': 7,
+                'vault_id': uuid4(),
+            }
+        ]
+    )
+    out = dispatch(
+        'memex_get_entity_cooccurrences',
+        {'entity_id': str(queried)},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    item = json.loads(out)['results'][0]
+    assert item['count'] == 7
+    assert item['name'] == 'Python'
+    assert item['type'] == 'tool'
+    assert item['entity_id'] == str(other)
+
+
+def test_get_entity_cooccurrences_pivots_when_queried_is_entity_2(config, vault_id):
+    """If the queried id is on side 2, still pivots to the correct counterpart."""
+    api = Mock()
+    queried = uuid4()
+    other = uuid4()
+    api.get_entity_cooccurrences = AsyncMock(
+        return_value=[
+            {
+                'entity_id_1': other,
+                'entity_id_2': queried,
+                'entity_1_name': 'Gopher',
+                'entity_1_type': 'mascot',
+                'entity_2_name': 'Rust',
+                'entity_2_type': 'tool',
+                'cooccurrence_count': 3,
+                'vault_id': uuid4(),
+            }
+        ]
+    )
+    out = dispatch(
+        'memex_get_entity_cooccurrences',
+        {'entity_id': str(queried)},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    item = json.loads(out)['results'][0]
+    assert item['name'] == 'Gopher'
+    assert item['entity_id'] == str(other)
+
+
+def test_get_entity_cooccurrences_missing_entity_id(config, vault_id):
+    api = Mock()
+    out = dispatch('memex_get_entity_cooccurrences', {}, api=api, config=config, vault_id=vault_id)
+    assert 'error' in json.loads(out)
+
+
+def test_unknown_tool(config, vault_id):
+    api = Mock()
+    out = dispatch('memex_nonexistent', {}, api=api, config=config, vault_id=vault_id)
+    assert 'Unknown tool' in json.loads(out)['error']
+
+
+def test_recall_forwards_api_errors(config, vault_id):
+    api = Mock()
+    api.search = AsyncMock(side_effect=RuntimeError('backend down'))
+    out = dispatch('memex_recall', {'query': 'x'}, api=api, config=config, vault_id=vault_id)
+    assert 'backend down' in json.loads(out)['error']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ memex_cli = { workspace = true }
 memex_mcp = { workspace = true }
 memex_common = { workspace = true }
 memex_eval = { workspace = true }
+hermes-agent = { git = "https://github.com/NousResearch/hermes-agent.git", branch = "main" }
 
 [tool.uv.workspace]
 members = [
@@ -28,6 +29,7 @@ members = [
     "packages/common",
     "packages/core",
     "packages/eval",
+    "packages/hermes-plugin",
     "packages/mcp",
 ]
 
@@ -80,6 +82,9 @@ cache_dir = "/home/vscode/.cache/pytest"
 asyncio_mode = "auto"
 
 [dependency-groups]
+hermes-integration = [
+    "hermes-agent",
+]
 dev = [
     "nest-asyncio>=1.6.0",
     "prek>=0.2.25",

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
     "memex-common",
     "memex-core",
     "memex-eval",
+    "memex-hermes-plugin",
     "memex-mcp",
 ]
 
@@ -220,6 +221,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.96.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/672f533dee813028d2c699bfd2a7f52c9118d7353680d9aa44b9e23f717f/anthropic-0.96.0.tar.gz", hash = "sha256:9de947b737f39452f68aa520f1c2239d44119c9b73b0fb6d4e6ca80f00279ee6", size = 658210, upload-time = "2026-04-16T14:28:02.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/5a/72f33204064b6e87601a71a6baf8d855769f8a0c1eaae8d06a1094872371/anthropic-0.96.0-py3-none-any.whl", hash = "sha256:9a6e335a354602a521cd9e777e92bfd46ba6e115bf9bbfe6135311e8fb2015b2", size = 635930, upload-time = "2026-04-16T14:28:01.436Z" },
 ]
 
 [[package]]
@@ -1091,6 +1111,21 @@ wheels = [
 ]
 
 [[package]]
+name = "edge-tts"
+version = "7.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "tabulate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/60/afbf548b43c78355e03926c6b1fff7500303a2da4d84db9e1324119e21ae/edge_tts-7.2.8.tar.gz", hash = "sha256:fcf185a0d527a0d2d003f9d5841facc1d5e0e7b3b88d5df9c32990402c6b8cd0", size = 27875, upload-time = "2026-03-22T19:57:50.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/2b/a8cb687b92a2690d2ad171f0c2fd1c8f18690363cca7618bab2bbe4cdf2b/edge_tts-7.2.8-py3-none-any.whl", hash = "sha256:361fe48ce7ef613adbe30f664e3765dd71029c6cb57427279eff8ad6df2eb211", size = 31026, upload-time = "2026-03-22T19:57:49.672Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1113,6 +1148,24 @@ wheels = [
 ]
 
 [[package]]
+name = "exa-py"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/d2/22f8e5b83fb7ff1a5b19528b21bb908504c8b6a716309b169801881e64ff/exa_py-2.12.0.tar.gz", hash = "sha256:2cd5fe2d47d8e0221f87dcb2be0f007cc0a1f0a643b16dfc586ab1421998f4fc", size = 58731, upload-time = "2026-04-15T12:55:17.616Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/87/e5c458741a34c945d6b612ec54f00088a6869ffc4f3f8a7b06ae080ec6af/exa_py-2.12.0-py3-none-any.whl", hash = "sha256:78b954ca99151228e4b853bd25e58829048a9a601d6187001befa512e0143f8f", size = 73896, upload-time = "2026-04-15T12:55:16.03Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1131,6 +1184,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fal-client"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "msgpack" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/c5/092950a61034ad8bc6fb50be63f9d749eb9129cbada93c95b54e3104a782/fal_client-0.13.2.tar.gz", hash = "sha256:d543d4ff49f27d84bc03852bd1c6aa343604e07d5ed31b9df78d625e010308cb", size = 32183, upload-time = "2026-03-24T16:33:42.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/6f/1d9c1a4e89b48bbb5bdd5d7b78717f9e5635fb7bf6ea3cbdbeb17a0c77f2/fal_client-0.13.2-py3-none-any.whl", hash = "sha256:1f26efc21067de136026086f44aa32655e457a9a3b67fb20617bba930953d553", size = 19739, upload-time = "2026-03-24T16:33:41.543Z" },
 ]
 
 [[package]]
@@ -1241,6 +1309,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "fire"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/00/f8d10588d2019d6d6452653def1ee807353b21983db48550318424b5ff18/fire-0.7.1.tar.gz", hash = "sha256:3b208f05c736de98fb343310d090dcc4d8c78b2a89ea4f32b837c586270a9cbf", size = 88720, upload-time = "2025-08-16T20:20:24.175Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4c/93d0f85318da65923e4b91c1c2ff03d8a458cbefebe3bc612a6693c7906d/fire-0.7.1-py3-none-any.whl", hash = "sha256:e43fd8a5033a9001e7e2973bab96070694b9f12f2e0ecf96d4683971b5ab1882", size = 115945, upload-time = "2025-08-16T20:20:22.87Z" },
+]
+
+[[package]]
+name = "firecrawl-py"
+version = "4.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "httpx" },
+    { name = "nest-asyncio" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/03/fc714c52f156add4c58665ff3ede3ff2b07d96e32742507ed94769a94227/firecrawl_py-4.22.2.tar.gz", hash = "sha256:c1bf17f6faf3b9599291e56d4b1b1d367777dbcf35b28568dd07084f1b0c9149", size = 174536, upload-time = "2026-04-15T21:34:42.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/35/adc7ff46b0f06261ce70b43ab0861c895d12bde7a7ceea95e45d45cb0a82/firecrawl_py-4.22.2-py3-none-any.whl", hash = "sha256:9f13f55ec7e8eb61a7fe91a2af09d5dd5c7539ec3f64f66280a7ceaa8b1bad10", size = 217823, upload-time = "2026-04-15T21:34:40.496Z" },
 ]
 
 [[package]]
@@ -1745,6 +1843,31 @@ wheels = [
 ]
 
 [[package]]
+name = "hermes-agent"
+version = "0.10.0"
+source = { git = "https://github.com/NousResearch/hermes-agent.git?branch=main#16accd44bdc5151aee8cac57e74fd3da15da3092" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "edge-tts" },
+    { name = "exa-py" },
+    { name = "fal-client" },
+    { name = "fire" },
+    { name = "firecrawl-py" },
+    { name = "httpx", extra = ["socks"] },
+    { name = "jinja2" },
+    { name = "openai" },
+    { name = "parallel-web" },
+    { name = "prompt-toolkit" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tenacity" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1815,6 +1938,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -2837,6 +2965,9 @@ dev = [
 docs = [
     { name = "zensical" },
 ]
+hermes-integration = [
+    { name = "hermes-agent" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2872,6 +3003,7 @@ dev = [
     { name = "types-dateparser", specifier = ">=1.3.0.20260211" },
 ]
 docs = [{ name = "zensical", specifier = ">=0.0.25" }]
+hermes-integration = [{ name = "hermes-agent", git = "https://github.com/NousResearch/hermes-agent.git?branch=main" }]
 
 [[package]]
 name = "memex-cli"
@@ -2888,6 +3020,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+hermes = [
+    { name = "memex-hermes-plugin" },
+]
 mcp = [
     { name = "memex-mcp" },
 ]
@@ -2906,6 +3041,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "memex-common", editable = "packages/common" },
     { name = "memex-core", marker = "extra == 'server'", editable = "packages/core" },
+    { name = "memex-hermes-plugin", marker = "extra == 'hermes'", editable = "packages/hermes-plugin" },
     { name = "memex-mcp", marker = "extra == 'mcp'", editable = "packages/mcp" },
     { name = "platformdirs", specifier = ">=4.5.1" },
     { name = "python-box", specifier = ">=7.3.2" },
@@ -2916,7 +3052,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12.0" },
     { name = "watchdog", marker = "extra == 'sync'", specifier = ">=4.0.0" },
 ]
-provides-extras = ["mcp", "server", "sync"]
+provides-extras = ["hermes", "mcp", "server", "sync"]
 
 [[package]]
 name = "memex-common"
@@ -3101,6 +3237,38 @@ requires-dist = [
 ]
 
 [[package]]
+name = "memex-hermes-plugin"
+source = { editable = "packages/hermes-plugin" }
+dependencies = [
+    { name = "httpx" },
+    { name = "memex-common" },
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-httpx" },
+    { name = "respx" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "memex-common", editable = "packages/common" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
+    { name = "pytest-httpx", specifier = ">=0.27.0" },
+    { name = "respx", specifier = ">=0.22.0" },
+]
+
+[[package]]
 name = "memex-mcp"
 source = { editable = "packages/mcp" }
 dependencies = [
@@ -3170,6 +3338,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
+    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
+    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
 ]
 
 [[package]]
@@ -3417,7 +3629,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.15.0"
+version = "2.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3429,9 +3641,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/f4/4690ecb5d70023ce6bfcfeabfe717020f654bde59a775058ec6ac4692463/openai-2.15.0.tar.gz", hash = "sha256:42eb8cbb407d84770633f31bf727d4ffb4138711c670565a41663d9439174fba", size = 627383, upload-time = "2026-01-09T22:10:08.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/df/c306f7375d42bafb379934c2df4c2fa3964656c8c782bac75ee10c102818/openai-2.15.0-py3-none-any.whl", hash = "sha256:6ae23b932cd7230f7244e52954daa6602716d6b9bf235401a107af731baea6c3", size = 1067879, upload-time = "2026-01-09T22:10:06.446Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
 ]
 
 [[package]]
@@ -3727,6 +3939,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/a0/ed160a00fb4f37d806406bc0a79a8b62fe67f29d00950f8d16203ff3409b/pandas-3.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:125eb901e233f155b268bbef9abd9afb5819db74f0e677e89a61b246228c71ac", size = 11799386, upload-time = "2026-01-21T15:51:57.457Z" },
     { url = "https://files.pythonhosted.org/packages/36/c8/2ac00d7255252c5e3cf61b35ca92ca25704b0188f7454ca4aec08a33cece/pandas-3.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b86d113b6c109df3ce0ad5abbc259fe86a1bd4adfd4a31a89da42f84f65509bb", size = 10873041, upload-time = "2026-01-21T15:52:00.034Z" },
     { url = "https://files.pythonhosted.org/packages/e6/3f/a80ac00acbc6b35166b42850e98a4f466e2c0d9c64054161ba9620f95680/pandas-3.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:1c39eab3ad38f2d7a249095f0a3d8f8c22cc0f847e98ccf5bbe732b272e2d9fa", size = 9441003, upload-time = "2026-01-21T15:52:02.281Z" },
+]
+
+[[package]]
+name = "parallel-web"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/2e/0cd24a64c4d60b3fa3b92279842b2cdf1dbce855453be93dca97a365d3a9/parallel_web-0.5.0.tar.gz", hash = "sha256:f3ca22818ab48bcfa3857375533be14593a4be2bcc1273b8748e298a477262f4", size = 154399, upload-time = "2026-04-21T06:02:32.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/b3/5016506c9f640994f49e832377560cedb8d253caf138354269b58ebbb3de/parallel_web-0.5.0-py3-none-any.whl", hash = "sha256:7ae137fac60103e3077cd55059568032aa3948c86fbfe22f31e650797d2342f1", size = 163855, upload-time = "2026-04-21T06:02:31.394Z" },
 ]
 
 [[package]]
@@ -4336,11 +4565,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]
@@ -4816,7 +5045,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -4824,9 +5053,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -4855,16 +5084,28 @@ wheels = [
 ]
 
 [[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
 name = "rich"
-version = "14.3.1"
+version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/84/4831f881aa6ff3c976f6d6809b58cdfa350593ffc0dc3c58f5f6586780fb/rich-14.3.1.tar.gz", hash = "sha256:b8c5f568a3a749f9290ec6bddedf835cec33696bfc1e48bcfecb276c7386e4b8", size = 230125, upload-time = "2026-01-24T21:40:44.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/2a/a1810c8627b9ec8c57ec5ec325d306701ae7be50235e8fd81266e002a3cc/rich-14.3.1-py3-none-any.whl", hash = "sha256:da750b1aebbff0b372557426fb3f35ba56de8ef954b3190315eb64076d6fb54e", size = 309952, upload-time = "2026-01-24T21:40:42.969Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]
@@ -5098,6 +5339,15 @@ wheels = [
 ]
 
 [[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5247,11 +5497,20 @@ wheels = [
 
 [[package]]
 name = "tenacity"
-version = "9.1.2"
+version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3020,9 +3020,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-hermes = [
-    { name = "memex-hermes-plugin" },
-]
 mcp = [
     { name = "memex-mcp" },
 ]
@@ -3041,7 +3038,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "memex-common", editable = "packages/common" },
     { name = "memex-core", marker = "extra == 'server'", editable = "packages/core" },
-    { name = "memex-hermes-plugin", marker = "extra == 'hermes'", editable = "packages/hermes-plugin" },
     { name = "memex-mcp", marker = "extra == 'mcp'", editable = "packages/mcp" },
     { name = "platformdirs", specifier = ">=4.5.1" },
     { name = "python-box", specifier = ">=7.3.2" },
@@ -3052,7 +3048,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12.0" },
     { name = "watchdog", marker = "extra == 'sync'", specifier = ">=4.0.0" },
 ]
-provides-extras = ["hermes", "mcp", "server", "sync"]
+provides-extras = ["mcp", "server", "sync"]
 
 [[package]]
 name = "memex-common"
@@ -3243,6 +3239,8 @@ dependencies = [
     { name = "httpx" },
     { name = "memex-common" },
     { name = "pyyaml" },
+    { name = "rich" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -3258,6 +3256,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "memex-common", editable = "packages/common" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "rich", specifier = ">=13.7.0" },
+    { name = "typer", specifier = ">=0.12.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

New `packages/hermes-plugin/` — a standalone memory provider for [Hermes Agent](https://hermes-agent.nousresearch.com) backed by Memex. Users install with `uv tool install 'memex-hermes-plugin @ git+.../packages/hermes-plugin'` and run `memex-hermes install`. No Memex CLI dependency.

### Two commits

1. **`a4a1a5a` feat(hermes-plugin)** — the plugin itself: 7 tools (recall / retrieve_notes / survey / retain / list_entities / get_entity_mentions / get_entity_cooccurrences), session briefing on init, two-layer prefetch, session-end transcript ingest, pre-compress capture, KV mirror, 3 memory modes, per-project vault binding via KV. 71 unit tests + 11 live integration tests (real Hermes loader × uvicorn-served Memex × testcontainers Postgres).
2. **`c60715c` refactor(hermes-plugin)** — decouple from `memex-cli`. Install CLI lives inside the plugin package as a `memex-hermes` console script; dropped `memex hermes` subcommand + `[hermes]` optional extra.

### Tool design

Tool schemas stay neutral (describe *what each tool does*); routing guidance (parallel for content lookup, sequential for graph exploration, survey for broad queries) is injected once per session via `system_prompt_block` — mirrors MCP/Claude-Code-plugin convention.

### Distribution

Existing `release.yaml` (on `v*` tags) already runs `uv build --all-packages` and attaches every workspace wheel to the GitHub release — including `memex_hermes_plugin-*.whl`. No new CI. No PyPI yet (matches the rest of Memex).

### Verified end-to-end against live Hermes

Installed `hermes-agent@main` from GitHub, discovery lists `memex: available=True`, real loader returns a `MemorProvider` subclass, all 15 lifecycle hooks exercised against a running Memex server — DSPy fact extraction round-trips the marker phrase, KV writes land under `app:hermes:user:<hash>`, session notes persist, three memory modes behave as specified.

## Test plan

- [x] `just test` — 71 unit tests pass (`packages/hermes-plugin`)
- [x] `just test-integration` — 11 live integration tests pass (testcontainers Postgres + uvicorn + hermes-agent)
- [x] `uv run pytest packages/cli/tests` — 374 CLI regression tests pass (no damage from removing `memex hermes` subcommand)
- [x] `uv run ruff check packages/hermes-plugin` — clean
- [x] Wheel inspection — `plugin.yaml` + `README.md` ship inside `memex_hermes_plugin-*.whl`
- [x] `memex-hermes install` console script installs into `\$HERMES_HOME/plugins/memex/`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)