### PR TITLE
ci: re-land pytest-timeout as safety net against 6h CI hangs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ follow_imports = "silent"
 explicit_package_bases = true
 
 [tool.pytest.ini_options]
+# Hard per-test timeout so a hung test can't lock CI for six hours.
+# Thread method is compatible with asyncio tests and forces a traceback
+# on the stuck thread at exit.
+addopts = "--timeout=300 --timeout-method=thread"
 markers = [
   "integration: marks integration tests",
   "llm: marks tests that require LLM calls",
@@ -93,6 +97,7 @@ dev = [
     "pytest-asyncio>=1.2.0",
     "pytest-httpx>=0.27.0",
     "pytest-async>=0.1.1",
+    "pytest-timeout>=2.3",
     "testcontainers>=4.14.0",
     "pytest-rerunfailures>=16.1",
     "pyinstrument>=5.1.2",

--- a/uv.lock
+++ b/uv.lock
@@ -2956,6 +2956,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
     { name = "pytest-rerunfailures" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "s3fs" },
     { name = "seaborn" },
@@ -2996,6 +2997,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-httpx", specifier = ">=0.27.0" },
     { name = "pytest-rerunfailures", specifier = ">=16.1" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "s3fs", specifier = ">=2024.6.0" },
     { name = "seaborn", specifier = ">=0.13.2" },
@@ -4754,6 +4756,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889, upload-time = "2025-10-10T07:06:01.238Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/54/60eabb34445e3db3d3d874dc1dfa72751bfec3265bd611cb13c8b290adea/pytest_rerunfailures-16.1-py3-none-any.whl", hash = "sha256:5d11b12c0ca9a1665b5054052fcc1084f8deadd9328962745ef6b04e26382e86", size = 14093, upload-time = "2025-10-10T07:06:00.019Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Re-apply `cf49888`, which was reverted in `60c130a` without a stated reason. The revert removed the only safeguard against a pre-existing, undiagnosed intermittent hang in `python-tests (3.12)` → `Run integration tests`.

## Evidence the hang is real and ongoing

Pulled job metadata for the five most recent `cancelled` CI runs on `main`:

| run | python-tests duration | outcome |
|---|---|---|
| 24799157634 | **21900 s** | cancelled — hit GHA's 6h hard runner limit |
| 24772182742 | **21900 s** | cancelled — same |
| 24709546228 | **21900 s** | cancelled — same |
| 24679566763 | **21900 s** | cancelled — same |
| 24674945691 | **21901 s** | cancelled — same |

Unit tests complete in ~62 s; `Run integration tests` step never completes and GitHub force-kills the runner. Because the kill is ungraceful, GitHub never uploads the log blob — all five have `HTTP 404 BlobNotFound` for the job log, so we don't know which test hangs.

## Evidence this change is safe

On `cf49888` (when pytest-timeout was active) the single CI run we have logs for shows:

- `pytest-timeout==2.4.0` loaded
- `timeout: 300.0s`, `timeout method: thread`
- **45 passed, 60 deselected, 5 warnings in 29.42s** — no timeout fired, no test came near the 5-min cap
- Total python-tests job: 3m23s vs typical 3m on a clean run

`--timeout-method=thread` is compatible with `pytest-asyncio` (unlike `signal`) and emits a traceback from the stuck thread when it fires, so the next hang leaves a useful log.

## Diagnostic contract

This PR **is not** a fix for the underlying hang — root cause is still unknown. It converts a non-actionable 6-hour wedge into a 5-minute pytest failure with a stack trace naming the stuck test. The follow-up fix lands as a separate PR once the next hang produces that trace.

## Test plan

- [ ] CI on this branch passes
- [ ] Next main-branch CI run after merge completes in normal time (~3 min for python-tests)
- [ ] Wait for a future intermittent hang; it should now fail in ≤5 min with a traceback identifying the stuck test

🤖 Generated with [Claude Code](https://claude.com/claude-code)