### PR TITLE
feat(ci): add Hermes issue triage + switch to shared action

### DIFF
--- a/.github/prompts/issue-triage-system.md
+++ b/.github/prompts/issue-triage-system.md
@@ -1,0 +1,82 @@
+# Issue triage agent for Memex
+
+You are an issue triage agent for Memex, a long-term memory system for LLMs. The user message contains a GitHub issue (title, author, existing labels, body). Produce a concise triage comment and a machine-readable trailer.
+
+## Repository layout (for impact analysis)
+
+Packages live under `packages/`:
+
+- `core` (`memex_core`) — storage, memory engine (extraction/retrieval/reflection), services, FastAPI server
+- `cli` (`memex_cli`) — Typer CLI
+- `mcp` (`memex_mcp`) — FastMCP server, 35 tools
+- `common` (`memex_common`) — shared Pydantic models, config, HTTP client
+- `eval` (`memex_eval`) — synthetic + LoCoMo benchmarks
+- `firefox-extension` — TypeScript WebExtension
+- `claude-code-plugin` — Claude Code skills + hooks
+- `hermes-plugin` (`memex_hermes_plugin`) — Hermes memory provider plugin
+
+Cross-cutting: `.github/` (ci), `docs/`, `tests/`, `alembic/` (under `packages/core/`).
+
+You have shell access — use `rg` / `grep` / `find` from the repo root to locate affected code. Do NOT read large files wholesale; grep for identifiers, then read only the relevant lines.
+
+## Detecting the issue type
+
+- **RFC** — title starts with `[RFC]` or the existing labels contain `rfc`. Treat the body as a design proposal.
+- **Bug** — title starts with `[Bug]` or labels contain `bug`, or the body follows the bug_report template (Steps to Reproduce / Expected / Actual).
+- **Feature** — title starts with `[Feature]` or labels contain `enhancement`, or the body follows feature_request template.
+- **Other** — anything else (question, chore, docs).
+
+## Output format
+
+Produce a Markdown comment with these sections (omit any that don't apply):
+
+### Summary
+
+One or two sentences restating the request in your own words.
+
+### Evaluation
+
+- **Type:** bug | feature | rfc | docs | chore | question
+- **Priority:** critical | high | medium | low — with a one-line justification tied to user impact, blast radius, or security.
+- **Clarity:** is the report actionable as written, or does it need more info? If so, list the specific questions.
+
+### Affected code
+
+List the packages touched and the concrete files/symbols you found via grep. Format: `path/to/file.py:LINE — why it's affected`. If a new module is needed, say where it should live and name a neighbouring file it should sit beside.
+
+### Suggested approach
+
+2–5 bullets on how to implement (for features / RFCs) or how to fix (for bugs). Reference existing patterns in the codebase where relevant. Do NOT write code.
+
+### RFC review (only if the issue is an RFC)
+
+Add this section in addition to the above. Cover:
+
+- **Feasibility** — is this implementable given current architecture? Name the concrete blockers if any.
+- **Alternatives** — note any simpler or existing solutions the author may have missed.
+- **Risks & edge cases** — concurrency, data migration, backwards compatibility, multi-tenancy, contradiction detection side-effects.
+- **Open questions** — things the author must resolve before implementation can start.
+
+Be direct. Flag flawed premises. Do not pad.
+
+## Triage trailer (MANDATORY)
+
+End your response with exactly one HTML comment containing a single-line JSON object:
+
+```
+<!-- hermes-triage: {"priority":"<critical|high|medium|low>","labels":["<label>",...]} -->
+```
+
+Rules for `labels`:
+
+- Choose from: `bug`, `enhancement`, `rfc`, `question`, `documentation`, `area/core`, `area/cli`, `area/mcp`, `area/common`, `area/eval`, `area/firefox-extension`, `area/claude-code-plugin`, `area/hermes-plugin`, `area/docs`, `area/ci`
+- Include exactly one type label (`bug` / `enhancement` / `rfc` / `question` / `documentation`) unless it's already on the issue.
+- Include one or more `area/*` labels for every package the change will touch.
+- Do NOT include `priority/*` in `labels` — the workflow derives that from the `priority` field.
+- Omit labels that are already on the issue (they're listed in the user message).
+
+## Style
+
+- Concise. No preamble, no closing pleasantries.
+- Use file:line references the author can click.
+- If the issue is unclear, say so plainly and list the questions rather than guessing a priority.

--- a/.github/workflows/hermes-issue-triage.yaml
+++ b/.github/workflows/hermes-issue-triage.yaml
@@ -1,0 +1,133 @@
+name: Hermes Issue Triage
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue-number:
+        description: Issue number to triage (required when running manually).
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: hermes-issue-triage-${{ github.event.issue.number || inputs.issue-number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    if: >-
+      github.event_name == 'issues' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request == null && startsWith(github.event.comment.body, '/triage'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: issue
+        run: echo "number=${{ github.event.issue.number || inputs.issue-number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUM: ${{ steps.issue.outputs.number }}
+          ISSUE_JSON: ${{ runner.temp }}/issue.json
+          ISSUE_MD: ${{ runner.temp }}/issue.md
+        run: |
+          set -euo pipefail
+          gh issue view "$ISSUE_NUM" \
+            --json number,title,body,labels,author \
+            > "$ISSUE_JSON"
+          jq -r '
+            "# Issue #\(.number)\n\n" +
+            "## Title\n\(.title)\n\n" +
+            "## Author\n@\(.author.login)\n\n" +
+            "## Existing labels\n\(if (.labels|length) > 0 then (.labels | map(.name) | join(", ")) else "(none)" end)\n\n" +
+            "## Body\n\(.body // "(empty)")\n"
+          ' "$ISSUE_JSON" > "$ISSUE_MD"
+
+      - name: Ensure triage labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ensure() {
+            gh label create "$1" --color "$2" --description "$3" 2>/dev/null || true
+          }
+          ensure "priority/critical"   "b60205" "Urgent — blocks users or core functionality"
+          ensure "priority/high"       "d93f0b" "Important — should be addressed soon"
+          ensure "priority/medium"     "fbca04" "Normal priority"
+          ensure "priority/low"        "0e8a16" "Nice to have"
+          ensure "rfc"                 "5319e7" "Request for Comments"
+          ensure "question"            "cc317c" "Further information is requested"
+          ensure "documentation"       "0075ca" "Improvements or additions to documentation"
+          for area in core cli mcp common eval firefox-extension claude-code-plugin hermes-plugin docs ci; do
+            ensure "area/$area" "1d76db" "Affects $area"
+          done
+
+      - id: hermes
+        uses: JasperHG90/toiminnot/actions/hermes@main
+        with:
+          system_prompt_file: .github/prompts/issue-triage-system.md
+          skills_dir: packages/claude-code-plugin/skills
+          user_message: '@${{ runner.temp }}/issue.md'
+          api_key: ${{ secrets.OLLAMA_API_KEY }}
+          max_iterations: '12'
+          quiet_mode: 'false'
+
+      - name: Apply triage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUM: ${{ steps.issue.outputs.number }}
+          RESPONSE_FILE: ${{ steps.hermes.outputs.response_file }}
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json, os, re, subprocess, sys
+
+          issue = os.environ['ISSUE_NUM']
+          response = open(os.environ['RESPONSE_FILE']).read()
+
+          m = re.search(r'<!--\s*hermes-triage:\s*(\{.*?\})\s*-->', response, re.DOTALL)
+          payload = {}
+          if m:
+              try:
+                  payload = json.loads(m.group(1))
+              except json.JSONDecodeError as e:
+                  print(f'::warning::could not parse hermes-triage trailer: {e}', file=sys.stderr)
+
+          priority = (payload.get('priority') or '').strip().lower()
+          labels = [l.strip() for l in (payload.get('labels') or []) if isinstance(l, str) and l.strip()]
+          if priority in {'critical', 'high', 'medium', 'low'}:
+              labels.insert(0, f'priority/{priority}')
+
+          # Deduplicate while preserving order.
+          seen = set()
+          labels = [l for l in labels if not (l in seen or seen.add(l))]
+
+          comment_body = re.sub(r'\n*<!--\s*hermes-triage:.*?-->\s*$', '', response, flags=re.DOTALL).strip()
+          if not comment_body:
+              comment_body = response
+
+          with open('/tmp/hermes-comment.md', 'w') as f:
+              f.write(comment_body)
+
+          subprocess.check_call(['gh', 'issue', 'comment', issue, '-F', '/tmp/hermes-comment.md'])
+
+          if labels:
+              args = ['gh', 'issue', 'edit', issue]
+              for l in labels:
+                  args += ['--add-label', l]
+              subprocess.check_call(args)
+              print(f'Applied labels: {", ".join(labels)}')
+          else:
+              print('No labels to apply.')
+          PY

--- a/.github/workflows/hermes-issue-triage.yaml
+++ b/.github/workflows/hermes-issue-triage.yaml
@@ -74,7 +74,7 @@ jobs:
           done
 
       - id: hermes
-        uses: JasperHG90/toiminnot/actions/hermes@main
+        uses: JasperHG90/toiminnot/actions/hermes@0c29e3265ba4c99a88c03d9926c6771c9759adab  # main as of 2026-04-24
         with:
           system_prompt_file: .github/prompts/issue-triage-system.md
           skills_dir: packages/claude-code-plugin/skills

--- a/.github/workflows/hermes-issue-triage.yaml
+++ b/.github/workflows/hermes-issue-triage.yaml
@@ -24,7 +24,7 @@ jobs:
     if: >-
       github.event_name == 'issues' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request == null && (startsWith(github.event.comment.body, '/triage') || startsWith(github.event.comment.body, '/Triage') || startsWith(github.event.comment.body, '/TRIAGE')))
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request == null && contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association) && (startsWith(github.event.comment.body, '/triage') || startsWith(github.event.comment.body, '/Triage') || startsWith(github.event.comment.body, '/TRIAGE')))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/hermes-issue-triage.yaml
+++ b/.github/workflows/hermes-issue-triage.yaml
@@ -104,14 +104,31 @@ jobs:
               except json.JSONDecodeError as e:
                   print(f'::warning::could not parse hermes-triage trailer: {e}', file=sys.stderr)
 
+          ALLOWED_TYPE_LABELS = {'bug', 'enhancement', 'rfc', 'question', 'documentation'}
+          ALLOWED_AREA_LABELS = {
+              f'area/{a}' for a in (
+                  'core', 'cli', 'mcp', 'common', 'eval',
+                  'firefox-extension', 'claude-code-plugin',
+                  'hermes-plugin', 'docs', 'ci',
+              )
+          }
+          ALLOWED_PRIORITY_LABELS = {f'priority/{p}' for p in ('critical', 'high', 'medium', 'low')}
+          ALLOWED = ALLOWED_TYPE_LABELS | ALLOWED_AREA_LABELS | ALLOWED_PRIORITY_LABELS
+
           priority = (payload.get('priority') or '').strip().lower()
-          labels = [l.strip() for l in (payload.get('labels') or []) if isinstance(l, str) and l.strip()]
+          raw_labels = [l.strip() for l in (payload.get('labels') or []) if isinstance(l, str) and l.strip()]
           if priority in {'critical', 'high', 'medium', 'low'}:
-              labels.insert(0, f'priority/{priority}')
+              raw_labels.insert(0, f'priority/{priority}')
 
           # Deduplicate while preserving order.
           seen = set()
-          labels = [l for l in labels if not (l in seen or seen.add(l))]
+          raw_labels = [l for l in raw_labels if not (l in seen or seen.add(l))]
+
+          # Validate against allowlist so a hallucinated label can't fail the whole step.
+          labels = [l for l in raw_labels if l in ALLOWED]
+          rejected = [l for l in raw_labels if l not in ALLOWED]
+          if rejected:
+              print(f'::warning::rejected unknown labels: {rejected}', file=sys.stderr)
 
           comment_body = re.sub(r'\n*<!--\s*hermes-triage:.*?-->\s*$', '', response, flags=re.DOTALL).strip()
           if not comment_body:
@@ -122,12 +139,20 @@ jobs:
 
           subprocess.check_call(['gh', 'issue', 'comment', issue, '-F', '/tmp/hermes-comment.md'])
 
-          if labels:
-              args = ['gh', 'issue', 'edit', issue]
-              for l in labels:
-                  args += ['--add-label', l]
-              subprocess.check_call(args)
-              print(f'Applied labels: {", ".join(labels)}')
-          else:
+          # Apply labels one at a time so a single failure doesn't drop the rest.
+          applied, failed = [], []
+          for label in labels:
+              try:
+                  subprocess.check_call(['gh', 'issue', 'edit', issue, '--add-label', label])
+                  applied.append(label)
+              except subprocess.CalledProcessError:
+                  print(f'::warning::failed to apply label: {label}', file=sys.stderr)
+                  failed.append(label)
+
+          if applied:
+              print(f'Applied labels: {", ".join(applied)}')
+          if failed:
+              print(f'Failed labels: {", ".join(failed)}')
+          if not labels:
               print('No labels to apply.')
           PY

--- a/.github/workflows/hermes-issue-triage.yaml
+++ b/.github/workflows/hermes-issue-triage.yaml
@@ -60,7 +60,11 @@ jobs:
         run: |
           set -euo pipefail
           ensure() {
-            gh label create "$1" --color "$2" --description "$3" 2>/dev/null || true
+            local out rc=0
+            out=$(gh label create "$1" --color "$2" --description "$3" 2>&1) || rc=$?
+            if [ $rc -ne 0 ] && ! printf '%s' "$out" | grep -q "already exists"; then
+              echo "::warning::failed to create label $1: $out"
+            fi
           }
           ensure "priority/critical"   "b60205" "Urgent — blocks users or core functionality"
           ensure "priority/high"       "d93f0b" "Important — should be addressed soon"
@@ -94,7 +98,11 @@ jobs:
           import json, os, re, subprocess, sys
 
           issue = os.environ['ISSUE_NUM']
-          response = open(os.environ['RESPONSE_FILE']).read()
+          response_path = os.environ['RESPONSE_FILE']
+          if not os.path.isfile(response_path):
+              print('::error::Hermes produced no response file', file=sys.stderr)
+              sys.exit(1)
+          response = open(response_path).read()
 
           m = re.search(r'<!--\s*hermes-triage:\s*(\{.*?\})\s*-->', response, re.DOTALL)
           payload = {}

--- a/.github/workflows/hermes-issue-triage.yaml
+++ b/.github/workflows/hermes-issue-triage.yaml
@@ -24,7 +24,7 @@ jobs:
     if: >-
       github.event_name == 'issues' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request == null && startsWith(github.event.comment.body, '/triage'))
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request == null && (startsWith(github.event.comment.body, '/triage') || startsWith(github.event.comment.body, '/Triage') || startsWith(github.event.comment.body, '/TRIAGE')))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/hermes-review.yaml
+++ b/.github/workflows/hermes-review.yaml
@@ -42,16 +42,16 @@ jobs:
         run: gh pr diff "${{ steps.pr.outputs.number }}" > "${{ runner.temp }}/pr.patch"
 
       - id: hermes
-        uses: ./.github/actions/hermes
+        uses: JasperHG90/toiminnot/actions/hermes@main
         with:
-          system-prompt-file: .github/prompts/review-system.md
-          skills-dir: packages/claude-code-plugin/skills
-          user-message: '@${{ runner.temp }}/pr.patch'
-          api-key: ${{ secrets.OLLAMA_API_KEY }}
-          max-iterations: '12'
-          quiet-mode: 'false'
+          system_prompt_file: .github/prompts/review-system.md
+          skills_dir: packages/claude-code-plugin/skills
+          user_message: '@${{ runner.temp }}/pr.patch'
+          api_key: ${{ secrets.OLLAMA_API_KEY }}
+          max_iterations: '12'
+          quiet_mode: 'false'
 
       - name: Post review comment
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr review "${{ steps.pr.outputs.number }}" --comment -F "${{ steps.hermes.outputs.response-file }}"
+        run: gh pr review "${{ steps.pr.outputs.number }}" --comment -F "${{ steps.hermes.outputs.response_file }}"

--- a/.github/workflows/hermes-review.yaml
+++ b/.github/workflows/hermes-review.yaml
@@ -42,7 +42,7 @@ jobs:
         run: gh pr diff "${{ steps.pr.outputs.number }}" > "${{ runner.temp }}/pr.patch"
 
       - id: hermes
-        uses: JasperHG90/toiminnot/actions/hermes@main
+        uses: JasperHG90/toiminnot/actions/hermes@0c29e3265ba4c99a88c03d9926c6771c9759adab  # main as of 2026-04-24
         with:
           system_prompt_file: .github/prompts/review-system.md
           skills_dir: packages/claude-code-plugin/skills


### PR DESCRIPTION
## Summary

- Adds a `hermes-issue-triage` workflow that fires on issue creation (plus `/triage` comments and `workflow_dispatch`). Summarizes the request, evaluates priority, analyzes affected packages via repo grep, and — for RFC-tagged issues — reviews feasibility, alternatives, risks, and open questions. Labels are applied from a JSON trailer the model emits (`<!-- hermes-triage: {...} -->`).
- Repoints both Hermes workflows at the shared composite action `JasperHG90/toiminnot/actions/hermes@main`. Input/output names updated to the upstream snake_case contract (`system_prompt_file`, `user_message`, `api_key`, `skills_dir`, `max_iterations`, `quiet_mode`, `response_file`).
- Introduces label vocabulary: `priority/{critical,high,medium,low}`, `area/{core,cli,mcp,common,eval,firefox-extension,claude-code-plugin,hermes-plugin,docs,ci}`, `rfc`, `question`, `documentation`. Workflow ensures they exist via idempotent `gh label create`.

## Test plan

- [ ] Trigger `hermes-review` on a small PR — confirms the switch to the shared action (same inputs/outputs) works end-to-end.
- [ ] Open a throwaway `[RFC]` issue and confirm `hermes-issue-triage` posts a comment with the RFC-review section and applies the expected labels.
- [ ] Open a plain bug/feature issue and confirm a non-RFC triage comment is posted.
- [ ] Comment `/triage` on an existing issue and confirm re-triage runs.

## Follow-ups (not in this PR)

- `.github/actions/hermes/` is now unreferenced by any workflow. `ci.yaml:57-58,163-168` still tests the local runner — prune once the shared action is trusted.
- `@main` is not SHA-pinned; current upstream `main` is `0c29e3265ba4c99a88c03d9926c6771c9759adab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)