### PR TITLE
feat(core): time-truthful vault summary recency and trend decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,509%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,512%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,514%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,520%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,506%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,509%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,520%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,521%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,513%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,514%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,512%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,513%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/cli/src/memex_cli/vaults.py
+++ b/packages/cli/src/memex_cli/vaults.py
@@ -335,6 +335,11 @@ async def vault_summary(
             inv_table.add_row(
                 'Recent (7d / 30d)', f'{recent.get("7d", 0)} / {recent.get("30d", 0)}'
             )
+        last_activity_at = inv.get('last_activity_at')
+        if last_activity_at:
+            days_since = inv.get('days_since_last_note')
+            suffix = f' ({days_since} days ago)' if days_since is not None else ''
+            inv_table.add_row('Last Activity', f'{last_activity_at}{suffix}')
         by_template = inv.get('by_template', {})
         if by_template:
             inv_table.add_row(

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1073,6 +1073,15 @@ class VaultSummaryConfig(BaseModel):
         le=500,
         description='Maximum token count for the vault narrative text.',
     )
+    dormant_threshold_days: int = Field(
+        default=30,
+        ge=1,
+        description='Age in days since the most recent note past which all theme trends '
+        'are forced to "dormant" on read, independent of the cached LLM value. '
+        'Time-sensitive inventory fields (recent_activity, last_activity_at, '
+        'days_since_last_note) are always recomputed on read; this threshold '
+        'governs only the trend demotion.',
+    )
 
 
 class ServerConfig(BaseModel):

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -998,7 +998,11 @@ class VaultSummaryDTO(BaseModel):
     )
     inventory: dict[str, Any] = Field(
         description='Computed content stats: total_notes, total_entities, date_range, '
-        'by_template, by_source_domain, top_tags, recent_activity.'
+        'by_template, by_source_domain, top_tags, recent_activity, '
+        'last_activity_at (ISO 8601 UTC string or null), '
+        'days_since_last_note (int or null). The time-sensitive fields '
+        '(recent_activity, last_activity_at, days_since_last_note, '
+        'date_range.latest) are recomputed against wall-clock now on every read.'
     )
     key_entities: list[dict[str, Any]] = Field(
         description='Top entities by mention count: [{name, type, mention_count}].'

--- a/packages/core/src/memex_core/services/vault_summary.py
+++ b/packages/core/src/memex_core/services/vault_summary.py
@@ -192,25 +192,17 @@ class VaultSummaryService:
         """
         now = _now if _now is not None else datetime.now(timezone.utc)
         async with self.metastore.session() as session:
-            recent_7d = (
+            recent_row = (
                 await session.execute(
-                    select(func.count())
+                    select(
+                        func.count().filter(col(Note.created_at) >= now - timedelta(days=7)),
+                        func.count().filter(col(Note.created_at) >= now - timedelta(days=30)),
+                    )
                     .select_from(Note)
                     .where(col(Note.vault_id) == vault_id)
                     .where(col(Note.status) == 'active')
-                    .where(col(Note.created_at) >= now - timedelta(days=7))
                 )
-            ).scalar() or 0
-
-            recent_30d = (
-                await session.execute(
-                    select(func.count())
-                    .select_from(Note)
-                    .where(col(Note.vault_id) == vault_id)
-                    .where(col(Note.status) == 'active')
-                    .where(col(Note.created_at) >= now - timedelta(days=30))
-                )
-            ).scalar() or 0
+            ).one_or_none()
 
             max_row = (
                 await session.execute(
@@ -220,6 +212,8 @@ class VaultSummaryService:
                 )
             ).one_or_none()
 
+        recent_7d = (recent_row[0] if recent_row else 0) or 0
+        recent_30d = (recent_row[1] if recent_row else 0) or 0
         last_activity_raw = max_row[0] if max_row else None
         publish_latest_raw = max_row[1] if max_row else None
 
@@ -232,13 +226,18 @@ class VaultSummaryService:
             last_activity_at = last_activity_utc.isoformat()
             days_since_last_note = max((now - last_activity_utc).days, 0)
 
+        date_range_latest: str | None = None
+        if publish_latest_raw is not None:
+            publish_latest_utc = publish_latest_raw
+            if publish_latest_utc.tzinfo is None:
+                publish_latest_utc = publish_latest_utc.replace(tzinfo=timezone.utc)
+            date_range_latest = publish_latest_utc.isoformat()
+
         return {
             'recent_activity': {'7d': recent_7d, '30d': recent_30d},
             'last_activity_at': last_activity_at,
             'days_since_last_note': days_since_last_note,
-            'date_range_latest': publish_latest_raw.isoformat()
-            if publish_latest_raw is not None
-            else None,
+            'date_range_latest': date_range_latest,
         }
 
     async def delete_summary(self, vault_id: UUID) -> bool:

--- a/packages/core/src/memex_core/services/vault_summary.py
+++ b/packages/core/src/memex_core/services/vault_summary.py
@@ -113,11 +113,59 @@ class VaultSummaryService:
         self.config = config
 
     async def get_summary(self, vault_id: UUID) -> VaultSummary | None:
-        """Fetch the current vault summary, or None if none exists."""
+        """Fetch the current vault summary, or None if none exists.
+
+        Applies a freshness overlay on read: time-sensitive inventory fields
+        (``recent_activity``, ``last_activity_at``, ``days_since_last_note``,
+        ``date_range.latest``) are recomputed against wall-clock ``now``, and
+        every theme's ``trend`` is forced to ``'dormant'`` when the vault has
+        had no notes within ``config.dormant_threshold_days``. The persisted
+        row is not modified.
+        """
         async with self.metastore.session() as session:
             stmt = select(VaultSummary).where(col(VaultSummary.vault_id) == vault_id)
             result = await session.execute(stmt)
-            return result.scalar_one_or_none()
+            summary = result.scalar_one_or_none()
+
+        if summary is None:
+            return None
+        return await self._apply_freshness_overlay(summary)
+
+    async def _apply_freshness_overlay(self, summary: VaultSummary) -> VaultSummary:
+        """Overlay fresh time-sensitive fields onto a detached summary.
+
+        The summary object is assumed to already be detached from its SQL
+        session, so in-place mutation does not trigger any write. Only
+        time-varying fields are touched; template/domain/tag aggregates keep
+        their persisted values.
+        """
+        fresh = await self._compute_inventory(summary.vault_id)
+
+        inventory = dict(summary.inventory) if summary.inventory else {}
+        inventory['recent_activity'] = fresh['recent_activity']
+        inventory['last_activity_at'] = fresh['last_activity_at']
+        inventory['days_since_last_note'] = fresh['days_since_last_note']
+
+        existing_date_range = dict(inventory.get('date_range') or {})
+        fresh_date_range = fresh.get('date_range') or {}
+        if fresh_date_range.get('latest'):
+            existing_date_range['latest'] = fresh_date_range['latest']
+        if existing_date_range:
+            inventory['date_range'] = existing_date_range
+
+        summary.inventory = inventory
+
+        days_since = fresh['days_since_last_note']
+        threshold = self.config.dormant_threshold_days
+        if days_since is not None and days_since > threshold and summary.themes:
+            demoted: list[dict[str, Any]] = []
+            for theme in summary.themes:
+                theme_copy = dict(theme)
+                theme_copy['trend'] = 'dormant'
+                demoted.append(theme_copy)
+            summary.themes = demoted
+
+        return summary
 
     async def delete_summary(self, vault_id: UUID) -> bool:
         """Delete the vault summary. Returns True if a summary was deleted."""
@@ -252,6 +300,8 @@ class VaultSummaryService:
         running_narrative = current_narrative
         running_themes = [LLMTheme(**t) if isinstance(t, dict) else t for t in current_themes]
 
+        current_time = datetime.now(timezone.utc).isoformat()
+
         for batch in batches:
             notes = [NoteMetadata(**n) for n in batch]
             predictor = dspy.Predict(VaultSummaryUpdateSignature)
@@ -267,6 +317,7 @@ class VaultSummaryService:
                         new_since_last=len(batch),
                         max_narrative_tokens=self.config.max_narrative_tokens,
                     ),
+                    'current_time': current_time,
                 },
                 operation_name='vault_summary_update',
             )
@@ -354,13 +405,14 @@ class VaultSummaryService:
         # LLM-synthesized fields
         total_payload_tokens = _estimate_tokens(json.dumps(notes_data, default=str))
         max_tokens = self.config.max_batch_tokens
+        current_time = datetime.now(timezone.utc).isoformat()
 
         if total_payload_tokens <= max_tokens:
-            narrative, themes = await self._tier1_single_call(notes_data, note_count)
+            narrative, themes = await self._tier1_single_call(notes_data, note_count, current_time)
         elif total_payload_tokens <= max_tokens * 10:
-            narrative, themes = await self._tier2_two_pass(notes_data, note_count)
+            narrative, themes = await self._tier2_two_pass(notes_data, note_count, current_time)
         else:
-            narrative, themes = await self._tier3_hierarchical(notes_data, note_count)
+            narrative, themes = await self._tier3_hierarchical(notes_data, note_count, current_time)
 
         # Persist
         async with self.metastore.session() as session:
@@ -487,6 +539,23 @@ class VaultSummaryService:
                 )
             ).scalar() or 0
 
+            last_activity_row = (
+                await session.execute(
+                    select(func.max(Note.created_at))
+                    .where(col(Note.vault_id) == vault_id)
+                    .where(col(Note.status) == 'active')
+                )
+            ).scalar()
+
+        last_activity_at: str | None = None
+        days_since_last_note: int | None = None
+        if last_activity_row is not None:
+            last_activity_utc = last_activity_row
+            if last_activity_utc.tzinfo is None:
+                last_activity_utc = last_activity_utc.replace(tzinfo=timezone.utc)
+            last_activity_at = last_activity_utc.isoformat()
+            days_since_last_note = max((now - last_activity_utc).days, 0)
+
         return {
             'total_notes': total_notes,
             'total_entities': total_entities,
@@ -495,6 +564,8 @@ class VaultSummaryService:
             'by_source_domain': dict(domain_counts.most_common(10)),
             'top_tags': dict(tag_counts.most_common(15)),
             'recent_activity': {'7d': recent_7d, '30d': recent_30d},
+            'last_activity_at': last_activity_at,
+            'days_since_last_note': days_since_last_note,
         }
 
     async def _compute_key_entities(self, vault_id: UUID, limit: int = 10) -> list[dict[str, Any]]:
@@ -641,6 +712,7 @@ class VaultSummaryService:
         self,
         notes_data: list[dict[str, Any]],
         note_count: int,
+        current_time: str,
     ) -> tuple[str, list[dict[str, Any]]]:
         """Tier 1: single LLM call for small payloads."""
         notes = [NoteMetadata(**n) for n in notes_data]
@@ -652,6 +724,7 @@ class VaultSummaryService:
                 'notes': notes,
                 'vault_note_count': note_count,
                 'max_narrative_tokens': self.config.max_narrative_tokens,
+                'current_time': current_time,
             },
             operation_name='vault_summary_full',
         )
@@ -661,18 +734,20 @@ class VaultSummaryService:
         self,
         notes_data: list[dict[str, Any]],
         note_count: int,
+        current_time: str,
     ) -> tuple[str, list[dict[str, Any]]]:
         """Tier 2: theme extraction per token-batch + synthesis."""
         batches = _split_into_token_batches(
             notes_data, self.config.max_batch_tokens, self.config.batch_size
         )
-        batch_results = await self._extract_themes_from_batches(batches)
-        return await self._merge_batch_results(batch_results, note_count)
+        batch_results = await self._extract_themes_from_batches(batches, current_time)
+        return await self._merge_batch_results(batch_results, note_count, current_time)
 
     async def _tier3_hierarchical(
         self,
         notes_data: list[dict[str, Any]],
         note_count: int,
+        current_time: str,
     ) -> tuple[str, list[dict[str, Any]]]:
         """Tier 3: theme extraction + recursive merge for very large vaults.
 
@@ -684,7 +759,9 @@ class VaultSummaryService:
         batches = _split_into_token_batches(
             notes_data, self.config.max_batch_tokens, self.config.batch_size
         )
-        batch_results: list[BatchResult] = await self._extract_themes_from_batches(batches)
+        batch_results: list[BatchResult] = await self._extract_themes_from_batches(
+            batches, current_time
+        )
 
         merge_group_size = self.config.batch_size
         while len(batch_results) > merge_group_size:
@@ -695,7 +772,9 @@ class VaultSummaryService:
             merged: list[BatchResult] = []
             for group in merge_groups:
                 try:
-                    narrative, themes = await self._merge_batch_results(group, note_count)
+                    narrative, themes = await self._merge_batch_results(
+                        group, note_count, current_time
+                    )
                     merged.append(
                         BatchResult(
                             batch_index=len(merged),
@@ -712,11 +791,12 @@ class VaultSummaryService:
                 return '', []
             batch_results = merged
 
-        return await self._merge_batch_results(batch_results, note_count)
+        return await self._merge_batch_results(batch_results, note_count, current_time)
 
     async def _extract_themes_from_batches(
         self,
         batches: list[list[dict[str, Any]]],
+        current_time: str,
     ) -> list[BatchResult]:
         """Extract themes from each batch via LLM calls."""
         total_batches = len(batches)
@@ -733,6 +813,7 @@ class VaultSummaryService:
                         'notes': notes,
                         'batch_index': i,
                         'total_batches': total_batches,
+                        'current_time': current_time,
                     },
                     operation_name='vault_summary_theme_extract',
                 )
@@ -759,6 +840,7 @@ class VaultSummaryService:
         self,
         batch_results: list[BatchResult],
         note_count: int,
+        current_time: str,
     ) -> tuple[str, list[dict[str, Any]]]:
         """Merge batch theme results into a final narrative and theme list."""
         predictor = dspy.Predict(VaultTopicMergeSignature)
@@ -768,6 +850,7 @@ class VaultSummaryService:
             input_kwargs={
                 'batch_results': batch_results,
                 'vault_note_count': note_count,
+                'current_time': current_time,
             },
             operation_name='vault_summary_theme_merge',
         )

--- a/packages/core/src/memex_core/services/vault_summary.py
+++ b/packages/core/src/memex_core/services/vault_summary.py
@@ -138,8 +138,17 @@ class VaultSummaryService:
         session, so in-place mutation does not trigger any write. Only
         time-varying fields are touched; template/domain/tag aggregates keep
         their persisted values.
+
+        Consistency: the row fetch in ``get_summary`` and the fresh-fields
+        query here run in separate transactions. A concurrent write between
+        the two can make the overlaid fields mildly inconsistent with the
+        persisted row (e.g. a note that appears in ``recent_activity`` but
+        not yet in the persisted ``total_notes``). Acceptable for the
+        display-only read path; writers (``update_summary``,
+        ``regenerate_summary``) use ``_compute_inventory`` and persist a
+        single coherent snapshot.
         """
-        fresh = await self._compute_inventory(summary.vault_id)
+        fresh = await self._compute_fresh_fields(summary.vault_id)
 
         inventory = dict(summary.inventory) if summary.inventory else {}
         inventory['recent_activity'] = fresh['recent_activity']
@@ -147,9 +156,8 @@ class VaultSummaryService:
         inventory['days_since_last_note'] = fresh['days_since_last_note']
 
         existing_date_range = dict(inventory.get('date_range') or {})
-        fresh_date_range = fresh.get('date_range') or {}
-        if fresh_date_range.get('latest'):
-            existing_date_range['latest'] = fresh_date_range['latest']
+        if fresh.get('date_range_latest'):
+            existing_date_range['latest'] = fresh['date_range_latest']
         if existing_date_range:
             inventory['date_range'] = existing_date_range
 
@@ -166,6 +174,72 @@ class VaultSummaryService:
             summary.themes = demoted
 
         return summary
+
+    async def _compute_fresh_fields(
+        self,
+        vault_id: UUID,
+        _now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Compute only the time-sensitive overlay fields. 3 SQL queries.
+
+        Used by the read path (``get_summary``) to avoid the full
+        ``_compute_inventory`` cost on every call. Returns a dict with
+        ``recent_activity`` (7d/30d counts), ``last_activity_at`` (ISO
+        string or None), ``days_since_last_note`` (int or None), and
+        ``date_range_latest`` (ISO string or None).
+
+        ``_now`` is injected for deterministic testing; defaults to wall-clock.
+        """
+        now = _now if _now is not None else datetime.now(timezone.utc)
+        async with self.metastore.session() as session:
+            recent_7d = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(Note)
+                    .where(col(Note.vault_id) == vault_id)
+                    .where(col(Note.status) == 'active')
+                    .where(col(Note.created_at) >= now - timedelta(days=7))
+                )
+            ).scalar() or 0
+
+            recent_30d = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(Note)
+                    .where(col(Note.vault_id) == vault_id)
+                    .where(col(Note.status) == 'active')
+                    .where(col(Note.created_at) >= now - timedelta(days=30))
+                )
+            ).scalar() or 0
+
+            max_row = (
+                await session.execute(
+                    select(func.max(Note.created_at), func.max(Note.publish_date))
+                    .where(col(Note.vault_id) == vault_id)
+                    .where(col(Note.status) == 'active')
+                )
+            ).one_or_none()
+
+        last_activity_raw = max_row[0] if max_row else None
+        publish_latest_raw = max_row[1] if max_row else None
+
+        last_activity_at: str | None = None
+        days_since_last_note: int | None = None
+        if last_activity_raw is not None:
+            last_activity_utc = last_activity_raw
+            if last_activity_utc.tzinfo is None:
+                last_activity_utc = last_activity_utc.replace(tzinfo=timezone.utc)
+            last_activity_at = last_activity_utc.isoformat()
+            days_since_last_note = max((now - last_activity_utc).days, 0)
+
+        return {
+            'recent_activity': {'7d': recent_7d, '30d': recent_30d},
+            'last_activity_at': last_activity_at,
+            'days_since_last_note': days_since_last_note,
+            'date_range_latest': publish_latest_raw.isoformat()
+            if publish_latest_raw is not None
+            else None,
+        }
 
     async def delete_summary(self, vault_id: UUID) -> bool:
         """Delete the vault summary. Returns True if a summary was deleted."""
@@ -450,10 +524,17 @@ class VaultSummaryService:
     # Computed fields (no LLM)
     # ------------------------------------------------------------------ #
 
-    async def _compute_inventory(self, vault_id: UUID) -> dict[str, Any]:
-        """Compute content inventory from DB aggregates. No LLM calls."""
+    async def _compute_inventory(
+        self,
+        vault_id: UUID,
+        _now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Compute content inventory from DB aggregates. No LLM calls.
+
+        ``_now`` is injected for deterministic testing; defaults to wall-clock.
+        """
         async with self.metastore.session() as session:
-            now = datetime.now(timezone.utc)
+            now = _now if _now is not None else datetime.now(timezone.utc)
 
             # Total active notes
             total_stmt = (

--- a/packages/core/src/memex_core/services/vault_summary.py
+++ b/packages/core/src/memex_core/services/vault_summary.py
@@ -27,6 +27,7 @@ from uuid import UUID
 
 import dspy
 from sqlalchemy import update as sa_update
+from sqlalchemy.orm import make_transient
 from sqlmodel import col, func, select
 
 from memex_common.config import VaultSummaryConfig
@@ -62,18 +63,35 @@ def _themes_to_dicts(themes: list[LLMTheme | dict[str, Any]]) -> list[dict[str, 
 
 
 def _to_utc_iso(value: datetime | None) -> str | None:
-    """Serialize a datetime as ISO 8601 UTC, defaulting naive timestamps to UTC.
+    """Serialize a datetime as ISO 8601, tagging naive values as UTC.
 
-    Postgres ``TIMESTAMP WITH TIME ZONE`` columns return aware datetimes, but
-    naive values can leak in from older rows or storage backends without tz
-    support. Normalizing here keeps every inventory/overlay timestamp ending
-    in ``+00:00`` so API consumers don't have to special-case both shapes.
+    Postgres ``TIMESTAMP WITH TIME ZONE`` columns return aware datetimes via
+    asyncpg (already UTC), so for the production path this is effectively
+    "ensure aware, then format". Naive values can still leak in from older
+    rows or non-tz-aware storage backends, in which case we *assume* UTC
+    rather than convert from it. This function does NOT convert other
+    timezones to UTC — an aware ``-05:00`` value is preserved as-is.
+    Renaming-shy callers can read this as "to ISO, defaulting to UTC".
     """
     if value is None:
         return None
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     return value.isoformat()
+
+
+def _days_ago(value: datetime | None, now: datetime) -> int | None:
+    """Whole days between ``value`` and ``now``, never negative.
+
+    Returns ``None`` if ``value`` is ``None``. Naive ``value`` is treated as
+    UTC, mirroring ``_to_utc_iso``. Clamping at 0 prevents future-dated
+    timestamps (clock skew, bad data) from producing negative counts.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return max((now - value).days, 0)
 
 
 def _estimate_tokens(text: str) -> int:
@@ -149,10 +167,12 @@ class VaultSummaryService:
     async def _apply_freshness_overlay(self, summary: VaultSummary) -> VaultSummary:
         """Overlay fresh time-sensitive fields onto a detached summary.
 
-        The summary object is assumed to already be detached from its SQL
-        session, so in-place mutation does not trigger any write. Only
-        time-varying fields are touched; template/domain/tag aggregates keep
-        their persisted values.
+        The summary object is detached after ``get_summary``'s session exits;
+        ``make_transient`` makes that intent explicit so any future caller that
+        accidentally re-attaches the object via ``session.add``/``merge`` won't
+        leak the overlay-only mutations into the database. Only time-varying
+        fields are touched; template/domain/tag aggregates keep their
+        persisted values.
 
         Consistency: the row fetch in ``get_summary`` and the fresh-fields
         query here run in separate transactions. A concurrent write between
@@ -163,6 +183,7 @@ class VaultSummaryService:
         ``regenerate_summary``) use ``_compute_inventory`` and persist a
         single coherent snapshot.
         """
+        make_transient(summary)
         fresh = await self._compute_fresh_fields(summary.vault_id)
 
         inventory = dict(summary.inventory) if summary.inventory else {}
@@ -232,17 +253,10 @@ class VaultSummaryService:
         last_activity_raw = max_row[0] if max_row else None
         publish_latest_raw = max_row[1] if max_row else None
 
-        days_since_last_note: int | None = None
-        if last_activity_raw is not None:
-            last_activity_utc = last_activity_raw
-            if last_activity_utc.tzinfo is None:
-                last_activity_utc = last_activity_utc.replace(tzinfo=timezone.utc)
-            days_since_last_note = max((now - last_activity_utc).days, 0)
-
         return {
             'recent_activity': {'7d': recent_7d, '30d': recent_30d},
             'last_activity_at': _to_utc_iso(last_activity_raw),
-            'days_since_last_note': days_since_last_note,
+            'days_since_last_note': _days_ago(last_activity_raw, now),
             'date_range_latest': _to_utc_iso(publish_latest_raw),
         }
 
@@ -633,13 +647,6 @@ class VaultSummaryService:
                 )
             ).scalar()
 
-        days_since_last_note: int | None = None
-        if last_activity_row is not None:
-            last_activity_utc = last_activity_row
-            if last_activity_utc.tzinfo is None:
-                last_activity_utc = last_activity_utc.replace(tzinfo=timezone.utc)
-            days_since_last_note = max((now - last_activity_utc).days, 0)
-
         return {
             'total_notes': total_notes,
             'total_entities': total_entities,
@@ -649,7 +656,7 @@ class VaultSummaryService:
             'top_tags': dict(tag_counts.most_common(15)),
             'recent_activity': {'7d': recent_7d, '30d': recent_30d},
             'last_activity_at': _to_utc_iso(last_activity_row),
-            'days_since_last_note': days_since_last_note,
+            'days_since_last_note': _days_ago(last_activity_row, now),
         }
 
     async def _compute_key_entities(self, vault_id: UUID, limit: int = 10) -> list[dict[str, Any]]:

--- a/packages/core/src/memex_core/services/vault_summary.py
+++ b/packages/core/src/memex_core/services/vault_summary.py
@@ -61,6 +61,21 @@ def _themes_to_dicts(themes: list[LLMTheme | dict[str, Any]]) -> list[dict[str, 
     return [t.model_dump() if isinstance(t, LLMTheme) else t for t in themes]
 
 
+def _to_utc_iso(value: datetime | None) -> str | None:
+    """Serialize a datetime as ISO 8601 UTC, defaulting naive timestamps to UTC.
+
+    Postgres ``TIMESTAMP WITH TIME ZONE`` columns return aware datetimes, but
+    naive values can leak in from older rows or storage backends without tz
+    support. Normalizing here keeps every inventory/overlay timestamp ending
+    in ``+00:00`` so API consumers don't have to special-case both shapes.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
+
+
 def _estimate_tokens(text: str) -> int:
     """Rough chars-to-tokens estimate (÷4)."""
     return len(text) // 4
@@ -217,27 +232,18 @@ class VaultSummaryService:
         last_activity_raw = max_row[0] if max_row else None
         publish_latest_raw = max_row[1] if max_row else None
 
-        last_activity_at: str | None = None
         days_since_last_note: int | None = None
         if last_activity_raw is not None:
             last_activity_utc = last_activity_raw
             if last_activity_utc.tzinfo is None:
                 last_activity_utc = last_activity_utc.replace(tzinfo=timezone.utc)
-            last_activity_at = last_activity_utc.isoformat()
             days_since_last_note = max((now - last_activity_utc).days, 0)
-
-        date_range_latest: str | None = None
-        if publish_latest_raw is not None:
-            publish_latest_utc = publish_latest_raw
-            if publish_latest_utc.tzinfo is None:
-                publish_latest_utc = publish_latest_utc.replace(tzinfo=timezone.utc)
-            date_range_latest = publish_latest_utc.isoformat()
 
         return {
             'recent_activity': {'7d': recent_7d, '30d': recent_30d},
-            'last_activity_at': last_activity_at,
+            'last_activity_at': _to_utc_iso(last_activity_raw),
             'days_since_last_note': days_since_last_note,
-            'date_range_latest': date_range_latest,
+            'date_range_latest': _to_utc_iso(publish_latest_raw),
         }
 
     async def delete_summary(self, vault_id: UUID) -> bool:
@@ -561,8 +567,8 @@ class VaultSummaryService:
             date_range: dict[str, str | None] = {'earliest': None, 'latest': None}
             if date_row and date_row[0]:
                 date_range = {
-                    'earliest': date_row[0].isoformat() if date_row[0] else None,
-                    'latest': date_row[1].isoformat() if date_row[1] else None,
+                    'earliest': _to_utc_iso(date_row[0]),
+                    'latest': _to_utc_iso(date_row[1]),
                 }
 
             # Template distribution, source domains, tags — from doc_metadata JSONB
@@ -627,13 +633,11 @@ class VaultSummaryService:
                 )
             ).scalar()
 
-        last_activity_at: str | None = None
         days_since_last_note: int | None = None
         if last_activity_row is not None:
             last_activity_utc = last_activity_row
             if last_activity_utc.tzinfo is None:
                 last_activity_utc = last_activity_utc.replace(tzinfo=timezone.utc)
-            last_activity_at = last_activity_utc.isoformat()
             days_since_last_note = max((now - last_activity_utc).days, 0)
 
         return {
@@ -644,7 +648,7 @@ class VaultSummaryService:
             'by_source_domain': dict(domain_counts.most_common(10)),
             'top_tags': dict(tag_counts.most_common(15)),
             'recent_activity': {'7d': recent_7d, '30d': recent_30d},
-            'last_activity_at': last_activity_at,
+            'last_activity_at': _to_utc_iso(last_activity_row),
             'days_since_last_note': days_since_last_note,
         }
 

--- a/packages/core/src/memex_core/services/vault_summary_signatures.py
+++ b/packages/core/src/memex_core/services/vault_summary_signatures.py
@@ -73,9 +73,10 @@ class VaultSummaryUpdateSignature(dspy.Signature):
     thematic synthesis (2-4 sentences, max 200 tokens) capturing what the vault
     is about and what cross-cutting patterns connect the themes.
 
-    Use publish_date fields to determine trend: growing (3+ new in 30d),
-    stable (1-2), dormant (none in 30d). Adjust note_count by adding new
-    notes that fit each theme to the existing count.
+    Use publish_date fields relative to current_time to determine trend:
+    growing (3+ new in the 30 days before current_time), stable (1-2),
+    dormant (none in 30 days). Adjust note_count by adding new notes that
+    fit each theme to the existing count.
     """
 
     current_narrative: str = dspy.InputField(
@@ -84,6 +85,10 @@ class VaultSummaryUpdateSignature(dspy.Signature):
     current_themes: list[LLMTheme] = dspy.InputField(desc='Current themes.')
     new_notes: list[NoteMetadata] = dspy.InputField(desc='Newly added notes with rich metadata.')
     vault_stats: VaultStats = dspy.InputField(desc='Vault statistics for context.')
+    current_time: str = dspy.InputField(
+        desc='Current wall-clock time in ISO 8601 UTC. Anchor the "last 30 days" '
+        'window for trend classification to this timestamp.'
+    )
 
     updated_narrative: str = dspy.OutputField(
         desc='Updated narrative. Short thematic synthesis (2-4 sentences), max 200 tokens. '
@@ -101,15 +106,20 @@ class VaultSummaryFullSignature(dspy.Signature):
     narrative. The narrative (2-4 sentences, max 200 tokens) should capture the
     overall scope of the vault and the patterns connecting its themes.
 
-    Use publish_date fields to determine each theme's trend: growing (3+ notes
-    added in last 30 days), stable (1-2), dormant (none in 30 days).
-    Pick 2-3 representative note titles per theme from the input.
+    Use publish_date fields relative to current_time to determine each theme's
+    trend: growing (3+ notes added in the 30 days before current_time),
+    stable (1-2), dormant (none in 30 days). Pick 2-3 representative note
+    titles per theme from the input.
     """
 
     notes: list[NoteMetadata] = dspy.InputField(desc='All note metadata in the vault.')
     vault_note_count: int = dspy.InputField(desc='Total number of notes in the vault.')
     max_narrative_tokens: int = dspy.InputField(
         desc='Maximum token count for the narrative output.'
+    )
+    current_time: str = dspy.InputField(
+        desc='Current wall-clock time in ISO 8601 UTC. Anchor the "last 30 days" '
+        'window for trend classification to this timestamp.'
     )
 
     narrative: str = dspy.OutputField(
@@ -124,11 +134,17 @@ class VaultTopicExtractSignature(dspy.Signature):
 
     Given a batch of note metadata, identify the key themes covered.
     This is the first pass in hierarchical summarization for large vaults.
+    Use publish_date fields relative to current_time when classifying each
+    theme's trend (growing / stable / dormant over the last 30 days).
     """
 
     notes: list[NoteMetadata] = dspy.InputField(desc='Note metadata in this batch.')
     batch_index: int = dspy.InputField(desc='The index of this batch (0-based).')
     total_batches: int = dspy.InputField(desc='Total number of batches being processed.')
+    current_time: str = dspy.InputField(
+        desc='Current wall-clock time in ISO 8601 UTC. Anchor the "last 30 days" '
+        'window for trend classification to this timestamp.'
+    )
 
     themes: list[LLMTheme] = dspy.OutputField(desc='Extracted themes from this batch.')
     batch_summary: str = dspy.OutputField(
@@ -144,13 +160,18 @@ class VaultTopicMergeSignature(dspy.Signature):
 
     Deduplicate themes that refer to the same concept under different names.
     Sum note_count when merging duplicate themes. Keep between 5-15 final themes.
-    Narrative must be under 200 tokens.
+    Narrative must be under 200 tokens. Use current_time to anchor each
+    merged theme's trend classification to the 30 days before that timestamp.
     """
 
     batch_results: list[BatchResult] = dspy.InputField(
         desc='Results from each batch: themes and batch summaries.'
     )
     vault_note_count: int = dspy.InputField(desc='Total number of notes in the vault.')
+    current_time: str = dspy.InputField(
+        desc='Current wall-clock time in ISO 8601 UTC. Anchor the "last 30 days" '
+        'window for trend classification to this timestamp.'
+    )
 
     narrative: str = dspy.OutputField(
         desc='Thematic synthesis from all batches, max 200 tokens. '

--- a/packages/core/tests/unit/services/conftest.py
+++ b/packages/core/tests/unit/services/conftest.py
@@ -1,0 +1,58 @@
+"""Shared mock helpers for ``vault_summary`` service tests.
+
+Used by ``test_vault_summary_service.py`` and ``test_vault_summary_regression.py``.
+Pytest auto-discovers this file and adds its directory to ``sys.path``, so
+sibling test modules can ``from conftest import _mock_inventory_session``.
+
+Adding a new SQL query in ``_compute_inventory`` requires updating only
+``_mock_inventory_session`` here, not every individual test.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _scalar_result(value):
+    r = MagicMock()
+    r.scalar = MagicMock(return_value=value)
+    return r
+
+
+def _one_or_none_result(value):
+    r = MagicMock()
+    r.one_or_none = MagicMock(return_value=value)
+    return r
+
+
+def _all_result(rows):
+    r = MagicMock()
+    r.all = MagicMock(return_value=rows)
+    return r
+
+
+def _mock_inventory_session(
+    *,
+    total_notes=0,
+    total_entities=0,
+    date_range=None,
+    doc_metadata=None,
+    recent_7d=0,
+    recent_30d=0,
+    last_activity=None,
+):
+    """Mock the 7 SQL queries issued by ``_compute_inventory``, keyed by purpose."""
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(total_notes),
+            _scalar_result(total_entities),
+            _one_or_none_result(date_range),
+            _all_result(doc_metadata or []),
+            _scalar_result(recent_7d),
+            _scalar_result(recent_30d),
+            _scalar_result(last_activity),
+        ]
+    )
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx, session

--- a/packages/core/tests/unit/services/test_vault_summary_regression.py
+++ b/packages/core/tests/unit/services/test_vault_summary_regression.py
@@ -29,6 +29,57 @@ def _make_service(config: VaultSummaryConfig | None = None) -> VaultSummaryServi
     )
 
 
+def _scalar_result(value):
+    r = MagicMock()
+    r.scalar = MagicMock(return_value=value)
+    return r
+
+
+def _one_or_none_result(value):
+    r = MagicMock()
+    r.one_or_none = MagicMock(return_value=value)
+    return r
+
+
+def _all_result(rows):
+    r = MagicMock()
+    r.all = MagicMock(return_value=rows)
+    return r
+
+
+def _mock_inventory_session(
+    *,
+    total_notes=0,
+    total_entities=0,
+    date_range=None,
+    doc_metadata=None,
+    recent_7d=0,
+    recent_30d=0,
+    last_activity=None,
+):
+    """Mock the 7 SQL queries issued by ``_compute_inventory``, keyed by purpose.
+
+    Mirrored in test_vault_summary_service.py. Adding a new query in
+    ``_compute_inventory`` requires updating only this helper.
+    """
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(total_notes),
+            _scalar_result(total_entities),
+            _one_or_none_result(date_range),
+            _all_result(doc_metadata or []),
+            _scalar_result(recent_7d),
+            _scalar_result(recent_30d),
+            _scalar_result(last_activity),
+        ]
+    )
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx, session
+
+
 # ─── 1. Version-tracking regression: no infinite loop ───
 
 
@@ -91,19 +142,12 @@ class TestVersionTrackingNoInfiniteLoop:
         ctx1.__aexit__ = AsyncMock(return_value=False)
 
         # Phase 2: compute_inventory session
-        inv_session = AsyncMock()
-        inv_results = [MagicMock() for _ in range(7)]
-        inv_results[0].scalar.return_value = 21  # total_notes
-        inv_results[1].scalar.return_value = 5  # total_entities
-        inv_results[2].one_or_none.return_value = None  # date_range
-        inv_results[3].all.return_value = []  # doc_metadata
-        inv_results[4].scalar.return_value = 2  # recent_7d
-        inv_results[5].scalar.return_value = 10  # recent_30d
-        inv_results[6].scalar.return_value = None  # last_activity_at
-        inv_session.execute = AsyncMock(side_effect=inv_results)
-        inv_ctx = AsyncMock()
-        inv_ctx.__aenter__ = AsyncMock(return_value=inv_session)
-        inv_ctx.__aexit__ = AsyncMock(return_value=False)
+        inv_ctx, _ = _mock_inventory_session(
+            total_notes=21,
+            total_entities=5,
+            recent_7d=2,
+            recent_30d=10,
+        )
 
         # Phase 2b: compute_key_entities session
         ke_session = AsyncMock()
@@ -221,20 +265,7 @@ class TestComputeInventory:
         svc = _make_service()
         vault_id = uuid4()
 
-        session = AsyncMock()
-        results = [MagicMock() for _ in range(7)]
-        results[0].scalar.return_value = 0  # total_notes
-        results[1].scalar.return_value = 0  # total_entities
-        results[2].one_or_none.return_value = (None, None)  # date_range
-        results[3].all.return_value = []  # doc_metadata
-        results[4].scalar.return_value = 0  # recent_7d
-        results[5].scalar.return_value = 0  # recent_30d
-        results[6].scalar.return_value = None  # last_activity_at
-        session.execute = AsyncMock(side_effect=results)
-
-        ctx = AsyncMock()
-        ctx.__aenter__ = AsyncMock(return_value=session)
-        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx, _ = _mock_inventory_session(date_range=(None, None))
         svc.metastore.session = lambda: ctx
 
         inv = await svc._compute_inventory(vault_id)
@@ -253,40 +284,42 @@ class TestComputeInventory:
         svc = _make_service()
         vault_id = uuid4()
 
-        session = AsyncMock()
-        results = [MagicMock() for _ in range(7)]
-        results[0].scalar.return_value = 3
-
-        results[1].scalar.return_value = 2
-
         date_row = MagicMock()
         date_row.__getitem__ = lambda self, idx: [
             datetime(2024, 1, 15, tzinfo=timezone.utc),
             datetime(2026, 4, 6, tzinfo=timezone.utc),
         ][idx]
-        results[2].one_or_none.return_value = date_row
 
-        # doc_metadata rows
-        results[3].all.return_value = [
-            (
-                {
-                    'template': 'article',
-                    'source_uri': 'https://arxiv.org/paper1',
-                    'tags': ['ai', 'ml'],
-                },
-            ),
-            ({'template': 'article', 'source_uri': 'https://arxiv.org/paper2', 'tags': ['ai']},),
-            ({'template': 'bookmark', 'source_uri': 'https://github.com/repo', 'tags': ['code']},),
-        ]
-
-        results[4].scalar.return_value = 1
-        results[5].scalar.return_value = 3
-        results[6].scalar.return_value = None  # last_activity_at
-        session.execute = AsyncMock(side_effect=results)
-
-        ctx = AsyncMock()
-        ctx.__aenter__ = AsyncMock(return_value=session)
-        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx, _ = _mock_inventory_session(
+            total_notes=3,
+            total_entities=2,
+            date_range=date_row,
+            doc_metadata=[
+                (
+                    {
+                        'template': 'article',
+                        'source_uri': 'https://arxiv.org/paper1',
+                        'tags': ['ai', 'ml'],
+                    },
+                ),
+                (
+                    {
+                        'template': 'article',
+                        'source_uri': 'https://arxiv.org/paper2',
+                        'tags': ['ai'],
+                    },
+                ),
+                (
+                    {
+                        'template': 'bookmark',
+                        'source_uri': 'https://github.com/repo',
+                        'tags': ['code'],
+                    },
+                ),
+            ],
+            recent_7d=1,
+            recent_30d=3,
+        )
         svc.metastore.session = lambda: ctx
 
         inv = await svc._compute_inventory(vault_id)
@@ -302,27 +335,15 @@ class TestComputeInventory:
         svc = _make_service()
         vault_id = uuid4()
 
-        session = AsyncMock()
-        results = [MagicMock() for _ in range(7)]
-        results[0].scalar.return_value = 2
-        results[1].scalar.return_value = 0
-        results[2].one_or_none.return_value = (None, None)
-
-        # Mixed: one valid, one None, one non-dict
-        results[3].all.return_value = [
-            ({'template': 'article', 'tags': ['ai']},),
-            (None,),
-            ('not-a-dict',),
-        ]
-
-        results[4].scalar.return_value = 0
-        results[5].scalar.return_value = 0
-        results[6].scalar.return_value = None  # last_activity_at
-        session.execute = AsyncMock(side_effect=results)
-
-        ctx = AsyncMock()
-        ctx.__aenter__ = AsyncMock(return_value=session)
-        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx, _ = _mock_inventory_session(
+            total_notes=2,
+            date_range=(None, None),
+            doc_metadata=[
+                ({'template': 'article', 'tags': ['ai']},),
+                (None,),
+                ('not-a-dict',),
+            ],
+        )
         svc.metastore.session = lambda: ctx
 
         inv = await svc._compute_inventory(vault_id)
@@ -336,24 +357,11 @@ class TestComputeInventory:
         svc = _make_service()
         vault_id = uuid4()
 
-        session = AsyncMock()
-        results = [MagicMock() for _ in range(7)]
-        results[0].scalar.return_value = 1
-        results[1].scalar.return_value = 0
-        results[2].one_or_none.return_value = (None, None)
-
-        results[3].all.return_value = [
-            ({'source_uri': 'not://a[valid/url', 'tags': []},),
-        ]
-
-        results[4].scalar.return_value = 0
-        results[5].scalar.return_value = 0
-        results[6].scalar.return_value = None  # last_activity_at
-        session.execute = AsyncMock(side_effect=results)
-
-        ctx = AsyncMock()
-        ctx.__aenter__ = AsyncMock(return_value=session)
-        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx, _ = _mock_inventory_session(
+            total_notes=1,
+            date_range=(None, None),
+            doc_metadata=[({'source_uri': 'not://a[valid/url', 'tags': []},)],
+        )
         svc.metastore.session = lambda: ctx
 
         # Should not raise

--- a/packages/core/tests/unit/services/test_vault_summary_regression.py
+++ b/packages/core/tests/unit/services/test_vault_summary_regression.py
@@ -92,13 +92,14 @@ class TestVersionTrackingNoInfiniteLoop:
 
         # Phase 2: compute_inventory session
         inv_session = AsyncMock()
-        inv_results = [MagicMock() for _ in range(6)]
+        inv_results = [MagicMock() for _ in range(7)]
         inv_results[0].scalar.return_value = 21  # total_notes
         inv_results[1].scalar.return_value = 5  # total_entities
         inv_results[2].one_or_none.return_value = None  # date_range
         inv_results[3].all.return_value = []  # doc_metadata
         inv_results[4].scalar.return_value = 2  # recent_7d
         inv_results[5].scalar.return_value = 10  # recent_30d
+        inv_results[6].scalar.return_value = None  # last_activity_at
         inv_session.execute = AsyncMock(side_effect=inv_results)
         inv_ctx = AsyncMock()
         inv_ctx.__aenter__ = AsyncMock(return_value=inv_session)
@@ -221,13 +222,14 @@ class TestComputeInventory:
         vault_id = uuid4()
 
         session = AsyncMock()
-        results = [MagicMock() for _ in range(6)]
+        results = [MagicMock() for _ in range(7)]
         results[0].scalar.return_value = 0  # total_notes
         results[1].scalar.return_value = 0  # total_entities
         results[2].one_or_none.return_value = (None, None)  # date_range
         results[3].all.return_value = []  # doc_metadata
         results[4].scalar.return_value = 0  # recent_7d
         results[5].scalar.return_value = 0  # recent_30d
+        results[6].scalar.return_value = None  # last_activity_at
         session.execute = AsyncMock(side_effect=results)
 
         ctx = AsyncMock()
@@ -252,7 +254,7 @@ class TestComputeInventory:
         vault_id = uuid4()
 
         session = AsyncMock()
-        results = [MagicMock() for _ in range(6)]
+        results = [MagicMock() for _ in range(7)]
         results[0].scalar.return_value = 3
 
         results[1].scalar.return_value = 2
@@ -279,6 +281,7 @@ class TestComputeInventory:
 
         results[4].scalar.return_value = 1
         results[5].scalar.return_value = 3
+        results[6].scalar.return_value = None  # last_activity_at
         session.execute = AsyncMock(side_effect=results)
 
         ctx = AsyncMock()
@@ -300,7 +303,7 @@ class TestComputeInventory:
         vault_id = uuid4()
 
         session = AsyncMock()
-        results = [MagicMock() for _ in range(6)]
+        results = [MagicMock() for _ in range(7)]
         results[0].scalar.return_value = 2
         results[1].scalar.return_value = 0
         results[2].one_or_none.return_value = (None, None)
@@ -314,6 +317,7 @@ class TestComputeInventory:
 
         results[4].scalar.return_value = 0
         results[5].scalar.return_value = 0
+        results[6].scalar.return_value = None  # last_activity_at
         session.execute = AsyncMock(side_effect=results)
 
         ctx = AsyncMock()
@@ -333,7 +337,7 @@ class TestComputeInventory:
         vault_id = uuid4()
 
         session = AsyncMock()
-        results = [MagicMock() for _ in range(6)]
+        results = [MagicMock() for _ in range(7)]
         results[0].scalar.return_value = 1
         results[1].scalar.return_value = 0
         results[2].one_or_none.return_value = (None, None)
@@ -344,6 +348,7 @@ class TestComputeInventory:
 
         results[4].scalar.return_value = 0
         results[5].scalar.return_value = 0
+        results[6].scalar.return_value = None  # last_activity_at
         session.execute = AsyncMock(side_effect=results)
 
         ctx = AsyncMock()

--- a/packages/core/tests/unit/services/test_vault_summary_regression.py
+++ b/packages/core/tests/unit/services/test_vault_summary_regression.py
@@ -13,6 +13,8 @@ from uuid import uuid4
 
 import pytest
 
+from conftest import _mock_inventory_session  # type: ignore[attr-defined]
+
 from memex_common.config import VaultSummaryConfig
 from memex_core.memory.sql_models import VaultSummary
 from memex_core.services.vault_summary import VaultSummaryService
@@ -27,57 +29,6 @@ def _make_service(config: VaultSummaryConfig | None = None) -> VaultSummaryServi
         lm=lm,
         config=config or VaultSummaryConfig(),
     )
-
-
-def _scalar_result(value):
-    r = MagicMock()
-    r.scalar = MagicMock(return_value=value)
-    return r
-
-
-def _one_or_none_result(value):
-    r = MagicMock()
-    r.one_or_none = MagicMock(return_value=value)
-    return r
-
-
-def _all_result(rows):
-    r = MagicMock()
-    r.all = MagicMock(return_value=rows)
-    return r
-
-
-def _mock_inventory_session(
-    *,
-    total_notes=0,
-    total_entities=0,
-    date_range=None,
-    doc_metadata=None,
-    recent_7d=0,
-    recent_30d=0,
-    last_activity=None,
-):
-    """Mock the 7 SQL queries issued by ``_compute_inventory``, keyed by purpose.
-
-    Mirrored in test_vault_summary_service.py. Adding a new query in
-    ``_compute_inventory`` requires updating only this helper.
-    """
-    session = AsyncMock()
-    session.execute = AsyncMock(
-        side_effect=[
-            _scalar_result(total_notes),
-            _scalar_result(total_entities),
-            _one_or_none_result(date_range),
-            _all_result(doc_metadata or []),
-            _scalar_result(recent_7d),
-            _scalar_result(recent_30d),
-            _scalar_result(last_activity),
-        ]
-    )
-    ctx = AsyncMock()
-    ctx.__aenter__ = AsyncMock(return_value=session)
-    ctx.__aexit__ = AsyncMock(return_value=False)
-    return ctx, session
 
 
 # ─── 1. Version-tracking regression: no infinite loop ───

--- a/packages/core/tests/unit/services/test_vault_summary_service.py
+++ b/packages/core/tests/unit/services/test_vault_summary_service.py
@@ -63,7 +63,8 @@ class TestGetSummary:
         summary = VaultSummary(vault_id=vault_id, narrative='Test summary')
         ctx, session = _mock_session(summary)
         svc.metastore.session = lambda: ctx
-        result = await svc.get_summary(vault_id)
+        with patch.object(svc, '_apply_freshness_overlay', AsyncMock(side_effect=lambda s: s)):
+            result = await svc.get_summary(vault_id)
         assert result == summary
 
     @pytest.mark.asyncio
@@ -74,6 +75,231 @@ class TestGetSummary:
         svc.metastore.session = lambda: ctx
         result = await svc.get_summary(vault_id)
         assert result is None
+
+
+class TestFreshnessOverlay:
+    """Overlay recomputes time-sensitive fields on read and demotes stale trends."""
+
+    @staticmethod
+    def _fresh(**overrides):
+        base = {
+            'recent_activity': {'7d': 0, '30d': 0},
+            'last_activity_at': None,
+            'days_since_last_note': None,
+            'date_range': {},
+        }
+        base.update(overrides)
+        return base
+
+    @pytest.mark.asyncio
+    async def test_overlays_fresh_recent_activity(self):
+        svc = _make_service()
+        vault_id = uuid4()
+        summary = VaultSummary(
+            vault_id=vault_id,
+            narrative='Test',
+            inventory={
+                'total_notes': 100,
+                'recent_activity': {'7d': 277, '30d': 405},
+                'last_activity_at': '2026-03-01T00:00:00+00:00',
+                'days_since_last_note': 0,
+                'date_range': {'earliest': '2025-01-01', 'latest': '2026-03-01'},
+            },
+            themes=[],
+        )
+        fresh = self._fresh(
+            recent_activity={'7d': 0, '30d': 0},
+            last_activity_at='2026-03-01T00:00:00+00:00',
+            days_since_last_note=54,
+            date_range={'latest': '2026-03-01'},
+        )
+        ctx, _ = _mock_session(summary)
+        svc.metastore.session = lambda: ctx
+        with patch.object(svc, '_compute_inventory', AsyncMock(return_value=fresh)):
+            result = await svc.get_summary(vault_id)
+        assert result is not None
+        assert result.inventory['recent_activity'] == {'7d': 0, '30d': 0}
+        assert result.inventory['last_activity_at'] == '2026-03-01T00:00:00+00:00'
+        assert result.inventory['days_since_last_note'] == 54
+        # Non-time-sensitive fields preserved from the persisted row
+        assert result.inventory['total_notes'] == 100
+
+    @pytest.mark.asyncio
+    async def test_demotes_theme_trends_when_vault_cold(self):
+        svc = _make_service(VaultSummaryConfig(dormant_threshold_days=30))
+        vault_id = uuid4()
+        persisted_themes = [
+            {'name': 'A', 'note_count': 5, 'description': 'x', 'trend': 'growing'},
+            {'name': 'B', 'note_count': 3, 'description': 'y', 'trend': 'stable'},
+            {'name': 'C', 'note_count': 1, 'description': 'z', 'trend': 'dormant'},
+        ]
+        summary = VaultSummary(
+            vault_id=vault_id, narrative='Test', inventory={}, themes=persisted_themes
+        )
+        fresh = self._fresh(last_activity_at='2026-03-01T00:00:00+00:00', days_since_last_note=50)
+        ctx, _ = _mock_session(summary)
+        svc.metastore.session = lambda: ctx
+        with patch.object(svc, '_compute_inventory', AsyncMock(return_value=fresh)):
+            result = await svc.get_summary(vault_id)
+        assert result is not None
+        assert [t['trend'] for t in result.themes] == ['dormant', 'dormant', 'dormant']
+        # Other theme fields preserved
+        assert result.themes[0]['name'] == 'A'
+        assert result.themes[1]['note_count'] == 3
+
+    @pytest.mark.asyncio
+    async def test_keeps_trends_when_vault_active(self):
+        svc = _make_service(VaultSummaryConfig(dormant_threshold_days=30))
+        vault_id = uuid4()
+        summary = VaultSummary(
+            vault_id=vault_id,
+            narrative='Test',
+            inventory={},
+            themes=[
+                {'name': 'A', 'note_count': 5, 'description': 'x', 'trend': 'growing'},
+                {'name': 'B', 'note_count': 3, 'description': 'y', 'trend': 'stable'},
+            ],
+        )
+        fresh = self._fresh(last_activity_at='2026-04-22T00:00:00+00:00', days_since_last_note=2)
+        ctx, _ = _mock_session(summary)
+        svc.metastore.session = lambda: ctx
+        with patch.object(svc, '_compute_inventory', AsyncMock(return_value=fresh)):
+            result = await svc.get_summary(vault_id)
+        assert result is not None
+        assert [t['trend'] for t in result.themes] == ['growing', 'stable']
+
+    @pytest.mark.asyncio
+    async def test_overlay_preserves_template_and_tag_counts(self):
+        svc = _make_service()
+        vault_id = uuid4()
+        summary = VaultSummary(
+            vault_id=vault_id,
+            narrative='Test',
+            inventory={
+                'by_template': {'daily': 10, 'meeting': 5},
+                'top_tags': {'work': 8, 'personal': 3},
+            },
+            themes=[],
+        )
+        fresh = self._fresh()
+        ctx, _ = _mock_session(summary)
+        svc.metastore.session = lambda: ctx
+        with patch.object(svc, '_compute_inventory', AsyncMock(return_value=fresh)):
+            result = await svc.get_summary(vault_id)
+        assert result is not None
+        assert result.inventory['by_template'] == {'daily': 10, 'meeting': 5}
+        assert result.inventory['top_tags'] == {'work': 8, 'personal': 3}
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_vault(self):
+        svc = _make_service()
+        vault_id = uuid4()
+        summary = VaultSummary(
+            vault_id=vault_id,
+            narrative='',
+            inventory={},
+            themes=[
+                {'name': 'A', 'note_count': 0, 'description': 'x', 'trend': 'stable'},
+            ],
+        )
+        fresh = self._fresh()
+        ctx, _ = _mock_session(summary)
+        svc.metastore.session = lambda: ctx
+        with patch.object(svc, '_compute_inventory', AsyncMock(return_value=fresh)):
+            result = await svc.get_summary(vault_id)
+        assert result is not None
+        assert result.inventory['last_activity_at'] is None
+        assert result.inventory['days_since_last_note'] is None
+        # Trend demotion should not run when last_activity is None
+        assert result.themes[0]['trend'] == 'stable'
+
+    @pytest.mark.asyncio
+    async def test_none_summary_skips_overlay(self):
+        svc = _make_service()
+        vault_id = uuid4()
+        ctx, _ = _mock_session(None)
+        svc.metastore.session = lambda: ctx
+        with patch.object(svc, '_compute_inventory', AsyncMock()) as mock_inv:
+            result = await svc.get_summary(vault_id)
+        assert result is None
+        mock_inv.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_compute_inventory_returns_last_activity_fields(self):
+        """_compute_inventory adds last_activity_at (ISO) and days_since_last_note."""
+        svc = _make_service()
+        vault_id = uuid4()
+        last_activity = datetime(2026, 4, 15, tzinfo=timezone.utc)
+        frozen_now = datetime(2026, 4, 24, tzinfo=timezone.utc)
+
+        class _FrozenDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return frozen_now if tz is None else frozen_now.astimezone(tz)
+
+        session = AsyncMock()
+        total_res = MagicMock()
+        total_res.scalar = MagicMock(return_value=10)
+        ent_res = MagicMock()
+        ent_res.scalar = MagicMock(return_value=5)
+        date_res = MagicMock()
+        date_res.one_or_none = MagicMock(return_value=None)
+        meta_res = MagicMock()
+        meta_res.all = MagicMock(return_value=[])
+        r7_res = MagicMock()
+        r7_res.scalar = MagicMock(return_value=2)
+        r30_res = MagicMock()
+        r30_res.scalar = MagicMock(return_value=5)
+        la_res = MagicMock()
+        la_res.scalar = MagicMock(return_value=last_activity)
+        session.execute = AsyncMock(
+            side_effect=[total_res, ent_res, date_res, meta_res, r7_res, r30_res, la_res]
+        )
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        svc.metastore.session = lambda: ctx
+
+        with patch('memex_core.services.vault_summary.datetime', _FrozenDatetime):
+            inv = await svc._compute_inventory(vault_id)
+
+        assert inv['last_activity_at'] == last_activity.isoformat()
+        assert inv['days_since_last_note'] == 9
+        assert inv['recent_activity'] == {'7d': 2, '30d': 5}
+
+    @pytest.mark.asyncio
+    async def test_compute_inventory_empty_vault_nulls(self):
+        """_compute_inventory handles max(created_at) == None (empty vault)."""
+        svc = _make_service()
+        vault_id = uuid4()
+
+        session = AsyncMock()
+        total_res = MagicMock()
+        total_res.scalar = MagicMock(return_value=0)
+        ent_res = MagicMock()
+        ent_res.scalar = MagicMock(return_value=0)
+        date_res = MagicMock()
+        date_res.one_or_none = MagicMock(return_value=None)
+        meta_res = MagicMock()
+        meta_res.all = MagicMock(return_value=[])
+        r7_res = MagicMock()
+        r7_res.scalar = MagicMock(return_value=0)
+        r30_res = MagicMock()
+        r30_res.scalar = MagicMock(return_value=0)
+        la_res = MagicMock()
+        la_res.scalar = MagicMock(return_value=None)
+        session.execute = AsyncMock(
+            side_effect=[total_res, ent_res, date_res, meta_res, r7_res, r30_res, la_res]
+        )
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        svc.metastore.session = lambda: ctx
+
+        inv = await svc._compute_inventory(vault_id)
+
+        assert inv['last_activity_at'] is None
+        assert inv['days_since_last_note'] is None
 
 
 class TestDeleteSummary:

--- a/packages/core/tests/unit/services/test_vault_summary_service.py
+++ b/packages/core/tests/unit/services/test_vault_summary_service.py
@@ -404,6 +404,30 @@ class TestFreshnessOverlay:
         assert inv['date_range']['earliest'].endswith('+00:00')
         assert inv['date_range']['latest'].endswith('+00:00')
 
+    def test_date_range_uses_publish_date_in_both_paths(self):
+        """Pin write-path and read-path to the same column for ``date_range``.
+
+        ``_compute_inventory`` (writer) computes ``date_range.{earliest,latest}``
+        from ``Note.publish_date``. ``_compute_fresh_fields`` (reader, used by
+        ``_apply_freshness_overlay``) overlays ``date_range.latest`` from the
+        same column. If a future change drifts one path to ``Note.created_at``,
+        the overlay would silently change the field's meaning across the API.
+        This test inspects the source of both methods to lock the invariant.
+        """
+        import inspect
+
+        from memex_core.services import vault_summary as vs
+
+        inv_src = inspect.getsource(vs.VaultSummaryService._compute_inventory)
+        fresh_src = inspect.getsource(vs.VaultSummaryService._compute_fresh_fields)
+
+        assert 'func.max(Note.publish_date)' in inv_src, (
+            '_compute_inventory must aggregate max(publish_date) for date_range.latest'
+        )
+        assert 'func.max(Note.publish_date)' in fresh_src, (
+            '_compute_fresh_fields must aggregate max(publish_date) for date_range_latest'
+        )
+
 
 class TestDeleteSummary:
     @pytest.mark.asyncio

--- a/packages/core/tests/unit/services/test_vault_summary_service.py
+++ b/packages/core/tests/unit/services/test_vault_summary_service.py
@@ -86,7 +86,7 @@ class TestFreshnessOverlay:
             'recent_activity': {'7d': 0, '30d': 0},
             'last_activity_at': None,
             'days_since_last_note': None,
-            'date_range': {},
+            'date_range_latest': None,
         }
         base.update(overrides)
         return base
@@ -111,11 +111,11 @@ class TestFreshnessOverlay:
             recent_activity={'7d': 0, '30d': 0},
             last_activity_at='2026-03-01T00:00:00+00:00',
             days_since_last_note=54,
-            date_range={'latest': '2026-03-01'},
+            date_range_latest='2026-03-01',
         )
         ctx, _ = _mock_session(summary)
         svc.metastore.session = lambda: ctx
-        with patch.object(svc, '_compute_inventory', AsyncMock(return_value=fresh)):
+        with patch.object(svc, '_compute_fresh_fields', AsyncMock(return_value=fresh)):
             result = await svc.get_summary(vault_id)
         assert result is not None
         assert result.inventory['recent_activity'] == {'7d': 0, '30d': 0}
@@ -139,7 +139,7 @@ class TestFreshnessOverlay:
         fresh = self._fresh(last_activity_at='2026-03-01T00:00:00+00:00', days_since_last_note=50)
         ctx, _ = _mock_session(summary)
         svc.metastore.session = lambda: ctx
-        with patch.object(svc, '_compute_inventory', AsyncMock(return_value=fresh)):
+        with patch.object(svc, '_compute_fresh_fields', AsyncMock(return_value=fresh)):
             result = await svc.get_summary(vault_id)
         assert result is not None
         assert [t['trend'] for t in result.themes] == ['dormant', 'dormant', 'dormant']
@@ -163,10 +163,31 @@ class TestFreshnessOverlay:
         fresh = self._fresh(last_activity_at='2026-04-22T00:00:00+00:00', days_since_last_note=2)
         ctx, _ = _mock_session(summary)
         svc.metastore.session = lambda: ctx
-        with patch.object(svc, '_compute_inventory', AsyncMock(return_value=fresh)):
+        with patch.object(svc, '_compute_fresh_fields', AsyncMock(return_value=fresh)):
             result = await svc.get_summary(vault_id)
         assert result is not None
         assert [t['trend'] for t in result.themes] == ['growing', 'stable']
+
+    @pytest.mark.asyncio
+    async def test_threshold_boundary_does_not_demote(self):
+        """days_since == threshold must NOT demote (strict > semantics)."""
+        svc = _make_service(VaultSummaryConfig(dormant_threshold_days=30))
+        vault_id = uuid4()
+        summary = VaultSummary(
+            vault_id=vault_id,
+            narrative='Test',
+            inventory={},
+            themes=[
+                {'name': 'A', 'note_count': 5, 'description': 'x', 'trend': 'growing'},
+            ],
+        )
+        fresh = self._fresh(last_activity_at='2026-03-25T00:00:00+00:00', days_since_last_note=30)
+        ctx, _ = _mock_session(summary)
+        svc.metastore.session = lambda: ctx
+        with patch.object(svc, '_compute_fresh_fields', AsyncMock(return_value=fresh)):
+            result = await svc.get_summary(vault_id)
+        assert result is not None
+        assert result.themes[0]['trend'] == 'growing'
 
     @pytest.mark.asyncio
     async def test_overlay_preserves_template_and_tag_counts(self):
@@ -184,7 +205,7 @@ class TestFreshnessOverlay:
         fresh = self._fresh()
         ctx, _ = _mock_session(summary)
         svc.metastore.session = lambda: ctx
-        with patch.object(svc, '_compute_inventory', AsyncMock(return_value=fresh)):
+        with patch.object(svc, '_compute_fresh_fields', AsyncMock(return_value=fresh)):
             result = await svc.get_summary(vault_id)
         assert result is not None
         assert result.inventory['by_template'] == {'daily': 10, 'meeting': 5}
@@ -205,7 +226,7 @@ class TestFreshnessOverlay:
         fresh = self._fresh()
         ctx, _ = _mock_session(summary)
         svc.metastore.session = lambda: ctx
-        with patch.object(svc, '_compute_inventory', AsyncMock(return_value=fresh)):
+        with patch.object(svc, '_compute_fresh_fields', AsyncMock(return_value=fresh)):
             result = await svc.get_summary(vault_id)
         assert result is not None
         assert result.inventory['last_activity_at'] is None
@@ -219,23 +240,75 @@ class TestFreshnessOverlay:
         vault_id = uuid4()
         ctx, _ = _mock_session(None)
         svc.metastore.session = lambda: ctx
-        with patch.object(svc, '_compute_inventory', AsyncMock()) as mock_inv:
+        with patch.object(svc, '_compute_fresh_fields', AsyncMock()) as mock_fresh:
             result = await svc.get_summary(vault_id)
         assert result is None
-        mock_inv.assert_not_called()
+        mock_fresh.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_compute_inventory_returns_last_activity_fields(self):
-        """_compute_inventory adds last_activity_at (ISO) and days_since_last_note."""
+    async def test_compute_fresh_fields_returns_expected_shape(self):
+        """_compute_fresh_fields returns the overlay keys with injected _now."""
+        svc = _make_service()
+        vault_id = uuid4()
+        frozen_now = datetime(2026, 4, 24, tzinfo=timezone.utc)
+        last_activity = datetime(2026, 4, 15, tzinfo=timezone.utc)
+        publish_latest = datetime(2026, 4, 20, tzinfo=timezone.utc)
+
+        session = AsyncMock()
+        r7_res = MagicMock()
+        r7_res.scalar = MagicMock(return_value=2)
+        r30_res = MagicMock()
+        r30_res.scalar = MagicMock(return_value=5)
+        max_row = MagicMock()
+        max_row.__getitem__ = lambda _self, idx: [last_activity, publish_latest][idx]
+        max_res = MagicMock()
+        max_res.one_or_none = MagicMock(return_value=max_row)
+        session.execute = AsyncMock(side_effect=[r7_res, r30_res, max_res])
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        svc.metastore.session = lambda: ctx
+
+        fresh = await svc._compute_fresh_fields(vault_id, _now=frozen_now)
+
+        assert fresh['recent_activity'] == {'7d': 2, '30d': 5}
+        assert fresh['last_activity_at'] == last_activity.isoformat()
+        assert fresh['days_since_last_note'] == 9
+        assert fresh['date_range_latest'] == publish_latest.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_compute_fresh_fields_empty_vault(self):
+        """_compute_fresh_fields handles empty vault (nulls)."""
+        svc = _make_service()
+        vault_id = uuid4()
+
+        session = AsyncMock()
+        r7_res = MagicMock()
+        r7_res.scalar = MagicMock(return_value=0)
+        r30_res = MagicMock()
+        r30_res.scalar = MagicMock(return_value=0)
+        max_res = MagicMock()
+        max_res.one_or_none = MagicMock(return_value=None)
+        session.execute = AsyncMock(side_effect=[r7_res, r30_res, max_res])
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        svc.metastore.session = lambda: ctx
+
+        fresh = await svc._compute_fresh_fields(vault_id)
+
+        assert fresh['last_activity_at'] is None
+        assert fresh['days_since_last_note'] is None
+        assert fresh['date_range_latest'] is None
+        assert fresh['recent_activity'] == {'7d': 0, '30d': 0}
+
+    @pytest.mark.asyncio
+    async def test_compute_inventory_accepts_injected_now(self):
+        """_compute_inventory uses injected _now without patching datetime globally."""
         svc = _make_service()
         vault_id = uuid4()
         last_activity = datetime(2026, 4, 15, tzinfo=timezone.utc)
         frozen_now = datetime(2026, 4, 24, tzinfo=timezone.utc)
-
-        class _FrozenDatetime(datetime):
-            @classmethod
-            def now(cls, tz=None):
-                return frozen_now if tz is None else frozen_now.astimezone(tz)
 
         session = AsyncMock()
         total_res = MagicMock()
@@ -260,8 +333,7 @@ class TestFreshnessOverlay:
         ctx.__aexit__ = AsyncMock(return_value=False)
         svc.metastore.session = lambda: ctx
 
-        with patch('memex_core.services.vault_summary.datetime', _FrozenDatetime):
-            inv = await svc._compute_inventory(vault_id)
+        inv = await svc._compute_inventory(vault_id, _now=frozen_now)
 
         assert inv['last_activity_at'] == last_activity.isoformat()
         assert inv['days_since_last_note'] == 9

--- a/packages/core/tests/unit/services/test_vault_summary_service.py
+++ b/packages/core/tests/unit/services/test_vault_summary_service.py
@@ -36,6 +36,80 @@ def _mock_session(existing_summary: VaultSummary | None = None):
     return ctx, session
 
 
+def _scalar_result(value):
+    r = MagicMock()
+    r.scalar = MagicMock(return_value=value)
+    return r
+
+
+def _one_or_none_result(value):
+    r = MagicMock()
+    r.one_or_none = MagicMock(return_value=value)
+    return r
+
+
+def _all_result(rows):
+    r = MagicMock()
+    r.all = MagicMock(return_value=rows)
+    return r
+
+
+def _max_row(*values):
+    """Build a SQLAlchemy-style row supporting [0], [1] subscript access."""
+    row = MagicMock()
+    captured = list(values)
+    row.__getitem__ = lambda _self, idx: captured[idx]
+    return row
+
+
+def _mock_session_with_results(*results):
+    """Build a mock async session whose execute() yields ``results`` in order."""
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=results)
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx, session
+
+
+def _mock_inventory_session(
+    *,
+    total_notes=0,
+    total_entities=0,
+    date_range=None,
+    doc_metadata=None,
+    recent_7d=0,
+    recent_30d=0,
+    last_activity=None,
+):
+    """Mock the 7 SQL queries issued by ``_compute_inventory``, keyed by purpose."""
+    return _mock_session_with_results(
+        _scalar_result(total_notes),
+        _scalar_result(total_entities),
+        _one_or_none_result(date_range),
+        _all_result(doc_metadata or []),
+        _scalar_result(recent_7d),
+        _scalar_result(recent_30d),
+        _scalar_result(last_activity),
+    )
+
+
+def _mock_fresh_fields_session(
+    *,
+    recent_7d=0,
+    recent_30d=0,
+    last_activity=None,
+    publish_latest=None,
+):
+    """Mock the 2 SQL queries issued by ``_compute_fresh_fields``, keyed by purpose."""
+    has_max = last_activity is not None or publish_latest is not None
+    max_value = _max_row(last_activity, publish_latest) if has_max else None
+    return _mock_session_with_results(
+        _one_or_none_result((recent_7d, recent_30d)),
+        _one_or_none_result(max_value),
+    )
+
+
 def _make_note_metadata(count: int = 5) -> tuple[list[dict], list, list]:
     """Build note metadata + IDs as returned by _fetch_note_metadata."""
     ids = [uuid4() for _ in range(count)]
@@ -254,19 +328,12 @@ class TestFreshnessOverlay:
         last_activity = datetime(2026, 4, 15, tzinfo=timezone.utc)
         publish_latest = datetime(2026, 4, 20, tzinfo=timezone.utc)
 
-        session = AsyncMock()
-        r7_res = MagicMock()
-        r7_res.scalar = MagicMock(return_value=2)
-        r30_res = MagicMock()
-        r30_res.scalar = MagicMock(return_value=5)
-        max_row = MagicMock()
-        max_row.__getitem__ = lambda _self, idx: [last_activity, publish_latest][idx]
-        max_res = MagicMock()
-        max_res.one_or_none = MagicMock(return_value=max_row)
-        session.execute = AsyncMock(side_effect=[r7_res, r30_res, max_res])
-        ctx = AsyncMock()
-        ctx.__aenter__ = AsyncMock(return_value=session)
-        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx, _ = _mock_fresh_fields_session(
+            recent_7d=2,
+            recent_30d=5,
+            last_activity=last_activity,
+            publish_latest=publish_latest,
+        )
         svc.metastore.session = lambda: ctx
 
         fresh = await svc._compute_fresh_fields(vault_id, _now=frozen_now)
@@ -282,17 +349,7 @@ class TestFreshnessOverlay:
         svc = _make_service()
         vault_id = uuid4()
 
-        session = AsyncMock()
-        r7_res = MagicMock()
-        r7_res.scalar = MagicMock(return_value=0)
-        r30_res = MagicMock()
-        r30_res.scalar = MagicMock(return_value=0)
-        max_res = MagicMock()
-        max_res.one_or_none = MagicMock(return_value=None)
-        session.execute = AsyncMock(side_effect=[r7_res, r30_res, max_res])
-        ctx = AsyncMock()
-        ctx.__aenter__ = AsyncMock(return_value=session)
-        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx, _ = _mock_fresh_fields_session()
         svc.metastore.session = lambda: ctx
 
         fresh = await svc._compute_fresh_fields(vault_id)
@@ -303,6 +360,30 @@ class TestFreshnessOverlay:
         assert fresh['recent_activity'] == {'7d': 0, '30d': 0}
 
     @pytest.mark.asyncio
+    async def test_compute_fresh_fields_normalizes_naive_publish_date(self):
+        """publish_date stored as naive datetime gets +00:00 in date_range_latest."""
+        svc = _make_service()
+        vault_id = uuid4()
+        frozen_now = datetime(2026, 4, 24, tzinfo=timezone.utc)
+        # Naive timestamps — what a buggy or pre-tz-migration DB might return
+        naive_last_activity = datetime(2026, 4, 15)
+        naive_publish_latest = datetime(2026, 4, 20)
+
+        ctx, _ = _mock_fresh_fields_session(
+            recent_7d=1,
+            recent_30d=3,
+            last_activity=naive_last_activity,
+            publish_latest=naive_publish_latest,
+        )
+        svc.metastore.session = lambda: ctx
+
+        fresh = await svc._compute_fresh_fields(vault_id, _now=frozen_now)
+
+        # Both fields end with +00:00, no naive-vs-aware drift
+        assert fresh['last_activity_at'].endswith('+00:00')
+        assert fresh['date_range_latest'].endswith('+00:00')
+
+    @pytest.mark.asyncio
     async def test_compute_inventory_accepts_injected_now(self):
         """_compute_inventory uses injected _now without patching datetime globally."""
         svc = _make_service()
@@ -310,27 +391,13 @@ class TestFreshnessOverlay:
         last_activity = datetime(2026, 4, 15, tzinfo=timezone.utc)
         frozen_now = datetime(2026, 4, 24, tzinfo=timezone.utc)
 
-        session = AsyncMock()
-        total_res = MagicMock()
-        total_res.scalar = MagicMock(return_value=10)
-        ent_res = MagicMock()
-        ent_res.scalar = MagicMock(return_value=5)
-        date_res = MagicMock()
-        date_res.one_or_none = MagicMock(return_value=None)
-        meta_res = MagicMock()
-        meta_res.all = MagicMock(return_value=[])
-        r7_res = MagicMock()
-        r7_res.scalar = MagicMock(return_value=2)
-        r30_res = MagicMock()
-        r30_res.scalar = MagicMock(return_value=5)
-        la_res = MagicMock()
-        la_res.scalar = MagicMock(return_value=last_activity)
-        session.execute = AsyncMock(
-            side_effect=[total_res, ent_res, date_res, meta_res, r7_res, r30_res, la_res]
+        ctx, _ = _mock_inventory_session(
+            total_notes=10,
+            total_entities=5,
+            recent_7d=2,
+            recent_30d=5,
+            last_activity=last_activity,
         )
-        ctx = AsyncMock()
-        ctx.__aenter__ = AsyncMock(return_value=session)
-        ctx.__aexit__ = AsyncMock(return_value=False)
         svc.metastore.session = lambda: ctx
 
         inv = await svc._compute_inventory(vault_id, _now=frozen_now)
@@ -345,27 +412,7 @@ class TestFreshnessOverlay:
         svc = _make_service()
         vault_id = uuid4()
 
-        session = AsyncMock()
-        total_res = MagicMock()
-        total_res.scalar = MagicMock(return_value=0)
-        ent_res = MagicMock()
-        ent_res.scalar = MagicMock(return_value=0)
-        date_res = MagicMock()
-        date_res.one_or_none = MagicMock(return_value=None)
-        meta_res = MagicMock()
-        meta_res.all = MagicMock(return_value=[])
-        r7_res = MagicMock()
-        r7_res.scalar = MagicMock(return_value=0)
-        r30_res = MagicMock()
-        r30_res.scalar = MagicMock(return_value=0)
-        la_res = MagicMock()
-        la_res.scalar = MagicMock(return_value=None)
-        session.execute = AsyncMock(
-            side_effect=[total_res, ent_res, date_res, meta_res, r7_res, r30_res, la_res]
-        )
-        ctx = AsyncMock()
-        ctx.__aenter__ = AsyncMock(return_value=session)
-        ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx, _ = _mock_inventory_session()
         svc.metastore.session = lambda: ctx
 
         inv = await svc._compute_inventory(vault_id)

--- a/packages/core/tests/unit/services/test_vault_summary_service.py
+++ b/packages/core/tests/unit/services/test_vault_summary_service.py
@@ -420,6 +420,26 @@ class TestFreshnessOverlay:
         assert inv['last_activity_at'] is None
         assert inv['days_since_last_note'] is None
 
+    @pytest.mark.asyncio
+    async def test_compute_inventory_normalizes_naive_date_range(self):
+        """date_range.earliest and .latest get +00:00 even when DB returns naive."""
+        svc = _make_service()
+        vault_id = uuid4()
+        naive_earliest = datetime(2024, 1, 15)
+        naive_latest = datetime(2026, 4, 6)
+        date_row = _max_row(naive_earliest, naive_latest)
+
+        ctx, _ = _mock_inventory_session(
+            total_notes=3,
+            date_range=date_row,
+        )
+        svc.metastore.session = lambda: ctx
+
+        inv = await svc._compute_inventory(vault_id)
+
+        assert inv['date_range']['earliest'].endswith('+00:00')
+        assert inv['date_range']['latest'].endswith('+00:00')
+
 
 class TestDeleteSummary:
     @pytest.mark.asyncio

--- a/packages/core/tests/unit/services/test_vault_summary_service.py
+++ b/packages/core/tests/unit/services/test_vault_summary_service.py
@@ -6,6 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from conftest import (  # type: ignore[attr-defined]
+    _mock_inventory_session,
+    _one_or_none_result,
+)
 
 from memex_common.config import VaultSummaryConfig
 from memex_core.memory.sql_models import VaultSummary
@@ -36,24 +40,6 @@ def _mock_session(existing_summary: VaultSummary | None = None):
     return ctx, session
 
 
-def _scalar_result(value):
-    r = MagicMock()
-    r.scalar = MagicMock(return_value=value)
-    return r
-
-
-def _one_or_none_result(value):
-    r = MagicMock()
-    r.one_or_none = MagicMock(return_value=value)
-    return r
-
-
-def _all_result(rows):
-    r = MagicMock()
-    r.all = MagicMock(return_value=rows)
-    return r
-
-
 def _max_row(*values):
     """Build a SQLAlchemy-style row supporting [0], [1] subscript access."""
     row = MagicMock()
@@ -70,28 +56,6 @@ def _mock_session_with_results(*results):
     ctx.__aenter__ = AsyncMock(return_value=session)
     ctx.__aexit__ = AsyncMock(return_value=False)
     return ctx, session
-
-
-def _mock_inventory_session(
-    *,
-    total_notes=0,
-    total_entities=0,
-    date_range=None,
-    doc_metadata=None,
-    recent_7d=0,
-    recent_30d=0,
-    last_activity=None,
-):
-    """Mock the 7 SQL queries issued by ``_compute_inventory``, keyed by purpose."""
-    return _mock_session_with_results(
-        _scalar_result(total_notes),
-        _scalar_result(total_entities),
-        _one_or_none_result(date_range),
-        _all_result(doc_metadata or []),
-        _scalar_result(recent_7d),
-        _scalar_result(recent_30d),
-        _scalar_result(last_activity),
-    )
 
 
 def _mock_fresh_fields_session(

--- a/packages/core/tests/unit/test_vault_summary_signatures.py
+++ b/packages/core/tests/unit/test_vault_summary_signatures.py
@@ -95,6 +95,7 @@ class TestVaultSummaryUpdateSignature:
         assert 'current_themes' in fields
         assert 'new_notes' in fields
         assert 'vault_stats' in fields
+        assert 'current_time' in fields
 
     def test_output_fields(self):
         fields = VaultSummaryUpdateSignature.output_fields
@@ -108,6 +109,7 @@ class TestVaultSummaryFullSignature:
         assert 'notes' in fields
         assert 'vault_note_count' in fields
         assert 'max_narrative_tokens' in fields
+        assert 'current_time' in fields
 
     def test_output_fields(self):
         fields = VaultSummaryFullSignature.output_fields
@@ -121,6 +123,7 @@ class TestVaultTopicExtractSignature:
         assert 'notes' in fields
         assert 'batch_index' in fields
         assert 'total_batches' in fields
+        assert 'current_time' in fields
 
     def test_output_fields(self):
         fields = VaultTopicExtractSignature.output_fields
@@ -133,8 +136,25 @@ class TestVaultTopicMergeSignature:
         fields = VaultTopicMergeSignature.input_fields
         assert 'batch_results' in fields
         assert 'vault_note_count' in fields
+        assert 'current_time' in fields
 
     def test_output_fields(self):
         fields = VaultTopicMergeSignature.output_fields
         assert 'narrative' in fields
         assert 'themes' in fields
+
+
+class TestSignaturesExposeCurrentTime:
+    """All four theme-producing signatures must ground trend on current_time."""
+
+    def test_all_signatures_declare_current_time_input(self):
+        signatures = [
+            VaultSummaryUpdateSignature,
+            VaultSummaryFullSignature,
+            VaultTopicExtractSignature,
+            VaultTopicMergeSignature,
+        ]
+        for sig in signatures:
+            assert 'current_time' in sig.input_fields, (
+                f'{sig.__name__} missing current_time input field'
+            )


### PR DESCRIPTION
## Summary

- `memex vault summary` was displaying cached values for time-sensitive inventory fields, so a cold vault kept showing `Recent (7d / 30d) = 277 / 405` and themes stuck on `growing` long after the last ingestion.
- `get_summary` now runs a read-time freshness overlay: `recent_activity`, `last_activity_at`, `days_since_last_note`, and `date_range.latest` are recomputed against wall-clock `now` on every read; every theme's `trend` is forced to `dormant` once the vault exceeds `VaultSummaryConfig.dormant_threshold_days` (default 30). Persisted JSONB is not mutated, non-time-sensitive aggregates (template/tag counts, `total_notes`, etc.) keep their cached values.
- All four DSPy signatures (`VaultSummaryFullSignature`, `VaultSummaryUpdateSignature`, `VaultTopicExtractSignature`, `VaultTopicMergeSignature`) now take a `current_time` input; threaded through every call site (`update_summary` batch loop, `_tier1_single_call`, `_extract_themes_from_batches`, `_merge_batch_results`) computed once per regeneration so all batches share the same anchor.
- CLI renders a new `Last Activity` row under `Recent (7d / 30d)` showing the absolute timestamp and days-ago count.

Motivating example (from a vault last updated 2026-04-03, on 2026-04-24): pre-fix, the CLI showed `Recent (7d / 30d) = 277 / 405` and every theme as `growing`. Post-fix: `0 / 0`, a `Last Activity` row reading `2026-04-03 ... (21 days ago)`, and every theme `dormant`.

## Test plan

- [x] `uv run pytest packages/core/tests/unit/services/test_vault_summary_service.py packages/core/tests/unit/test_vault_summary_signatures.py -v` — 55 pass including 8 new overlay cases + the new `test_all_signatures_declare_current_time_input`.
- [x] `uv run pytest packages/core/tests/unit` — 1867 pass (fixed 5 regression tests in `test_vault_summary_regression.py` that mocked exactly 6 `session.execute` results; now 7 to cover the new `max(Note.created_at)` aggregate).
- [x] `uv run pytest packages/cli/tests packages/mcp/tests packages/common/tests` — 376 / 309 / 109 pass; no regressions.
- [x] `just prek` — ruff + ruff-format + mypy clean.
- [ ] Manual: `memex vault summary <cold-vault>` shows `Recent (7d / 30d) = 0 / 0`, a `Last Activity` row, and every theme's trend reading `dormant`.
- [ ] Manual: after ingesting a new note, re-run without `--regenerate` and confirm `Recent (7d / 30d)` and `Last Activity` update immediately.
- [ ] Manual: `memex vault summary <warm-vault> --regenerate` — LLM now receives `current_time`; sanity-check that produced trends match the real note-date distribution.

## Files changed

- `packages/core/src/memex_core/services/vault_summary.py` — `_compute_inventory` gains `last_activity_at` + `days_since_last_note`; new `_apply_freshness_overlay`; `current_time` threaded through all DSPy call sites.
- `packages/core/src/memex_core/services/vault_summary_signatures.py` — `current_time` InputField added to all 4 signatures; docstrings updated.
- `packages/common/src/memex_common/config.py` — `VaultSummaryConfig.dormant_threshold_days` (default 30).
- `packages/common/src/memex_common/schemas.py` — `VaultSummaryDTO.inventory` docstring updated to document the new keys (generic `dict[str, Any]`, no schema migration).
- `packages/cli/src/memex_cli/vaults.py` — new `Last Activity` row.
- Tests + test-count badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)