### PR TITLE
fix(core): stop fabricating ghost IDs for virtual memory units (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,221%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,506%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/core/src/memex_core/memory/retrieval/engine.py
+++ b/packages/core/src/memex_core/memory/retrieval/engine.py
@@ -63,8 +63,9 @@ K_RRF = 60
 CANDIDATE_POOL_SIZE = 60
 
 # Namespace for deterministic virtual MemoryUnit ids synthesized from
-# MentalModel observations. Derived from uuid5(NAMESPACE_URL, ...) — stable
-# across processes, unlike Python's PYTHONHASHSEED-salted hash().
+# MentalModel observations. Stable across processes, unlike Python's
+# PYTHONHASHSEED-salted hash(). Reproducible via:
+#   uuid5(uuid.NAMESPACE_URL, 'memex/retrieval/virtual-mental-model-observation')
 _VIRTUAL_UNIT_NS = UUID('bf63d7e5-1e6a-5cf4-9f33-2e85d3a48d38')
 
 

--- a/packages/core/src/memex_core/memory/retrieval/engine.py
+++ b/packages/core/src/memex_core/memory/retrieval/engine.py
@@ -3,7 +3,7 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from uuid import UUID
+from uuid import UUID, uuid5
 import asyncio
 from datetime import datetime, timezone
 from typing import Any, Sequence
@@ -61,6 +61,11 @@ def derive_note_status(units: list[MemoryUnit], superseded_threshold: float = 0.
 # RRF Constant
 K_RRF = 60
 CANDIDATE_POOL_SIZE = 60
+
+# Namespace for deterministic virtual MemoryUnit ids synthesized from
+# MentalModel observations. Derived from uuid5(NAMESPACE_URL, ...) — stable
+# across processes, unlike Python's PYTHONHASHSEED-salted hash().
+_VIRTUAL_UNIT_NS = UUID('bf63d7e5-1e6a-5cf4-9f33-2e85d3a48d38')
 
 
 @dataclass
@@ -1315,7 +1320,7 @@ class RetrievalEngine:
                 if mid:
                     evidence_ids.append(str(mid))
 
-            virtual_id = UUID(int=hash(str(model.id) + title) & (2**128 - 1))
+            virtual_id = uuid5(_VIRTUAL_UNIT_NS, f'{model.id}:{title}')
             units.append(
                 MemoryUnit(
                     id=virtual_id,
@@ -1324,12 +1329,13 @@ class RetrievalEngine:
                     status=ContentStatus.ACTIVE,
                     event_date=model.last_refreshed,
                     vault_id=model.vault_id,
-                    note_id=model.id,
+                    note_id=None,
                     embedding=[],
                     unit_metadata={
                         'observation': True,
                         'virtual': True,
                         'trend': str(trend.value) if hasattr(trend, 'value') else str(trend),
+                        'mental_model_id': str(model.id),
                         'evidence_ids': evidence_ids,
                     },
                 )

--- a/packages/core/tests/unit/memory/retrieval/test_retrieval_engine.py
+++ b/packages/core/tests/unit/memory/retrieval/test_retrieval_engine.py
@@ -59,8 +59,17 @@ async def test_convert_mm_to_units():
     assert len(units) == 2
     assert units[0].text == '[Test Model] Obs 1: Content 1'
     assert units[0].fact_type == 'observation'
-    assert units[0].note_id == mm_id
+    # Virtual units have no backing Note row — note_id must stay None so
+    # downstream point-lookups don't 404 on a MentalModel id.
+    assert units[0].note_id is None
+    assert units[0].unit_metadata['mental_model_id'] == str(mm_id)
     assert units[0].unit_metadata['observation'] is True
+    assert units[0].unit_metadata['virtual'] is True
+    # Synthetic id must be a well-formed uuid5 (no 64-bit-hash leading-zero artifact).
+    assert units[0].id.int >> 64 != 0
+    # Stable across calls — same (model.id, title) → same id.
+    units_again = engine._convert_mm_to_units(model)
+    assert units_again[0].id == units[0].id
     # New observation with recent evidence defaults to 'new'
     assert units[0].unit_metadata['trend'] == 'new'
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -1196,7 +1196,9 @@ _VALID_KV_NAMESPACES = ('global:', 'user:', 'project:', 'app:')
 
 def _serialize_memory_unit(unit: Any) -> dict[str, Any]:
     """Trim a MemoryUnitDTO to the fields useful to the model."""
-    return {
+    metadata = getattr(unit, 'metadata', None) or {}
+    is_virtual = bool(metadata.get('virtual')) if isinstance(metadata, dict) else False
+    out: dict[str, Any] = {
         'id': str(getattr(unit, 'id', '')),
         'text': getattr(unit, 'text', ''),
         'type': getattr(unit, 'fact_type', None),
@@ -1204,6 +1206,13 @@ def _serialize_memory_unit(unit: Any) -> dict[str, Any]:
         'note_id': str(u) if (u := getattr(unit, 'note_id', None)) else None,
         'mentioned_at': (m.isoformat() if (m := getattr(unit, 'mentioned_at', None)) else None),
     }
+    if is_virtual:
+        # Synthesized from a MentalModel observation; `id` is a deterministic
+        # placeholder, not a DB row — agents must not point-lookup it.
+        out['virtual'] = True
+        out['mental_model_id'] = metadata.get('mental_model_id')
+        out['evidence_ids'] = metadata.get('evidence_ids', [])
+    return out
 
 
 def _serialize_note_result(result: Any) -> dict[str, Any]:
@@ -2108,7 +2117,8 @@ def _serialize_memory_unit_full(unit: Any) -> dict[str, Any]:
         lnk for lnk in links_raw if isinstance(lnk, dict) and lnk.get('relation') == 'contradiction'
     ]
 
-    return {
+    is_virtual = bool(metadata.get('virtual')) if isinstance(metadata, dict) else False
+    out: dict[str, Any] = {
         'id': str(getattr(unit, 'id', '')),
         'text': getattr(unit, 'text', ''),
         'fact_type': getattr(unit, 'fact_type', None),
@@ -2117,6 +2127,11 @@ def _serialize_memory_unit_full(unit: Any) -> dict[str, Any]:
         'superseded_by': superseded,
         'contradictions': contradictions,
     }
+    if is_virtual:
+        out['virtual'] = True
+        out['mental_model_id'] = metadata.get('mental_model_id')
+        out['evidence_ids'] = metadata.get('evidence_ids', [])
+    return out
 
 
 def handle_get_memory_links(

--- a/packages/hermes-plugin/tests/test_virtual_serialization.py
+++ b/packages/hermes-plugin/tests/test_virtual_serialization.py
@@ -67,12 +67,12 @@ def test_serialize_memory_unit_omits_virtual_fields_for_real_units():
 
 def test_serialize_memory_unit_full_flags_virtual():
     mm_id = uuid4()
-    evidence_ids = [uuid4()]
+    evidence_ids = [uuid4(), uuid4()]
     out = _serialize_memory_unit_full(_virtual_unit(mm_id, evidence_ids))
 
     assert out['virtual'] is True
     assert out['mental_model_id'] == str(mm_id)
-    assert out['evidence_ids'] == [str(evidence_ids[0])]
+    assert out['evidence_ids'] == [str(e) for e in evidence_ids]
     assert out['note_id'] is None
 
 

--- a/packages/hermes-plugin/tests/test_virtual_serialization.py
+++ b/packages/hermes-plugin/tests/test_virtual_serialization.py
@@ -1,0 +1,83 @@
+"""Regression tests for virtual-unit serialization (GH #47: Ghost IDs).
+
+Virtual MemoryUnits are synthesized at recall time from MentalModel
+observations; they have no backing DB row. The serializer must flag them
+clearly so agents do not attempt point-lookups on their synthetic ids.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from memex_hermes_plugin.memex.tools import (
+    _serialize_memory_unit,
+    _serialize_memory_unit_full,
+)
+
+
+def _virtual_unit(mm_id, evidence_ids):
+    return SimpleNamespace(
+        id=uuid4(),
+        text='[Entity] Obs title: content',
+        fact_type='observation',
+        status='active',
+        note_id=None,
+        mentioned_at=None,
+        metadata={
+            'virtual': True,
+            'observation': True,
+            'mental_model_id': str(mm_id),
+            'evidence_ids': [str(e) for e in evidence_ids],
+            'trend': 'new',
+        },
+    )
+
+
+def _real_unit():
+    return SimpleNamespace(
+        id=uuid4(),
+        text='A real fact',
+        fact_type='world',
+        status='active',
+        note_id=uuid4(),
+        mentioned_at=None,
+        metadata={},
+    )
+
+
+def test_serialize_memory_unit_flags_virtual():
+    mm_id = uuid4()
+    evidence_ids = [uuid4(), uuid4()]
+    out = _serialize_memory_unit(_virtual_unit(mm_id, evidence_ids))
+
+    assert out['virtual'] is True
+    assert out['mental_model_id'] == str(mm_id)
+    assert out['evidence_ids'] == [str(e) for e in evidence_ids]
+    assert out['note_id'] is None
+
+
+def test_serialize_memory_unit_omits_virtual_fields_for_real_units():
+    out = _serialize_memory_unit(_real_unit())
+    assert 'virtual' not in out
+    assert 'mental_model_id' not in out
+    assert 'evidence_ids' not in out
+    assert out['note_id'] is not None
+
+
+def test_serialize_memory_unit_full_flags_virtual():
+    mm_id = uuid4()
+    evidence_ids = [uuid4()]
+    out = _serialize_memory_unit_full(_virtual_unit(mm_id, evidence_ids))
+
+    assert out['virtual'] is True
+    assert out['mental_model_id'] == str(mm_id)
+    assert out['evidence_ids'] == [str(evidence_ids[0])]
+    assert out['note_id'] is None
+
+
+def test_serialize_memory_unit_full_omits_virtual_fields_for_real_units():
+    out = _serialize_memory_unit_full(_real_unit())
+    assert 'virtual' not in out
+    assert 'mental_model_id' not in out
+    assert 'evidence_ids' not in out

--- a/packages/mcp/src/memex_mcp/models.py
+++ b/packages/mcp/src/memex_mcp/models.py
@@ -123,6 +123,12 @@ class McpMemoryUnitBase(BaseModel):
     links: list[McpMemoryLink] = Field(default_factory=list)
     staleness: Staleness | None = None
     previously_returned: bool = False
+    # Virtual units are synthesized from MentalModel observations — their `id`
+    # is a deterministic placeholder, not a DB row. When `virtual=True`, agents
+    # should not point-lookup `id`; resolve via `evidence_ids` instead.
+    virtual: bool = False
+    mental_model_id: UUID | None = None
+    evidence_ids: list[UUID] = Field(default_factory=list)
 
     @field_validator('tags', mode='before')
     @classmethod

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -1131,8 +1131,18 @@ def _build_memory_unit_model(
     unit_metadata = res.metadata if isinstance(res.metadata, dict) else {}
     tags = unit_metadata.get('tags', [])
 
+    # Virtual metadata stores UUIDs as strings (JSONB round-trip); coerce to
+    # UUID at the MCP boundary so the Pydantic model stays typed, and skip
+    # malformed entries rather than raising — corrupted metadata must not
+    # break the whole response.
     is_virtual = bool(unit_metadata.get('virtual'))
-    mental_model_id = unit_metadata.get('mental_model_id') if is_virtual else None
+    mental_model_id_raw = unit_metadata.get('mental_model_id') if is_virtual else None
+    mental_model_id_uuid: UUID | None = None
+    if mental_model_id_raw:
+        try:
+            mental_model_id_uuid = UUID(str(mental_model_id_raw))
+        except (ValueError, TypeError):
+            mental_model_id_uuid = None
     evidence_ids_raw = unit_metadata.get('evidence_ids', []) if is_virtual else []
     evidence_ids: list[UUID] = []
     for eid in evidence_ids_raw or []:
@@ -1153,7 +1163,7 @@ def _build_memory_unit_model(
         'status': getattr(res, 'status', 'active'),
         'superseded_by': supersessions,
         'virtual': is_virtual,
-        'mental_model_id': UUID(str(mental_model_id)) if mental_model_id else None,
+        'mental_model_id': mental_model_id_uuid,
         'evidence_ids': evidence_ids,
     }
 

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -1131,6 +1131,16 @@ def _build_memory_unit_model(
     unit_metadata = res.metadata if isinstance(res.metadata, dict) else {}
     tags = unit_metadata.get('tags', [])
 
+    is_virtual = bool(unit_metadata.get('virtual'))
+    mental_model_id = unit_metadata.get('mental_model_id') if is_virtual else None
+    evidence_ids_raw = unit_metadata.get('evidence_ids', []) if is_virtual else []
+    evidence_ids: list[UUID] = []
+    for eid in evidence_ids_raw or []:
+        try:
+            evidence_ids.append(UUID(str(eid)))
+        except (ValueError, TypeError):
+            continue
+
     base_kwargs: dict[str, Any] = {
         'id': res.id,
         'text': res.text,
@@ -1142,6 +1152,9 @@ def _build_memory_unit_model(
         'tags': tags,
         'status': getattr(res, 'status', 'active'),
         'superseded_by': supersessions,
+        'virtual': is_virtual,
+        'mental_model_id': UUID(str(mental_model_id)) if mental_model_id else None,
+        'evidence_ids': evidence_ids,
     }
 
     links_raw = unit_metadata.get('links', [])

--- a/packages/mcp/tests/test_virtual_unit_model.py
+++ b/packages/mcp/tests/test_virtual_unit_model.py
@@ -1,0 +1,62 @@
+"""Regression tests for virtual-unit MCP serialization (GH #47: Ghost IDs).
+
+Virtual MemoryUnits surfaced from MentalModel observations flow through
+``_build_memory_unit_model``; the McpObservation it returns must expose
+``virtual=True`` + ``mental_model_id`` + ``evidence_ids`` so MCP clients can
+avoid point-lookups on synthetic ids.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from memex_mcp.server import _build_memory_unit_model
+
+
+def _dto(*, virtual: bool, mm_id=None, evidence_ids=None):
+    metadata: dict = {}
+    if virtual:
+        metadata = {
+            'virtual': True,
+            'observation': True,
+            'mental_model_id': str(mm_id),
+            'evidence_ids': [str(e) for e in (evidence_ids or [])],
+            'trend': 'new',
+        }
+    return SimpleNamespace(
+        id=uuid4(),
+        text='[Entity] Obs: body',
+        fact_type='observation',
+        score=0.9,
+        confidence=1.0,
+        note_id=None if virtual else uuid4(),
+        node_ids=[],
+        status='active',
+        metadata=metadata,
+        superseded_by=[],
+        event_date=None,
+        mentioned_at=None,
+        occurred_start=None,
+        occurred_end=None,
+    )
+
+
+def test_build_memory_unit_model_flags_virtual():
+    mm_id = uuid4()
+    evidence_ids = [uuid4(), uuid4()]
+    model = _build_memory_unit_model(_dto(virtual=True, mm_id=mm_id, evidence_ids=evidence_ids))
+
+    assert model.virtual is True
+    assert model.mental_model_id == mm_id
+    assert model.evidence_ids == evidence_ids
+    assert model.note_id is None
+
+
+def test_build_memory_unit_model_defaults_for_real_units():
+    model = _build_memory_unit_model(_dto(virtual=False))
+
+    assert model.virtual is False
+    assert model.mental_model_id is None
+    assert model.evidence_ids == []
+    assert model.note_id is not None


### PR DESCRIPTION
## Summary
- `_convert_mm_to_units` was constructing synthetic ids with `UUID(int=hash(str(model.id) + title) & (2**128-1))`. Python's `hash()` is 64-bit signed and salted per-process, so positive hashes produced `00000000-0000-0000-XXXX-XXXXXXXXXXXX` and negatives produced `ffffffff-ffff-ffff-XXXX-XXXXXXXXXXXX`, both unstable across restarts. It also set `note_id=model.id` — a MentalModel id in a Note FK slot, causing `memex_read_note` / `memex_get_lineage` to 404.
- Replace with `uuid5(_VIRTUAL_UNIT_NS, f'{model.id}:{title}')` (stable, full 128-bit), set `note_id=None`, and stash `model.id` as `unit_metadata['mental_model_id']`.
- Recall serializers (`_serialize_memory_unit`, `_serialize_memory_unit_full`, `_build_memory_unit_model`) now surface `virtual=true` + `mental_model_id` + `evidence_ids` on synthetic units so agents don't try to look them up and can reach the backing data via real evidence memory ids.
- `McpMemoryUnitBase` gains three optional, defaulted fields — backwards-compatible.

Closes #47.

## Test plan
- [x] Regression test asserts `id.int >> 64 != 0`, `note_id is None`, stability across calls, and `virtual`/`mental_model_id`/`evidence_ids` in both Hermes-plugin dict serializers and the MCP `_build_memory_unit_model`.
- [x] `just prek` (ruff + ruff-format + mypy) clean.
- [x] core unit (1858), common (109), mcp non-integration (309 + 2 new), hermes non-integration (272 + 4 new), root E2E (35), core integration (283) — all green.
- [ ] hermes_integration suite (requires `hermes-agent` git dep) — skipped in this env.
- [ ] Live agent exercise against a running Memex server with a MentalModel-surfacing query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)