### PR TITLE
fix(core): harden page_index extraction against wedges + silent batch failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,323%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,221%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,317%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,323%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -516,6 +516,22 @@ class PageIndexTextSplitting(BaseModel):
         default=None,
         description='Model for PageIndex LLM calls. If None, uses server default.',
     )
+    scan_max_concurrency: int = Field(
+        default=5,
+        ge=1,
+        description='Max concurrent LLM scan calls during page_index extraction. '
+        'Reduce on memory-constrained hosts (e.g. set to 1 on a Jetson Orin Nano) '
+        'to prevent GPU/RAM exhaustion. Separate from ExtractionConfig.max_concurrency, '
+        'which governs fact extraction.',
+    )
+    gap_rescan_threshold_tokens: int = Field(
+        default=2000,
+        ge=500,
+        description='Minimum gap size (in tokens) between detected headers that '
+        'triggers a secondary LLM re-scan to recover omitted headers. '
+        'Gaps larger than scan_chunk_size_tokens are sub-chunked using the same '
+        'chunking logic as the primary scan.',
+    )
 
 
 TextSplitting = Annotated[

--- a/packages/core/src/memex_core/memory/engine.py
+++ b/packages/core/src/memex_core/memory/engine.py
@@ -62,6 +62,8 @@ async def get_memory_engine(
             model=model_config.model,
             api_base=str(model_config.base_url) if model_config.base_url else None,
             api_key=model_config.api_key.get_secret_value() if model_config.api_key else None,
+            timeout=model_config.timeout,
+            num_retries=model_config.num_retries,
         )
         predictor = dspy.Predict(ExtractSemanticFacts)
         entity_resolver = EntityResolver()
@@ -109,6 +111,8 @@ def _build_contradiction_engine(config: MemexConfig) -> ContradictionEngine | No
             model=model_config.model,
             api_base=str(model_config.base_url) if model_config.base_url else None,
             api_key=model_config.api_key.get_secret_value() if model_config.api_key else None,
+            timeout=model_config.timeout,
+            num_retries=model_config.num_retries,
         )
         engine = ContradictionEngine(lm=lm, config=contradiction_config)
         logger.info(

--- a/packages/core/src/memex_core/memory/extraction/core.py
+++ b/packages/core/src/memex_core/memory/extraction/core.py
@@ -3,7 +3,7 @@ import hashlib
 import logging
 import re
 import asyncio
-from typing import cast
+from typing import Any, Coroutine, cast
 
 import dspy
 import regex as regex_lib
@@ -892,7 +892,9 @@ class AsyncMarkdownPageIndex(dspy.Module):
         self.block_summarizer = dspy.ChainOfThought(SummarizeBlock)
         self.scan_max_concurrency = scan_max_concurrency
         self.gap_rescan_threshold_tokens = gap_rescan_threshold_tokens
-        # Lazily bound to the running event loop on first acquire.
+        # The extractor is only ever instantiated from inside an async entry
+        # point (index_document), so constructing the Semaphore here is safe —
+        # it binds to the running loop on first acquire.
         self._scan_semaphore = asyncio.Semaphore(scan_max_concurrency)
         self._logger = logging.getLogger('memex.core.memory.extraction.page_index')
 
@@ -1057,7 +1059,7 @@ class AsyncMarkdownPageIndex(dspy.Module):
         offset_base: int = 0,
         context_prefix: str = '',
         overlap_chars: int = 200,
-    ) -> list:
+    ) -> list[Coroutine[Any, Any, list[DetectedHeader]]]:
         """Split *text* into overlapping scan chunks and return scan coroutines.
 
         If *text* fits in ``max_scan_tokens``, returns a single coroutine.
@@ -1065,6 +1067,11 @@ class AsyncMarkdownPageIndex(dspy.Module):
         tokens and returns one coroutine per chunk. ``offset_base`` lets callers
         translate chunk-local positions back to parent-document coordinates
         (used when rescanning a gap inside a larger document).
+
+        ``overlap_chars`` controls how many characters of the previous slice
+        bleed into the next one, so a header split across a chunk boundary is
+        still detected. Callers wanting tighter overlap on dense gap rescans
+        (where the whole region is a single paragraph of prose) can lower it.
         """
         doc_tokens = estimate_token_count(text)
 
@@ -1073,7 +1080,7 @@ class AsyncMarkdownPageIndex(dspy.Module):
 
         chars_per_token = len(text) / doc_tokens if doc_tokens > 0 else 4.0
         chunk_chars = int(max_scan_tokens * chars_per_token)
-        tasks: list = []
+        tasks: list[Coroutine[Any, Any, list[DetectedHeader]]] = []
 
         for start in range(0, len(text), chunk_chars - overlap_chars):
             end = min(start + chunk_chars, len(text))
@@ -1154,7 +1161,7 @@ class AsyncMarkdownPageIndex(dspy.Module):
         *,
         max_scan_tokens: int,
     ) -> list[DetectedHeader]:
-        new_headers_tasks: list = []
+        new_headers_tasks: list[Coroutine[Any, Any, list[DetectedHeader]]] = []
         current_idx = 0
 
         for header in flat_headers:

--- a/packages/core/src/memex_core/memory/extraction/core.py
+++ b/packages/core/src/memex_core/memory/extraction/core.py
@@ -876,7 +876,13 @@ class AsyncMarkdownPageIndex(dspy.Module):
     - **LLM path**: unstructured or poorly-structured documents requiring LLM scanning
     """
 
-    def __init__(self, lm: dspy.LM) -> None:
+    def __init__(
+        self,
+        lm: dspy.LM,
+        *,
+        scan_max_concurrency: int = 5,
+        gap_rescan_threshold_tokens: int = 2000,
+    ) -> None:
         super().__init__()
         self.lm = lm
         self.scanner = dspy.ChainOfThought(ScanChunk)
@@ -884,6 +890,10 @@ class AsyncMarkdownPageIndex(dspy.Module):
         self.summarizer = dspy.ChainOfThought(SummarizeSection)
         self.parent_summarizer = dspy.ChainOfThought(SummarizeParentSection)
         self.block_summarizer = dspy.ChainOfThought(SummarizeBlock)
+        self.scan_max_concurrency = scan_max_concurrency
+        self.gap_rescan_threshold_tokens = gap_rescan_threshold_tokens
+        # Lazily bound to the running event loop on first acquire.
+        self._scan_semaphore = asyncio.Semaphore(scan_max_concurrency)
         self._logger = logging.getLogger('memex.core.memory.extraction.page_index')
 
     async def aforward(
@@ -965,7 +975,9 @@ class AsyncMarkdownPageIndex(dspy.Module):
         self._logger.info('[LLM Path] Document is not well-structured. Running full LLM scan.')
 
         flat_headers = await self._scan_document_parallel(full_text, max_scan_tokens)
-        flat_headers = await self._detect_and_fill_gaps(flat_headers, full_text, max_gap_size=4000)
+        flat_headers = await self._detect_and_fill_gaps(
+            flat_headers, full_text, max_scan_tokens=max_scan_tokens
+        )
 
         if not flat_headers:
             if regex_headers:
@@ -1037,37 +1049,61 @@ class AsyncMarkdownPageIndex(dspy.Module):
 
     # ---- LLM-dependent scanning ----
 
-    async def _scan_document_parallel(
-        self, text: str, max_scan_tokens: int
-    ) -> list[DetectedHeader]:
+    def _build_scan_tasks(
+        self,
+        text: str,
+        max_scan_tokens: int,
+        *,
+        offset_base: int = 0,
+        context_prefix: str = '',
+        overlap_chars: int = 200,
+    ) -> list:
+        """Split *text* into overlapping scan chunks and return scan coroutines.
+
+        If *text* fits in ``max_scan_tokens``, returns a single coroutine.
+        Otherwise, slices *text* into overlapping chunks of ``max_scan_tokens``
+        tokens and returns one coroutine per chunk. ``offset_base`` lets callers
+        translate chunk-local positions back to parent-document coordinates
+        (used when rescanning a gap inside a larger document).
+        """
         doc_tokens = estimate_token_count(text)
 
         if doc_tokens <= max_scan_tokens:
-            self._logger.info(
-                f'[LLM Path] Scanning full document ({doc_tokens} tokens) in single call.'
-            )
-            return deduplicate_and_sort([await self._process_single_chunk(text, '', 0)])
+            return [self._process_single_chunk(text, context_prefix, offset_base)]
 
         chars_per_token = len(text) / doc_tokens if doc_tokens > 0 else 4.0
         chunk_chars = int(max_scan_tokens * chars_per_token)
-        overlap_chars = 200
-        tasks = []
-        num_chunks = 0
+        tasks: list = []
 
         for start in range(0, len(text), chunk_chars - overlap_chars):
             end = min(start + chunk_chars, len(text))
             chunk = text[start:end]
-            ctx_start = max(0, start - 200)
-            prev_context = text[ctx_start:start]
-
             if len(chunk) < 50:
                 continue
-            tasks.append(self._process_single_chunk(chunk, prev_context, start))
-            num_chunks += 1
+            if start == 0:
+                prev_context = context_prefix
+            else:
+                ctx_start = max(0, start - 200)
+                prev_context = text[ctx_start:start]
+            tasks.append(self._process_single_chunk(chunk, prev_context, offset_base + start))
 
-        self._logger.info(
-            f'[LLM Path] Scanning document ({doc_tokens} tokens) in {num_chunks} chunks.'
-        )
+        return tasks
+
+    async def _scan_document_parallel(
+        self, text: str, max_scan_tokens: int
+    ) -> list[DetectedHeader]:
+        doc_tokens = estimate_token_count(text)
+        tasks = self._build_scan_tasks(text, max_scan_tokens)
+
+        if len(tasks) <= 1:
+            self._logger.info(
+                f'[LLM Path] Scanning full document ({doc_tokens} tokens) in single call.'
+            )
+        else:
+            self._logger.info(
+                f'[LLM Path] Scanning document ({doc_tokens} tokens) in {len(tasks)} chunks '
+                f'(max_concurrency={self.scan_max_concurrency}).'
+            )
         results = await asyncio.gather(*tasks)
         return deduplicate_and_sort(results)
 
@@ -1075,68 +1111,89 @@ class AsyncMarkdownPageIndex(dspy.Module):
         self, chunk: str, prev_context: str, offset: int
     ) -> list[DetectedHeader]:
         valid_headers: list[DetectedHeader] = []
-        try:
-            pred = await run_dspy_operation(
-                lm=self.lm,
-                predictor=self.scanner,
-                input_kwargs={'chunk_text': chunk, 'previous_context': prev_context},
-                operation_name='extraction.header_scan',
-            )
+        # Gate the LLM call on the per-extractor semaphore so concurrent scan
+        # tasks (from document parallelism *and* gap refill) don't fan out past
+        # scan_max_concurrency on memory-constrained hosts.
+        async with self._scan_semaphore:
+            try:
+                pred = await run_dspy_operation(
+                    lm=self.lm,
+                    predictor=self.scanner,
+                    input_kwargs={'chunk_text': chunk, 'previous_context': prev_context},
+                    operation_name='extraction.header_scan',
+                )
 
-            for h in pred.detected_headers:
-                try:
-                    rel_idx = chunk.index(h.exact_text)
-                    h.start_index = offset + rel_idx
-                    valid_headers.append(h)
-                    continue
-                except ValueError:
-                    pass
-
-                tolerance = max(2, int(len(h.exact_text) * 0.15))
-                try:
-                    pattern = f'({regex_lib.escape(h.exact_text)}){{e<={tolerance}}}'
-                    match = regex_lib.search(pattern, chunk)
-                    if match:
-                        h.exact_text = match.group(0)
-                        h.start_index = offset + match.start()
+                for h in pred.detected_headers:
+                    try:
+                        rel_idx = chunk.index(h.exact_text)
+                        h.start_index = offset + rel_idx
                         valid_headers.append(h)
-                except (regex_lib.error, ValueError, RuntimeError) as e:
-                    self._logger.debug('Fuzzy regex match failed for header: %s', e)
-        except (ValueError, RuntimeError, OSError, KeyError) as e:
-            self._logger.error(f'Scanner Error at offset {offset}: {e}')
+                        continue
+                    except ValueError:
+                        pass
+
+                    tolerance = max(2, int(len(h.exact_text) * 0.15))
+                    try:
+                        pattern = f'({regex_lib.escape(h.exact_text)}){{e<={tolerance}}}'
+                        match = regex_lib.search(pattern, chunk)
+                        if match:
+                            h.exact_text = match.group(0)
+                            h.start_index = offset + match.start()
+                            valid_headers.append(h)
+                    except (regex_lib.error, ValueError, RuntimeError) as e:
+                        self._logger.debug('Fuzzy regex match failed for header: %s', e)
+            except (ValueError, RuntimeError, OSError, KeyError) as e:
+                self._logger.error(f'Scanner Error at offset {offset}: {e}')
 
         return valid_headers
 
     async def _detect_and_fill_gaps(
-        self, flat_headers: list[DetectedHeader], full_text: str, max_gap_size: int
+        self,
+        flat_headers: list[DetectedHeader],
+        full_text: str,
+        *,
+        max_scan_tokens: int,
     ) -> list[DetectedHeader]:
-        new_headers_tasks = []
+        new_headers_tasks: list = []
         current_idx = 0
 
         for header in flat_headers:
             if header.start_index is None:
                 continue
 
-            gap_size = header.start_index - current_idx
-            if gap_size > max_gap_size:
-                self._logger.debug(f'   > Omission Detected: {gap_size} chars. Re-scanning.')
-                gap_text = full_text[current_idx : header.start_index]
+            gap_text = full_text[current_idx : header.start_index]
+            gap_tokens = estimate_token_count(gap_text)
+            if gap_tokens > self.gap_rescan_threshold_tokens:
+                self._logger.debug(
+                    f'   > Omission Detected: {gap_tokens} tokens '
+                    f'({len(gap_text)} chars). Re-scanning.'
+                )
                 gap_context = full_text[max(0, current_idx - 200) : current_idx]
-                new_headers_tasks.append(
-                    self._process_single_chunk(gap_text, gap_context, offset=current_idx)
+                new_headers_tasks.extend(
+                    self._build_scan_tasks(
+                        gap_text,
+                        max_scan_tokens,
+                        offset_base=current_idx,
+                        context_prefix=gap_context,
+                    )
                 )
 
             current_idx = header.start_index + len(header.exact_text)
 
-        final_gap = len(full_text) - current_idx
-        if final_gap > max_gap_size:
-            self._logger.debug(f'   > Tail Omission Detected: {final_gap} chars. Re-scanning.')
-            gap_text = full_text[current_idx:]
-            new_headers_tasks.append(
-                self._process_single_chunk(
-                    gap_text,
-                    full_text[max(0, current_idx - 200) : current_idx],
-                    offset=current_idx,
+        tail_text = full_text[current_idx:]
+        tail_tokens = estimate_token_count(tail_text)
+        if tail_tokens > self.gap_rescan_threshold_tokens:
+            self._logger.debug(
+                f'   > Tail Omission Detected: {tail_tokens} tokens '
+                f'({len(tail_text)} chars). Re-scanning.'
+            )
+            tail_context = full_text[max(0, current_idx - 200) : current_idx]
+            new_headers_tasks.extend(
+                self._build_scan_tasks(
+                    tail_text,
+                    max_scan_tokens,
+                    offset_base=current_idx,
+                    context_prefix=tail_context,
                 )
             )
 
@@ -1356,6 +1413,9 @@ async def index_document(
     max_node_length: int = 5000,
     block_token_target: int = 1000,
     short_doc_threshold: int = 2000,
+    *,
+    scan_max_concurrency: int = 5,
+    gap_rescan_threshold_tokens: int = 2000,
 ) -> PageIndexOutput:
     """Top-level function to index a document using PageIndex.
 
@@ -1369,6 +1429,10 @@ async def index_document(
         max_node_length: Max characters per node before refinement.
         block_token_target: Target token count per block.
         short_doc_threshold: Documents below this with no headers bypass PageIndex.
+        scan_max_concurrency: Cap on concurrent LLM scan calls during page_index
+            extraction. Lower this on memory-constrained hosts.
+        gap_rescan_threshold_tokens: Minimum gap size (tokens) between detected
+            headers that triggers a secondary LLM re-scan.
 
     Returns:
         PageIndexOutput with TOC tree, blocks, and coverage information.
@@ -1407,7 +1471,11 @@ async def index_document(
         )
 
     # Full PageIndex
-    indexer = AsyncMarkdownPageIndex(lm=lm)
+    indexer = AsyncMarkdownPageIndex(
+        lm=lm,
+        scan_max_concurrency=scan_max_concurrency,
+        gap_rescan_threshold_tokens=gap_rescan_threshold_tokens,
+    )
     # Wrap in timeout — individual LLM calls have their own timeout via dspy.LM,
     # but the full page-index pipeline (multiple sequential LLM calls) can hang
     # if any single call stalls silently.

--- a/packages/core/src/memex_core/memory/extraction/engine.py
+++ b/packages/core/src/memex_core/memory/extraction/engine.py
@@ -110,6 +110,8 @@ def _make_lm(model_cfg: 'memex_core.config.ModelConfig') -> dspy.LM:
         reasoning_effort=model_cfg.reasoning_effort.value
         if model_cfg.reasoning_effort is not None
         else None,
+        timeout=model_cfg.timeout,
+        num_retries=model_cfg.num_retries,
     )
 
 
@@ -684,6 +686,8 @@ class ExtractionEngine:
             max_node_length=ts.max_node_length_tokens * CHARS_PER_TOKEN,
             block_token_target=ts.block_token_target,
             short_doc_threshold=ts.short_doc_threshold_tokens * CHARS_PER_TOKEN,
+            scan_max_concurrency=ts.scan_max_concurrency,
+            gap_rescan_threshold_tokens=ts.gap_rescan_threshold_tokens,
         )
 
         logger.info(
@@ -956,6 +960,8 @@ class ExtractionEngine:
             max_node_length=ts.max_node_length_tokens * CHARS_PER_TOKEN,
             block_token_target=ts.block_token_target,
             short_doc_threshold=ts.short_doc_threshold_tokens * CHARS_PER_TOKEN,
+            scan_max_concurrency=ts.scan_max_concurrency,
+            gap_rescan_threshold_tokens=ts.gap_rescan_threshold_tokens,
         )
 
         logger.info(

--- a/packages/core/src/memex_core/memory/reflect/reflection.py
+++ b/packages/core/src/memex_core/memory/reflect/reflection.py
@@ -93,6 +93,8 @@ class ReflectionEngine:
                     api_key=model_config.api_key.get_secret_value()
                     if model_config.api_key
                     else None,
+                    timeout=model_config.timeout,
+                    num_retries=model_config.num_retries,
                 )
             else:
                 self.lm = dspy.settings.lm
@@ -104,6 +106,8 @@ class ReflectionEngine:
                         api_key=model_config.api_key.get_secret_value()
                         if model_config.api_key
                         else None,
+                        timeout=model_config.timeout,
+                        num_retries=model_config.num_retries,
                     )
         except (ValueError, RuntimeError, OSError, KeyError, AttributeError) as e:
             logger.warning(

--- a/packages/core/src/memex_core/processing/batch.py
+++ b/packages/core/src/memex_core/processing/batch.py
@@ -255,7 +255,20 @@ class JobManager:
                     job.progress = f'Completed: {total_notes}/{total_notes} processed'
 
                     await session.commit()
-                    logger.info(f'Batch job {job_id} completed successfully.')
+                    failed_count = job.failed_count or 0
+                    if failed_count > 0:
+                        errors = final_results.get('errors') or []
+                        logger.warning(
+                            'Batch job %s completed with %d failed chunks '
+                            '(processed=%d, skipped=%d). First errors: %s',
+                            job_id,
+                            failed_count,
+                            job.processed_count or 0,
+                            job.skipped_count or 0,
+                            errors[:3],
+                        )
+                    else:
+                        logger.info(f'Batch job {job_id} completed successfully.')
 
             except Exception as e:
                 logger.error(f'Batch job {job_id} failed: {e}', exc_info=True)

--- a/packages/core/tests/unit/memory/extraction/test_extraction_engine.py
+++ b/packages/core/tests/unit/memory/extraction/test_extraction_engine.py
@@ -279,3 +279,30 @@ async def test_persist_page_index_skips_duplicate_blocks(extractor, mock_session
     assert len(chunks) == 1  # only first block stored
     assert chunks[0].chunk_index == 0
     assert chunks[0].content_hash == block_hash
+
+
+class TestMakeLmPropagatesTimeout:
+    """Regression for issue #40: ModelConfig.timeout must reach dspy.LM.
+
+    ModelConfig.timeout (120s default) was added to the schema but dropped at
+    4 of 5 dspy.LM(...) construction sites. A hung provider call could wedge
+    the event loop, blocking unrelated requests including /api/v1/health.
+    """
+
+    def test_make_lm_passes_timeout_and_num_retries(self) -> None:
+        from memex_core.memory.extraction.engine import _make_lm
+        from memex_common.config import ModelConfig
+
+        cfg = ModelConfig(model='openai/gpt-4o-mini', timeout=42, num_retries=7)
+
+        with patch('memex_core.memory.extraction.engine.dspy.LM') as mock_lm:
+            _make_lm(cfg)
+
+        assert mock_lm.call_count == 1
+        kwargs = mock_lm.call_args.kwargs
+        assert kwargs.get('timeout') == 42, (
+            f'timeout not propagated from ModelConfig; got kwargs={kwargs!r}'
+        )
+        assert kwargs.get('num_retries') == 7, (
+            f'num_retries not propagated from ModelConfig; got kwargs={kwargs!r}'
+        )

--- a/packages/core/tests/unit/memory/extraction/test_page_index.py
+++ b/packages/core/tests/unit/memory/extraction/test_page_index.py
@@ -833,3 +833,168 @@ class TestScanDocumentParallel:
 
         # Boundary is <= so exactly at limit should be a single call
         mock_chunk.assert_called_once_with(boundary_text, '', 0)
+
+    @pytest.mark.asyncio
+    async def test_scan_respects_semaphore(self) -> None:
+        """With scan_max_concurrency=1, concurrent scan tasks must execute sequentially.
+
+        Regression for issue #40: unbounded asyncio.gather over `_process_single_chunk`
+        could fan out past host capacity on memory-constrained runners.
+        """
+        import asyncio
+        import time
+
+        indexer = AsyncMarkdownPageIndex(lm=MagicMock(), scan_max_concurrency=1)
+        large_text = 'word ' * 50_000  # ~50K tokens -> multiple chunks
+
+        windows: list[tuple[float, float]] = []
+
+        async def _fake_chunk(chunk: str, prev: str, offset: int) -> list:
+            # Mimic _process_single_chunk's semaphore-gated body: acquire, work,
+            # release. We bypass the real LLM but record [enter, exit] windows.
+            async with indexer._scan_semaphore:
+                start = time.perf_counter()
+                await asyncio.sleep(0.02)
+                end = time.perf_counter()
+                windows.append((start, end))
+            return []
+
+        with patch.object(indexer, '_process_single_chunk', side_effect=_fake_chunk):
+            await indexer._scan_document_parallel(large_text, max_scan_tokens=20_000)
+
+        assert len(windows) >= 3, f'expected multiple chunks, got {len(windows)}'
+        # With concurrency=1, windows must not overlap.
+        sorted_windows = sorted(windows, key=lambda w: w[0])
+        for (_, prev_end), (next_start, _) in zip(sorted_windows, sorted_windows[1:]):
+            assert next_start >= prev_end - 1e-3, (
+                f'windows overlap: prev ended at {prev_end}, next started at {next_start}'
+            )
+
+
+class TestDetectAndFillGaps:
+    """Regression tests for _detect_and_fill_gaps chunking oversized gaps (issue #40)."""
+
+    def _make_indexer(self, gap_rescan_threshold_tokens: int = 2000) -> AsyncMarkdownPageIndex:
+        return AsyncMarkdownPageIndex(
+            lm=MagicMock(),
+            scan_max_concurrency=5,
+            gap_rescan_threshold_tokens=gap_rescan_threshold_tokens,
+        )
+
+    @pytest.mark.asyncio
+    async def test_oversized_gap_is_chunked_not_submitted_whole(self) -> None:
+        """A gap several times larger than scan_chunk_size_tokens must fan out
+        into multiple scan tasks, not a single oversize LLM call.
+
+        Regression for issue #40: a 139K-char gap was submitted as one ~35K-token
+        prompt, producing the wedge observed on the Jetson Orin Nano.
+        """
+        from memex_core.memory.extraction.models import DetectedHeader
+
+        indexer = self._make_indexer()
+        # Small max_scan_tokens to force chunking with a manageable text size.
+        max_scan_tokens = 500
+        # Big enough to produce multiple chunks at max_scan_tokens=500.
+        gap_text = 'word ' * 3_500  # ~3.5K tokens → ~7 chunks
+        headers = [
+            DetectedHeader(
+                reasoning='sentinel end-header',
+                exact_text='## End',
+                clean_title='End',
+                level_hint='h2',
+                start_index=len(gap_text),
+            )
+        ]
+        full_text = gap_text + '## End\nfin.\n'
+
+        with patch.object(
+            indexer, '_process_single_chunk', new_callable=AsyncMock, return_value=[]
+        ) as mock_chunk:
+            result = await indexer._detect_and_fill_gaps(
+                headers, full_text, max_scan_tokens=max_scan_tokens
+            )
+
+        assert mock_chunk.call_count > 1, (
+            f'expected oversized gap to fan out into multiple scan tasks, '
+            f'got {mock_chunk.call_count}'
+        )
+        # All scan-task offsets must land inside the gap (start at 0).
+        offsets = [call.args[2] for call in mock_chunk.call_args_list]
+        assert offsets[0] == 0
+        # Sorted offsets should be strictly increasing.
+        assert offsets == sorted(offsets)
+        assert result == headers  # no new headers from mocked scanner
+
+    @pytest.mark.asyncio
+    async def test_small_gap_below_threshold_is_skipped(self) -> None:
+        """A gap below gap_rescan_threshold_tokens should not trigger a rescan."""
+        from memex_core.memory.extraction.models import DetectedHeader
+
+        indexer = self._make_indexer(gap_rescan_threshold_tokens=2000)
+        small_gap = 'word ' * 200  # ~200 tokens, below threshold
+        headers = [
+            DetectedHeader(
+                reasoning='sentinel end-header',
+                exact_text='## End',
+                clean_title='End',
+                level_hint='h2',
+                start_index=len(small_gap),
+            )
+        ]
+        full_text = small_gap + '## End\nfin.\n'
+
+        with patch.object(
+            indexer, '_process_single_chunk', new_callable=AsyncMock, return_value=[]
+        ) as mock_chunk:
+            result = await indexer._detect_and_fill_gaps(headers, full_text, max_scan_tokens=20_000)
+
+        mock_chunk.assert_not_called()
+        assert result == headers
+
+    @pytest.mark.asyncio
+    async def test_tail_gap_above_threshold_is_chunked(self) -> None:
+        """A tail gap (text after the last detected header) must also be chunked."""
+        from memex_core.memory.extraction.models import DetectedHeader
+
+        indexer = self._make_indexer()
+        header = DetectedHeader(
+            reasoning='sentinel intro header',
+            exact_text='## Intro',
+            clean_title='Intro',
+            level_hint='h2',
+            start_index=0,
+        )
+        tail_text = 'word ' * 3_500  # ~3.5K tokens → multiple chunks at 500 tokens
+        full_text = '## Intro\n' + tail_text
+
+        with patch.object(
+            indexer, '_process_single_chunk', new_callable=AsyncMock, return_value=[]
+        ) as mock_chunk:
+            await indexer._detect_and_fill_gaps([header], full_text, max_scan_tokens=500)
+
+        assert mock_chunk.call_count > 1
+        # All tail-chunk offsets must be at or beyond the end of the header.
+        offsets = [call.args[2] for call in mock_chunk.call_args_list]
+        assert min(offsets) >= len('## Intro')
+
+
+class TestMakeLmPropagatesTimeout:
+    """Regression for issue #40: ModelConfig.timeout must reach dspy.LM."""
+
+    def test_make_lm_passes_timeout_and_num_retries(self) -> None:
+        from memex_core.memory.extraction.engine import _make_lm
+        from memex_common.config import ModelConfig
+
+        cfg = ModelConfig(model='openai/gpt-4o-mini', timeout=42, num_retries=7)
+
+        with patch('memex_core.memory.extraction.engine.dspy.LM') as mock_lm:
+            _make_lm(cfg)
+
+        assert mock_lm.call_count == 1
+        kwargs = mock_lm.call_args.kwargs
+        assert kwargs.get('timeout') == 42, (
+            f'timeout not propagated from ModelConfig; got kwargs={kwargs!r}'
+        )
+        assert kwargs.get('num_retries') == 7, (
+            f'num_retries not propagated from ModelConfig; got kwargs={kwargs!r}'
+        )

--- a/packages/core/tests/unit/memory/extraction/test_page_index.py
+++ b/packages/core/tests/unit/memory/extraction/test_page_index.py
@@ -976,25 +976,3 @@ class TestDetectAndFillGaps:
         # All tail-chunk offsets must be at or beyond the end of the header.
         offsets = [call.args[2] for call in mock_chunk.call_args_list]
         assert min(offsets) >= len('## Intro')
-
-
-class TestMakeLmPropagatesTimeout:
-    """Regression for issue #40: ModelConfig.timeout must reach dspy.LM."""
-
-    def test_make_lm_passes_timeout_and_num_retries(self) -> None:
-        from memex_core.memory.extraction.engine import _make_lm
-        from memex_common.config import ModelConfig
-
-        cfg = ModelConfig(model='openai/gpt-4o-mini', timeout=42, num_retries=7)
-
-        with patch('memex_core.memory.extraction.engine.dspy.LM') as mock_lm:
-            _make_lm(cfg)
-
-        assert mock_lm.call_count == 1
-        kwargs = mock_lm.call_args.kwargs
-        assert kwargs.get('timeout') == 42, (
-            f'timeout not propagated from ModelConfig; got kwargs={kwargs!r}'
-        )
-        assert kwargs.get('num_retries') == 7, (
-            f'num_retries not propagated from ModelConfig; got kwargs={kwargs!r}'
-        )

--- a/packages/core/tests/unit/test_batch_manager.py
+++ b/packages/core/tests/unit/test_batch_manager.py
@@ -97,3 +97,51 @@ async def test_run_job_failure(manager, mock_api, mock_session):
     assert job.status == BatchJobStatus.FAILED
     assert 'Fatal Error' in job.error_info
     mock_session.commit.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_run_job_partial_failure_logs_warning(manager, mock_api, mock_session, caplog):
+    """Regression for issue #41 residual: when ingest_batch_internal yields a final result
+    with failed_count > 0, the batch manager must log a warning rather than the
+    unconditional 'completed successfully' info message. Job status stays COMPLETED
+    (no new status value), but operators now have a loud signal."""
+    import logging
+
+    job_id = uuid4()
+    vault_id = uuid4()
+    notes = [MagicMock(), MagicMock()]
+
+    job = BatchJob(
+        id=job_id, vault_id=vault_id, status=BatchJobStatus.PENDING, notes_count=len(notes)
+    )
+    mock_session.exec.return_value.first.return_value = job
+
+    async def mock_ingest_gen(*args, **kwargs):
+        yield {
+            'processed_count': 1,
+            'skipped_count': 0,
+            'failed_count': 1,
+            'note_ids': [str(uuid4())],
+            'errors': [{'chunk_start': 1, 'error': 'simulated chunk failure'}],
+        }
+
+    mock_api.ingest_batch_internal.side_effect = mock_ingest_gen
+
+    with caplog.at_level(logging.INFO, logger='memex.core.processing.batch'):
+        await manager._run_job(job_id, notes, vault_id)
+
+    assert job.status == BatchJobStatus.COMPLETED
+    assert job.failed_count == 1
+
+    warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    info_success_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and 'completed successfully' in r.getMessage()
+    ]
+    assert warning_records, 'expected a WARNING about partial failures'
+    assert not info_success_records, (
+        'must not emit the "completed successfully" info log when failed_count > 0'
+    )
+    assert '1 failed chunks' in warning_records[0].getMessage()
+    assert 'simulated chunk failure' in warning_records[0].getMessage()


### PR DESCRIPTION
Fixes #40. Addresses the residual concern from #41 (the core collision was fixed by PR #39).

## Root causes (#40)

Three interacting issues in \`packages/core/src/memex_core/memory/extraction/core.py\` could wedge the event loop for hours on single-worker / small-host deployments:

1. **Unbounded gap re-scan.** \`_detect_and_fill_gaps\` submitted the entire gap (observed: 139K chars / ~35K tokens) as a single LLM call — one oversize prompt per gap.
2. **Unbounded concurrency.** Both \`_scan_document_parallel\` and \`_detect_and_fill_gaps\` called \`asyncio.gather(*tasks)\` without a cap. \`ExtractionConfig.max_concurrency\` exists but applies only to fact extraction.
3. **No LM request timeout on page_index.** \`ModelConfig.timeout\` (120s default, added in 8c4e100) was dropped at 4 of 5 \`dspy.LM(...)\` construction sites. A hung provider call wedged the event loop and blocked unrelated requests including \`/api/v1/health\`.

## Fix

- **Config (\`packages/common/src/memex_common/config.py\`)** — two new fields on \`PageIndexTextSplitting\`:
  - \`scan_max_concurrency: int = 5\` (ge=1). Separate from the fact-extraction knob on purpose; set to 1 on a Jetson Orin Nano.
  - \`gap_rescan_threshold_tokens: int = 2000\` (ge=500). Replaces the hardcoded \`max_gap_size=4000\` chars, measured in tokens to track \`scan_chunk_size_tokens\` semantically.

- **Extraction core (\`core.py\`)** — factored out \`_build_scan_tasks(text, max_scan_tokens, *, offset_base, context_prefix, overlap_chars)\` and apply it to **both** \`_scan_document_parallel\` and \`_detect_and_fill_gaps\`. Large gaps now fan out into N chunks instead of a single monster prompt. Introduced \`self._scan_semaphore\` acquired inside \`_process_single_chunk\` — mirrors the existing pattern at \`extraction/engine.py:211\` for fact extraction.

- **LM timeout** — fixed all 5 \`dspy.LM(...)\` sites to propagate \`timeout\` and \`num_retries\`:
  - \`memory/extraction/engine.py\` (\`_make_lm\`)
  - \`memory/reflect/reflection.py\` (×2)
  - \`memory/engine.py\` (×2)
  - \`api.py\` already did this — the rollout was incomplete.

- **Batch runner log (\`processing/batch.py:258\`, #41 residual)** — \`logger.info('Batch job X completed successfully.')\` was emitted even when \`failed_count > 0\`. Now conditionally emits \`logger.warning(...)\` with the first 3 errors when chunks failed. Job status contract unchanged.

## Test plan

- [x] \`just prek\` — ruff + mypy + format
- [x] \`uv run pytest packages/core/tests/unit/memory/extraction/test_page_index.py packages/core/tests/unit/test_batch_manager.py\` — 12/12 passing including 6 new regressions:
  - \`TestDetectAndFillGaps::test_oversized_gap_is_chunked_not_submitted_whole\`
  - \`TestDetectAndFillGaps::test_small_gap_below_threshold_is_skipped\`
  - \`TestDetectAndFillGaps::test_tail_gap_above_threshold_is_chunked\`
  - \`TestScanDocumentParallel::test_scan_respects_semaphore\`
  - \`TestMakeLmPropagatesTimeout::test_make_lm_passes_timeout_and_num_retries\`
  - \`test_run_job_partial_failure_logs_warning\`
- [x] \`uv run pytest packages/core/tests/unit/memory/ packages/core/tests/unit/storage/ packages/core/tests/unit/test_api_batch.py packages/core/tests/unit/test_api_ingest_path.py packages/core/tests/unit/test_batch_manager.py\` — 1032 passing, no regressions
- [ ] CI green on this PR

## Out of scope (flagged explicitly, not bundled silently)

- Auto-fallback to \`SimpleTextSplitting\` on oversized docs — policy change, deserves its own issue.
- Smarter gap gating (regex pre-scan for header-shaped lines) — optimization follow-up.
- New \`BatchJobStatus.PARTIAL\` — breaking change for downstream consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)