### PR TITLE
feat: surface templates in MCP/hermes routing so agents reach for them

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,684%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,692%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/claude-code-plugin/skills/remember/SKILL.md
+++ b/packages/claude-code-plugin/skills/remember/SKILL.md
@@ -25,9 +25,15 @@ You have been invoked via the `/remember` slash command.
    - **tags**: Always include `"claude-code"` and `"manual-capture"`. Add 1-3 additional
      topic tags derived from the content.
 
-3. **Save the memory.**
+3. **Consider a template (for structured content).**
+   If the memory is an architectural decision, technical brief, retro, or RFC,
+   call `memex_list_templates` then `memex_get_template(slug)`, follow the
+   structure when writing `markdown_content`, and pass `template: "<slug>"` to
+   `memex_add_note`. Skip for short, unstructured captures.
+
+4. **Save the memory.**
    Call the `memex_add_note` MCP tool with the values above and set `background: true`
    so ingestion does not block the conversation.
 
-4. **Confirm to the user.**
+5. **Confirm to the user.**
    After calling the tool, briefly confirm what was saved and mention the title.

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -123,7 +123,11 @@ Match the tool to the query type:
   / `memex_kv_list()`. Keys MUST start with a namespace: `global:`, `user:`,
   `project:<id>:`, or `app:<id>:`. Deletion is CLI-only (use `memex kv delete`).
 - **Capturing work** → `memex_retain`. Pass the session note key below for
-  incremental progress captures; omit it for a standalone note."""
+  incremental progress captures; omit it for a standalone note.
+- **Templates for structured captures** → `memex_list_templates` to see slugs,
+  `memex_get_template(slug)` for the markdown scaffold, then `memex_retain(...,
+  template=slug)` so the note is tagged for filtering. Prefer a template for
+  ADRs, retros, technical briefs, RFCs, or any note with clear sections."""
 
 
 def format_briefing_block(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -292,7 +292,9 @@ RETAIN_SCHEMA: dict[str, Any] = {
         'Ingest a note into Memex. If note_key is provided and matches an existing '
         'note, the content is upserted (enables incremental session capture). Pass '
         'the session note key from the system prompt to append meaningful progress '
-        'to the running session note.'
+        'to the running session note. For structured captures (ADRs, retros, '
+        'technical briefs, RFCs), call memex_list_templates first and pass the '
+        'chosen slug as `template` for provenance and downstream filtering.'
     ),
     'parameters': {
         'type': 'object',
@@ -339,6 +341,15 @@ RETAIN_SCHEMA: dict[str, Any] = {
                 'description': (
                     'Stable key for upsert. Use the session note key to append to the '
                     'running session note. Omit for a fresh note.'
+                ),
+            },
+            'template': {
+                'type': 'string',
+                'description': (
+                    'Template slug used to create this note (provenance/filtering '
+                    'only — does not scaffold the body). Use memex_list_templates '
+                    'to discover slugs. Recommended for ADRs, retros, technical '
+                    'briefs, RFCs. Omit to use the default hermes-user-note tag.'
                 ),
             },
         },
@@ -861,8 +872,9 @@ RENAME_NOTE_SCHEMA: dict[str, Any] = {
 GET_TEMPLATE_SCHEMA: dict[str, Any] = {
     'name': 'memex_get_template',
     'description': (
-        'Get a markdown template for memex_retain. Use memex_list_templates '
-        'to discover available template slugs.'
+        'Fetch a markdown scaffold to follow when writing a structured note. '
+        'Call this BEFORE memex_retain for ADRs, retros, technical briefs, RFCs, '
+        'or any note with clear sections. Use memex_list_templates to discover slugs.'
     ),
     'parameters': {
         'type': 'object',
@@ -879,8 +891,9 @@ GET_TEMPLATE_SCHEMA: dict[str, Any] = {
 LIST_TEMPLATES_SCHEMA: dict[str, Any] = {
     'name': 'memex_list_templates',
     'description': (
-        'List all available note templates with metadata (slug, display name, '
-        'description, source layer).'
+        'List note templates (built-in + user-registered). Call this when about to '
+        'capture structured content — pick a slug, fetch the body with '
+        'memex_get_template, then pass `template=slug` to memex_retain.'
     ),
     'parameters': {
         'type': 'object',
@@ -891,8 +904,9 @@ LIST_TEMPLATES_SCHEMA: dict[str, Any] = {
 REGISTER_TEMPLATE_SCHEMA: dict[str, Any] = {
     'name': 'memex_register_template',
     'description': (
-        'Register a new note template from inline markdown content. Stored in '
-        'the global scope by default.'
+        'Register a custom note template from inline markdown. Use when a recurring '
+        'capture pattern (sprint retro, incident postmortem, etc.) does not match a '
+        'built-in. Stored in the global scope by default.'
     ),
     'parameters': {
         'type': 'object',
@@ -1437,6 +1451,7 @@ def handle_retain(
 
     tags = args.get('tags') or []
     note_key = args.get('note_key') or None
+    template = args.get('template') or HERMES_USER_NOTE_TEMPLATE
 
     from memex_common.schemas import NoteCreateDTO
 
@@ -1448,7 +1463,7 @@ def handle_retain(
         note_key=note_key,
         vault_id=str(vault_id) if vault_id else None,
         author='hermes',
-        template=HERMES_USER_NOTE_TEMPLATE,
+        template=template,
     )
 
     try:
@@ -2401,7 +2416,16 @@ def handle_list_templates(
         }
         for t in templates or []
     ]
-    return json.dumps({'count': len(results), 'results': results})
+    return json.dumps(
+        {
+            'count': len(results),
+            'results': results,
+            'next': (
+                'memex_get_template(slug) → write content following the structure → '
+                'memex_retain(..., template=slug) so the note is tagged for filtering.'
+            ),
+        }
+    )
 
 
 def handle_register_template(

--- a/packages/hermes-plugin/tests/test_briefing.py
+++ b/packages/hermes-plugin/tests/test_briefing.py
@@ -162,6 +162,18 @@ def test_routing_guide_documents_batch_fetch():
     assert 'memex_get_memory_units' in _ROUTING_GUIDE
 
 
+def test_routing_guide_documents_templates():
+    """Templates bullet must surface the list → get → retain(template=) flow.
+
+    Without this, agents skip templates even for content that maps cleanly onto
+    a built-in (ADR, RFC, retro, technical brief).
+    """
+    assert '**Templates for structured captures**' in _ROUTING_GUIDE
+    assert 'memex_list_templates' in _ROUTING_GUIDE
+    assert 'memex_get_template' in _ROUTING_GUIDE
+    assert 'template=slug' in _ROUTING_GUIDE
+
+
 def test_routing_guide_bullets_render_in_formatted_block():
     """Guide must flow through format_briefing_block end-to-end."""
     block = format_briefing_block(
@@ -177,6 +189,7 @@ def test_routing_guide_bullets_render_in_formatted_block():
         '**Batch fetch**',
         '**Lineage / relationships**',
         '**KV store**',
+        '**Templates for structured captures**',
         'memex_find_note',
     ):
         assert marker in block

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -308,6 +308,76 @@ def test_retain_missing_required_params(config, vault_id):
     assert 'error' in json.loads(out)
 
 
+def test_retain_schema_advertises_template_param():
+    """RETAIN_SCHEMA exposes an optional `template` property so agents can pick one.
+
+    The schema is what the model sees; if `template` isn't here, the agent
+    can't pass it even if our handler would accept it.
+    """
+    retain = next(s for s in ALL_SCHEMAS if s['name'] == 'memex_retain')
+    assert 'template' in retain['parameters']['properties'], (
+        'memex_retain must expose a `template` property for ADR/RFC/retro provenance'
+    )
+    assert 'template' not in retain['parameters'].get('required', [])
+
+
+def test_retain_uses_provided_template(config, vault_id):
+    """Agent-supplied template slug round-trips into the NoteCreateDTO."""
+    api = Mock()
+    api.ingest = AsyncMock(return_value=IngestResponse(status='success', note_id=str(uuid4())))
+    out = dispatch(
+        'memex_retain',
+        {
+            'name': 'ADR: postgres advisory locks',
+            'description': 'leader election strategy',
+            'content': '# ADR\n\n## Context\n...',
+            'template': 'architectural_decision_record',
+        },
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    assert json.loads(out)['status'] == 'success'
+    dto = api.ingest.call_args.args[0]
+    assert dto.template == 'architectural_decision_record'
+
+
+def test_retain_falls_back_to_hermes_user_note_template(config, vault_id):
+    """Omitting template preserves the prior default tag."""
+    from memex_hermes_plugin.memex.templates import HERMES_USER_NOTE_TEMPLATE
+
+    api = Mock()
+    api.ingest = AsyncMock(return_value=IngestResponse(status='success', note_id=str(uuid4())))
+    dispatch(
+        'memex_retain',
+        {
+            'name': 'plain note',
+            'description': 'free-form capture',
+            'content': '# Plain\n\n## Body\n...',
+        },
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    dto = api.ingest.call_args.args[0]
+    assert dto.template == HERMES_USER_NOTE_TEMPLATE
+
+
+def test_list_templates_output_includes_action_hint(config, vault_id):
+    """handle_list_templates returns a `next` field pointing to the follow-up flow.
+
+    JSON output, so the hint lives as a structured key rather than appended text.
+    """
+    api = Mock()
+    out = dispatch('memex_list_templates', {}, api=api, config=config, vault_id=vault_id)
+    data = json.loads(out)
+    assert 'next' in data, 'list_templates must surface a follow-up hint to the agent'
+    nxt = data['next']
+    assert 'memex_get_template' in nxt
+    assert 'memex_retain' in nxt
+    assert 'template=slug' in nxt
+
+
 def test_list_entities(config, vault_id):
     api = Mock()
     api.search_entities = AsyncMock(return_value=[_fake_entity('Rust')])
@@ -3247,4 +3317,91 @@ def test_retain_content_is_structured_markdown_via_gemini():
     ]
     assert not offenders, 'inline `**Label:** value` anti-pattern leaked into body:\n' + '\n'.join(
         offenders
+    )
+
+
+@pytest.mark.llm
+@pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
+@pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
+def test_hermes_routes_structured_capture_to_templates_via_gemini():
+    """Real LLM round-trip: the briefing routing guide + RETAIN_SCHEMA template
+    affordance must steer the model to the templates flow when capturing
+    structured content (e.g. an agent reflection / postmortem).
+
+    Pairs with the MCP-side test in
+    packages/mcp/tests/test_tool_templates.py — both surfaces have to actually
+    move the agent toward templates, not just satisfy static schema checks.
+    """
+    import litellm
+
+    from memex_hermes_plugin.memex.briefing import _ROUTING_GUIDE
+    from memex_hermes_plugin.memex.tools import (
+        GET_TEMPLATE_SCHEMA,
+        LIST_TEMPLATES_SCHEMA,
+        RETAIN_SCHEMA,
+    )
+
+    tool_defs = [
+        {
+            'type': 'function',
+            'function': {
+                'name': s['name'],
+                'description': s['description'],
+                'parameters': s['parameters'],
+            },
+        }
+        for s in (LIST_TEMPLATES_SCHEMA, GET_TEMPLATE_SCHEMA, RETAIN_SCHEMA)
+    ]
+
+    resp = litellm.completion(
+        model='gemini/gemini-3-flash-preview',
+        messages=[
+            {'role': 'system', 'content': _ROUTING_GUIDE},
+            {
+                'role': 'user',
+                'content': (
+                    "Today's daily reflect cron ran but the assistant could not "
+                    'retrieve its conclusions later — the reflection output got '
+                    'buried in a raw session log instead of being indexed as a '
+                    'standalone summary. Capture this as a structured agent '
+                    'reflection / postmortem so future me can find the lesson '
+                    'when searching for "conclusions".'
+                ),
+            },
+        ],
+        tools=tool_defs,
+        temperature=0,
+        timeout=30,
+        api_key=os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'),
+    )
+
+    tool_calls = resp.choices[0].message.tool_calls or []
+    assert tool_calls, f'model did not call any tool: {resp.choices[0].message!r}'
+
+    first = tool_calls[0]
+    name = first.function.name
+    args = json.loads(first.function.arguments or '{}')
+
+    # Same three behaviors as the MCP-side test prove the routing worked.
+    if name == 'memex_list_templates':
+        return
+    if name == 'memex_get_template':
+        slug = args.get('slug') or args.get('type')
+        assert slug == 'agent_reflection', (
+            f'agent fetched template {slug!r}; expected agent_reflection'
+        )
+        return
+    if name == 'memex_retain':
+        template = args.get('template')
+        assert template == 'agent_reflection', (
+            f'agent called memex_retain without (or with wrong) template '
+            f'(template={template!r}). The routing fix must steer structured '
+            f'captures to a template. Tool call args: {args!r}'
+        )
+        return
+
+    pytest.fail(
+        f'agent called unexpected tool {name!r}; expected one of '
+        f'memex_list_templates / memex_get_template / memex_retain. '
+        f'All tool calls: {[(tc.function.name, tc.function.arguments) for tc in tool_calls]!r}'
     )

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -277,6 +277,17 @@ IF user wants to annotate a note or update their commentary:
   - `memex_update_user_notes(note_id, user_notes)` — update user annotations on a note
   - `memex_search_user_notes(query)` — search only user annotations (source_context='user_notes')
 
+IF capturing structured content (architecture decision, RFC, retro, technical brief, learning):
+  → TEMPLATES (capture flow)
+  1. `memex_list_templates()` — see what's available with descriptions
+  2. `memex_get_template(slug)` — fetch the markdown scaffold
+  3. Write your note body following the template structure
+  4. `memex_add_note(..., template=slug)` — pass the slug so the note is tagged
+     and filterable later (`memex_list_notes(template=slug)`, vault summaries).
+  Built-ins: `general_note`, `technical_brief`, `architectural_decision_record`,
+  `request_for_comments`, `agent_reflection`, `quick_note`. Prefer a template over
+  free-form when the content has clear sections.
+
 RULES:
 - Only use IDs from tool output. Never fabricate IDs.
 - Filter before reading. Never call `memex_get_page_indices` on unconfirmed notes.
@@ -743,8 +754,12 @@ def _get_template_registry(ctx: Context) -> TemplateRegistry:
 
 @mcp.tool(
     name='memex_get_template',
-    description='Get a markdown template for memex_add_note. Use memex_list_templates to see available templates.',
-    tags={'write'},
+    description=(
+        'Fetch a markdown scaffold to follow when writing a structured note. '
+        'Call this BEFORE memex_add_note for ADRs, retros, technical briefs, RFCs, '
+        'or any note with clear sections. Use memex_list_templates to discover slugs.'
+    ),
+    tags={'write', 'templates'},
     annotations={'readOnlyHint': True},
 )
 def memex_get_template(
@@ -769,8 +784,12 @@ def memex_get_template(
 
 @mcp.tool(
     name='memex_list_templates',
-    description='List all available note templates with metadata (slug, name, description, source).',
-    tags={'write'},
+    description=(
+        'List note templates (built-in + user-registered). Call this when about to '
+        'capture structured content — pick a slug, fetch the body with '
+        'memex_get_template, then pass `template=slug` to memex_add_note.'
+    ),
+    tags={'write', 'templates'},
     annotations={'readOnlyHint': True},
 )
 def memex_list_templates(ctx: Context) -> str:
@@ -778,11 +797,18 @@ def memex_list_templates(ctx: Context) -> str:
     try:
         registry = _get_template_registry(ctx)
         templates = registry.list_templates()
+        if not templates:
+            return 'No templates available.'
         lines = []
         for t in templates:
             source_tag = f'[{t.source}]'
             lines.append(f'- **{t.slug}** {source_tag} — {t.display_name}: {t.description}')
-        return '\n'.join(lines) if lines else 'No templates available.'
+        lines.append('')
+        lines.append(
+            'Next: `memex_get_template(slug)` to fetch the body, then write your '
+            'content following the structure and call `memex_add_note(..., template=slug)`.'
+        )
+        return '\n'.join(lines)
     except Exception as e:
         logger.error(f'List templates failed: {e}', exc_info=True)
         raise ToolError(f'Failed to list templates: {e}')
@@ -791,10 +817,11 @@ def memex_list_templates(ctx: Context) -> str:
 @mcp.tool(
     name='memex_register_template',
     description=(
-        'Register a new note template. Creates a template from inline content. '
-        'To delete a template, use the CLI: memex note template delete <slug>'
+        'Register a custom note template from inline markdown. Use when a recurring '
+        'capture pattern (sprint retro, incident postmortem, etc.) does not match a '
+        'built-in. To delete a template, use the CLI: memex note template delete <slug>'
     ),
-    tags={'write'},
+    tags={'write', 'templates'},
     annotations={'readOnlyHint': False},
 )
 def memex_register_template(
@@ -863,7 +890,12 @@ async def memex_active_vault(ctx: Context) -> str:
 
 @mcp.tool(
     name='memex_add_note',
-    description='Add a new note or document to Memex. Ingest content into a vault. Confirm vault with user first, or pass vault_id.',
+    description=(
+        'Add a new note or document to Memex. Ingest content into a vault. Confirm '
+        'vault with user first, or pass vault_id. For structured captures (ADRs, '
+        'retros, technical briefs, RFCs), call memex_list_templates first and pass '
+        'the chosen slug as `template` for provenance and downstream filtering.'
+    ),
     tags={'write'},
     annotations={'readOnlyHint': False},
     timeout=120.0,

--- a/packages/mcp/tests/test_discovery_mode.py
+++ b/packages/mcp/tests/test_discovery_mode.py
@@ -6,7 +6,16 @@ from fastmcp.server.transforms.search.bm25 import BM25SearchTransform
 from memex_mcp.server import mcp
 
 
-EXPECTED_TAGS = {'search', 'read', 'write', 'browse', 'entities', 'assets', 'storage'}
+EXPECTED_TAGS = {
+    'search',
+    'read',
+    'write',
+    'browse',
+    'entities',
+    'assets',
+    'storage',
+    'templates',
+}
 
 # Natural-language queries mapped to expected tool(s) — used for BM25 recall testing.
 BM25_TEST_CASES: list[tuple[str, list[str]]] = [

--- a/packages/mcp/tests/test_tool_templates.py
+++ b/packages/mcp/tests/test_tool_templates.py
@@ -114,10 +114,29 @@ class TestListTemplates:
     async def test_lists_all_builtins(self, template_config, mcp_client: Client) -> None:
         result = await mcp_client.call_tool('memex_list_templates', {})
         text = result.content[0].text
-        assert 'general_note' in text
-        assert 'technical_brief' in text
-        assert 'quick_note' in text
+        for slug in (
+            'general_note',
+            'technical_brief',
+            'quick_note',
+            'architectural_decision_record',
+            'request_for_comments',
+            'agent_reflection',
+        ):
+            assert slug in text, f'expected built-in {slug!r} in list output'
         assert '[builtin]' in text
+
+    @pytest.mark.asyncio
+    async def test_output_includes_action_hint(self, template_config, mcp_client: Client) -> None:
+        """The list output ends with a closing hint pointing to the next call.
+
+        This is the UX intervention that turns templates into a discoverable flow:
+        agents see the list AND the next step in the same response.
+        """
+        result = await mcp_client.call_tool('memex_list_templates', {})
+        text = result.content[0].text
+        assert 'memex_get_template(slug)' in text
+        assert 'memex_add_note' in text
+        assert 'template=slug' in text
 
     @pytest.mark.asyncio
     async def test_includes_user_templates(self, template_config, mcp_client: Client) -> None:
@@ -178,3 +197,114 @@ class TestRegisterTemplate:
         )
         text = result.content[0].text
         assert 'Registered' in text
+
+
+# ---------------------------------------------------------------------------
+# Live LLM check: server instructions + tool descriptions actually steer the
+# model to the templates flow when capturing structured content.
+#
+# Static schema assertions don't prove model obedience — only a real turn does.
+# Mirrors the pattern in
+# packages/hermes-plugin/tests/test_tools.py::test_retain_content_is_structured_markdown_via_gemini.
+# ---------------------------------------------------------------------------
+
+import importlib.util as _ilu  # noqa: E402
+import json as _json  # noqa: E402
+import os as _os  # noqa: E402
+
+_HAS_GEMINI_KEY = bool(_os.environ.get('GEMINI_API_KEY') or _os.environ.get('GOOGLE_API_KEY'))
+_HAS_LITELLM = _ilu.find_spec('litellm') is not None
+
+
+@pytest.mark.llm
+@pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
+@pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
+def test_mcp_routes_structured_capture_to_templates_via_gemini() -> None:
+    """An LLM agent given the MCP server instructions + tool descriptions must
+    reach for templates when asked to capture structured content (e.g. an ADR).
+
+    This is the contract behind the discoverability fix: descriptions and routing
+    are not just text changes — they have to actually shift behavior. We pin Gemini
+    to match the rest of the repo's LLM-gated tests; any model strong enough to
+    follow tool schemas will do.
+    """
+    import asyncio
+
+    import litellm
+
+    from memex_mcp.server import mcp
+
+    async def _collect():
+        names = ('memex_list_templates', 'memex_get_template', 'memex_add_note')
+        tools = [await mcp.get_tool(n) for n in names]
+        return tools, mcp.instructions
+
+    tools_raw, instructions = asyncio.run(_collect())
+    tool_defs = [
+        {
+            'type': 'function',
+            'function': {
+                'name': t.name,
+                'description': t.description,
+                'parameters': t.parameters,
+            },
+        }
+        for t in tools_raw
+    ]
+
+    resp = litellm.completion(
+        model='gemini/gemini-3-flash-preview',
+        messages=[
+            {'role': 'system', 'content': instructions},
+            {
+                'role': 'user',
+                'content': (
+                    'We need to record a permanent architectural decision: we will '
+                    'use Postgres advisory locks for leader election across our '
+                    'background-worker fleet. Context: exactly-once execution is '
+                    'required. Alternatives considered: Redis locks (rejected — '
+                    'extra dependency) and etcd (rejected — operational weight). '
+                    'Save this to memex now in the my-project vault.'
+                ),
+            },
+        ],
+        tools=tool_defs,
+        temperature=0,
+        timeout=30,
+        api_key=_os.environ.get('GEMINI_API_KEY') or _os.environ.get('GOOGLE_API_KEY'),
+    )
+
+    tool_calls = resp.choices[0].message.tool_calls or []
+    assert tool_calls, f'model did not call any tool: {resp.choices[0].message!r}'
+
+    first = tool_calls[0]
+    name = first.function.name
+    args = _json.loads(first.function.arguments or '{}')
+
+    # Three behaviors prove the routing worked:
+    #   1. memex_list_templates() — agent is exploring templates first
+    #   2. memex_get_template('architectural_decision_record') — direct fetch
+    #   3. memex_add_note(template='architectural_decision_record', ...) — direct
+    #      provenance-tagged write (still proves agent picked up the slug)
+    if name == 'memex_list_templates':
+        return
+    if name == 'memex_get_template':
+        slug = args.get('type') or args.get('slug')
+        assert slug == 'architectural_decision_record', (
+            f'agent fetched template {slug!r}; expected architectural_decision_record'
+        )
+        return
+    if name == 'memex_add_note':
+        template = args.get('template')
+        assert template == 'architectural_decision_record', (
+            f'agent called memex_add_note without (or with wrong) template '
+            f'(template={template!r}). The whole point of the routing fix is that '
+            f'a structured capture should reach for templates. Tool call args: {args!r}'
+        )
+        return
+
+    pytest.fail(
+        f'agent called unexpected tool {name!r}; expected one of '
+        f'memex_list_templates / memex_get_template / memex_add_note. '
+        f'All tool calls: {[(tc.function.name, tc.function.arguments) for tc in tool_calls]!r}'
+    )


### PR DESCRIPTION
## Summary

- Templates were a hidden affordance: 6 built-ins ship and the MCP/hermes tools expose them, but descriptions explained WHAT (not WHEN), no routing prompt mentioned them, and `memex_retain` had no template param at all. Agents skipped templates even for content that maps cleanly onto an ADR / RFC / retro / technical brief.
- This PR makes the **list → get → write → add(`template=slug`)** workflow visible across MCP, hermes, and the `/remember` skill. Template semantics are unchanged — still provenance-only (the slug tags the note for filtering; the agent writes the body).
- New: optional `template` param on hermes' `memex_retain` (parity with `memex_add_note`); falls back to `HERMES_USER_NOTE_TEMPLATE` so existing behavior is preserved.

### Surfaces touched

| Surface | Change |
| --- | --- |
| `packages/mcp/src/memex_mcp/server.py` | TEMPLATES routing block in server `instructions`; WHEN-led rewrites of `memex_list_templates` / `memex_get_template` / `memex_register_template` / `memex_add_note` descriptions; `templates` tag added to template tools; closing action hint appended to `memex_list_templates` output |
| `packages/hermes-plugin/.../tools.py` | `template` param added to `RETAIN_SCHEMA`; `handle_retain` plumbs it through with `HERMES_USER_NOTE_TEMPLATE` fallback; WHEN-led rewrites of `GET_TEMPLATE_SCHEMA` / `LIST_TEMPLATES_SCHEMA` / `REGISTER_TEMPLATE_SCHEMA` descriptions; `next` field added to `handle_list_templates` JSON |
| `packages/hermes-plugin/.../briefing.py` | New `**Templates for structured captures**` bullet in `_ROUTING_GUIDE` |
| `packages/claude-code-plugin/skills/remember/SKILL.md` | New Step 3 "Consider a template" before the save call |
| `packages/mcp/tests/test_discovery_mode.py` | `EXPECTED_TAGS` extended with `templates` |

### Validation

Two LLM-driven tests added (Gemini via litellm, same pattern as the existing `test_retain_content_is_structured_markdown_via_gemini`). Per the principle that schema changes need a real LLM turn — not just static asserts — to prove model obedience:

- `test_mcp_routes_structured_capture_to_templates_via_gemini` — MCP server `instructions` + edited tool descriptions; ADR-shaped capture; asserts the first tool call is `memex_list_templates`, `memex_get_template('architectural_decision_record')`, or `memex_add_note(template='architectural_decision_record', ...)`.
- `test_hermes_routes_structured_capture_to_templates_via_gemini` — `_ROUTING_GUIDE` + `RETAIN_SCHEMA` / `LIST_TEMPLATES_SCHEMA` / `GET_TEMPLATE_SCHEMA`; postmortem-shaped capture; asserts the same three behaviors against `agent_reflection`.

Both pass; ran 3× back-to-back at `temperature=0` → **6/6 successful turns**, no flakes.

Plus 6 static tests added/extended (action-hint, schema parity, all-builtins listing, briefing routing-guide regression guard).

## Test plan

- [x] `prek` (lint, format, mypy, badge): all green
- [x] `uv run pytest packages/mcp/tests/ packages/hermes-plugin/tests/` — 224 passing, no regressions
- [x] `uv run pytest -m llm packages/mcp/tests/test_tool_templates.py packages/hermes-plugin/tests/test_tools.py` — 2/2 pass × 3 runs
- [ ] Manual MCP smoke (post-merge): connect a Claude Code session, ask "save our decision to use Postgres advisory locks as a permanent record", verify the agent calls `memex_list_templates` → `memex_get_template('architectural_decision_record')` → `memex_add_note(..., template='architectural_decision_record')`
- [ ] Manual hermes smoke (post-merge): trigger a postmortem-shaped capture, verify the briefing renders the new bullet and `doc_metadata.template == 'agent_reflection'` on the resulting note

## Out of scope (intentional)

- **Auto-scaffolding the body** when `template` is set and content is empty — kept the 3-step workflow per scope discussion.
- **Adding a `when_to_use` field to template TOMLs** — existing `description` field carries the WHEN; sharpening individual descriptions is a separate, smaller PR.
- **Pre-existing `test_live_hermes.py` failures** (3 tests expecting the old 7-tool surface; broken since #38's 27-tool parity commit) — confirmed unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)