### PR TITLE
fix(core): reject empty path in /resources and filestore reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,717%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,721%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,700%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,717%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,684%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,700%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/core/src/memex_core/server/resources.py
+++ b/packages/core/src/memex_core/server/resources.py
@@ -12,7 +12,7 @@ from memex_common.schemas import LineageDirection, LineageResponse
 from memex_core.api import MemexAPI
 from memex_core.server.auth import require_read
 from memex_core.server.common import _handle_error, get_api
-from memex_core.storage.filestore import _is_root_key
+from memex_core.storage.filestore import is_root_key
 
 logger = logging.getLogger('memex.core.server.resources')
 
@@ -26,7 +26,7 @@ async def get_resource(path: str, api: Annotated[MemexAPI, Depends(get_api)]):
 
     from fastapi.responses import Response
 
-    if _is_root_key(path):
+    if is_root_key(path):
         raise HTTPException(status_code=404, detail='Resource path is empty')
 
     try:

--- a/packages/core/src/memex_core/server/resources.py
+++ b/packages/core/src/memex_core/server/resources.py
@@ -12,6 +12,7 @@ from memex_common.schemas import LineageDirection, LineageResponse
 from memex_core.api import MemexAPI
 from memex_core.server.auth import require_read
 from memex_core.server.common import _handle_error, get_api
+from memex_core.storage.filestore import _is_root_key
 
 logger = logging.getLogger('memex.core.server.resources')
 
@@ -25,7 +26,7 @@ async def get_resource(path: str, api: Annotated[MemexAPI, Depends(get_api)]):
 
     from fastapi.responses import Response
 
-    if not path or not path.strip().strip('/'):
+    if _is_root_key(path):
         raise HTTPException(status_code=404, detail='Resource path is empty')
 
     try:

--- a/packages/core/src/memex_core/server/resources.py
+++ b/packages/core/src/memex_core/server/resources.py
@@ -25,6 +25,9 @@ async def get_resource(path: str, api: Annotated[MemexAPI, Depends(get_api)]):
 
     from fastapi.responses import Response
 
+    if not path or not path.strip().strip('/'):
+        raise HTTPException(status_code=404, detail='Resource path is empty')
+
     try:
         content = await api.get_resource(path)
         media_type, _ = mimetypes.guess_type(path)

--- a/packages/core/src/memex_core/storage/filestore.py
+++ b/packages/core/src/memex_core/storage/filestore.py
@@ -23,6 +23,18 @@ from memex_core.config import (
 T = TypeVar('T', bound=FileStoreConfig)
 
 
+def _is_root_key(key: str) -> bool:
+    """Return True if *key* would resolve to the storage root.
+
+    Empty / whitespace-only / all-slash keys are rewritten to the root by
+    :func:`validate_path_safe` (the empty-key form is intentional — see
+    :meth:`BaseAsyncFileStore.check_connection`). Public read and write
+    entry points must reject such keys so callers don't end up issuing
+    operations against the bucket prefix itself.
+    """
+    return not key or not key.strip().strip('/')
+
+
 def validate_path_safe(base_path: str, requested_path: str, *, local: bool = False) -> str:
     """Validate that a requested path does not escape the base directory.
 
@@ -192,6 +204,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             src_key: Source path relative to root.
             dest_key: Destination path relative to root.
         """
+        if _is_root_key(src_key) or _is_root_key(dest_key):
+            raise ValueError(f'Refusing to move with root key: src={src_key!r}, dest={dest_key!r}')
         src_fp = self.join_path(src_key)
         dest_fp = self.join_path(dest_key)
         self._logger.debug(f'Moving file from {src_fp} to {dest_fp}')
@@ -225,6 +239,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             data: The data to be saved.
             txn_id: Optional transaction id. When provided the write is staged.
         """
+        if _is_root_key(key):
+            raise ValueError(f'Refusing to save to root key: {key!r}')
         if txn_id is not None:
             stage = self._get_stage(txn_id)
             target = f'{key}.stage_{txn_id}'
@@ -250,17 +266,13 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             txn_id: Optional transaction id. When provided the delete is deferred.
             recursive: Whether to delete recursively.
         """
+        if _is_root_key(key):
+            raise ValueError(f'Refusing to delete root key: {key!r}')
         if txn_id is not None:
             stage = self._get_stage(txn_id)
             stage.pending_deletes[key] = recursive
         else:
             await self._delete(key, recursive=recursive)
-
-    @staticmethod
-    def _is_root_key(key: str) -> bool:
-        # Empty / whitespace / all-slashes resolve to the storage root and would
-        # otherwise be silently rewritten to the bucket prefix by validate_path_safe.
-        return not key or not key.strip().strip('/')
 
     async def load(self, key: str) -> bytes:
         """
@@ -272,7 +284,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             The loaded string data.
         """
-        if self._is_root_key(key):
+        if _is_root_key(key):
             raise FileNotFoundError(f'Resource key is empty: {key!r}')
         fp = self.join_path(key)
         self._logger.debug(f'Loading data from path: {fp}')
@@ -289,7 +301,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key exists, False otherwise.
         """
-        if self._is_root_key(key):
+        if _is_root_key(key):
             return False
         self._logger.debug(f'Checking for existence of key: {key}')
         async with self._semaphore:
@@ -305,7 +317,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key is a directory, False otherwise.
         """
-        if self._is_root_key(key):
+        if _is_root_key(key):
             return False
         async with self._semaphore:
             return await self._fs._isdir(self.join_path(key))

--- a/packages/core/src/memex_core/storage/filestore.py
+++ b/packages/core/src/memex_core/storage/filestore.py
@@ -256,6 +256,12 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         else:
             await self._delete(key, recursive=recursive)
 
+    @staticmethod
+    def _is_root_key(key: str) -> bool:
+        # Empty / whitespace / all-slashes resolve to the storage root and would
+        # otherwise be silently rewritten to the bucket prefix by validate_path_safe.
+        return not key or not key.strip().strip('/')
+
     async def load(self, key: str) -> bytes:
         """
         Load data from the storage backend.
@@ -266,6 +272,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             The loaded string data.
         """
+        if self._is_root_key(key):
+            raise FileNotFoundError(f'Resource key is empty: {key!r}')
         fp = self.join_path(key)
         self._logger.debug(f'Loading data from path: {fp}')
         async with self._semaphore:
@@ -281,6 +289,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key exists, False otherwise.
         """
+        if self._is_root_key(key):
+            return False
         self._logger.debug(f'Checking for existence of key: {key}')
         async with self._semaphore:
             return await self._fs._exists(self.join_path(key))
@@ -295,6 +305,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key is a directory, False otherwise.
         """
+        if self._is_root_key(key):
+            return False
         async with self._semaphore:
             return await self._fs._isdir(self.join_path(key))
 

--- a/packages/core/src/memex_core/storage/filestore.py
+++ b/packages/core/src/memex_core/storage/filestore.py
@@ -23,7 +23,7 @@ from memex_core.config import (
 T = TypeVar('T', bound=FileStoreConfig)
 
 
-def _is_root_key(key: str) -> bool:
+def is_root_key(key: str) -> bool:
     """Return True if *key* would resolve to the storage root.
 
     Empty / whitespace-only / all-slash keys are rewritten to the root by
@@ -31,6 +31,16 @@ def _is_root_key(key: str) -> bool:
     :meth:`BaseAsyncFileStore.check_connection`). Public read and write
     entry points must reject such keys so callers don't end up issuing
     operations against the bucket prefix itself.
+
+    Convention for callers using this guard:
+      * Read methods (``load``) raise ``FileNotFoundError`` so the HTTP
+        layer maps to 404.
+      * Mutating methods (``save`` / ``delete`` / ``move_file``) raise
+        ``ValueError`` because operating on the root is a programmer
+        error / refusal-to-act, not a "missing resource".
+      * Existence-style queries (``exists`` / ``is_dir`` / ``glob``) return
+        a falsy value (``False`` / ``[]``) — empty input legitimately maps
+        to "no such resource".
     """
     return not key or not key.strip().strip('/')
 
@@ -204,7 +214,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             src_key: Source path relative to root.
             dest_key: Destination path relative to root.
         """
-        if _is_root_key(src_key) or _is_root_key(dest_key):
+        if is_root_key(src_key) or is_root_key(dest_key):
             raise ValueError(f'Refusing to move with root key: src={src_key!r}, dest={dest_key!r}')
         src_fp = self.join_path(src_key)
         dest_fp = self.join_path(dest_key)
@@ -239,7 +249,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             data: The data to be saved.
             txn_id: Optional transaction id. When provided the write is staged.
         """
-        if _is_root_key(key):
+        if is_root_key(key):
             raise ValueError(f'Refusing to save to root key: {key!r}')
         if txn_id is not None:
             stage = self._get_stage(txn_id)
@@ -266,7 +276,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             txn_id: Optional transaction id. When provided the delete is deferred.
             recursive: Whether to delete recursively.
         """
-        if _is_root_key(key):
+        if is_root_key(key):
             raise ValueError(f'Refusing to delete root key: {key!r}')
         if txn_id is not None:
             stage = self._get_stage(txn_id)
@@ -284,7 +294,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             The loaded string data.
         """
-        if _is_root_key(key):
+        if is_root_key(key):
             raise FileNotFoundError(f'Resource key is empty: {key!r}')
         fp = self.join_path(key)
         self._logger.debug(f'Loading data from path: {fp}')
@@ -301,7 +311,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key exists, False otherwise.
         """
-        if _is_root_key(key):
+        if is_root_key(key):
             return False
         self._logger.debug(f'Checking for existence of key: {key}')
         async with self._semaphore:
@@ -317,7 +327,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key is a directory, False otherwise.
         """
-        if _is_root_key(key):
+        if is_root_key(key):
             return False
         async with self._semaphore:
             return await self._fs._isdir(self.join_path(key))
@@ -332,6 +342,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             A list of matching file paths.
         """
+        if is_root_key(pattern):
+            return []
         async with self._semaphore:
             return cast(list[str], await self._fs._glob(self.join_path(pattern)))
 

--- a/packages/core/tests/unit/storage/test_filestore.py
+++ b/packages/core/tests/unit/storage/test_filestore.py
@@ -628,6 +628,17 @@ async def test_move_file_rejects_root_dest(store: LocalAsyncFileStore, bad_key: 
     assert await store.exists('src.txt') is True
 
 
+@pytest.mark.parametrize('bad_pattern', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_glob_root_pattern_returns_empty(
+    store: LocalAsyncFileStore, bad_pattern: str
+) -> None:
+    # glob('') would otherwise list everything under the storage root, leaking
+    # an enumeration of the bucket prefix. Existence-style queries return [].
+    await store.save('a.txt', b'a')
+    assert await store.glob(bad_pattern) == []
+
+
 @pytest.mark.asyncio
 async def test_delete_root_key_does_not_delete_files(store: LocalAsyncFileStore) -> None:
     # Regression for the HIGH finding: an accidental delete('/', recursive=True)

--- a/packages/core/tests/unit/storage/test_filestore.py
+++ b/packages/core/tests/unit/storage/test_filestore.py
@@ -591,3 +591,50 @@ async def test_check_connection_still_works_after_guard(store: LocalAsyncFileSto
     # check_connection bypasses load/exists/is_dir and calls _fs._ls(join_path(''))
     # directly, so it must still succeed.
     assert await store.check_connection() is True
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_save_rejects_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
+    # save with a root key would write at the bucket prefix on S3 / fail with
+    # IsADirectoryError locally — refuse explicitly so the error is loud.
+    with pytest.raises(ValueError, match='Refusing to save'):
+        await store.save(bad_key, b'data')
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_delete_rejects_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
+    # delete(root_key, recursive=True) on S3 would target the bucket prefix —
+    # potentially destroying every object under it.
+    with pytest.raises(ValueError, match='Refusing to delete'):
+        await store.delete(bad_key, recursive=True)
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_move_file_rejects_root_src(store: LocalAsyncFileStore, bad_key: str) -> None:
+    with pytest.raises(ValueError, match='Refusing to move'):
+        await store.move_file(bad_key, 'dst.txt')
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_move_file_rejects_root_dest(store: LocalAsyncFileStore, bad_key: str) -> None:
+    await store.save('src.txt', b'data')
+    with pytest.raises(ValueError, match='Refusing to move'):
+        await store.move_file('src.txt', bad_key)
+    # Source must still exist — the guard runs before any side effects.
+    assert await store.exists('src.txt') is True
+
+
+@pytest.mark.asyncio
+async def test_delete_root_key_does_not_delete_files(store: LocalAsyncFileStore) -> None:
+    # Regression for the HIGH finding: an accidental delete('/', recursive=True)
+    # must not remove existing data under the root.
+    await store.save('keep/a.txt', b'a')
+    await store.save('keep/b.txt', b'b')
+    with pytest.raises(ValueError):
+        await store.delete('/', recursive=True)
+    assert await store.exists('keep/a.txt') is True
+    assert await store.exists('keep/b.txt') is True

--- a/packages/core/tests/unit/storage/test_filestore.py
+++ b/packages/core/tests/unit/storage/test_filestore.py
@@ -554,3 +554,40 @@ class TestGetFilestore:
         config.model_dump.return_value = {'type': 'ftp'}
         with pytest.raises(ValueError, match='Unsupported file store type'):
             get_filestore(config)
+
+
+# ---------------------------------------------------------------------------
+# Empty-key rejection
+#
+# An empty / whitespace-only / all-slash key would be silently rewritten to the
+# storage root by ``validate_path_safe`` (root is allowed there because
+# ``check_connection`` lists the root). Public read methods must reject this so
+# callers don't end up issuing a "GET bucket/" against S3, which boto rejects
+# with ParamValidationError on the empty Key.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_load_rejects_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
+    with pytest.raises(FileNotFoundError, match='Resource key is empty'):
+        await store.load(bad_key)
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_exists_returns_false_for_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
+    assert await store.exists(bad_key) is False
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_is_dir_returns_false_for_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
+    assert await store.is_dir(bad_key) is False
+
+
+@pytest.mark.asyncio
+async def test_check_connection_still_works_after_guard(store: LocalAsyncFileStore) -> None:
+    # check_connection bypasses load/exists/is_dir and calls _fs._ls(join_path(''))
+    # directly, so it must still succeed.
+    assert await store.check_connection() is True

--- a/tests/test_e2e_resources.py
+++ b/tests/test_e2e_resources.py
@@ -108,4 +108,4 @@ def test_resource_empty_path_returns_404(client: TestClient, path: str):
     """An empty/root path must 404 cleanly, not 500 from boto on an empty Key."""
     resp = client.get(f'/api/v1/resources/{path}')
     assert resp.status_code == 404
-    assert 'empty' in resp.json()['detail'].lower()
+    assert resp.json()['detail'] == 'Resource path is empty'

--- a/tests/test_e2e_resources.py
+++ b/tests/test_e2e_resources.py
@@ -100,3 +100,12 @@ def test_resource_not_found(client: TestClient):
     """Test 404 for non-existent resource."""
     resp = client.get('/api/v1/resources/non/existent/path.txt')
     assert resp.status_code == 404
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize('path', ['', '/', '///'])
+def test_resource_empty_path_returns_404(client: TestClient, path: str):
+    """An empty/root path must 404 cleanly, not 500 from boto on an empty Key."""
+    resp = client.get(f'/api/v1/resources/{path}')
+    assert resp.status_code == 404
+    assert 'empty' in resp.json()['detail'].lower()


### PR DESCRIPTION
## Summary

- Production was returning 500s from `GET /api/v1/resources/` because an empty `{path:path}` propagated through the service chain into `s3fs._cat_file`, which boto then rejected with `ParamValidationError: Invalid length for parameter Key, value: 0, valid min length: 1`.
- Root cause: `validate_path_safe` returns the storage root for an empty key (intentional — `check_connection` lists the bucket root), but `BaseAsyncFileStore.load` and the `/resources` route never rejected empty inputs from public callers.
- Fix is a defence-in-depth pair: `load` now raises `FileNotFoundError` on empty/whitespace/all-slash keys (the route already converts that to a clean 404); `exists` / `is_dir` return `False` for the same; the route shortcuts an obvious empty path to 404 before entering the service layer. `validate_path_safe` / `join_path` are unchanged.

## Test plan

- [x] `packages/core/tests/unit/storage/test_filestore.py` — new parametrized tests assert `load`/`exists`/`is_dir` reject `''`, `'/'`, `'///'`, `'   '`, plus a regression test that `check_connection` still works (it bypasses the guarded methods).
- [x] `tests/test_e2e_resources.py` — new parametrized integration test asserts `GET /api/v1/resources/{empty}` returns **404** with body `{"detail": "...empty..."}` against a real Postgres testcontainer.
- [x] Existing filestore unit + integration suites still pass (92 tests, including `test_storage_refactor`, `test_int_filestore`).
- [x] `just prek` passes (ruff, ruff-format, mypy, badge).