### PR TITLE
fix(core): use fresh uuid4() for ingestion staging txn_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,316%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,317%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/core/src/memex_core/services/ingestion.py
+++ b/packages/core/src/memex_core/services/ingestion.py
@@ -11,7 +11,7 @@ import re
 import tempfile
 from datetime import date, datetime, timezone
 from typing import Any, AsyncGenerator
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import dspy
 import stamina
@@ -415,7 +415,10 @@ ingested_at: {now}
                 logger.info(f'Document {note_uuid} exists but content changed. Incremental update.')
 
         # 3. Open Transaction
-        async with AsyncTransaction(self.metastore, self.filestore, note_uuid) as txn:
+        # Staging txn_id must be unique per in-flight transaction, not derived from
+        # note_uuid — two concurrent ingests of the same content would collide on
+        # the filestore's _active_stages dict and clobber each other's temp paths.
+        async with AsyncTransaction(self.metastore, self.filestore, str(uuid4())) as txn:
             # 4. Stage Files (FS)
             asset_path = f'assets/{vault_name}/{note_uuid}'
             asset_files_list = []
@@ -603,7 +606,10 @@ ingested_at: {now}
         """
         from memex_core.api import inject_user_notes
 
-        chunk_txn_id = chunk[0][2]
+        # Staging txn_id must be unique per in-flight transaction; deriving it from
+        # the note UUID (the idempotency key) causes concurrent ingests of the same
+        # content to collide on the filestore's _active_stages dict.
+        chunk_txn_id = uuid4()
         processed_ids: list[str] = []
         _pending_contradictions: list = []
 

--- a/packages/core/tests/unit/test_api_batch.py
+++ b/packages/core/tests/unit/test_api_batch.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import uuid4, UUID
+from uuid import UUID, uuid4
 from memex_core.api import NoteInput
 from memex_common.schemas import NoteCreateDTO
 
@@ -130,3 +130,54 @@ async def test_ingest_batch_internal_resolves_title(
         retain_call = api.memory.retain.call_args
         retain_contents = retain_call[1]['contents']
         assert retain_contents[0].payload['note_name'] == 'Resolved Title From Content'
+
+
+@pytest.mark.asyncio
+async def test_process_chunk_uses_fresh_staging_txn_id(
+    api, mock_metastore, mock_filestore, mock_session
+):
+    """Regression: the staging txn_id must not be derived from the note UUID.
+
+    Two concurrent ingests of the same note content share an idempotency key (note UUID).
+    If the staging txn_id is derived from it, both transactions collide in the filestore's
+    process-wide _active_stages dict ("Staging transaction already active"). The txn_id must
+    be fresh per transaction, and must differ across two calls that ingest identical content.
+    """
+    vault_id = uuid4()
+    api._ingestion._vaults.resolve_vault_identifier = AsyncMock(return_value=vault_id)
+
+    note_dto = NoteCreateDTO(
+        name='Same content',
+        description='Same desc',
+        content='c2FtZS1ieXRlcw==',  # "same-bytes"
+    )
+    expected_note_uuid = UUID(NoteInput.calculate_idempotency_key_from_dto(note_dto))
+
+    captured_txn_ids: list[str] = []
+
+    def _capture_txn(metastore, filestore, txn_id):
+        captured_txn_ids.append(txn_id)
+        m = AsyncMock()
+        m.db_session = MagicMock()
+        m.__aenter__.return_value = m
+        return m
+
+    mock_vault = MagicMock()
+    mock_vault.name = 'test-vault'
+    mock_session.get.return_value = mock_vault
+    api.memory.retain = AsyncMock(return_value={'unit_ids': [uuid4()]})
+
+    with patch('memex_core.services.ingestion.AsyncTransaction', side_effect=_capture_txn):
+        async for _ in api.ingest_batch_internal(notes=[note_dto], vault_id=vault_id, batch_size=1):
+            pass
+        async for _ in api.ingest_batch_internal(notes=[note_dto], vault_id=vault_id, batch_size=1):
+            pass
+
+    assert len(captured_txn_ids) == 2, f'Expected 2 transactions, got {captured_txn_ids}'
+    assert captured_txn_ids[0] != captured_txn_ids[1], (
+        'Staging txn_id is identical across two ingests of the same content — '
+        'concurrent ingestions will collide in the filestore._active_stages dict.'
+    )
+    assert str(expected_note_uuid) not in captured_txn_ids, (
+        f'Staging txn_id must not be the note UUID {expected_note_uuid}; got {captured_txn_ids}.'
+    )


### PR DESCRIPTION
## Summary

- The staging `transaction_id` passed into `AsyncTransaction` was derived from the note's idempotency key (its UUID), so two concurrent ingests of the same content produced the same txn_id and collided in the filestore's process-wide `_active_stages` dict, raising \`Staging transaction 'X' is already active\`.
- The collision window is large in practice because the \`async with AsyncTransaction\` block wraps LLM fact extraction (\`memory.retain\` → page indexing / DSPy), which can hold the staging slot open for tens of seconds on large docs — plenty of time for a second batch request for the same note to arrive.
- Both call sites are fixed:
  - \`IngestionService.ingest\` (single-note path) — \`services/ingestion.py:418\`
  - \`IngestionService._process_chunk\` (batch path) — \`services/ingestion.py:606\`

The staging `transaction_id` is ephemeral (in-memory dict key + temp-file suffix `{key}.stage_{txn_id}`); it is not persisted, not used for crash recovery, and not referenced anywhere after `__aexit__`. Only requirement is *unique while active*, which `uuid4()` satisfies.

## Observed error

```
[error] Failed to begin file staging: Staging transaction '5e209192-718c-a919-a2fd-5b39a9bf6a03' is already active.
  File "packages/core/src/memex_core/storage/transaction.py", line 41, in __aenter__
    self.fs.begin_staging(self.txn_id)
  File "packages/core/src/memex_core/storage/filestore.py", line 121, in begin_staging
    raise ValueError(f'Staging transaction {transaction_id!r} is already active.')
```

## Test plan

- [x] \`just prek\` (ruff + mypy + format)
- [x] \`uv run pytest packages/core/tests/unit/test_api_batch.py packages/core/tests/unit/test_api_ingest_path.py packages/core/tests/unit/storage/test_transaction.py packages/core/tests/unit/storage/test_filestore.py\` → 88/88 passing including new regression \`test_process_chunk_uses_fresh_staging_txn_id\`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)