### PR TITLE
fix(#59): asset retrieval reliability — REST 500→404 + disk-handoff for binary tool results

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,762%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,766%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,762%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,772%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,717%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,721%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,956%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,959%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,920%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,943%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,721%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,456%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,456%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,458%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,465%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,762%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,700%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,717%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,871%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,920%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,458%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,465%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,684%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,700%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,951%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,956%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,465%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,871%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/common/pyproject.toml
+++ b/packages/common/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "pyyaml>=6.0.3",
     "httpx>=0.27.0",
     "tomli_w>=1.0.0",
+    "cachetools>=5",
+    "Pillow>=10",
 ]
 
 [build-system]

--- a/packages/common/src/memex_common/asset_cache.py
+++ b/packages/common/src/memex_common/asset_cache.py
@@ -80,9 +80,11 @@ class SessionAssetCache:
     ) -> None:
         if tempdir is None:
             self.tempdir = Path(tempfile.mkdtemp(prefix='memex-assets-'))
+            self._owns_tempdir = True
         else:
             tempdir.mkdir(parents=True, exist_ok=True)
             self.tempdir = tempdir
+            self._owns_tempdir = False
         self._cache: _EvictingLRUCache = _EvictingLRUCache(
             maxsize=maxsize,
             on_evict=self._unlink_evicted,
@@ -121,21 +123,37 @@ class SessionAssetCache:
         cached: Path | None
         with self._mutation_lock:
             cached = self._cache.get(path)
-        if cached is not None and await asyncio.to_thread(cached.exists):
-            mime, _ = mimetypes.guess_type(str(cached))
-            size = await asyncio.to_thread(_stat_size, cached)
-            return cached, mime, size
+        if cached is not None:
+            # Lockless fast path; eviction between checks falls through to refetch.
+            try:
+                if await asyncio.to_thread(cached.exists):
+                    mime, _ = mimetypes.guess_type(str(cached))
+                    size = await asyncio.to_thread(_stat_size, cached)
+                    return cached, mime, size
+            except FileNotFoundError:
+                pass
 
         lock = self._lock_for(path)
         async with lock:
             with self._mutation_lock:
                 cached = self._cache.get(path)
-            if cached is not None and await asyncio.to_thread(cached.exists):
-                mime, _ = mimetypes.guess_type(str(cached))
-                size = await asyncio.to_thread(_stat_size, cached)
-                return cached, mime, size
+            if cached is not None:
+                try:
+                    if await asyncio.to_thread(cached.exists):
+                        mime, _ = mimetypes.guess_type(str(cached))
+                        size = await asyncio.to_thread(_stat_size, cached)
+                        return cached, mime, size
+                except FileNotFoundError:
+                    pass
 
-            data = await fetch(path)
+            try:
+                data = await fetch(path)
+            except Exception:
+                # Drop the orphan lock if no entry was ever stored.
+                with self._mutation_lock:
+                    if path not in self._cache:
+                        self._locks.pop(path, None)
+                raise
             local = self._local_path_for(path)
             await asyncio.to_thread(local.write_bytes, data)
             with self._mutation_lock:
@@ -171,11 +189,24 @@ class SessionAssetCache:
         return local_path
 
     def cleanup(self) -> None:
-        """Remove the session tempdir and all cached files. Idempotent."""
+        """Drop all cache state and unlink backing files. Idempotent.
+
+        If the tempdir was auto-created (no ``tempdir=`` argument), it is
+        removed wholesale. A caller-supplied tempdir is preserved — only the
+        files this cache wrote into it are unlinked.
+        """
         with self._mutation_lock:
+            entries = list(self._cache.values())
+            # ``LRUCache.clear()`` is dict.clear() — bypasses popitem(), so
+            # file unlinks are done explicitly here.
             self._cache.clear()
             self._locks.clear()
-        shutil.rmtree(self.tempdir, ignore_errors=True)
+        if self._owns_tempdir:
+            shutil.rmtree(self.tempdir, ignore_errors=True)
+        else:
+            for local in entries:
+                with contextlib.suppress(FileNotFoundError, OSError):
+                    os.unlink(local)
 
     def __len__(self) -> int:
         with self._mutation_lock:

--- a/packages/common/src/memex_common/asset_cache.py
+++ b/packages/common/src/memex_common/asset_cache.py
@@ -9,6 +9,7 @@ the LRU bound is exceeded.
 from __future__ import annotations
 
 import asyncio
+import logging
 import mimetypes
 import os
 import shutil
@@ -19,6 +20,8 @@ from pathlib import Path
 from typing import Any
 
 from cachetools import LRUCache
+
+logger = logging.getLogger(__name__)
 
 
 class _EvictingLRUCache(LRUCache):
@@ -71,14 +74,17 @@ class SessionAssetCache:
         self._locks: dict[str, asyncio.Lock] = {}
         self._global_lock = asyncio.Lock()
 
-    @staticmethod
-    def _unlink_evicted(_key: str, value: Path) -> None:
+    def _unlink_evicted(self, key: str, value: Path) -> None:
         try:
             os.unlink(value)
         except FileNotFoundError:
             pass
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug('Failed to unlink evicted cache file %s: %s', value, exc)
+        # Drop the per-key lock in the same critical section as the eviction so
+        # the locks dict stays bounded by the LRU. Keys registered via
+        # ``register()`` have no lock entry; ``pop(..., None)`` is a no-op.
+        self._locks.pop(key, None)
 
     def _local_path_for(self, path: str) -> Path:
         digest = sha256(path.encode('utf-8')).hexdigest()[:16]
@@ -122,6 +128,23 @@ class SessionAssetCache:
             self._cache[path] = local
             mime, _ = mimetypes.guess_type(str(local))
             return local, mime, local.stat().st_size
+
+    def register(self, local_path: Path) -> Path:
+        """Insert an externally-created file into the LRU.
+
+        Used by callers that produce derived files in the session tempdir
+        (for example, resized image siblings) so those files participate in
+        LRU eviction and session cleanup. ``local_path`` must already live
+        under ``self.tempdir``; otherwise ``ValueError`` is raised.
+        """
+        resolved = local_path.resolve()
+        tempdir_resolved = self.tempdir.resolve()
+        if not resolved.is_relative_to(tempdir_resolved):
+            raise ValueError(
+                f'register() refused: {local_path} is not inside session tempdir {self.tempdir}'
+            )
+        self._cache[str(local_path)] = local_path
+        return local_path
 
     def cleanup(self) -> None:
         """Remove the session tempdir and all cached files. Idempotent."""

--- a/packages/common/src/memex_common/asset_cache.py
+++ b/packages/common/src/memex_common/asset_cache.py
@@ -9,6 +9,7 @@ the LRU bound is exceeded.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import mimetypes
 import os
@@ -22,6 +23,10 @@ from typing import Any
 from cachetools import LRUCache
 
 logger = logging.getLogger(__name__)
+
+
+def _stat_size(path: Path) -> int:
+    return path.stat().st_size
 
 
 class _EvictingLRUCache(LRUCache):
@@ -81,9 +86,7 @@ class SessionAssetCache:
             pass
         except OSError as exc:
             logger.debug('Failed to unlink evicted cache file %s: %s', value, exc)
-        # Drop the per-key lock in the same critical section as the eviction so
-        # the locks dict stays bounded by the LRU. Keys registered via
-        # ``register()`` have no lock entry; ``pop(..., None)`` is a no-op.
+        # Bound the locks dict to the LRU size.
         self._locks.pop(key, None)
 
     def _local_path_for(self, path: str) -> Path:
@@ -104,30 +107,36 @@ class SessionAssetCache:
         path: str,
         fetch: Callable[[str], Awaitable[bytes]],
     ) -> tuple[Path, str | None, int]:
-        """Return ``(local_path, mime_type, size_bytes)`` for ``path``.
-
-        On cache hit the existing file is stat'd and returned; on miss the
-        ``fetch`` coroutine is awaited and the bytes are written to the
-        session tempdir before being inserted into the LRU cache.
-        """
-        cached = self._cache.get(path)
-        if cached is not None and cached.exists():
+        """Return ``(local_path, mime_type, size_bytes)`` for ``path``."""
+        cached: Path | None = self._cache.get(path)
+        if cached is not None and await asyncio.to_thread(cached.exists):
             mime, _ = mimetypes.guess_type(str(cached))
-            return cached, mime, cached.stat().st_size
+            size = await asyncio.to_thread(_stat_size, cached)
+            return cached, mime, size
 
         lock = await self._lock_for(path)
         async with lock:
             cached = self._cache.get(path)
-            if cached is not None and cached.exists():
+            if cached is not None and await asyncio.to_thread(cached.exists):
                 mime, _ = mimetypes.guess_type(str(cached))
-                return cached, mime, cached.stat().st_size
+                size = await asyncio.to_thread(_stat_size, cached)
+                return cached, mime, size
 
             data = await fetch(path)
             local = self._local_path_for(path)
-            local.write_bytes(data)
+            await asyncio.to_thread(local.write_bytes, data)
             self._cache[path] = local
             mime, _ = mimetypes.guess_type(str(local))
-            return local, mime, local.stat().st_size
+            size = await asyncio.to_thread(_stat_size, local)
+            return local, mime, size
+
+    def invalidate(self, path: str) -> None:
+        """Drop ``path`` from the LRU and unlink its backing file. Idempotent."""
+        local = self._cache.pop(path, None)
+        if local is not None:
+            with contextlib.suppress(FileNotFoundError, OSError):
+                os.unlink(local)
+        self._locks.pop(path, None)
 
     def register(self, local_path: Path) -> Path:
         """Insert an externally-created file into the LRU.

--- a/packages/common/src/memex_common/asset_cache.py
+++ b/packages/common/src/memex_common/asset_cache.py
@@ -54,6 +54,9 @@ class _EvictingLRUCache(LRUCache):
         return key, value
 
 
+MAX_RESOURCE_BYTES: int = 50 * 1024 * 1024
+
+
 class SessionAssetCache:
     """Per-session on-disk cache for fetched assets.
 
@@ -64,10 +67,10 @@ class SessionAssetCache:
     accepts either form.
 
     Concurrent ``get_or_fetch`` calls for the same path coalesce into a
-    single fetch. Mutations to the underlying cache are serialised with
-    a ``threading.Lock`` so the Hermes plugin can call ``register`` /
-    ``invalidate`` from its synchronous dispatch thread while the MCP
-    event loop is also running.
+    single fetch. A single ``threading.Lock`` serialises every mutation
+    of ``_cache`` and ``_locks`` so the Hermes plugin can call
+    ``register`` / ``invalidate`` from its synchronous dispatch thread
+    while the MCP event loop is also running.
     """
 
     def __init__(
@@ -85,7 +88,6 @@ class SessionAssetCache:
             on_evict=self._unlink_evicted,
         )
         self._locks: dict[str, asyncio.Lock] = {}
-        self._global_lock = asyncio.Lock()
         self._mutation_lock = threading.Lock()
 
     def _unlink_evicted(self, key: str, value: Path) -> None:
@@ -102,8 +104,8 @@ class SessionAssetCache:
         safe_name = Path(path).name or 'asset'
         return self.tempdir / f'{digest}-{safe_name}'
 
-    async def _lock_for(self, path: str) -> asyncio.Lock:
-        async with self._global_lock:
+    def _lock_for(self, path: str) -> asyncio.Lock:
+        with self._mutation_lock:
             lock = self._locks.get(path)
             if lock is None:
                 lock = asyncio.Lock()
@@ -124,7 +126,7 @@ class SessionAssetCache:
             size = await asyncio.to_thread(_stat_size, cached)
             return cached, mime, size
 
-        lock = await self._lock_for(path)
+        lock = self._lock_for(path)
         async with lock:
             with self._mutation_lock:
                 cached = self._cache.get(path)
@@ -170,10 +172,10 @@ class SessionAssetCache:
 
     def cleanup(self) -> None:
         """Remove the session tempdir and all cached files. Idempotent."""
-        shutil.rmtree(self.tempdir, ignore_errors=True)
         with self._mutation_lock:
             self._cache.clear()
             self._locks.clear()
+        shutil.rmtree(self.tempdir, ignore_errors=True)
 
     def __len__(self) -> int:
         with self._mutation_lock:

--- a/packages/common/src/memex_common/asset_cache.py
+++ b/packages/common/src/memex_common/asset_cache.py
@@ -55,6 +55,7 @@ class _EvictingLRUCache(LRUCache):
 
 
 MAX_RESOURCE_BYTES: int = 50 * 1024 * 1024
+MAX_GET_RESOURCES_PATHS: int = 50
 
 
 class SessionAssetCache:

--- a/packages/common/src/memex_common/asset_cache.py
+++ b/packages/common/src/memex_common/asset_cache.py
@@ -15,6 +15,7 @@ import mimetypes
 import os
 import shutil
 import tempfile
+import threading
 from collections.abc import Awaitable, Callable
 from hashlib import sha256
 from pathlib import Path
@@ -56,10 +57,17 @@ class _EvictingLRUCache(LRUCache):
 class SessionAssetCache:
     """Per-session on-disk cache for fetched assets.
 
-    Files live in ``self.tempdir`` and are keyed by their original asset path.
-    When the LRU bound is exceeded the evicted file is unlinked from disk.
-    Concurrent ``get_or_fetch`` calls for the same path coalesce into a single
-    fetch.
+    Files live in ``self.tempdir`` and are keyed by their original asset
+    path; ``get_or_fetch`` uses that key. ``register`` (used for derived
+    files like resized siblings) keys by the file's own absolute string
+    path instead, so the two key spaces are disjoint and ``__contains__``
+    accepts either form.
+
+    Concurrent ``get_or_fetch`` calls for the same path coalesce into a
+    single fetch. Mutations to the underlying cache are serialised with
+    a ``threading.Lock`` so the Hermes plugin can call ``register`` /
+    ``invalidate`` from its synchronous dispatch thread while the MCP
+    event loop is also running.
     """
 
     def __init__(
@@ -78,6 +86,7 @@ class SessionAssetCache:
         )
         self._locks: dict[str, asyncio.Lock] = {}
         self._global_lock = asyncio.Lock()
+        self._mutation_lock = threading.Lock()
 
     def _unlink_evicted(self, key: str, value: Path) -> None:
         try:
@@ -86,7 +95,6 @@ class SessionAssetCache:
             pass
         except OSError as exc:
             logger.debug('Failed to unlink evicted cache file %s: %s', value, exc)
-        # Bound the locks dict to the LRU size.
         self._locks.pop(key, None)
 
     def _local_path_for(self, path: str) -> Path:
@@ -108,7 +116,9 @@ class SessionAssetCache:
         fetch: Callable[[str], Awaitable[bytes]],
     ) -> tuple[Path, str | None, int]:
         """Return ``(local_path, mime_type, size_bytes)`` for ``path``."""
-        cached: Path | None = self._cache.get(path)
+        cached: Path | None
+        with self._mutation_lock:
+            cached = self._cache.get(path)
         if cached is not None and await asyncio.to_thread(cached.exists):
             mime, _ = mimetypes.guess_type(str(cached))
             size = await asyncio.to_thread(_stat_size, cached)
@@ -116,7 +126,8 @@ class SessionAssetCache:
 
         lock = await self._lock_for(path)
         async with lock:
-            cached = self._cache.get(path)
+            with self._mutation_lock:
+                cached = self._cache.get(path)
             if cached is not None and await asyncio.to_thread(cached.exists):
                 mime, _ = mimetypes.guess_type(str(cached))
                 size = await asyncio.to_thread(_stat_size, cached)
@@ -125,26 +136,27 @@ class SessionAssetCache:
             data = await fetch(path)
             local = self._local_path_for(path)
             await asyncio.to_thread(local.write_bytes, data)
-            self._cache[path] = local
+            with self._mutation_lock:
+                self._cache[path] = local
             mime, _ = mimetypes.guess_type(str(local))
             size = await asyncio.to_thread(_stat_size, local)
             return local, mime, size
 
     def invalidate(self, path: str) -> None:
         """Drop ``path`` from the LRU and unlink its backing file. Idempotent."""
-        local = self._cache.pop(path, None)
+        with self._mutation_lock:
+            local = self._cache.pop(path, None)
+            self._locks.pop(path, None)
         if local is not None:
             with contextlib.suppress(FileNotFoundError, OSError):
                 os.unlink(local)
-        self._locks.pop(path, None)
 
     def register(self, local_path: Path) -> Path:
         """Insert an externally-created file into the LRU.
 
-        Used by callers that produce derived files in the session tempdir
-        (for example, resized image siblings) so those files participate in
-        LRU eviction and session cleanup. ``local_path`` must already live
-        under ``self.tempdir``; otherwise ``ValueError`` is raised.
+        Keyed by ``str(local_path)`` (the file's own absolute path) — distinct
+        from ``get_or_fetch`` which keys by the upstream asset path. ``local_path``
+        must already live under ``self.tempdir``; ``ValueError`` otherwise.
         """
         resolved = local_path.resolve()
         tempdir_resolved = self.tempdir.resolve()
@@ -152,20 +164,24 @@ class SessionAssetCache:
             raise ValueError(
                 f'register() refused: {local_path} is not inside session tempdir {self.tempdir}'
             )
-        self._cache[str(local_path)] = local_path
+        with self._mutation_lock:
+            self._cache[str(local_path)] = local_path
         return local_path
 
     def cleanup(self) -> None:
         """Remove the session tempdir and all cached files. Idempotent."""
         shutil.rmtree(self.tempdir, ignore_errors=True)
-        self._cache.clear()
-        self._locks.clear()
+        with self._mutation_lock:
+            self._cache.clear()
+            self._locks.clear()
 
     def __len__(self) -> int:
-        return len(self._cache)
+        with self._mutation_lock:
+            return len(self._cache)
 
     def __contains__(self, path: object) -> bool:
-        return path in self._cache
+        with self._mutation_lock:
+            return path in self._cache
 
     def __repr__(self) -> str:
         return (

--- a/packages/common/src/memex_common/asset_cache.py
+++ b/packages/common/src/memex_common/asset_cache.py
@@ -1,0 +1,149 @@
+"""Session-scoped on-disk asset cache for binary resources.
+
+Used by MCP and Hermes plugin tooling to hand off asset bytes to consuming
+agents via the filesystem instead of inlining base64 in tool results. The
+cache owns a tempdir for the duration of the session and evicts files when
+the LRU bound is exceeded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import mimetypes
+import os
+import shutil
+import tempfile
+from collections.abc import Awaitable, Callable
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from cachetools import LRUCache
+
+
+class _EvictingLRUCache(LRUCache):
+    """LRUCache subclass that calls a hook on each eviction.
+
+    The hook receives ``(key, value)`` for the entry being pushed out so the
+    owner can clean up backing resources (e.g. unlink a temp file).
+    """
+
+    def __init__(
+        self,
+        maxsize: int,
+        on_evict: Callable[[str, Path], None],
+    ) -> None:
+        super().__init__(maxsize=maxsize)
+        self._on_evict = on_evict
+
+    def popitem(self) -> tuple[str, Path]:
+        key, value = super().popitem()
+        try:
+            self._on_evict(key, value)
+        except Exception:  # noqa: BLE001 - eviction must never raise
+            pass
+        return key, value
+
+
+class SessionAssetCache:
+    """Per-session on-disk cache for fetched assets.
+
+    Files live in ``self.tempdir`` and are keyed by their original asset path.
+    When the LRU bound is exceeded the evicted file is unlinked from disk.
+    Concurrent ``get_or_fetch`` calls for the same path coalesce into a single
+    fetch.
+    """
+
+    def __init__(
+        self,
+        tempdir: Path | None = None,
+        maxsize: int = 64,
+    ) -> None:
+        if tempdir is None:
+            self.tempdir = Path(tempfile.mkdtemp(prefix='memex-assets-'))
+        else:
+            tempdir.mkdir(parents=True, exist_ok=True)
+            self.tempdir = tempdir
+        self._cache: _EvictingLRUCache = _EvictingLRUCache(
+            maxsize=maxsize,
+            on_evict=self._unlink_evicted,
+        )
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._global_lock = asyncio.Lock()
+
+    @staticmethod
+    def _unlink_evicted(_key: str, value: Path) -> None:
+        try:
+            os.unlink(value)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+
+    def _local_path_for(self, path: str) -> Path:
+        digest = sha256(path.encode('utf-8')).hexdigest()[:16]
+        safe_name = Path(path).name or 'asset'
+        return self.tempdir / f'{digest}-{safe_name}'
+
+    async def _lock_for(self, path: str) -> asyncio.Lock:
+        async with self._global_lock:
+            lock = self._locks.get(path)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[path] = lock
+            return lock
+
+    async def get_or_fetch(
+        self,
+        path: str,
+        fetch: Callable[[str], Awaitable[bytes]],
+    ) -> tuple[Path, str | None, int]:
+        """Return ``(local_path, mime_type, size_bytes)`` for ``path``.
+
+        On cache hit the existing file is stat'd and returned; on miss the
+        ``fetch`` coroutine is awaited and the bytes are written to the
+        session tempdir before being inserted into the LRU cache.
+        """
+        cached = self._cache.get(path)
+        if cached is not None and cached.exists():
+            mime, _ = mimetypes.guess_type(str(cached))
+            return cached, mime, cached.stat().st_size
+
+        lock = await self._lock_for(path)
+        async with lock:
+            cached = self._cache.get(path)
+            if cached is not None and cached.exists():
+                mime, _ = mimetypes.guess_type(str(cached))
+                return cached, mime, cached.stat().st_size
+
+            data = await fetch(path)
+            local = self._local_path_for(path)
+            local.write_bytes(data)
+            self._cache[path] = local
+            mime, _ = mimetypes.guess_type(str(local))
+            return local, mime, local.stat().st_size
+
+    def cleanup(self) -> None:
+        """Remove the session tempdir and all cached files. Idempotent."""
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+        self._cache.clear()
+        self._locks.clear()
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+    def __contains__(self, path: object) -> bool:
+        return path in self._cache
+
+    def __repr__(self) -> str:
+        return (
+            f'SessionAssetCache(tempdir={self.tempdir!s}, '
+            f'size={len(self._cache)}/{self._cache.maxsize})'
+        )
+
+    # Allow ``with SessionAssetCache(...) as cache:`` style usage in tests.
+    def __enter__(self) -> 'SessionAssetCache':
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.cleanup()

--- a/packages/common/src/memex_common/asset_resize.py
+++ b/packages/common/src/memex_common/asset_resize.py
@@ -1,0 +1,74 @@
+"""Image resize helper used by MCP and Hermes plugin tools.
+
+Reads ``local_path`` with Pillow, applies ``Image.thumbnail`` (preserving
+aspect ratio), and writes the resized copy beside the source. Path
+confinement is the caller's responsibility — this helper only enforces a
+format allowlist so SVG/PDF/audio cannot smuggle through Pillow plugins.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PIL import Image, UnidentifiedImageError
+
+_ALLOWED_INPUT_FORMATS: frozenset[str] = frozenset({'PNG', 'JPEG', 'JPG', 'WEBP', 'GIF'})
+
+_SUFFIX_TO_FORMAT: dict[str, str] = {
+    '.png': 'PNG',
+    '.jpg': 'JPEG',
+    '.jpeg': 'JPEG',
+    '.webp': 'WEBP',
+    '.gif': 'GIF',
+}
+
+
+def _allowed_formats_message() -> str:
+    return 'allowed: ' + ', '.join(sorted(_ALLOWED_INPUT_FORMATS))
+
+
+def resize_image(
+    local_path: Path,
+    *,
+    max_width: int = 1280,
+    max_height: int = 1280,
+    format: str | None = None,
+) -> tuple[Path, int]:
+    """Resize ``local_path`` to fit within ``max_width`` x ``max_height``.
+
+    Returns ``(dest_path, dest_size_bytes)``. The destination is written as a
+    sibling of the source with a ``-{w}x{h}`` stem suffix and the same (or
+    explicitly-overridden) format. Rejects any source whose suffix or
+    Pillow-detected format is not in the allowlist.
+    """
+    suffix = local_path.suffix.lower()
+    suffix_format = _SUFFIX_TO_FORMAT.get(suffix)
+    if suffix_format is None:
+        raise ValueError(f'Unsupported image suffix {suffix!r}; {_allowed_formats_message()}')
+
+    try:
+        with Image.open(local_path) as img:
+            detected = (img.format or '').upper()
+            if detected not in _ALLOWED_INPUT_FORMATS:
+                raise ValueError(
+                    f'Unsupported image format {detected!r}; {_allowed_formats_message()}'
+                )
+
+            output_format = (format or detected).upper()
+            if output_format == 'JPG':
+                output_format = 'JPEG'
+
+            img.thumbnail((max_width, max_height))
+            dest_path = local_path.with_stem(f'{local_path.stem}-{max_width}x{max_height}')
+
+            save_img: Image.Image = img
+            if output_format == 'JPEG' and img.mode not in ('RGB', 'L'):
+                save_img = img.convert('RGB')
+
+            save_img.save(dest_path, format=output_format)
+    except UnidentifiedImageError as exc:
+        raise ValueError(
+            f'Could not decode image at {local_path}; {_allowed_formats_message()}'
+        ) from exc
+
+    return dest_path, dest_path.stat().st_size

--- a/packages/common/src/memex_common/asset_resize.py
+++ b/packages/common/src/memex_common/asset_resize.py
@@ -25,6 +25,10 @@ _ALLOWED_INPUT_FORMATS: frozenset[str] = frozenset({'PNG', 'JPEG', 'WEBP', 'GIF'
 # its hard-error path is at 2× that; we want a deterministic refusal.
 _MAX_DECODED_PIXELS: int = 32 * 1024 * 1024  # 32 megapixels
 
+# Align Pillow's own threshold so its DecompressionBombError fires at the
+# same point as our explicit pre-check.
+Image.MAX_IMAGE_PIXELS = _MAX_DECODED_PIXELS
+
 _SUFFIX_TO_FORMAT: dict[str, str] = {
     '.png': 'PNG',
     '.jpg': 'JPEG',

--- a/packages/common/src/memex_common/asset_resize.py
+++ b/packages/common/src/memex_common/asset_resize.py
@@ -21,13 +21,10 @@ if TYPE_CHECKING:
 _ALLOWED_INPUT_FORMATS: frozenset[str] = frozenset({'PNG', 'JPEG', 'WEBP', 'GIF'})
 
 # Decompression-bomb cap, checked from the lazy ``Image.open`` header
-# before pixel decode. Pillow's stock ``MAX_IMAGE_PIXELS`` only warns and
-# its hard-error path is at 2× that; we want a deterministic refusal.
+# before pixel decode. Mutating ``Image.MAX_IMAGE_PIXELS`` would be
+# process-global and step on other Pillow consumers; this explicit
+# header-based guard fires deterministically before any decode.
 _MAX_DECODED_PIXELS: int = 32 * 1024 * 1024  # 32 megapixels
-
-# Align Pillow's own threshold so its DecompressionBombError fires at the
-# same point as our explicit pre-check.
-Image.MAX_IMAGE_PIXELS = _MAX_DECODED_PIXELS
 
 _SUFFIX_TO_FORMAT: dict[str, str] = {
     '.png': 'PNG',

--- a/packages/common/src/memex_common/asset_resize.py
+++ b/packages/common/src/memex_common/asset_resize.py
@@ -39,7 +39,7 @@ def resize_image(
     *,
     max_width: int = 1280,
     max_height: int = 1280,
-    format: str | None = None,
+    output_format: str | None = None,
 ) -> tuple[Path, int]:
     """Resize ``local_path`` to fit within ``max_width`` x ``max_height``.
 
@@ -61,25 +61,25 @@ def resize_image(
                     f'Unsupported image format {detected!r}; {_allowed_formats_message()}'
                 )
 
-            output_format = (format or detected).upper()
-            if output_format == 'JPG':
-                output_format = 'JPEG'
-            if output_format not in _FORMAT_TO_SUFFIX:
+            resolved_format = (output_format or detected).upper()
+            if resolved_format == 'JPG':
+                resolved_format = 'JPEG'
+            if resolved_format not in _FORMAT_TO_SUFFIX:
                 raise ValueError(
-                    f'Unsupported output format {output_format!r}; {_allowed_formats_message()}'
+                    f'Unsupported output format {resolved_format!r}; {_allowed_formats_message()}'
                 )
 
             img.thumbnail((max_width, max_height))
-            dest_suffix = _FORMAT_TO_SUFFIX[output_format]
+            dest_suffix = _FORMAT_TO_SUFFIX[resolved_format]
             dest_path = local_path.with_name(
                 f'{local_path.stem}-{max_width}x{max_height}{dest_suffix}'
             )
 
             save_img: Image.Image = img
-            if output_format == 'JPEG' and img.mode not in ('RGB', 'L'):
+            if resolved_format == 'JPEG' and img.mode not in ('RGB', 'L'):
                 save_img = img.convert('RGB')
 
-            save_img.save(dest_path, format=output_format)
+            save_img.save(dest_path, format=resolved_format)
     except UnidentifiedImageError as exc:
         raise ValueError(
             f'Could not decode image at {local_path}; {_allowed_formats_message()}'

--- a/packages/common/src/memex_common/asset_resize.py
+++ b/packages/common/src/memex_common/asset_resize.py
@@ -8,9 +8,15 @@ format allowlist so SVG/PDF/audio cannot smuggle through Pillow plugins.
 
 from __future__ import annotations
 
+import contextlib
+import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from PIL import Image, UnidentifiedImageError
+
+if TYPE_CHECKING:
+    from memex_common.asset_cache import SessionAssetCache
 
 _ALLOWED_INPUT_FORMATS: frozenset[str] = frozenset({'PNG', 'JPEG', 'WEBP', 'GIF'})
 
@@ -97,4 +103,65 @@ def resize_image(
             f'Could not decode image at {local_path}; {_allowed_formats_message()}'
         ) from exc
 
-    return dest_path, dest_path.stat().st_size
+    try:
+        size = dest_path.stat().st_size
+    except OSError as exc:
+        raise ValueError(f'Resize destination is unavailable: {exc}') from exc
+    return dest_path, size
+
+
+def validate_and_resize(
+    cache: SessionAssetCache,
+    local_path_str: str,
+    *,
+    max_width: int,
+    max_height: int,
+    output_format: str | None,
+) -> tuple[Path, int]:
+    """Resize an image confined to ``cache.tempdir``.
+
+    Resolves ``local_path_str`` strictly, refuses anything outside the
+    cache, runs :func:`resize_image`, re-checks the destination resolves
+    inside the cache (TOCTOU defense), and registers the result so it
+    participates in LRU eviction. Raises :class:`ValueError` on any
+    rejection — callers translate to their own error type.
+    """
+    if max_width <= 0 or max_height <= 0:
+        raise ValueError('max_width and max_height must be positive')
+
+    try:
+        cache_root = cache.tempdir.resolve(strict=True)
+    except OSError as exc:
+        raise ValueError(f'Asset cache tempdir is unavailable: {exc}') from exc
+
+    try:
+        resolved_input = Path(local_path_str).resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ValueError(f'local_path does not exist: {local_path_str}') from exc
+    except OSError as exc:
+        raise ValueError(f'Could not resolve local_path: {exc}') from exc
+
+    if not resolved_input.is_relative_to(cache_root):
+        raise ValueError('local_path must point inside the session asset cache')
+
+    dest_path, size = resize_image(
+        resolved_input,
+        max_width=max_width,
+        max_height=max_height,
+        output_format=output_format,
+    )
+
+    try:
+        resolved_dest = dest_path.resolve(strict=True)
+    except OSError as exc:
+        with contextlib.suppress(FileNotFoundError, OSError):
+            os.unlink(dest_path)
+        raise ValueError('Resize destination escaped session cache') from exc
+
+    if not resolved_dest.is_relative_to(cache_root):
+        with contextlib.suppress(FileNotFoundError, OSError):
+            os.unlink(dest_path)
+        raise ValueError('Resize destination escaped session cache')
+
+    cache.register(dest_path)
+    return dest_path, size

--- a/packages/common/src/memex_common/asset_resize.py
+++ b/packages/common/src/memex_common/asset_resize.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from PIL import Image, UnidentifiedImageError
 
-_ALLOWED_INPUT_FORMATS: frozenset[str] = frozenset({'PNG', 'JPEG', 'JPG', 'WEBP', 'GIF'})
+_ALLOWED_INPUT_FORMATS: frozenset[str] = frozenset({'PNG', 'JPEG', 'WEBP', 'GIF'})
 
 _SUFFIX_TO_FORMAT: dict[str, str] = {
     '.png': 'PNG',
@@ -20,6 +20,13 @@ _SUFFIX_TO_FORMAT: dict[str, str] = {
     '.jpeg': 'JPEG',
     '.webp': 'WEBP',
     '.gif': 'GIF',
+}
+
+_FORMAT_TO_SUFFIX: dict[str, str] = {
+    'PNG': '.png',
+    'JPEG': '.jpg',
+    'WEBP': '.webp',
+    'GIF': '.gif',
 }
 
 
@@ -57,9 +64,16 @@ def resize_image(
             output_format = (format or detected).upper()
             if output_format == 'JPG':
                 output_format = 'JPEG'
+            if output_format not in _FORMAT_TO_SUFFIX:
+                raise ValueError(
+                    f'Unsupported output format {output_format!r}; {_allowed_formats_message()}'
+                )
 
             img.thumbnail((max_width, max_height))
-            dest_path = local_path.with_stem(f'{local_path.stem}-{max_width}x{max_height}')
+            dest_suffix = _FORMAT_TO_SUFFIX[output_format]
+            dest_path = local_path.with_name(
+                f'{local_path.stem}-{max_width}x{max_height}{dest_suffix}'
+            )
 
             save_img: Image.Image = img
             if output_format == 'JPEG' and img.mode not in ('RGB', 'L'):

--- a/packages/common/src/memex_common/asset_resize.py
+++ b/packages/common/src/memex_common/asset_resize.py
@@ -14,13 +14,9 @@ from PIL import Image, UnidentifiedImageError
 
 _ALLOWED_INPUT_FORMATS: frozenset[str] = frozenset({'PNG', 'JPEG', 'WEBP', 'GIF'})
 
-# Decompression-bomb cap. Pillow's stock ``MAX_IMAGE_PIXELS`` (~89 MP) only
-# emits a warning, and its hard-error path is at 2× that. We enforce a
-# stricter, deterministic 32 MP budget by checking ``img.size`` after
-# ``Image.open`` (which reads only the header) and before ``thumbnail()``
-# triggers the actual decode. No process-global Pillow state is mutated, so
-# concurrent callers don't race and unrelated Pillow users elsewhere in the
-# process are unaffected.
+# Decompression-bomb cap, checked from the lazy ``Image.open`` header
+# before pixel decode. Pillow's stock ``MAX_IMAGE_PIXELS`` only warns and
+# its hard-error path is at 2× that; we want a deterministic refusal.
 _MAX_DECODED_PIXELS: int = 32 * 1024 * 1024  # 32 megapixels
 
 _SUFFIX_TO_FORMAT: dict[str, str] = {
@@ -57,6 +53,9 @@ def resize_image(
     explicitly-overridden) format. Rejects any source whose suffix or
     Pillow-detected format is not in the allowlist.
     """
+    if max_width <= 0 or max_height <= 0:
+        raise ValueError('max_width and max_height must be positive')
+
     suffix = local_path.suffix.lower()
     suffix_format = _SUFFIX_TO_FORMAT.get(suffix)
     if suffix_format is None:
@@ -70,10 +69,6 @@ def resize_image(
                     f'Unsupported image format {detected!r}; {_allowed_formats_message()}'
                 )
 
-            # ``Image.open`` is lazy — only the header is read, so ``img.size``
-            # is reliable before any pixels are decoded. Reject oversize
-            # inputs here so a pathological 100k×100k PNG can't exhaust
-            # memory inside ``thumbnail()``.
             width, height = img.size
             if width * height > _MAX_DECODED_PIXELS:
                 raise ValueError('Image is too large to safely decode')

--- a/packages/common/src/memex_common/asset_resize.py
+++ b/packages/common/src/memex_common/asset_resize.py
@@ -14,6 +14,15 @@ from PIL import Image, UnidentifiedImageError
 
 _ALLOWED_INPUT_FORMATS: frozenset[str] = frozenset({'PNG', 'JPEG', 'WEBP', 'GIF'})
 
+# Decompression-bomb cap. Pillow's stock ``MAX_IMAGE_PIXELS`` (~89 MP) only
+# emits a warning, and its hard-error path is at 2× that. We enforce a
+# stricter, deterministic 32 MP budget by checking ``img.size`` after
+# ``Image.open`` (which reads only the header) and before ``thumbnail()``
+# triggers the actual decode. No process-global Pillow state is mutated, so
+# concurrent callers don't race and unrelated Pillow users elsewhere in the
+# process are unaffected.
+_MAX_DECODED_PIXELS: int = 32 * 1024 * 1024  # 32 megapixels
+
 _SUFFIX_TO_FORMAT: dict[str, str] = {
     '.png': 'PNG',
     '.jpg': 'JPEG',
@@ -60,6 +69,14 @@ def resize_image(
                 raise ValueError(
                     f'Unsupported image format {detected!r}; {_allowed_formats_message()}'
                 )
+
+            # ``Image.open`` is lazy — only the header is read, so ``img.size``
+            # is reliable before any pixels are decoded. Reject oversize
+            # inputs here so a pathological 100k×100k PNG can't exhaust
+            # memory inside ``thumbnail()``.
+            width, height = img.size
+            if width * height > _MAX_DECODED_PIXELS:
+                raise ValueError('Image is too large to safely decode')
 
             resolved_format = (output_format or detected).upper()
             if resolved_format == 'JPG':

--- a/packages/common/tests/test_asset_cache.py
+++ b/packages/common/tests/test_asset_cache.py
@@ -60,17 +60,36 @@ async def test_lru_eviction_unlinks_file(tmp_path: Path) -> None:
     assert not first.exists()
 
 
-async def test_cleanup_removes_tempdir(tmp_path: Path) -> None:
+async def test_cleanup_unlinks_files_in_caller_tempdir(tmp_path: Path) -> None:
+    """A caller-supplied tempdir is preserved by ``cleanup()``; only the
+    files this cache wrote get unlinked. This protects callers who share a
+    tempdir with other components from having that directory yanked out."""
     cache = _make_cache(tmp_path)
     fetcher = _CountingFetcher()
-    await cache.get_or_fetch('foo.png', fetcher)
+    local, _, _ = await cache.get_or_fetch('foo.png', fetcher)
     tempdir = cache.tempdir
+    assert tempdir.exists()
+    assert local.exists()
+
+    cache.cleanup()
+
+    assert tempdir.exists()
+    assert not local.exists()
+    # Idempotent — no error on second call.
+    cache.cleanup()
+
+
+async def test_cleanup_removes_auto_created_tempdir() -> None:
+    """When no tempdir is provided, cleanup() rmtrees the auto-created one."""
+    cache = SessionAssetCache()
+    tempdir = cache.tempdir
+    fetcher = _CountingFetcher()
+    await cache.get_or_fetch('foo.png', fetcher)
     assert tempdir.exists()
 
     cache.cleanup()
 
     assert not tempdir.exists()
-    # Idempotent — no error on second call.
     cache.cleanup()
 
 
@@ -128,10 +147,13 @@ async def test_repr_and_membership(tmp_path: Path) -> None:
 async def test_context_manager_calls_cleanup(tmp_path: Path) -> None:
     target = tmp_path / 'ctx'
     with SessionAssetCache(tempdir=target) as cache:
-        await cache.get_or_fetch('foo.png', _CountingFetcher())
+        local, _, _ = await cache.get_or_fetch('foo.png', _CountingFetcher())
         assert cache.tempdir.exists()
+        assert local.exists()
 
-    assert not target.exists()
+    # Caller-supplied tempdir is preserved; the file inside is unlinked.
+    assert target.exists()
+    assert not local.exists()
 
 
 async def test_eviction_then_refetch_recreates_file(tmp_path: Path) -> None:
@@ -287,3 +309,47 @@ async def test_invalidate_then_refetch_calls_fetch_again(tmp_path: Path) -> None
     await cache.get_or_fetch('foo.png', fetcher)
 
     assert len(fetcher.calls) == 2
+
+
+async def test_fast_path_survives_concurrent_unlink(tmp_path: Path) -> None:
+    """If the backing file is unlinked between cache lookup and stat, the
+    fast path falls through to the locked path and refetches — no
+    ``FileNotFoundError`` propagates to the caller.
+
+    This simulates the race where one coroutine evicts an entry while
+    another is mid-fast-path on the same key.
+    """
+    cache = _make_cache(tmp_path)
+    fetcher = _CountingFetcher()
+
+    local, _, _ = await cache.get_or_fetch('foo.png', fetcher)
+    assert local.exists()
+
+    # Unlink the file out from under the cache without touching the LRU
+    # entry — the next lookup hits the fast path with a stale entry.
+    local.unlink()
+    assert not local.exists()
+    assert 'foo.png' in cache  # entry still tracked
+
+    refetched, _, _ = await cache.get_or_fetch('foo.png', fetcher)
+    assert refetched.exists()
+    assert len(fetcher.calls) == 2
+
+
+async def test_fetch_failure_drops_orphan_lock(tmp_path: Path) -> None:
+    """A failing ``fetch()`` must not leak its per-path lock.
+
+    Without explicit cleanup, every transient error on a distinct path
+    would grow ``_locks`` unboundedly even though no cache entry is ever
+    stored for it.
+    """
+    cache = _make_cache(tmp_path)
+
+    async def boom(_path: str) -> bytes:
+        raise RuntimeError('upstream broke')
+
+    with pytest.raises(RuntimeError, match='upstream broke'):
+        await cache.get_or_fetch('boom.png', boom)
+
+    assert 'boom.png' not in cache._locks
+    assert 'boom.png' not in cache

--- a/packages/common/tests/test_asset_cache.py
+++ b/packages/common/tests/test_asset_cache.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
+
 from memex_common.asset_cache import SessionAssetCache
 
 
@@ -143,3 +145,112 @@ async def test_eviction_then_refetch_recreates_file(tmp_path: Path) -> None:
 
     assert again.exists()
     assert len(fetcher.calls) == 3
+
+
+async def test_lock_dict_bounded_by_lru_size(tmp_path: Path) -> None:
+    """Per-path locks must be evicted alongside their cache entries.
+
+    Without this, a long-running session that fetches many distinct paths
+    would grow ``_locks`` unboundedly even though the LRU caps the file
+    count. The eviction hook drops the matching lock in the same critical
+    section as the file unlink.
+    """
+    cache = _make_cache(tmp_path, maxsize=2)
+    fetcher = _CountingFetcher()
+
+    for path in ('one.png', 'two.png', 'three.png', 'four.png', 'five.png'):
+        await cache.get_or_fetch(path, fetcher)
+
+    assert len(cache._locks) <= 2
+    # The lock dict must track the same set of keys the LRU still holds.
+    assert set(cache._locks).issubset(set(cache._cache))
+
+
+async def test_register_inserts_into_lru(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    sibling = cache.tempdir / 'resized.png'
+    sibling.write_bytes(b'\x89PNG\r\n\x1a\n')
+
+    returned = cache.register(sibling)
+
+    assert returned == sibling
+    assert str(sibling) in cache._cache
+
+
+async def test_register_evicts_when_over_maxsize(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path, maxsize=2)
+    paths: list[Path] = []
+    for name in ('a.png', 'b.png', 'c.png'):
+        target = cache.tempdir / name
+        target.write_bytes(b'\x89PNG\r\n\x1a\n')
+        cache.register(target)
+        paths.append(target)
+
+    # First registration must have been evicted (LRU policy) and unlinked.
+    assert not paths[0].exists()
+    assert paths[1].exists()
+    assert paths[2].exists()
+
+
+async def test_register_rejects_path_outside_tempdir(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    outside = tmp_path / 'outside.png'
+    outside.write_bytes(b'\x89PNG\r\n\x1a\n')
+
+    with pytest.raises(ValueError, match='not inside session tempdir'):
+        cache.register(outside)
+
+
+async def test_eviction_then_read_raises_clean_filenotfound(tmp_path: Path) -> None:
+    """Documents the contract for callers reading file:// URIs after subsequent fetches.
+
+    Once an asset is evicted under LRU pressure, its on-disk file is unlinked.
+    Callers holding the previously-returned ``Path`` must handle ``FileNotFoundError``
+    gracefully — the cache makes no promise that the file remains readable
+    after later cache activity.
+    """
+    cache = _make_cache(tmp_path, maxsize=1)
+    fetcher = _CountingFetcher()
+
+    first, _, _ = await cache.get_or_fetch('a.png', fetcher)
+    assert first.exists()
+
+    # Fetching b.png evicts a.png; the underlying file must be gone.
+    await cache.get_or_fetch('b.png', fetcher)
+    assert not first.exists()
+
+    with pytest.raises(FileNotFoundError):
+        first.read_bytes()
+
+
+async def test_eviction_oserror_logged_not_raised(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ``OSError`` during eviction unlink must be logged but never raised.
+
+    Permission-denied or transient FS errors on cleanup must not crash the
+    eviction path — the LRU's invariants depend on ``popitem()`` returning.
+    """
+    import logging as stdlib_logging
+    import os as stdlib_os
+
+    cache = _make_cache(tmp_path, maxsize=1)
+    fetcher = _CountingFetcher()
+    await cache.get_or_fetch('a.png', fetcher)
+
+    real_unlink = stdlib_os.unlink
+
+    def flaky_unlink(path: str | Path) -> None:
+        if Path(path).name.endswith('a.png') or 'a.png' in str(path):
+            raise OSError('simulated permission denied')
+        real_unlink(path)
+
+    monkeypatch.setattr('memex_common.asset_cache.os.unlink', flaky_unlink)
+
+    with caplog.at_level(stdlib_logging.DEBUG, logger='memex_common.asset_cache'):
+        # Evicting a.png must not raise even though unlink fails.
+        await cache.get_or_fetch('b.png', fetcher)
+
+    assert any('Failed to unlink evicted cache file' in record.message for record in caplog.records)

--- a/packages/common/tests/test_asset_cache.py
+++ b/packages/common/tests/test_asset_cache.py
@@ -1,0 +1,145 @@
+"""Tests for memex_common.asset_cache.SessionAssetCache."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from memex_common.asset_cache import SessionAssetCache
+
+
+def _make_cache(tmp_path: Path, maxsize: int = 64) -> SessionAssetCache:
+    return SessionAssetCache(tempdir=tmp_path / 'assets', maxsize=maxsize)
+
+
+class _CountingFetcher:
+    def __init__(self, payload: bytes = b'pixels') -> None:
+        self.calls: list[str] = []
+        self.payload = payload
+
+    async def __call__(self, path: str) -> bytes:
+        self.calls.append(path)
+        return self.payload
+
+
+async def test_get_or_fetch_caches_first_call(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    fetcher = _CountingFetcher()
+
+    first_path, _, _ = await cache.get_or_fetch('a/b/foo.png', fetcher)
+    second_path, _, _ = await cache.get_or_fetch('a/b/foo.png', fetcher)
+
+    assert first_path == second_path
+    assert len(fetcher.calls) == 1
+
+
+async def test_get_or_fetch_returns_correct_mime(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    fetcher = _CountingFetcher(payload=b'\x89PNG\r\n\x1a\n')
+
+    local, mime, size = await cache.get_or_fetch('image/foo.png', fetcher)
+
+    assert mime == 'image/png'
+    assert size == len(fetcher.payload)
+    assert local.exists()
+    assert local.read_bytes() == fetcher.payload
+
+
+async def test_lru_eviction_unlinks_file(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path, maxsize=2)
+    fetcher = _CountingFetcher()
+
+    first, _, _ = await cache.get_or_fetch('one.png', fetcher)
+    second, _, _ = await cache.get_or_fetch('two.png', fetcher)
+    third, _, _ = await cache.get_or_fetch('three.png', fetcher)
+
+    assert second.exists()
+    assert third.exists()
+    assert not first.exists()
+
+
+async def test_cleanup_removes_tempdir(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    fetcher = _CountingFetcher()
+    await cache.get_or_fetch('foo.png', fetcher)
+    tempdir = cache.tempdir
+    assert tempdir.exists()
+
+    cache.cleanup()
+
+    assert not tempdir.exists()
+    # Idempotent — no error on second call.
+    cache.cleanup()
+
+
+async def test_concurrent_same_path_coalesces(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+
+    barrier = asyncio.Event()
+    call_count = 0
+
+    async def slow_fetch(_path: str) -> bytes:
+        nonlocal call_count
+        call_count += 1
+        await barrier.wait()
+        return b'data'
+
+    task_a = asyncio.create_task(cache.get_or_fetch('shared.png', slow_fetch))
+    task_b = asyncio.create_task(cache.get_or_fetch('shared.png', slow_fetch))
+    # Give both tasks a chance to enter get_or_fetch and contend on the lock.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    barrier.set()
+    result_a, _, _ = await task_a
+    result_b, _, _ = await task_b
+
+    assert call_count == 1
+    assert result_a == result_b
+
+
+async def test_filename_with_path_separators_is_sanitised(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    fetcher = _CountingFetcher()
+
+    # ``Path('foo/bar/../etc/passwd').name == 'passwd'`` — but the resolved
+    # parent must still be the session tempdir, not anywhere else on disk.
+    malicious = 'foo/bar/../etc/passwd'
+    local, _, _ = await cache.get_or_fetch(malicious, fetcher)
+
+    resolved_parent = local.resolve().parent
+    expected_parent = cache.tempdir.resolve()
+    assert resolved_parent == expected_parent
+    # Sanity: the file is inside the tempdir.
+    assert str(local.resolve()).startswith(str(expected_parent))
+
+
+async def test_repr_and_membership(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    fetcher = _CountingFetcher()
+    await cache.get_or_fetch('foo.png', fetcher)
+
+    assert 'foo.png' in cache
+    assert len(cache) == 1
+    assert 'SessionAssetCache' in repr(cache)
+
+
+async def test_context_manager_calls_cleanup(tmp_path: Path) -> None:
+    target = tmp_path / 'ctx'
+    with SessionAssetCache(tempdir=target) as cache:
+        await cache.get_or_fetch('foo.png', _CountingFetcher())
+        assert cache.tempdir.exists()
+
+    assert not target.exists()
+
+
+async def test_eviction_then_refetch_recreates_file(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path, maxsize=1)
+    fetcher = _CountingFetcher()
+
+    await cache.get_or_fetch('one.png', fetcher)
+    await cache.get_or_fetch('two.png', fetcher)
+    # one.png evicted; refetch should call fetch a third time.
+    again, _, _ = await cache.get_or_fetch('one.png', fetcher)
+
+    assert again.exists()
+    assert len(fetcher.calls) == 3

--- a/packages/common/tests/test_asset_cache.py
+++ b/packages/common/tests/test_asset_cache.py
@@ -254,3 +254,33 @@ async def test_eviction_oserror_logged_not_raised(
         await cache.get_or_fetch('b.png', fetcher)
 
     assert any('Failed to unlink evicted cache file' in record.message for record in caplog.records)
+
+
+async def test_invalidate_drops_entry_and_unlinks(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    fetcher = _CountingFetcher()
+
+    local, _, _ = await cache.get_or_fetch('foo.png', fetcher)
+    assert local.exists()
+    assert 'foo.png' in cache
+
+    cache.invalidate('foo.png')
+
+    assert 'foo.png' not in cache
+    assert not local.exists()
+
+
+async def test_invalidate_unknown_key_is_noop(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    cache.invalidate('never-fetched.png')
+
+
+async def test_invalidate_then_refetch_calls_fetch_again(tmp_path: Path) -> None:
+    cache = _make_cache(tmp_path)
+    fetcher = _CountingFetcher()
+
+    await cache.get_or_fetch('foo.png', fetcher)
+    cache.invalidate('foo.png')
+    await cache.get_or_fetch('foo.png', fetcher)
+
+    assert len(fetcher.calls) == 2

--- a/packages/common/tests/test_asset_cache.py
+++ b/packages/common/tests/test_asset_cache.py
@@ -190,6 +190,9 @@ async def test_register_evicts_when_over_maxsize(tmp_path: Path) -> None:
     assert not paths[0].exists()
     assert paths[1].exists()
     assert paths[2].exists()
+    # register() never creates a per-key asyncio lock, so the locks dict
+    # must stay empty under register-only workloads.
+    assert cache._locks == {}
 
 
 async def test_register_rejects_path_outside_tempdir(tmp_path: Path) -> None:

--- a/packages/common/tests/test_asset_resize.py
+++ b/packages/common/tests/test_asset_resize.py
@@ -1,0 +1,106 @@
+"""Tests for memex_common.asset_resize.resize_image."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from memex_common.asset_resize import resize_image
+
+
+def _write_png(path: Path, size: tuple[int, int] = (2000, 2000)) -> int:
+    img = Image.new('RGB', size, color=(120, 200, 80))
+    img.save(path, format='PNG')
+    return path.stat().st_size
+
+
+def test_resize_writes_smaller_file(tmp_path: Path) -> None:
+    src = tmp_path / 'big.png'
+    src_size = _write_png(src, size=(2000, 2000))
+
+    dest, dest_size = resize_image(src, max_width=256, max_height=256)
+
+    assert dest.exists()
+    assert dest != src
+    assert dest.parent == src.parent
+    assert dest_size < src_size
+    with Image.open(dest) as out:
+        assert max(out.size) <= 256
+
+
+def test_resize_preserves_aspect_ratio(tmp_path: Path) -> None:
+    src = tmp_path / 'rect.png'
+    Image.new('RGB', (1000, 500), color=(0, 0, 0)).save(src, format='PNG')
+
+    dest, _ = resize_image(src, max_width=200, max_height=200)
+
+    with Image.open(dest) as out:
+        # Aspect ratio (2:1) must be preserved within rounding.
+        assert out.size[0] == 200
+        assert out.size[1] == 100
+
+
+def test_resize_default_dimensions() -> None:
+    sig = inspect.signature(resize_image)
+    assert sig.parameters['max_width'].default == 1280
+    assert sig.parameters['max_height'].default == 1280
+    assert sig.parameters['format'].default is None
+
+
+def test_resize_rejects_svg(tmp_path: Path) -> None:
+    src = tmp_path / 'icon.svg'
+    src.write_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"/>')
+
+    with pytest.raises(ValueError, match='Unsupported image suffix'):
+        resize_image(src)
+
+
+def test_resize_rejects_pdf(tmp_path: Path) -> None:
+    src = tmp_path / 'doc.pdf'
+    src.write_bytes(b'%PDF-1.4 fake')
+
+    with pytest.raises(ValueError, match='Unsupported image suffix'):
+        resize_image(src)
+
+
+def test_resize_rejects_wav(tmp_path: Path) -> None:
+    src = tmp_path / 'sound.wav'
+    src.write_bytes(b'RIFF....WAVEfmt ')
+
+    with pytest.raises(ValueError, match='Unsupported image suffix'):
+        resize_image(src)
+
+
+def test_resize_rejects_disguised_format(tmp_path: Path) -> None:
+    """A file with a .png suffix but not actually a decodable image is rejected."""
+    src = tmp_path / 'fake.png'
+    src.write_bytes(b'not really a png')
+
+    with pytest.raises(ValueError):
+        resize_image(src)
+
+
+def test_resize_with_explicit_format(tmp_path: Path) -> None:
+    src = tmp_path / 'big.png'
+    _write_png(src, size=(800, 800))
+
+    dest, _ = resize_image(src, max_width=200, max_height=200, format='JPEG')
+
+    with Image.open(dest) as out:
+        assert out.format == 'JPEG'
+
+
+def test_resize_jpeg_input(tmp_path: Path) -> None:
+    src = tmp_path / 'photo.jpg'
+    Image.new('RGB', (1500, 1500), color=(10, 20, 30)).save(src, format='JPEG')
+
+    dest, dest_size = resize_image(src, max_width=300, max_height=300)
+
+    assert dest.exists()
+    assert dest_size > 0
+    with Image.open(dest) as out:
+        assert out.format == 'JPEG'
+        assert max(out.size) <= 300

--- a/packages/common/tests/test_asset_resize.py
+++ b/packages/common/tests/test_asset_resize.py
@@ -89,6 +89,33 @@ def test_resize_with_explicit_format(tmp_path: Path) -> None:
 
     dest, _ = resize_image(src, max_width=200, max_height=200, format='JPEG')
 
+    # Suffix must reflect the actual bytes — a JPEG override on a .png
+    # source must not leave the dest with a .png extension.
+    assert dest.suffix.lower() in {'.jpg', '.jpeg'}
+    with Image.open(dest) as out:
+        assert out.format == 'JPEG'
+
+
+def test_resize_explicit_format_webp(tmp_path: Path) -> None:
+    src = tmp_path / 'photo.png'
+    _write_png(src, size=(800, 800))
+
+    dest, _ = resize_image(src, max_width=200, max_height=200, format='WEBP')
+
+    assert dest.suffix.lower() == '.webp'
+    with Image.open(dest) as out:
+        assert out.format == 'WEBP'
+
+
+def test_resize_explicit_format_jpg_alias(tmp_path: Path) -> None:
+    src = tmp_path / 'photo.png'
+    _write_png(src, size=(800, 800))
+
+    # ``'JPG'`` is a common-but-non-canonical alias and must canonicalize
+    # to ``.jpg`` on disk and ``JPEG`` in the bytes.
+    dest, _ = resize_image(src, max_width=200, max_height=200, format='JPG')
+
+    assert dest.suffix.lower() in {'.jpg', '.jpeg'}
     with Image.open(dest) as out:
         assert out.format == 'JPEG'
 

--- a/packages/common/tests/test_asset_resize.py
+++ b/packages/common/tests/test_asset_resize.py
@@ -150,6 +150,15 @@ def test_resize_rejects_oversize_pixel_budget(tmp_path: Path, monkeypatch) -> No
         resize_image(src, max_width=64, max_height=64)
 
 
+def test_resize_rejects_nonpositive_dimensions(tmp_path: Path) -> None:
+    src = tmp_path / 'tiny.png'
+    Image.new('RGB', (50, 50), color=(0, 0, 0)).save(src, format='PNG')
+
+    for mw, mh in [(0, 64), (64, 0), (-1, 64), (64, -1)]:
+        with pytest.raises(ValueError, match='must be positive'):
+            resize_image(src, max_width=mw, max_height=mh)
+
+
 def test_resize_pixel_budget_at_boundary(tmp_path: Path, monkeypatch) -> None:
     """An image exactly at the budget is accepted; one pixel over is rejected.
     Locks in the ``>`` (not ``>=``) comparison so the cap can be set to the

--- a/packages/common/tests/test_asset_resize.py
+++ b/packages/common/tests/test_asset_resize.py
@@ -131,3 +131,38 @@ def test_resize_jpeg_input(tmp_path: Path) -> None:
     with Image.open(dest) as out:
         assert out.format == 'JPEG'
         assert max(out.size) <= 300
+
+
+def test_resize_rejects_oversize_pixel_budget(tmp_path: Path, monkeypatch) -> None:
+    """An image whose ``width*height`` exceeds ``_MAX_DECODED_PIXELS`` must
+    be rejected with a clean ``ValueError`` BEFORE Pillow decodes any
+    pixels. This is the canonical decompression-bomb defense — both MCP
+    and Hermes inherit it through the helper."""
+    src = tmp_path / 'huge.png'
+    Image.new('RGB', (200, 200), color=(0, 0, 0)).save(src, format='PNG')
+
+    monkeypatch.setattr(
+        'memex_common.asset_resize._MAX_DECODED_PIXELS',
+        1000,  # 200x200 = 40000 px, well above this
+    )
+
+    with pytest.raises(ValueError, match='too large to safely decode'):
+        resize_image(src, max_width=64, max_height=64)
+
+
+def test_resize_pixel_budget_at_boundary(tmp_path: Path, monkeypatch) -> None:
+    """An image exactly at the budget is accepted; one pixel over is rejected.
+    Locks in the ``>`` (not ``>=``) comparison so the cap can be set to the
+    exact image size without spurious rejection."""
+    src = tmp_path / 'boundary.png'
+    Image.new('RGB', (100, 100), color=(0, 0, 0)).save(src, format='PNG')  # 10000 px
+
+    # Exactly at budget — accepted.
+    monkeypatch.setattr('memex_common.asset_resize._MAX_DECODED_PIXELS', 10000)
+    dest, _ = resize_image(src, max_width=32, max_height=32)
+    assert dest.exists()
+
+    # One pixel below image size — rejected.
+    monkeypatch.setattr('memex_common.asset_resize._MAX_DECODED_PIXELS', 9999)
+    with pytest.raises(ValueError, match='too large to safely decode'):
+        resize_image(src, max_width=32, max_height=32)

--- a/packages/common/tests/test_asset_resize.py
+++ b/packages/common/tests/test_asset_resize.py
@@ -47,7 +47,7 @@ def test_resize_default_dimensions() -> None:
     sig = inspect.signature(resize_image)
     assert sig.parameters['max_width'].default == 1280
     assert sig.parameters['max_height'].default == 1280
-    assert sig.parameters['format'].default is None
+    assert sig.parameters['output_format'].default is None
 
 
 def test_resize_rejects_svg(tmp_path: Path) -> None:
@@ -87,7 +87,7 @@ def test_resize_with_explicit_format(tmp_path: Path) -> None:
     src = tmp_path / 'big.png'
     _write_png(src, size=(800, 800))
 
-    dest, _ = resize_image(src, max_width=200, max_height=200, format='JPEG')
+    dest, _ = resize_image(src, max_width=200, max_height=200, output_format='JPEG')
 
     # Suffix must reflect the actual bytes — a JPEG override on a .png
     # source must not leave the dest with a .png extension.
@@ -100,7 +100,7 @@ def test_resize_explicit_format_webp(tmp_path: Path) -> None:
     src = tmp_path / 'photo.png'
     _write_png(src, size=(800, 800))
 
-    dest, _ = resize_image(src, max_width=200, max_height=200, format='WEBP')
+    dest, _ = resize_image(src, max_width=200, max_height=200, output_format='WEBP')
 
     assert dest.suffix.lower() == '.webp'
     with Image.open(dest) as out:
@@ -113,7 +113,7 @@ def test_resize_explicit_format_jpg_alias(tmp_path: Path) -> None:
 
     # ``'JPG'`` is a common-but-non-canonical alias and must canonicalize
     # to ``.jpg`` on disk and ``JPEG`` in the bytes.
-    dest, _ = resize_image(src, max_width=200, max_height=200, format='JPG')
+    dest, _ = resize_image(src, max_width=200, max_height=200, output_format='JPG')
 
     assert dest.suffix.lower() in {'.jpg', '.jpeg'}
     with Image.open(dest) as out:

--- a/packages/core/src/memex_core/server/resources.py
+++ b/packages/core/src/memex_core/server/resources.py
@@ -12,7 +12,7 @@ from memex_common.schemas import LineageDirection, LineageResponse
 from memex_core.api import MemexAPI
 from memex_core.server.auth import require_read
 from memex_core.server.common import _handle_error, get_api
-from memex_core.storage.filestore import _is_root_key
+from memex_core.storage.filestore import is_root_key
 
 logger = logging.getLogger('memex.core.server.resources')
 
@@ -26,7 +26,7 @@ async def get_resource(path: str, api: Annotated[MemexAPI, Depends(get_api)]):
 
     from fastapi.responses import Response
 
-    if _is_root_key(path):
+    if is_root_key(path):
         raise HTTPException(status_code=404, detail='Resource path is empty')
 
     try:

--- a/packages/core/src/memex_core/server/resources.py
+++ b/packages/core/src/memex_core/server/resources.py
@@ -12,6 +12,7 @@ from memex_common.schemas import LineageDirection, LineageResponse
 from memex_core.api import MemexAPI
 from memex_core.server.auth import require_read
 from memex_core.server.common import _handle_error, get_api
+from memex_core.storage.filestore import _is_root_key
 
 logger = logging.getLogger('memex.core.server.resources')
 
@@ -25,7 +26,7 @@ async def get_resource(path: str, api: Annotated[MemexAPI, Depends(get_api)]):
 
     from fastapi.responses import Response
 
-    if not path or not path.strip().strip('/'):
+    if _is_root_key(path):
         raise HTTPException(status_code=404, detail='Resource path is empty')
 
     try:

--- a/packages/core/src/memex_core/server/resources.py
+++ b/packages/core/src/memex_core/server/resources.py
@@ -25,6 +25,9 @@ async def get_resource(path: str, api: Annotated[MemexAPI, Depends(get_api)]):
 
     from fastapi.responses import Response
 
+    if not path or not path.strip().strip('/'):
+        raise HTTPException(status_code=404, detail='Resource path is empty')
+
     try:
         content = await api.get_resource(path)
         media_type, _ = mimetypes.guess_type(path)

--- a/packages/core/src/memex_core/storage/filestore.py
+++ b/packages/core/src/memex_core/storage/filestore.py
@@ -32,6 +32,16 @@ def is_root_key(key: str) -> bool:
     entry points must reject such keys so callers don't end up issuing
     operations against the bucket prefix itself.
 
+    Also rejects current-/parent-directory tokens (``.``, ``..``, ``./``,
+    ``../``, ``/.``, ``/..``) because FastAPI URL-decodes ``%2E`` /
+    ``%2E%2E`` and these inputs likewise resolve to the storage root via
+    :func:`validate_path_safe` (``.`` collapses to root) or to a path
+    traversal (``..`` raises ``ValueError`` from
+    :func:`validate_path_safe`). Treating them as root-equivalent here
+    forces callers down their own "empty / not-found" branch so HTTP
+    handlers can return a clean 404 instead of a 500 from the eventual
+    ``IsADirectoryError`` / ``KeyError`` / ``ValueError``.
+
     Convention for callers using this guard:
       * Read methods (``load``) raise ``FileNotFoundError`` so the HTTP
         layer maps to 404.
@@ -42,7 +52,10 @@ def is_root_key(key: str) -> bool:
         a falsy value (``False`` / ``[]``) — empty input legitimately maps
         to "no such resource".
     """
-    return not key or not key.strip().strip('/')
+    if not key or not key.strip().strip('/'):
+        return True
+    parts = [p for p in key.strip().split('/') if p]
+    return all(p in ('.', '..') for p in parts)
 
 
 def validate_path_safe(base_path: str, requested_path: str, *, local: bool = False) -> str:

--- a/packages/core/src/memex_core/storage/filestore.py
+++ b/packages/core/src/memex_core/storage/filestore.py
@@ -26,21 +26,19 @@ T = TypeVar('T', bound=FileStoreConfig)
 def is_root_key(key: str) -> bool:
     """Return True if *key* would resolve to the storage root.
 
-    Empty / whitespace-only / all-slash keys are rewritten to the root by
-    :func:`validate_path_safe` (the empty-key form is intentional — see
-    :meth:`BaseAsyncFileStore.check_connection`). Public read and write
-    entry points must reject such keys so callers don't end up issuing
-    operations against the bucket prefix itself.
+    Any input that ``posixpath.normpath`` collapses to ``.`` or ``..`` is
+    treated as root-equivalent — that includes empty / whitespace /
+    all-slash keys, bare ``.``/``..`` tokens (and their URL-decoded
+    ``%2E``/``%2E%2E`` variants, since FastAPI decodes the path before it
+    reaches the route), and any mixed-segment shape that cancels to root
+    (``foo/..``, ``a/b/../..``, ``foo/../bar/..``, …).
 
-    Also rejects current-/parent-directory tokens (``.``, ``..``, ``./``,
-    ``../``, ``/.``, ``/..``) because FastAPI URL-decodes ``%2E`` /
-    ``%2E%2E`` and these inputs likewise resolve to the storage root via
-    :func:`validate_path_safe` (``.`` collapses to root) or to a path
-    traversal (``..`` raises ``ValueError`` from
-    :func:`validate_path_safe`). Treating them as root-equivalent here
-    forces callers down their own "empty / not-found" branch so HTTP
-    handlers can return a clean 404 instead of a 500 from the eventual
-    ``IsADirectoryError`` / ``KeyError`` / ``ValueError``.
+    Without this guard those inputs reach :func:`validate_path_safe` and
+    return the storage root unchanged: ``_cat_file(root)`` then raises
+    ``IsADirectoryError`` (local) / ``KeyError`` (S3), which the FastAPI
+    error handler maps to 500. Forcing them down the "root key" branch
+    lets each public entry point pick the right outcome (404, refuse,
+    empty list) and produce a clean response.
 
     Convention for callers using this guard:
       * Read methods (``load``) raise ``FileNotFoundError`` so the HTTP
@@ -52,10 +50,20 @@ def is_root_key(key: str) -> bool:
         a falsy value (``False`` / ``[]``) — empty input legitimately maps
         to "no such resource".
     """
-    if not key or not key.strip().strip('/'):
+    if not key or not key.strip():
         return True
-    parts = [p for p in key.strip().split('/') if p]
-    return all(p in ('.', '..') for p in parts)
+    stripped = key.strip().lstrip('/')
+    if not stripped:
+        return True
+    normalized = posixpath.normpath(stripped)
+    if normalized == '.':
+        return True
+    # ``posixpath.normpath`` cancels matching ``foo/..`` pairs but leaves
+    # leading ``..`` segments untouched (they would escape the root). An
+    # input whose normalised form is only ``..`` segments still has no
+    # proper file component, so refuse it here rather than let it hit
+    # ``validate_path_safe`` and raise a ``ValueError`` (mapped to 500).
+    return all(p == '..' for p in normalized.split('/'))
 
 
 def validate_path_safe(base_path: str, requested_path: str, *, local: bool = False) -> str:

--- a/packages/core/src/memex_core/storage/filestore.py
+++ b/packages/core/src/memex_core/storage/filestore.py
@@ -23,6 +23,18 @@ from memex_core.config import (
 T = TypeVar('T', bound=FileStoreConfig)
 
 
+def _is_root_key(key: str) -> bool:
+    """Return True if *key* would resolve to the storage root.
+
+    Empty / whitespace-only / all-slash keys are rewritten to the root by
+    :func:`validate_path_safe` (the empty-key form is intentional — see
+    :meth:`BaseAsyncFileStore.check_connection`). Public read and write
+    entry points must reject such keys so callers don't end up issuing
+    operations against the bucket prefix itself.
+    """
+    return not key or not key.strip().strip('/')
+
+
 def validate_path_safe(base_path: str, requested_path: str, *, local: bool = False) -> str:
     """Validate that a requested path does not escape the base directory.
 
@@ -192,6 +204,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             src_key: Source path relative to root.
             dest_key: Destination path relative to root.
         """
+        if _is_root_key(src_key) or _is_root_key(dest_key):
+            raise ValueError(f'Refusing to move with root key: src={src_key!r}, dest={dest_key!r}')
         src_fp = self.join_path(src_key)
         dest_fp = self.join_path(dest_key)
         self._logger.debug(f'Moving file from {src_fp} to {dest_fp}')
@@ -225,6 +239,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             data: The data to be saved.
             txn_id: Optional transaction id. When provided the write is staged.
         """
+        if _is_root_key(key):
+            raise ValueError(f'Refusing to save to root key: {key!r}')
         if txn_id is not None:
             stage = self._get_stage(txn_id)
             target = f'{key}.stage_{txn_id}'
@@ -250,17 +266,13 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             txn_id: Optional transaction id. When provided the delete is deferred.
             recursive: Whether to delete recursively.
         """
+        if _is_root_key(key):
+            raise ValueError(f'Refusing to delete root key: {key!r}')
         if txn_id is not None:
             stage = self._get_stage(txn_id)
             stage.pending_deletes[key] = recursive
         else:
             await self._delete(key, recursive=recursive)
-
-    @staticmethod
-    def _is_root_key(key: str) -> bool:
-        # Empty / whitespace / all-slashes resolve to the storage root and would
-        # otherwise be silently rewritten to the bucket prefix by validate_path_safe.
-        return not key or not key.strip().strip('/')
 
     async def load(self, key: str) -> bytes:
         """
@@ -272,7 +284,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             The loaded string data.
         """
-        if self._is_root_key(key):
+        if _is_root_key(key):
             raise FileNotFoundError(f'Resource key is empty: {key!r}')
         fp = self.join_path(key)
         self._logger.debug(f'Loading data from path: {fp}')
@@ -289,7 +301,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key exists, False otherwise.
         """
-        if self._is_root_key(key):
+        if _is_root_key(key):
             return False
         self._logger.debug(f'Checking for existence of key: {key}')
         async with self._semaphore:
@@ -305,7 +317,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key is a directory, False otherwise.
         """
-        if self._is_root_key(key):
+        if _is_root_key(key):
             return False
         async with self._semaphore:
             return await self._fs._isdir(self.join_path(key))

--- a/packages/core/src/memex_core/storage/filestore.py
+++ b/packages/core/src/memex_core/storage/filestore.py
@@ -256,6 +256,12 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         else:
             await self._delete(key, recursive=recursive)
 
+    @staticmethod
+    def _is_root_key(key: str) -> bool:
+        # Empty / whitespace / all-slashes resolve to the storage root and would
+        # otherwise be silently rewritten to the bucket prefix by validate_path_safe.
+        return not key or not key.strip().strip('/')
+
     async def load(self, key: str) -> bytes:
         """
         Load data from the storage backend.
@@ -266,6 +272,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             The loaded string data.
         """
+        if self._is_root_key(key):
+            raise FileNotFoundError(f'Resource key is empty: {key!r}')
         fp = self.join_path(key)
         self._logger.debug(f'Loading data from path: {fp}')
         async with self._semaphore:
@@ -281,6 +289,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key exists, False otherwise.
         """
+        if self._is_root_key(key):
+            return False
         self._logger.debug(f'Checking for existence of key: {key}')
         async with self._semaphore:
             return await self._fs._exists(self.join_path(key))
@@ -295,6 +305,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key is a directory, False otherwise.
         """
+        if self._is_root_key(key):
+            return False
         async with self._semaphore:
             return await self._fs._isdir(self.join_path(key))
 

--- a/packages/core/src/memex_core/storage/filestore.py
+++ b/packages/core/src/memex_core/storage/filestore.py
@@ -23,7 +23,7 @@ from memex_core.config import (
 T = TypeVar('T', bound=FileStoreConfig)
 
 
-def _is_root_key(key: str) -> bool:
+def is_root_key(key: str) -> bool:
     """Return True if *key* would resolve to the storage root.
 
     Empty / whitespace-only / all-slash keys are rewritten to the root by
@@ -31,6 +31,16 @@ def _is_root_key(key: str) -> bool:
     :meth:`BaseAsyncFileStore.check_connection`). Public read and write
     entry points must reject such keys so callers don't end up issuing
     operations against the bucket prefix itself.
+
+    Convention for callers using this guard:
+      * Read methods (``load``) raise ``FileNotFoundError`` so the HTTP
+        layer maps to 404.
+      * Mutating methods (``save`` / ``delete`` / ``move_file``) raise
+        ``ValueError`` because operating on the root is a programmer
+        error / refusal-to-act, not a "missing resource".
+      * Existence-style queries (``exists`` / ``is_dir`` / ``glob``) return
+        a falsy value (``False`` / ``[]``) — empty input legitimately maps
+        to "no such resource".
     """
     return not key or not key.strip().strip('/')
 
@@ -204,7 +214,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             src_key: Source path relative to root.
             dest_key: Destination path relative to root.
         """
-        if _is_root_key(src_key) or _is_root_key(dest_key):
+        if is_root_key(src_key) or is_root_key(dest_key):
             raise ValueError(f'Refusing to move with root key: src={src_key!r}, dest={dest_key!r}')
         src_fp = self.join_path(src_key)
         dest_fp = self.join_path(dest_key)
@@ -239,7 +249,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             data: The data to be saved.
             txn_id: Optional transaction id. When provided the write is staged.
         """
-        if _is_root_key(key):
+        if is_root_key(key):
             raise ValueError(f'Refusing to save to root key: {key!r}')
         if txn_id is not None:
             stage = self._get_stage(txn_id)
@@ -266,7 +276,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
             txn_id: Optional transaction id. When provided the delete is deferred.
             recursive: Whether to delete recursively.
         """
-        if _is_root_key(key):
+        if is_root_key(key):
             raise ValueError(f'Refusing to delete root key: {key!r}')
         if txn_id is not None:
             stage = self._get_stage(txn_id)
@@ -284,7 +294,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             The loaded string data.
         """
-        if _is_root_key(key):
+        if is_root_key(key):
             raise FileNotFoundError(f'Resource key is empty: {key!r}')
         fp = self.join_path(key)
         self._logger.debug(f'Loading data from path: {fp}')
@@ -301,7 +311,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key exists, False otherwise.
         """
-        if _is_root_key(key):
+        if is_root_key(key):
             return False
         self._logger.debug(f'Checking for existence of key: {key}')
         async with self._semaphore:
@@ -317,7 +327,7 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             True if the key is a directory, False otherwise.
         """
-        if _is_root_key(key):
+        if is_root_key(key):
             return False
         async with self._semaphore:
             return await self._fs._isdir(self.join_path(key))
@@ -332,6 +342,8 @@ class BaseAsyncFileStore(Generic[T], metaclass=ABCMeta):
         Returns:
             A list of matching file paths.
         """
+        if is_root_key(pattern):
+            return []
         async with self._semaphore:
             return cast(list[str], await self._fs._glob(self.join_path(pattern)))
 

--- a/packages/core/tests/integration/test_server_resources.py
+++ b/packages/core/tests/integration/test_server_resources.py
@@ -65,15 +65,25 @@ def test_resource_empty_path_returns_404(client: TestClient, path: str) -> None:
         '/%2E',
         '/%2E%2E',
         '%2E%2F%2E',
+        # Mixed dot-segment shapes that ``posixpath.normpath`` cancels back
+        # to root. Without the normpath-based guard, ``foo/..`` slipped
+        # past ``is_root_key``: ``validate_path_safe`` returned the bare
+        # storage root and ``_cat_file(root)`` raised ``IsADirectoryError``
+        # → 500. Slashes are percent-encoded (``%2F``) so httpx doesn't
+        # collapse the path client-side before it reaches the server —
+        # FastAPI decodes ``%2F`` back inside the ``{path:path}`` capture.
+        'foo%2F..',
+        'a%2Fb%2F..%2F..',
+        'foo%2F..%2Fbar%2F..',
+        'foo%2F%2E%2E',
     ],
 )
 def test_resource_dot_path_returns_404(client: TestClient, path: str) -> None:
-    """``.``/``..`` and their URL-encoded variants must 404, not 500.
+    """``.``/``..`` and any normpath-collapsing variants must 404, not 500.
 
-    Without the extended ``is_root_key`` guard, FastAPI URL-decodes ``%2E``
-    to ``.``; ``validate_path_safe`` then collapses that to the storage
-    root and ``_cat_file(root)`` raises ``IsADirectoryError`` which the
-    ``OSError`` branch of ``_handle_error`` previously mapped to 500.
+    Covers the URL-decoded ``%2E``/``%2E%2E`` reproducer and the mixed
+    dot-segment shapes (``foo/..`` etc.) that ``posixpath.normpath``
+    cancels back to the storage root.
     """
     resp = client.get(f'/api/v1/resources/{path}')
     assert resp.status_code == 404

--- a/packages/core/tests/integration/test_server_resources.py
+++ b/packages/core/tests/integration/test_server_resources.py
@@ -1,0 +1,93 @@
+"""Route-level integration tests for ``GET /api/v1/resources``.
+
+These cover AC-001: empty/whitespace/dot-equivalent paths must return a clean
+404 (not a 500 from the underlying filestore). Includes the literal
+``?paths=foo`` reproducer from issue #59 — FastAPI ``redirect_slashes``
+turns it into a 307 to ``/api/v1/resources/`` which then must 404.
+
+The happy-path round-trip lives in ``tests/test_e2e_resources.py`` (full
+ingestion E2E with a real LLM); these tests stay in ``[core]`` and use
+``app.dependency_overrides`` so they run without the LLM marker.
+"""
+
+from unittest.mock import AsyncMock
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memex_core.server import app
+from memex_core.server.common import get_api
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """TestClient with the ``MemexAPI`` dependency mocked.
+
+    The route guards run before the API is touched, so the mock only needs
+    to exist — these tests never expect ``api.get_resource`` to be called.
+    """
+    mock_api = AsyncMock()
+    app.dependency_overrides[get_api] = lambda: mock_api
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides = {}
+
+
+@pytest.mark.parametrize('path', ['', '/', '///'])
+def test_resource_empty_path_returns_404(client: TestClient, path: str) -> None:
+    """An empty / whitespace / all-slash path must 404 cleanly, not 500."""
+    resp = client.get(f'/api/v1/resources/{path}')
+    assert resp.status_code == 404
+    assert resp.json()['detail'] == 'Resource path is empty'
+
+
+@pytest.mark.parametrize(
+    'path',
+    [
+        # Literal '.' / './' / '/.' / '/./' are normalised away by httpx but
+        # still hit the route as the empty path — covered for completeness.
+        '.',
+        './',
+        '/.',
+        '/./',
+        # Percent-encoded forms survive httpx URL normalisation and are
+        # decoded by FastAPI inside the route — these are the actual
+        # adversarial reproducer for AC-001's "no 500" promise.
+        '%2E',
+        '%2E/',
+        '%2E%2E',
+        '%2E%2E/',
+        '/%2E',
+        '/%2E%2E',
+        '%2E%2F%2E',
+    ],
+)
+def test_resource_dot_path_returns_404(client: TestClient, path: str) -> None:
+    """``.``/``..`` and their URL-encoded variants must 404, not 500.
+
+    Without the extended ``is_root_key`` guard, FastAPI URL-decodes ``%2E``
+    to ``.``; ``validate_path_safe`` then collapses that to the storage
+    root and ``_cat_file(root)`` raises ``IsADirectoryError`` which the
+    ``OSError`` branch of ``_handle_error`` previously mapped to 500.
+    """
+    resp = client.get(f'/api/v1/resources/{path}')
+    assert resp.status_code == 404
+    assert resp.json()['detail'] == 'Resource path is empty'
+
+
+def test_resource_query_param_paths_returns_404(client: TestClient) -> None:
+    """The literal ``?paths=foo`` reproducer from issue #59 must 404, not 500.
+
+    FastAPI's ``redirect_slashes`` redirects ``GET /api/v1/resources?paths=foo``
+    to ``GET /api/v1/resources/?paths=foo``; the route's ``{path:path}``
+    parameter then receives the empty string. Followed end-to-end, the
+    response must be a clean 404.
+    """
+    resp = client.get('/api/v1/resources?paths=foo', follow_redirects=True)
+    assert resp.status_code == 404
+    assert resp.json()['detail'] == 'Resource path is empty'

--- a/packages/core/tests/unit/storage/test_filestore.py
+++ b/packages/core/tests/unit/storage/test_filestore.py
@@ -7,7 +7,29 @@ from memex_core.storage.filestore import (
     S3AsyncFileStore,
     GCSAsyncFileStore,
     get_filestore,
+    is_root_key,
 )
+
+
+# Inputs that all resolve to the storage root: empty / whitespace / slash /
+# dot-equivalent (URL-decoded ``%2E``/``%2E%2E``). All are rejected by the
+# empty-path guards on every public entry point.
+ROOT_EQUIVALENT_KEYS = [
+    '',
+    '/',
+    '///',
+    '   ',
+    '.',
+    '..',
+    './',
+    '../',
+    '/.',
+    '/..',
+    '/./',
+    '/../',
+    './..',
+    '../..',
+]
 from memex_core.config import LocalFileStoreConfig
 from memex_common.config import S3FileStoreConfig, GCSFileStoreConfig
 
@@ -567,20 +589,20 @@ class TestGetFilestore:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.parametrize('bad_key', ROOT_EQUIVALENT_KEYS)
 @pytest.mark.asyncio
 async def test_load_rejects_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
     with pytest.raises(FileNotFoundError, match='Resource key is empty'):
         await store.load(bad_key)
 
 
-@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.parametrize('bad_key', ROOT_EQUIVALENT_KEYS)
 @pytest.mark.asyncio
 async def test_exists_returns_false_for_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
     assert await store.exists(bad_key) is False
 
 
-@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.parametrize('bad_key', ROOT_EQUIVALENT_KEYS)
 @pytest.mark.asyncio
 async def test_is_dir_returns_false_for_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
     assert await store.is_dir(bad_key) is False
@@ -593,7 +615,7 @@ async def test_check_connection_still_works_after_guard(store: LocalAsyncFileSto
     assert await store.check_connection() is True
 
 
-@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.parametrize('bad_key', ROOT_EQUIVALENT_KEYS)
 @pytest.mark.asyncio
 async def test_save_rejects_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
     # save with a root key would write at the bucket prefix on S3 / fail with
@@ -602,7 +624,7 @@ async def test_save_rejects_root_key(store: LocalAsyncFileStore, bad_key: str) -
         await store.save(bad_key, b'data')
 
 
-@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.parametrize('bad_key', ROOT_EQUIVALENT_KEYS)
 @pytest.mark.asyncio
 async def test_delete_rejects_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
     # delete(root_key, recursive=True) on S3 would target the bucket prefix —
@@ -611,14 +633,14 @@ async def test_delete_rejects_root_key(store: LocalAsyncFileStore, bad_key: str)
         await store.delete(bad_key, recursive=True)
 
 
-@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.parametrize('bad_key', ROOT_EQUIVALENT_KEYS)
 @pytest.mark.asyncio
 async def test_move_file_rejects_root_src(store: LocalAsyncFileStore, bad_key: str) -> None:
     with pytest.raises(ValueError, match='Refusing to move'):
         await store.move_file(bad_key, 'dst.txt')
 
 
-@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.parametrize('bad_key', ROOT_EQUIVALENT_KEYS)
 @pytest.mark.asyncio
 async def test_move_file_rejects_root_dest(store: LocalAsyncFileStore, bad_key: str) -> None:
     await store.save('src.txt', b'data')
@@ -628,7 +650,7 @@ async def test_move_file_rejects_root_dest(store: LocalAsyncFileStore, bad_key: 
     assert await store.exists('src.txt') is True
 
 
-@pytest.mark.parametrize('bad_pattern', ['', '/', '///', '   '])
+@pytest.mark.parametrize('bad_pattern', ROOT_EQUIVALENT_KEYS)
 @pytest.mark.asyncio
 async def test_glob_root_pattern_returns_empty(
     store: LocalAsyncFileStore, bad_pattern: str
@@ -637,6 +659,35 @@ async def test_glob_root_pattern_returns_empty(
     # an enumeration of the bucket prefix. Existence-style queries return [].
     await store.save('a.txt', b'a')
     assert await store.glob(bad_pattern) == []
+
+
+@pytest.mark.parametrize('key', ROOT_EQUIVALENT_KEYS)
+def test_is_root_key_rejects_root_equivalent(key: str) -> None:
+    """All empty / whitespace / slash / dot-equivalent inputs are root-equivalent.
+
+    Covers the URL-decoded ``%2E`` / ``%2E%2E`` reproducer that previously
+    bypassed the guard and returned 500 from the resources route.
+    """
+    assert is_root_key(key) is True
+
+
+@pytest.mark.parametrize(
+    'key',
+    [
+        'foo',
+        'foo/bar',
+        '/foo',
+        '..foo',
+        '.foo',
+        'foo/.',
+        'foo/..',
+        './foo',
+        '../foo',
+    ],
+)
+def test_is_root_key_accepts_real_paths(key: str) -> None:
+    """Real paths — including ones containing ``.``/``..`` segments — are not root."""
+    assert is_root_key(key) is False
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/unit/storage/test_filestore.py
+++ b/packages/core/tests/unit/storage/test_filestore.py
@@ -628,6 +628,17 @@ async def test_move_file_rejects_root_dest(store: LocalAsyncFileStore, bad_key: 
     assert await store.exists('src.txt') is True
 
 
+@pytest.mark.parametrize('bad_pattern', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_glob_root_pattern_returns_empty(
+    store: LocalAsyncFileStore, bad_pattern: str
+) -> None:
+    # glob('') would otherwise list everything under the storage root, leaking
+    # an enumeration of the bucket prefix. Existence-style queries return [].
+    await store.save('a.txt', b'a')
+    assert await store.glob(bad_pattern) == []
+
+
 @pytest.mark.asyncio
 async def test_delete_root_key_does_not_delete_files(store: LocalAsyncFileStore) -> None:
     # Regression for the HIGH finding: an accidental delete('/', recursive=True)

--- a/packages/core/tests/unit/storage/test_filestore.py
+++ b/packages/core/tests/unit/storage/test_filestore.py
@@ -591,3 +591,50 @@ async def test_check_connection_still_works_after_guard(store: LocalAsyncFileSto
     # check_connection bypasses load/exists/is_dir and calls _fs._ls(join_path(''))
     # directly, so it must still succeed.
     assert await store.check_connection() is True
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_save_rejects_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
+    # save with a root key would write at the bucket prefix on S3 / fail with
+    # IsADirectoryError locally — refuse explicitly so the error is loud.
+    with pytest.raises(ValueError, match='Refusing to save'):
+        await store.save(bad_key, b'data')
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_delete_rejects_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
+    # delete(root_key, recursive=True) on S3 would target the bucket prefix —
+    # potentially destroying every object under it.
+    with pytest.raises(ValueError, match='Refusing to delete'):
+        await store.delete(bad_key, recursive=True)
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_move_file_rejects_root_src(store: LocalAsyncFileStore, bad_key: str) -> None:
+    with pytest.raises(ValueError, match='Refusing to move'):
+        await store.move_file(bad_key, 'dst.txt')
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_move_file_rejects_root_dest(store: LocalAsyncFileStore, bad_key: str) -> None:
+    await store.save('src.txt', b'data')
+    with pytest.raises(ValueError, match='Refusing to move'):
+        await store.move_file('src.txt', bad_key)
+    # Source must still exist — the guard runs before any side effects.
+    assert await store.exists('src.txt') is True
+
+
+@pytest.mark.asyncio
+async def test_delete_root_key_does_not_delete_files(store: LocalAsyncFileStore) -> None:
+    # Regression for the HIGH finding: an accidental delete('/', recursive=True)
+    # must not remove existing data under the root.
+    await store.save('keep/a.txt', b'a')
+    await store.save('keep/b.txt', b'b')
+    with pytest.raises(ValueError):
+        await store.delete('/', recursive=True)
+    assert await store.exists('keep/a.txt') is True
+    assert await store.exists('keep/b.txt') is True

--- a/packages/core/tests/unit/storage/test_filestore.py
+++ b/packages/core/tests/unit/storage/test_filestore.py
@@ -11,9 +11,11 @@ from memex_core.storage.filestore import (
 )
 
 
-# Inputs that all resolve to the storage root: empty / whitespace / slash /
-# dot-equivalent (URL-decoded ``%2E``/``%2E%2E``). All are rejected by the
-# empty-path guards on every public entry point.
+# Inputs that ``posixpath.normpath`` collapses to no real path component:
+# empty / whitespace / slash, bare ``.``/``..`` (and URL-decoded
+# ``%2E``/``%2E%2E`` variants), and mixed-segment shapes that cancel back
+# to root (``foo/..``). All are rejected by the empty-path guards on every
+# public entry point.
 ROOT_EQUIVALENT_KEYS = [
     '',
     '/',
@@ -29,6 +31,11 @@ ROOT_EQUIVALENT_KEYS = [
     '/../',
     './..',
     '../..',
+    'foo/..',
+    'a/b/../..',
+    'foo/../bar/..',
+    './foo/..',
+    '/foo/..',
 ]
 from memex_core.config import LocalFileStoreConfig
 from memex_common.config import S3FileStoreConfig, GCSFileStoreConfig
@@ -679,14 +686,21 @@ def test_is_root_key_rejects_root_equivalent(key: str) -> None:
         '/foo',
         '..foo',
         '.foo',
+        # ``foo/.`` and ``./foo`` normalise to ``foo`` — a real path.
         'foo/.',
-        'foo/..',
         './foo',
+        # ``../foo`` escapes root but still names a real component, so
+        # it's not "no path"; ``validate_path_safe`` raises on it.
         '../foo',
+        'a/./b',
     ],
 )
 def test_is_root_key_accepts_real_paths(key: str) -> None:
-    """Real paths — including ones containing ``.``/``..`` segments — are not root."""
+    """Inputs that normalise to a real path component are not root-equivalent.
+
+    ``foo/..`` is *not* in this list — it cancels to ``.`` and is covered
+    by ``test_is_root_key_rejects_root_equivalent`` instead.
+    """
     assert is_root_key(key) is False
 
 

--- a/packages/core/tests/unit/storage/test_filestore.py
+++ b/packages/core/tests/unit/storage/test_filestore.py
@@ -554,3 +554,40 @@ class TestGetFilestore:
         config.model_dump.return_value = {'type': 'ftp'}
         with pytest.raises(ValueError, match='Unsupported file store type'):
             get_filestore(config)
+
+
+# ---------------------------------------------------------------------------
+# Empty-key rejection
+#
+# An empty / whitespace-only / all-slash key would be silently rewritten to the
+# storage root by ``validate_path_safe`` (root is allowed there because
+# ``check_connection`` lists the root). Public read methods must reject this so
+# callers don't end up issuing a "GET bucket/" against S3, which boto rejects
+# with ParamValidationError on the empty Key.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_load_rejects_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
+    with pytest.raises(FileNotFoundError, match='Resource key is empty'):
+        await store.load(bad_key)
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_exists_returns_false_for_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
+    assert await store.exists(bad_key) is False
+
+
+@pytest.mark.parametrize('bad_key', ['', '/', '///', '   '])
+@pytest.mark.asyncio
+async def test_is_dir_returns_false_for_root_key(store: LocalAsyncFileStore, bad_key: str) -> None:
+    assert await store.is_dir(bad_key) is False
+
+
+@pytest.mark.asyncio
+async def test_check_connection_still_works_after_guard(store: LocalAsyncFileStore) -> None:
+    # check_connection bypasses load/exists/is_dir and calls _fs._ls(join_path(''))
+    # directly, so it must still succeed.
+    assert await store.check_connection() is True

--- a/packages/hermes-plugin/pyproject.toml
+++ b/packages/hermes-plugin/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pyyaml>=6.0.0",
     "typer>=0.12.0",
     "rich>=13.7.0",
+    "Pillow>=10",
 ]
 
 [project.scripts]

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -155,6 +155,7 @@ class MemexMemoryProvider(MemoryProvider):
         from memex_common.client import RemoteMemexAPI
 
         self._api = RemoteMemexAPI(self._client)
+        assert self._asset_cache is None, 'initialize() called twice; prior asset cache leaked'
         self._asset_cache = SessionAssetCache()
 
         try:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -23,6 +23,7 @@ from uuid import UUID
 
 import httpx
 from agent.memory_provider import MemoryProvider  # type: ignore[import-not-found]
+from memex_common.asset_cache import SessionAssetCache
 
 from .async_bridge import run_sync, shutdown_loop
 from .briefing import BriefingCache, format_briefing_block
@@ -61,11 +62,16 @@ class MemexMemoryProvider(MemoryProvider):
         self._platform: str = ''
         self._briefing = BriefingCache()
         self._prefetch = PrefetchCache()
+        self._asset_cache: SessionAssetCache | None = None
         self._turn_buffer: list[dict[str, str]] = []
         self._turn_count = 0
         self._shutdown_registered = False
         self._state_lock = threading.Lock()
         self._atexit_lock = threading.Lock()
+
+    @property
+    def asset_cache(self) -> SessionAssetCache | None:
+        return self._asset_cache
 
     # -- Identity ------------------------------------------------------------
 
@@ -149,6 +155,7 @@ class MemexMemoryProvider(MemoryProvider):
         from memex_common.client import RemoteMemexAPI
 
         self._api = RemoteMemexAPI(self._client)
+        self._asset_cache = SessionAssetCache()
 
         try:
             self._vault_name = resolve_vault(
@@ -254,6 +261,7 @@ class MemexMemoryProvider(MemoryProvider):
             api=self._api,
             config=self._config,
             vault_id=self._vault_id,
+            asset_cache=self._asset_cache,
         )
 
     # -- Prefetch ------------------------------------------------------------
@@ -360,6 +368,13 @@ class MemexMemoryProvider(MemoryProvider):
         if client is not None:
             try:
                 run_sync(client.aclose(), timeout=5.0)
+            except Exception:
+                pass
+        cache = self._asset_cache
+        self._asset_cache = None
+        if cache is not None:
+            try:
+                cache.cleanup()
             except Exception:
                 pass
         shutdown_loop(thread_join_timeout=5.0)

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import base64
 import binascii
-import contextlib
 import json
 import logging
 import mimetypes
@@ -2593,14 +2592,7 @@ def handle_get_resources(
                 timeout=30.0,
             )
             if size_bytes > _MAX_RESOURCE_BYTES:
-                # AC-011: oversize entries are ``error``-only — unlink the
-                # bytes so the cap can't be bypassed by reading from disk
-                # and so the tempdir doesn't accumulate rejected payloads.
-                # The LRU entry is left in place; ``get_or_fetch`` checks
-                # ``cached.exists()`` and re-runs ``fetch`` when the file is
-                # missing, so the cap is re-evaluated on retry.
-                with contextlib.suppress(FileNotFoundError, OSError):
-                    os.unlink(local_path)
+                asset_cache.invalidate(path)
                 results.append(
                     {
                         'path': path,
@@ -2676,10 +2668,6 @@ def handle_resize_image(
     if not resolved_input.is_relative_to(cache_root):
         return tool_error('local_path must point inside the session asset cache')
 
-    # Decompression-bomb protection lives inside ``resize_image`` itself:
-    # it checks ``img.size`` after ``Image.open`` (header-only) and before
-    # any pixel decoding, raising ``ValueError('Image is too large to
-    # safely decode')`` past the ``_MAX_DECODED_PIXELS`` budget.
     try:
         dest_path, dest_size = resize_image(
             resolved_input,
@@ -2690,10 +2678,8 @@ def handle_resize_image(
     except ValueError as exc:
         return tool_error(str(exc))
 
-    # Re-resolve the destination after resize. The earlier ``resolved_input``
-    # check closed the input-side TOCTOU window, but ``resize_image`` reopens
-    # the path internally and writes a sibling — a swap between calls could
-    # land the output outside the session cache. Verify before returning.
+    # Re-check confinement post-resize to close the TOCTOU window between
+    # the input resolve and Pillow's internal reopen.
     try:
         resolved_dest = dest_path.resolve(strict=True)
     except (FileNotFoundError, OSError) as exc:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import inspect
 import json
 import logging
 import mimetypes
@@ -33,7 +34,7 @@ from typing import Any, Protocol, cast
 from uuid import UUID
 
 
-from memex_common.asset_cache import SessionAssetCache
+from memex_common.asset_cache import MAX_RESOURCE_BYTES, SessionAssetCache
 from memex_common.asset_resize import validate_and_resize
 from tools.registry import tool_error  # type: ignore[import-not-found]
 
@@ -1249,10 +1250,6 @@ def _is_unsafe_asset_filename(filename: Any) -> bool:
 # defensively because some clients ignore schema-level limits.
 _MAX_GET_RESOURCES_PATHS = 50
 _MAX_ADD_ASSETS_ITEMS = 20
-
-# Per-asset byte cap for ``handle_get_resources``. A single oversized asset
-# would otherwise OOM the host when base64-encoded (base64 inflates by ~33%).
-_MAX_RESOURCE_BYTES = 50 * 1024 * 1024  # 50 MiB
 
 # Canonical KV key namespaces per RFC-012. Hermes is the ``key`` holder here;
 # ``_scope_from_key`` above derives these from stored entries.
@@ -2590,14 +2587,13 @@ def handle_get_resources(
                 asset_cache.get_or_fetch(path, api.get_resource),
                 timeout=30.0,
             )
-            if size_bytes > _MAX_RESOURCE_BYTES:
+            if size_bytes > MAX_RESOURCE_BYTES:
                 asset_cache.invalidate(path)
                 results.append(
                     {
                         'path': path,
                         'error': (
-                            f'Resource exceeds max size '
-                            f'({size_bytes} > {_MAX_RESOURCE_BYTES} bytes)'
+                            f'Resource exceeds max size ({size_bytes} > {MAX_RESOURCE_BYTES} bytes)'
                         ),
                     }
                 )
@@ -2698,10 +2694,10 @@ def handle_add_assets(
         b64 = a.get('content_b64')
         if not isinstance(b64, str):
             return tool_error(f'Asset {fn!r} has non-string content_b64')
-        if (len(b64) * 3) // 4 > _MAX_RESOURCE_BYTES:
+        if (len(b64) * 3) // 4 > MAX_RESOURCE_BYTES:
             return tool_error(
                 f'Asset {fn!r} exceeds max size '
-                f'(~{(len(b64) * 3) // 4} > {_MAX_RESOURCE_BYTES} bytes)'
+                f'(~{(len(b64) * 3) // 4} > {MAX_RESOURCE_BYTES} bytes)'
             )
 
     filenames = [a['filename'] for a in assets]
@@ -2714,10 +2710,10 @@ def handle_add_assets(
             decoded = base64.b64decode(a['content_b64'], validate=True)
             # Post-decode check kept as defense-in-depth: the pre-check is
             # an upper-bound estimate, so the exact bytes are still verified.
-            if len(decoded) > _MAX_RESOURCE_BYTES:
+            if len(decoded) > MAX_RESOURCE_BYTES:
                 return tool_error(
                     f'Asset {a["filename"]!r} exceeds max size '
-                    f'({len(decoded)} > {_MAX_RESOURCE_BYTES} bytes)'
+                    f'({len(decoded)} > {MAX_RESOURCE_BYTES} bytes)'
                 )
             files[a['filename']] = decoded
     except (binascii.Error, ValueError, TypeError, KeyError) as e:
@@ -2910,15 +2906,16 @@ HANDLERS: dict[str, _StdHandler | _AssetCacheHandler] = {
 }
 
 
-# Tool names whose handlers accept the ``asset_cache`` keyword. Disk-handoff
-# tools need access to the per-session cache; the remaining handlers do not
-# and ignore the kwarg.
-_ASSET_CACHE_TOOLS: frozenset[str] = frozenset(
-    {
-        'memex_get_resources',
-        'memex_resize_image',
-    }
-)
+_ACCEPTS_ASSET_CACHE: dict[int, bool] = {}
+
+
+def _accepts_asset_cache(handler: _StdHandler | _AssetCacheHandler) -> bool:
+    key = id(handler)
+    cached = _ACCEPTS_ASSET_CACHE.get(key)
+    if cached is None:
+        cached = 'asset_cache' in inspect.signature(handler).parameters
+        _ACCEPTS_ASSET_CACHE[key] = cached
+    return cached
 
 
 def dispatch(
@@ -2934,7 +2931,7 @@ def dispatch(
     if handler is None:
         return tool_error(f'Unknown tool: {tool_name}')
     try:
-        if tool_name in _ASSET_CACHE_TOOLS:
+        if _accepts_asset_cache(handler):
             return cast(_AssetCacheHandler, handler)(
                 api, config, vault_id, args, asset_cache=asset_cache
             )

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -25,13 +25,17 @@ from __future__ import annotations
 
 import base64
 import binascii
+import contextlib
 import json
 import logging
 import mimetypes
+import os
 from pathlib import Path
 from typing import Any, Protocol
 from uuid import UUID
 
+from memex_common.asset_cache import SessionAssetCache
+from memex_common.asset_resize import resize_image
 from tools.registry import tool_error  # type: ignore[import-not-found]
 
 from .async_bridge import run_sync
@@ -942,11 +946,14 @@ LIST_ASSETS_SCHEMA: dict[str, Any] = {
 GET_RESOURCES_SCHEMA: dict[str, Any] = {
     'name': 'memex_get_resources',
     'description': (
-        'Retrieve one or more file attachments by path. Returns base64-encoded '
-        'bytes (diverges from MCP which returns native Image/Audio/File). '
-        'Per-path failure isolation: failures produce {path, error} entries '
-        'interleaved with successful {path, filename, mime_type, content_b64, '
-        'size_bytes} entries. Get paths from memex_list_assets.'
+        'Retrieve one or more file attachments by path. The bytes are written '
+        'to a per-session tempdir on the local filesystem; the tool returns '
+        '{path, local_path, filename, mime_type, size_bytes} per asset. The '
+        'tool result NEVER contains the bytes inline — read each `local_path` '
+        'directly from disk. Per-path failure isolation: failures produce '
+        '{path, error} entries interleaved with successful entries. Repeat '
+        'fetches of the same path within a session are served from a local '
+        'LRU cache. Get paths from memex_list_assets.'
     ),
     'parameters': {
         'type': 'object',
@@ -959,6 +966,50 @@ GET_RESOURCES_SCHEMA: dict[str, Any] = {
             },
         },
         'required': ['paths'],
+    },
+}
+
+RESIZE_IMAGE_SCHEMA: dict[str, Any] = {
+    'name': 'memex_resize_image',
+    'description': (
+        'Resize an image previously fetched into the session asset cache by '
+        'memex_get_resources. The `local_path` MUST point inside the session '
+        'tempdir — paths outside it are rejected to prevent reading or '
+        'writing arbitrary filesystem locations. Allowed input formats are '
+        'PNG, JPEG, WEBP, and GIF; SVG, PDF, audio, and other types are '
+        'rejected. The resized copy is written as a sibling of the source '
+        'inside the same tempdir; the tool returns {local_path, size_bytes} '
+        'pointing at the new file.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'local_path': {
+                'type': 'string',
+                'description': (
+                    'Absolute path inside the session asset cache tempdir, '
+                    'e.g. a `local_path` returned by memex_get_resources.'
+                ),
+            },
+            'max_width': {
+                'type': 'integer',
+                'description': 'Maximum width in pixels (default 1280).',
+                'default': 1280,
+            },
+            'max_height': {
+                'type': 'integer',
+                'description': 'Maximum height in pixels (default 1280).',
+                'default': 1280,
+            },
+            'format': {
+                'type': 'string',
+                'description': (
+                    "Optional output format override; one of 'PNG', 'JPEG', "
+                    "'WEBP', 'GIF'. Defaults to the input format."
+                ),
+            },
+        },
+        'required': ['local_path'],
     },
 }
 
@@ -1125,6 +1176,7 @@ ALL_SCHEMAS: list[dict[str, Any]] = [
     # --- Assets (Stream 5) ---
     LIST_ASSETS_SCHEMA,
     GET_RESOURCES_SCHEMA,
+    RESIZE_IMAGE_SCHEMA,
     ADD_ASSETS_SCHEMA,
     # --- KV store (Stream 5) ---
     KV_WRITE_SCHEMA,
@@ -2479,9 +2531,24 @@ def handle_list_assets(
 
 
 def handle_get_resources(
-    api: MemexAPIProtocol, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
+    api: MemexAPIProtocol,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+    args: dict[str, Any],
+    *,
+    asset_cache: SessionAssetCache | None = None,
 ) -> str:
-    """Fetch assets by path; return base64-encoded bytes with per-path failure isolation."""
+    """Fetch assets by path; hand off bytes via disk paths in a session tempdir.
+
+    The tool result NEVER contains the bytes inline — agents read each
+    ``local_path`` directly. This sidesteps the Hermes harness'
+    ``tool_output.max_bytes`` ceiling that would otherwise truncate base64
+    payloads. Repeat fetches of the same path within a session are served
+    from a per-process LRU cache.
+    """
+    if asset_cache is None:
+        return tool_error('Asset cache is not initialized.')
+
     try:
         paths = _require(args, 'paths')
     except ValueError as e:
@@ -2496,31 +2563,105 @@ def handle_get_resources(
     results: list[dict[str, Any]] = []
     for path in paths:
         try:
-            content_bytes = run_sync(api.get_resource(path), timeout=30.0)
-            if len(content_bytes) > _MAX_RESOURCE_BYTES:
+            local_path, mime_type, size_bytes = run_sync(
+                asset_cache.get_or_fetch(path, api.get_resource),
+                timeout=30.0,
+            )
+            if size_bytes > _MAX_RESOURCE_BYTES:
+                # AC-011: oversize entries are ``error``-only — unlink the
+                # bytes so the cap can't be bypassed by reading from disk
+                # and so the tempdir doesn't accumulate rejected payloads.
+                # The LRU entry is left in place; ``get_or_fetch`` checks
+                # ``cached.exists()`` and re-runs ``fetch`` when the file is
+                # missing, so the cap is re-evaluated on retry.
+                with contextlib.suppress(FileNotFoundError, OSError):
+                    os.unlink(local_path)
                 results.append(
                     {
                         'path': path,
                         'error': (
                             f'Resource exceeds max size '
-                            f'({len(content_bytes)} > {_MAX_RESOURCE_BYTES} bytes)'
+                            f'({size_bytes} > {_MAX_RESOURCE_BYTES} bytes)'
                         ),
                     }
                 )
                 continue
-            mime_type, _ = mimetypes.guess_type(path)
             results.append(
                 {
                     'path': path,
+                    'local_path': str(local_path),
                     'filename': Path(path).name,
                     'mime_type': mime_type,
-                    'content_b64': base64.b64encode(content_bytes).decode('ascii'),
-                    'size_bytes': len(content_bytes),
+                    'size_bytes': size_bytes,
                 }
             )
         except Exception as exc:
             results.append({'path': path, 'error': str(exc)})
     return json.dumps({'results': results})
+
+
+def handle_resize_image(
+    api: MemexAPIProtocol,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+    args: dict[str, Any],
+    *,
+    asset_cache: SessionAssetCache | None = None,
+) -> str:
+    """Resize an image previously fetched into the session asset cache.
+
+    Path-confinement: ``local_path`` MUST resolve to a file inside the
+    session tempdir. Anything that resolves outside (including via ``..``
+    traversal) is rejected with ``tool_error`` before Pillow runs.
+    """
+    if asset_cache is None:
+        return tool_error('Asset cache is not initialized.')
+
+    try:
+        local_path_arg = _require(args, 'local_path')
+    except ValueError as e:
+        return tool_error(str(e))
+
+    if not isinstance(local_path_arg, str):
+        return tool_error("'local_path' must be a string")
+
+    max_width = args.get('max_width', 1280)
+    max_height = args.get('max_height', 1280)
+    if not isinstance(max_width, int) or not isinstance(max_height, int):
+        return tool_error("'max_width' and 'max_height' must be integers")
+    if max_width <= 0 or max_height <= 0:
+        return tool_error("'max_width' and 'max_height' must be positive")
+
+    output_format = args.get('format')
+    if output_format is not None and not isinstance(output_format, str):
+        return tool_error("'format' must be a string when provided")
+
+    try:
+        cache_root = asset_cache.tempdir.resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        return tool_error(f'Asset cache tempdir is unavailable: {exc}')
+
+    try:
+        resolved_input = Path(local_path_arg).resolve(strict=True)
+    except FileNotFoundError:
+        return tool_error(f'local_path does not exist: {local_path_arg!r}')
+    except OSError as exc:
+        return tool_error(f'Could not resolve local_path: {exc}')
+
+    if not resolved_input.is_relative_to(cache_root):
+        return tool_error('local_path must point inside the session asset cache')
+
+    try:
+        dest_path, dest_size = resize_image(
+            resolved_input,
+            max_width=max_width,
+            max_height=max_height,
+            format=output_format,
+        )
+    except ValueError as exc:
+        return tool_error(str(exc))
+
+    return json.dumps({'local_path': str(dest_path), 'size_bytes': dest_size})
 
 
 def handle_add_assets(
@@ -2737,6 +2878,7 @@ HANDLERS = {
     # --- Assets (Stream 5) ---
     'memex_list_assets': handle_list_assets,
     'memex_get_resources': handle_get_resources,
+    'memex_resize_image': handle_resize_image,
     'memex_add_assets': handle_add_assets,
     # --- KV store (Stream 5) ---
     'memex_kv_write': handle_kv_write,
@@ -2746,6 +2888,17 @@ HANDLERS = {
 }
 
 
+# Tool names whose handlers accept the ``asset_cache`` keyword. Disk-handoff
+# tools need access to the per-session cache; the remaining handlers do not
+# and ignore the kwarg.
+_ASSET_CACHE_TOOLS: frozenset[str] = frozenset(
+    {
+        'memex_get_resources',
+        'memex_resize_image',
+    }
+)
+
+
 def dispatch(
     tool_name: str,
     args: dict[str, Any],
@@ -2753,11 +2906,14 @@ def dispatch(
     api: MemexAPIProtocol,
     config: HermesMemexConfig,
     vault_id: UUID | None,
+    asset_cache: SessionAssetCache | None = None,
 ) -> str:
-    handler = HANDLERS.get(tool_name)
+    handler: Any = HANDLERS.get(tool_name)
     if handler is None:
         return tool_error(f'Unknown tool: {tool_name}')
     try:
+        if tool_name in _ASSET_CACHE_TOOLS:
+            return handler(api, config, vault_id, args, asset_cache=asset_cache)
         return handler(api, config, vault_id, args)
     except VaultResolutionError as exc:
         return tool_error(f'Unknown vault: {exc.name!r}')
@@ -2804,6 +2960,7 @@ __all__ = [
     'ADD_ASSETS_SCHEMA',
     'GET_RESOURCES_SCHEMA',
     'LIST_ASSETS_SCHEMA',
+    'RESIZE_IMAGE_SCHEMA',
     # --- KV store (Stream 5) ---
     'KV_GET_SCHEMA',
     'KV_LIST_SCHEMA',

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -34,7 +34,6 @@ from pathlib import Path
 from typing import Any, Protocol
 from uuid import UUID
 
-from PIL import Image
 
 from memex_common.asset_cache import SessionAssetCache
 from memex_common.asset_resize import resize_image
@@ -2653,6 +2652,10 @@ def handle_resize_image(
     if not resolved_input.is_relative_to(cache_root):
         return tool_error('local_path must point inside the session asset cache')
 
+    # Decompression-bomb protection lives inside ``resize_image`` itself:
+    # it checks ``img.size`` after ``Image.open`` (header-only) and before
+    # any pixel decoding, raising ``ValueError('Image is too large to
+    # safely decode')`` past the ``_MAX_DECODED_PIXELS`` budget.
     try:
         dest_path, dest_size = resize_image(
             resolved_input,
@@ -2660,12 +2663,6 @@ def handle_resize_image(
             max_height=max_height,
             output_format=output_format,
         )
-    except Image.DecompressionBombError:
-        # Pillow flags images past ``Image.MAX_IMAGE_PIXELS`` (default 89 MP)
-        # before any pixels are decoded. Catch here so a pathological
-        # 100k x 100k PNG cannot exhaust memory through ``resize_image``'s
-        # internal ``Image.open`` call.
-        return tool_error('Image is too large to safely decode')
     except ValueError as exc:
         return tool_error(str(exc))
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -2906,11 +2906,11 @@ HANDLERS: dict[str, _StdHandler | _AssetCacheHandler] = {
 }
 
 
-_ACCEPTS_ASSET_CACHE: dict[int, bool] = {}
+_ACCEPTS_ASSET_CACHE: dict[str, bool] = {}
 
 
 def _accepts_asset_cache(handler: _StdHandler | _AssetCacheHandler) -> bool:
-    key = id(handler)
+    key = getattr(handler, '__qualname__', repr(handler))
     cached = _ACCEPTS_ASSET_CACHE.get(key)
     if cached is None:
         cached = 'asset_cache' in inspect.signature(handler).parameters

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -34,6 +34,8 @@ from pathlib import Path
 from typing import Any, Protocol
 from uuid import UUID
 
+from PIL import Image
+
 from memex_common.asset_cache import SessionAssetCache
 from memex_common.asset_resize import resize_image
 from tools.registry import tool_error  # type: ignore[import-not-found]
@@ -1001,7 +1003,7 @@ RESIZE_IMAGE_SCHEMA: dict[str, Any] = {
                 'description': 'Maximum height in pixels (default 1280).',
                 'default': 1280,
             },
-            'format': {
+            'output_format': {
                 'type': 'string',
                 'description': (
                     "Optional output format override; one of 'PNG', 'JPEG', "
@@ -2632,9 +2634,9 @@ def handle_resize_image(
     if max_width <= 0 or max_height <= 0:
         return tool_error("'max_width' and 'max_height' must be positive")
 
-    output_format = args.get('format')
+    output_format = args.get('output_format')
     if output_format is not None and not isinstance(output_format, str):
-        return tool_error("'format' must be a string when provided")
+        return tool_error("'output_format' must be a string when provided")
 
     try:
         cache_root = asset_cache.tempdir.resolve(strict=True)
@@ -2656,10 +2658,36 @@ def handle_resize_image(
             resolved_input,
             max_width=max_width,
             max_height=max_height,
-            format=output_format,
+            output_format=output_format,
         )
+    except Image.DecompressionBombError:
+        # Pillow flags images past ``Image.MAX_IMAGE_PIXELS`` (default 89 MP)
+        # before any pixels are decoded. Catch here so a pathological
+        # 100k x 100k PNG cannot exhaust memory through ``resize_image``'s
+        # internal ``Image.open`` call.
+        return tool_error('Image is too large to safely decode')
     except ValueError as exc:
         return tool_error(str(exc))
+
+    # Re-resolve the destination after resize. The earlier ``resolved_input``
+    # check closed the input-side TOCTOU window, but ``resize_image`` reopens
+    # the path internally and writes a sibling — a swap between calls could
+    # land the output outside the session cache. Verify before returning.
+    try:
+        resolved_dest = dest_path.resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        return tool_error(f'Resize destination is unavailable: {exc}')
+
+    if not resolved_dest.is_relative_to(cache_root):
+        try:
+            os.unlink(dest_path)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+        return tool_error('Resize destination escaped session cache')
+
+    asset_cache.register(dest_path)
 
     return json.dumps({'local_path': str(dest_path), 'size_bytes': dest_size})
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -34,7 +34,11 @@ from typing import Any, Protocol, cast
 from uuid import UUID
 
 
-from memex_common.asset_cache import MAX_RESOURCE_BYTES, SessionAssetCache
+from memex_common.asset_cache import (
+    MAX_GET_RESOURCES_PATHS,
+    MAX_RESOURCE_BYTES,
+    SessionAssetCache,
+)
 from memex_common.asset_resize import validate_and_resize
 from tools.registry import tool_error  # type: ignore[import-not-found]
 
@@ -1248,7 +1252,6 @@ def _is_unsafe_asset_filename(filename: Any) -> bool:
 # Bulk-input caps on list-type tool arguments. These mirror the ``maxItems``
 # values declared in the tool schemas; the handlers also enforce them
 # defensively because some clients ignore schema-level limits.
-_MAX_GET_RESOURCES_PATHS = 50
 _MAX_ADD_ASSETS_ITEMS = 20
 
 # Canonical KV key namespaces per RFC-012. Hermes is the ``key`` holder here;
@@ -2577,8 +2580,8 @@ def handle_get_resources(
     if not isinstance(paths, list):
         return tool_error("'paths' must be an array of strings")
 
-    if len(paths) > _MAX_GET_RESOURCES_PATHS:
-        return tool_error(f'Too many paths: {len(paths)} (max {_MAX_GET_RESOURCES_PATHS}).')
+    if len(paths) > MAX_GET_RESOURCES_PATHS:
+        return tool_error(f'Too many paths: {len(paths)} (max {MAX_GET_RESOURCES_PATHS}).')
 
     results: list[dict[str, Any]] = []
     for path in paths:
@@ -2906,18 +2909,6 @@ HANDLERS: dict[str, _StdHandler | _AssetCacheHandler] = {
 }
 
 
-_ACCEPTS_ASSET_CACHE: dict[str, bool] = {}
-
-
-def _accepts_asset_cache(handler: _StdHandler | _AssetCacheHandler) -> bool:
-    key = getattr(handler, '__qualname__', repr(handler))
-    cached = _ACCEPTS_ASSET_CACHE.get(key)
-    if cached is None:
-        cached = 'asset_cache' in inspect.signature(handler).parameters
-        _ACCEPTS_ASSET_CACHE[key] = cached
-    return cached
-
-
 def dispatch(
     tool_name: str,
     args: dict[str, Any],
@@ -2931,7 +2922,7 @@ def dispatch(
     if handler is None:
         return tool_error(f'Unknown tool: {tool_name}')
     try:
-        if _accepts_asset_cache(handler):
+        if 'asset_cache' in inspect.signature(handler).parameters:
             return cast(_AssetCacheHandler, handler)(
                 api, config, vault_id, args, asset_cache=asset_cache
             )

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -28,14 +28,13 @@ import binascii
 import json
 import logging
 import mimetypes
-import os
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 from uuid import UUID
 
 
 from memex_common.asset_cache import SessionAssetCache
-from memex_common.asset_resize import resize_image
+from memex_common.asset_resize import validate_and_resize
 from tools.registry import tool_error  # type: ignore[import-not-found]
 
 from .async_bridge import run_sync
@@ -2646,55 +2645,21 @@ def handle_resize_image(
     max_height = args.get('max_height', 1280)
     if not isinstance(max_width, int) or not isinstance(max_height, int):
         return tool_error("'max_width' and 'max_height' must be integers")
-    if max_width <= 0 or max_height <= 0:
-        return tool_error("'max_width' and 'max_height' must be positive")
 
     output_format = args.get('output_format')
     if output_format is not None and not isinstance(output_format, str):
         return tool_error("'output_format' must be a string when provided")
 
     try:
-        cache_root = asset_cache.tempdir.resolve(strict=True)
-    except (FileNotFoundError, OSError) as exc:
-        return tool_error(f'Asset cache tempdir is unavailable: {exc}')
-
-    try:
-        resolved_input = Path(local_path_arg).resolve(strict=True)
-    except FileNotFoundError:
-        return tool_error(f'local_path does not exist: {local_path_arg!r}')
-    except OSError as exc:
-        return tool_error(f'Could not resolve local_path: {exc}')
-
-    if not resolved_input.is_relative_to(cache_root):
-        return tool_error('local_path must point inside the session asset cache')
-
-    try:
-        dest_path, dest_size = resize_image(
-            resolved_input,
+        dest_path, dest_size = validate_and_resize(
+            asset_cache,
+            local_path_arg,
             max_width=max_width,
             max_height=max_height,
             output_format=output_format,
         )
     except ValueError as exc:
         return tool_error(str(exc))
-
-    # Re-check confinement post-resize to close the TOCTOU window between
-    # the input resolve and Pillow's internal reopen.
-    try:
-        resolved_dest = dest_path.resolve(strict=True)
-    except (FileNotFoundError, OSError) as exc:
-        return tool_error(f'Resize destination is unavailable: {exc}')
-
-    if not resolved_dest.is_relative_to(cache_root):
-        try:
-            os.unlink(dest_path)
-        except FileNotFoundError:
-            pass
-        except OSError:
-            pass
-        return tool_error('Resize destination escaped session cache')
-
-    asset_cache.register(dest_path)
 
     return json.dumps({'local_path': str(dest_path), 'size_bytes': dest_size})
 
@@ -2878,7 +2843,29 @@ def handle_kv_list(
     return json.dumps({'results': [_serialize_kv_entry(e) for e in entries or []]})
 
 
-HANDLERS = {
+class _StdHandler(Protocol):
+    def __call__(
+        self,
+        api: MemexAPIProtocol,
+        config: HermesMemexConfig,
+        vault_id: UUID | None,
+        args: dict[str, Any],
+    ) -> str: ...
+
+
+class _AssetCacheHandler(Protocol):
+    def __call__(
+        self,
+        api: MemexAPIProtocol,
+        config: HermesMemexConfig,
+        vault_id: UUID | None,
+        args: dict[str, Any],
+        *,
+        asset_cache: SessionAssetCache | None = None,
+    ) -> str: ...
+
+
+HANDLERS: dict[str, _StdHandler | _AssetCacheHandler] = {
     # --- Vault-scoped (Stream 1) ---
     'memex_recall': handle_recall,
     'memex_retrieve_notes': handle_retrieve_notes,
@@ -2943,13 +2930,15 @@ def dispatch(
     vault_id: UUID | None,
     asset_cache: SessionAssetCache | None = None,
 ) -> str:
-    handler: Any = HANDLERS.get(tool_name)
+    handler = HANDLERS.get(tool_name)
     if handler is None:
         return tool_error(f'Unknown tool: {tool_name}')
     try:
         if tool_name in _ASSET_CACHE_TOOLS:
-            return handler(api, config, vault_id, args, asset_cache=asset_cache)
-        return handler(api, config, vault_id, args)
+            return cast(_AssetCacheHandler, handler)(
+                api, config, vault_id, args, asset_cache=asset_cache
+            )
+        return cast(_StdHandler, handler)(api, config, vault_id, args)
     except VaultResolutionError as exc:
         return tool_error(f'Unknown vault: {exc.name!r}')
 

--- a/packages/hermes-plugin/tests/test_handle_get_resources.py
+++ b/packages/hermes-plugin/tests/test_handle_get_resources.py
@@ -115,9 +115,9 @@ def test_get_resources_oversize_rejected_after_download(config, vault_id, asset_
     """AC-011: an asset whose bytes exceed ``_MAX_RESOURCE_BYTES`` after the
     fetch lands as an ``error`` entry AND the file is removed from disk —
     the oversize bytes must not leak into the tempdir."""
-    from memex_hermes_plugin.memex import tools as tools_mod
 
-    monkeypatch.setattr(tools_mod, '_MAX_RESOURCE_BYTES', 4, raising=True)
+    monkeypatch.setattr('memex_common.asset_cache.MAX_RESOURCE_BYTES', 4)
+    monkeypatch.setattr('memex_hermes_plugin.memex.tools.MAX_RESOURCE_BYTES', 4)
 
     api = Mock()
     api.get_resource = AsyncMock(return_value=b'TOOBIG!')

--- a/packages/hermes-plugin/tests/test_handle_get_resources.py
+++ b/packages/hermes-plugin/tests/test_handle_get_resources.py
@@ -1,0 +1,285 @@
+"""Tests for the disk-handoff variant of ``handle_get_resources`` and the
+provider-level ``SessionAssetCache`` lifecycle.
+
+The MCP / Hermes harness has a ``tool_output.max_bytes`` ceiling that
+silently truncated base64 payloads; issue #59 replaces inline bytes with
+local-file paths under a per-session tempdir. These tests cover:
+
+- AC-006: response shape contains ``local_path`` / ``size_bytes`` and
+  explicitly does NOT contain ``content_b64``.
+- AC-004 / cache hit: repeat fetches of the same path call the API once.
+- AC-011: oversize assets surface as ``error`` entries AND the bytes are
+  unlinked so the tempdir doesn't leak the rejected payload.
+- AC-007: the provider mints a ``SessionAssetCache`` in ``initialize`` and
+  ``_atexit_shutdown`` removes its tempdir.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+
+from memex_common.asset_cache import SessionAssetCache
+from memex_hermes_plugin.memex.config import HermesMemexConfig
+from memex_hermes_plugin.memex.provider import MemexMemoryProvider
+from memex_hermes_plugin.memex.tools import dispatch
+
+
+@pytest.fixture
+def config() -> HermesMemexConfig:
+    return HermesMemexConfig()
+
+
+@pytest.fixture
+def vault_id():
+    return uuid4()
+
+
+@pytest.fixture
+def asset_cache(tmp_path: Path):
+    cache = SessionAssetCache(tempdir=tmp_path / 'cache')
+    yield cache
+    cache.cleanup()
+
+
+def test_get_resources_returns_local_path(config, vault_id, asset_cache):
+    """AC-006: response shape has ``local_path``, ``path``, ``filename``,
+    ``mime_type``, ``size_bytes``; ``content_b64`` is NEVER set."""
+    api = Mock()
+    raw = b'PNG_FAKE'
+    api.get_resource = AsyncMock(return_value=raw)
+    out = dispatch(
+        'memex_get_resources',
+        {'paths': ['abc/diagram.png']},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    entry = data['results'][0]
+    assert entry['path'] == 'abc/diagram.png'
+    assert entry['filename'] == 'diagram.png'
+    assert entry['mime_type'] == 'image/png'
+    assert entry['size_bytes'] == len(raw)
+    assert 'local_path' in entry
+    assert 'content_b64' not in entry, 'disk-handoff must never inline bytes'
+    assert 'error' not in entry
+
+    # The local_path resolves inside the cache's tempdir and contains the
+    # bytes returned by api.get_resource.
+    local = Path(entry['local_path'])
+    assert local.exists()
+    assert local.read_bytes() == raw
+    assert local.resolve().is_relative_to(asset_cache.tempdir.resolve())
+
+
+def test_get_resources_caches_repeat_calls(config, vault_id, asset_cache):
+    """AC-004: a second fetch for the same path is served from the LRU cache,
+    so ``api.get_resource`` is awaited exactly once."""
+    api = Mock()
+    api.get_resource = AsyncMock(return_value=b'cached-bytes')
+
+    args = {'paths': ['abc/repeat.png']}
+
+    out1 = dispatch(
+        'memex_get_resources',
+        args,
+        api=api,
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    out2 = dispatch(
+        'memex_get_resources',
+        args,
+        api=api,
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+
+    assert api.get_resource.await_count == 1, 'Repeat fetches must hit the cache, not the API'
+    # Both responses point at the same on-disk file.
+    p1 = json.loads(out1)['results'][0]['local_path']
+    p2 = json.loads(out2)['results'][0]['local_path']
+    assert p1 == p2
+
+
+def test_get_resources_oversize_rejected_after_download(config, vault_id, asset_cache, monkeypatch):
+    """AC-011: an asset whose bytes exceed ``_MAX_RESOURCE_BYTES`` after the
+    fetch lands as an ``error`` entry AND the file is removed from disk —
+    the oversize bytes must not leak into the tempdir."""
+    from memex_hermes_plugin.memex import tools as tools_mod
+
+    monkeypatch.setattr(tools_mod, '_MAX_RESOURCE_BYTES', 4, raising=True)
+
+    api = Mock()
+    api.get_resource = AsyncMock(return_value=b'TOOBIG!')
+
+    out = dispatch(
+        'memex_get_resources',
+        {'paths': ['oversize.png']},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    entry = json.loads(out)['results'][0]
+    assert entry['path'] == 'oversize.png'
+    assert 'error' in entry
+    assert 'exceeds max size' in entry['error']
+    assert 'local_path' not in entry
+    assert 'content_b64' not in entry
+
+    # No leftover bytes in the cache tempdir.
+    leftover = list(asset_cache.tempdir.iterdir())
+    assert leftover == [], f'oversize asset bytes leaked into tempdir: {leftover!r}'
+
+
+def test_get_resources_partial_failure_isolation(config, vault_id, asset_cache):
+    """Per-path partial failure isolation: a missing asset becomes an error
+    entry without aborting the whole batch, AND no ``content_b64`` ever
+    appears (regression guard)."""
+    api = Mock()
+    api.get_resource = AsyncMock(
+        side_effect=[b'ok1', FileNotFoundError('missing'), b'ok3'],
+    )
+
+    out = dispatch(
+        'memex_get_resources',
+        {'paths': ['p1.png', 'p2.png', 'p3.png']},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    results = json.loads(out)['results']
+    assert len(results) == 3
+    assert 'local_path' in results[0]
+    assert 'error' not in results[0]
+    assert results[1]['path'] == 'p2.png'
+    assert 'error' in results[1]
+    assert 'local_path' not in results[1]
+    assert 'local_path' in results[2]
+    for entry in results:
+        assert 'content_b64' not in entry
+
+
+def test_get_resources_rejects_too_many_paths(config, vault_id, asset_cache):
+    api = Mock()
+    api.get_resource = AsyncMock()
+    out = dispatch(
+        'memex_get_resources',
+        {'paths': [f'p{i}.png' for i in range(51)]},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'too many' in data['error'].lower()
+    api.get_resource.assert_not_awaited()
+
+
+def test_get_resources_without_cache_returns_error(config, vault_id):
+    """Defensive: without an initialized cache the handler refuses to run
+    rather than silently writing to a process-wide tempdir."""
+    api = Mock()
+    api.get_resource = AsyncMock()
+    out = dispatch(
+        'memex_get_resources',
+        {'paths': ['x.png']},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+        asset_cache=None,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    api.get_resource.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Provider-level lifecycle (AC-007)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stubbed_provider(tmp_path, monkeypatch):
+    """Spin up a fully initialized ``MemexMemoryProvider`` with a stubbed API.
+
+    Mirrors ``provider_with_stubbed_api`` from ``test_provider.py`` so we can
+    exercise the cache lifecycle without standing up a real Memex server.
+    """
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
+    monkeypatch.setenv('MEMEX_VAULT', 'test-vault')
+
+    fake_api = Mock()
+    fake_api.kv_get = AsyncMock(return_value=None)
+    fake_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+    fake_api.get_session_briefing = AsyncMock(return_value='# Briefing')
+    fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(uuid4())))
+    fake_api.kv_put = AsyncMock()
+
+    with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
+        provider = MemexMemoryProvider()
+        provider.initialize('session-cache', hermes_home=str(tmp_path), platform='cli')
+        try:
+            yield provider
+        finally:
+            try:
+                provider.shutdown()
+            except Exception:
+                pass
+
+
+def test_provider_initialize_creates_cache(stubbed_provider):
+    """AC-007: ``initialize`` mints a ``SessionAssetCache`` exposed as a
+    public attribute."""
+    cache = stubbed_provider.asset_cache
+    assert isinstance(cache, SessionAssetCache)
+    assert cache.tempdir.exists()
+    assert cache.tempdir.is_dir()
+
+
+def test_atexit_shutdown_cleans_cache(tmp_path, monkeypatch):
+    """AC-007: directly invoking ``_atexit_shutdown`` (without waiting for
+    real ``atexit`` firing) removes the session tempdir."""
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
+    monkeypatch.setenv('MEMEX_VAULT', 'test-vault')
+
+    fake_api = Mock()
+    fake_api.kv_get = AsyncMock(return_value=None)
+    fake_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+    fake_api.get_session_briefing = AsyncMock(return_value='')
+    fake_api.ingest = AsyncMock()
+    fake_api.kv_put = AsyncMock()
+
+    with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
+        provider = MemexMemoryProvider()
+        provider.initialize('session-atexit', hermes_home=str(tmp_path), platform='cli')
+
+    cache = provider.asset_cache
+    assert cache is not None
+    cache_tempdir = cache.tempdir
+    assert cache_tempdir.exists()
+
+    # Drop a marker file so we can prove the directory was wiped.
+    marker = cache_tempdir / 'marker.bin'
+    marker.write_bytes(b'before shutdown')
+    assert marker.exists()
+
+    provider._atexit_shutdown()
+
+    assert not cache_tempdir.exists(), f'atexit shutdown left tempdir behind: {cache_tempdir}'
+    # Cache reference is dropped so a re-entry mints a fresh one.
+    assert provider.asset_cache is None

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -75,7 +75,7 @@ def test_get_tool_schemas_respects_memory_mode(tmp_path: Path, monkeypatch: pyte
 
 
 def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
-    """Hybrid mode exposes exactly the 34 Memex tools (AC-086)."""
+    """Hybrid mode exposes exactly the 35 Memex tools (AC-086 + AC-008)."""
     provider, *_ = provider_with_stubbed_api
     schemas = provider.get_tool_schemas()
     names = {s['name'] for s in schemas}
@@ -114,6 +114,7 @@ def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
         # Stream 5 (assets/KV)
         'memex_list_assets',
         'memex_get_resources',
+        'memex_resize_image',
         'memex_add_assets',
         'memex_kv_write',
         'memex_kv_get',
@@ -133,8 +134,9 @@ def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
 class TestGetToolSchemasBeforeInitialize:
     def test_returns_all_schemas_pre_init(self):
         """The v0.1.13 bug was returning []; we now return the full set
-        pre-init. After Stream 6 we register exactly 34 tools (7 baseline
-        + 27 new), and the assertion is strict equality.
+        pre-init. After Stream 6 + asset disk-handoff we register exactly 35
+        tools (7 baseline + 27 from prior streams + memex_resize_image), and
+        the assertion is strict equality.
         """
         p = MemexMemoryProvider()
         # NOTE: no initialize() call.
@@ -175,6 +177,7 @@ class TestGetToolSchemasBeforeInitialize:
             # Stream 5 (assets/KV)
             'memex_list_assets',
             'memex_get_resources',
+            'memex_resize_image',
             'memex_add_assets',
             'memex_kv_write',
             'memex_kv_get',
@@ -194,9 +197,10 @@ class TestGetToolSchemasBeforeInitialize:
         """A fresh provider with no config always exposes tools. Only an
         initialized provider whose config explicitly says ``context`` hides them.
         """
-        # Pre-init: full 34-tool set (7 Stream 1 baseline + 27 new).
+        # Pre-init: full 35-tool set (7 Stream 1 baseline + 27 from prior
+        # streams + memex_resize_image).
         p = MemexMemoryProvider()
-        assert len(p.get_tool_schemas()) == 34
+        assert len(p.get_tool_schemas()) == 35
 
         # After init in context mode: empty.
         monkeypatch.setenv('HERMES_HOME', str(tmp_path))

--- a/packages/hermes-plugin/tests/test_resize.py
+++ b/packages/hermes-plugin/tests/test_resize.py
@@ -187,3 +187,120 @@ def test_resize_rejects_negative_dimensions(config, vault_id, asset_cache):
     data = json.loads(out)
     assert 'error' in data
     assert 'positive' in data['error'].lower() or 'must be' in data['error'].lower()
+
+
+def test_resize_registers_dest_in_cache(config, vault_id, asset_cache, tmp_path):
+    """Finding 4: a successful resize must insert the destination into the
+    LRU so the resized sibling participates in eviction and session cleanup
+    (otherwise it leaks until the session tempdir is torn down)."""
+    src = _write_png(asset_cache.tempdir / 'sample.png', size=(640, 480))
+
+    out = dispatch(
+        'memex_resize_image',
+        {'local_path': str(src), 'max_width': 64, 'max_height': 64},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' not in data
+    dest = Path(data['local_path'])
+    assert str(dest) in asset_cache
+
+
+def test_resize_rejects_dest_path_escape(monkeypatch, config, vault_id, asset_cache, tmp_path):
+    """Finding 10: defense-in-depth post-resize TOCTOU check. If the
+    destination resolves outside the cache root (e.g. via a symlink swap
+    while ``resize_image`` was running), the handler must unlink the file
+    and return a ``tool_error``."""
+    src = _write_png(asset_cache.tempdir / 'sample.png', size=(640, 480))
+
+    # Anchor a fake target outside the cache root that ``resolve`` will
+    # return in place of the real destination's resolution. The decoy needs
+    # to exist so ``resolve(strict=True)`` does not raise.
+    escape_dir = tmp_path / 'escape'
+    escape_dir.mkdir()
+    decoy = escape_dir / 'escaped.png'
+    _write_png(decoy)
+
+    real_resolve = Path.resolve
+
+    def fake_resolve(self: Path, *args, **kwargs):  # type: ignore[no-untyped-def]
+        # Only redirect resolution for paths produced by ``resize_image`` —
+        # those land in the cache tempdir with the deterministic
+        # ``-{w}x{h}.<suffix>`` stem. Everything else (the cache root, the
+        # input path) keeps its real resolution so the input-side checks
+        # still pass.
+        if self.parent == asset_cache.tempdir and '-64x64' in self.name:
+            return decoy
+        return real_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, 'resolve', fake_resolve)
+
+    # Capture the dest path the handler will actually unlink (the real
+    # in-cache file) so we can assert the cleanup branch ran.
+    expected_dest = asset_cache.tempdir / f'{src.stem}-64x64.png'
+
+    out = dispatch(
+        'memex_resize_image',
+        {'local_path': str(src), 'max_width': 64, 'max_height': 64},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'escaped' in data['error'].lower() or 'cache' in data['error'].lower()
+    # The handler unlinks ``dest_path`` (the original, in-cache target) —
+    # not the resolved decoy — so absence of the in-cache file proves the
+    # cleanup branch ran.
+    assert not expected_dest.exists()
+
+
+def test_resize_accepts_output_format_kwarg(config, vault_id, asset_cache):
+    """Finding 11: the renamed kwarg flows through to ``resize_image`` and
+    yields a destination with the requested suffix."""
+    src = _write_png(asset_cache.tempdir / 'sample.png', size=(128, 128))
+
+    out = dispatch(
+        'memex_resize_image',
+        {
+            'local_path': str(src),
+            'max_width': 64,
+            'max_height': 64,
+            'output_format': 'JPEG',
+        },
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' not in data
+    assert Path(data['local_path']).suffix == '.jpg'
+
+
+def test_resize_rejects_decompression_bomb(monkeypatch, config, vault_id, asset_cache):
+    """Finding 7: monkey-patch ``Image.MAX_IMAGE_PIXELS`` to a tiny value and
+    feed in an image larger than the cap. The tool must surface a
+    ``tool_error`` (Pillow raises ``DecompressionBombError`` once the cap is
+    crossed; the handler maps that to a ``ValueError`` from the helper)."""
+    # 200x200 = 40k pixels, well above the cap below.
+    src = _write_png(asset_cache.tempdir / 'huge.png', size=(200, 200))
+
+    monkeypatch.setattr(Image, 'MAX_IMAGE_PIXELS', 100)
+
+    out = dispatch(
+        'memex_resize_image',
+        {'local_path': str(src), 'max_width': 64, 'max_height': 64},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    err = data['error'].lower()
+    assert 'too large' in err or 'decompression' in err or 'safely decode' in err

--- a/packages/hermes-plugin/tests/test_resize.py
+++ b/packages/hermes-plugin/tests/test_resize.py
@@ -238,8 +238,12 @@ def test_resize_rejects_dest_path_escape(monkeypatch, config, vault_id, asset_ca
 
     monkeypatch.setattr(Path, 'resolve', fake_resolve)
 
-    # Capture the dest path the handler will actually unlink (the real
-    # in-cache file) so we can assert the cleanup branch ran.
+    # Sanity check: the monkeypatch must NOT redirect the cache root or
+    # the input path, otherwise the input-side confinement check would
+    # falsely pass and the test would prove nothing.
+    assert asset_cache.tempdir.resolve(strict=True) == asset_cache.tempdir
+    assert src.resolve(strict=True) == src
+
     expected_dest = asset_cache.tempdir / f'{src.stem}-64x64.png'
 
     out = dispatch(

--- a/packages/hermes-plugin/tests/test_resize.py
+++ b/packages/hermes-plugin/tests/test_resize.py
@@ -283,14 +283,16 @@ def test_resize_accepts_output_format_kwarg(config, vault_id, asset_cache):
 
 
 def test_resize_rejects_decompression_bomb(monkeypatch, config, vault_id, asset_cache):
-    """Finding 7: monkey-patch ``Image.MAX_IMAGE_PIXELS`` to a tiny value and
-    feed in an image larger than the cap. The tool must surface a
-    ``tool_error`` (Pillow raises ``DecompressionBombError`` once the cap is
-    crossed; the handler maps that to a ``ValueError`` from the helper)."""
-    # 200x200 = 40k pixels, well above the cap below.
+    """An image whose pixel count exceeds the shared ``_MAX_DECODED_PIXELS``
+    budget must be rejected before any pixels are decoded. The helper raises
+    ``ValueError`` and the handler maps that to a ``tool_error``."""
+    # 200x200 = 40k pixels, well above the patched cap below.
     src = _write_png(asset_cache.tempdir / 'huge.png', size=(200, 200))
 
-    monkeypatch.setattr(Image, 'MAX_IMAGE_PIXELS', 100)
+    monkeypatch.setattr(
+        'memex_common.asset_resize._MAX_DECODED_PIXELS',
+        1000,
+    )
 
     out = dispatch(
         'memex_resize_image',
@@ -303,4 +305,4 @@ def test_resize_rejects_decompression_bomb(monkeypatch, config, vault_id, asset_
     data = json.loads(out)
     assert 'error' in data
     err = data['error'].lower()
-    assert 'too large' in err or 'decompression' in err or 'safely decode' in err
+    assert 'too large to safely decode' in err

--- a/packages/hermes-plugin/tests/test_resize.py
+++ b/packages/hermes-plugin/tests/test_resize.py
@@ -1,0 +1,189 @@
+"""Tests for the ``memex_resize_image`` tool handler.
+
+Resize lives in ``memex_common.asset_resize`` (covered by its own suite); the
+Hermes-side tests here focus on the tool plumbing — argument validation,
+path-confinement to the session asset cache, and the JSON response shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from PIL import Image
+
+from memex_common.asset_cache import SessionAssetCache
+from memex_hermes_plugin.memex.config import HermesMemexConfig
+from memex_hermes_plugin.memex.tools import dispatch
+
+
+@pytest.fixture
+def config() -> HermesMemexConfig:
+    return HermesMemexConfig()
+
+
+@pytest.fixture
+def vault_id():
+    return uuid4()
+
+
+@pytest.fixture
+def asset_cache(tmp_path: Path):
+    cache = SessionAssetCache(tempdir=tmp_path / 'cache')
+    yield cache
+    cache.cleanup()
+
+
+def _write_png(path: Path, *, size: tuple[int, int] = (640, 480)) -> Path:
+    """Write a deterministic PNG of the given size into ``path``."""
+    img = Image.new('RGB', size, color=(255, 0, 0))
+    img.save(path, format='PNG')
+    return path
+
+
+def test_resize_writes_smaller_file(config, vault_id, asset_cache, tmp_path):
+    """Happy path: a 640x480 PNG inside the cache resized to 64x64 produces a
+    sibling file with byte-size strictly less than the source."""
+    src = _write_png(asset_cache.tempdir / 'sample.png', size=(640, 480))
+    src_size = src.stat().st_size
+
+    out = dispatch(
+        'memex_resize_image',
+        {'local_path': str(src), 'max_width': 64, 'max_height': 64},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' not in data
+    dest = Path(data['local_path'])
+    assert dest.exists()
+    assert dest.parent == asset_cache.tempdir
+    assert data['size_bytes'] == dest.stat().st_size
+    assert dest.stat().st_size < src_size
+
+    with Image.open(dest) as img:
+        assert img.width <= 64 and img.height <= 64
+
+
+def test_resize_rejects_path_outside_tempdir(config, vault_id, asset_cache):
+    """AC-009: ``/etc/passwd`` is well outside the session tempdir → tool_error."""
+    out = dispatch(
+        'memex_resize_image',
+        {'local_path': '/etc/passwd'},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'session asset cache' in data['error'].lower() or 'inside' in data['error'].lower()
+
+
+def test_resize_rejects_path_via_relative_traversal(config, vault_id, asset_cache, tmp_path):
+    """AC-009: a path like ``<tempdir>/../escape.png`` resolves outside the
+    cache and must be rejected, even though the prefix matches before
+    resolution."""
+    # Drop a real PNG OUTSIDE the cache (sibling to the cache dir) so the
+    # resolved target exists; otherwise the helper would short-circuit on
+    # FileNotFoundError before the confinement check.
+    escape_dir = tmp_path / 'escape'
+    escape_dir.mkdir()
+    _write_png(escape_dir / 'evil.png')
+    sneaky = asset_cache.tempdir / '..' / 'escape' / 'evil.png'
+
+    out = dispatch(
+        'memex_resize_image',
+        {'local_path': str(sneaky)},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'inside' in data['error'].lower() or 'cache' in data['error'].lower()
+
+
+def test_resize_rejects_unsupported_format(config, vault_id, asset_cache):
+    """AC-010: SVG (or any other non-allowlisted suffix) inside the cache is
+    rejected with a clear error before Pillow is invoked."""
+    svg_path = asset_cache.tempdir / 'diagram.svg'
+    svg_path.write_text('<svg xmlns="http://www.w3.org/2000/svg"/>')
+
+    out = dispatch(
+        'memex_resize_image',
+        {'local_path': str(svg_path)},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert '.svg' in data['error'].lower() or 'unsupported' in data['error'].lower()
+
+
+def test_resize_rejects_missing_local_path(config, vault_id, asset_cache):
+    """Argument validation: omitting ``local_path`` is a tool_error."""
+    out = dispatch(
+        'memex_resize_image',
+        {},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'local_path' in data['error']
+
+
+def test_resize_rejects_nonexistent_path(config, vault_id, asset_cache):
+    """``Path.resolve(strict=True)`` on a missing file surfaces a clean
+    tool_error rather than letting an OSError escape through dispatch."""
+    out = dispatch(
+        'memex_resize_image',
+        {'local_path': str(asset_cache.tempdir / 'does-not-exist.png')},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'does not exist' in data['error'].lower() or 'not exist' in data['error'].lower()
+
+
+def test_resize_without_cache_returns_error(config, vault_id):
+    """Defensive: handler refuses to run when no cache is wired in."""
+    out = dispatch(
+        'memex_resize_image',
+        {'local_path': '/tmp/whatever.png'},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=None,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+
+
+def test_resize_rejects_negative_dimensions(config, vault_id, asset_cache):
+    """Defensive: negative or zero width/height is a tool_error."""
+    src = _write_png(asset_cache.tempdir / 'tiny.png', size=(32, 32))
+    out = dispatch(
+        'memex_resize_image',
+        {'local_path': str(src), 'max_width': 0, 'max_height': 64},
+        api=None,  # type: ignore[arg-type]
+        config=config,
+        vault_id=vault_id,
+        asset_cache=asset_cache,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'positive' in data['error'].lower() or 'must be' in data['error'].lower()

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -117,7 +117,8 @@ def _fake_entity(name: str = 'Rust') -> EntityDTO:
 
 
 def test_all_schemas_have_required_fields():
-    """All 34 tools (7 pre-existing + 27 new) must be registered exactly (AC-086)."""
+    """All 35 tools (7 pre-existing + 27 from prior streams + memex_resize_image)
+    must be registered exactly (AC-086 + AC-008)."""
     names = {s['name'] for s in ALL_SCHEMAS}
     stream_1_baseline = {
         'memex_recall',
@@ -157,6 +158,7 @@ def test_all_schemas_have_required_fields():
     stream_5_assets_kv = {
         'memex_list_assets',
         'memex_get_resources',
+        'memex_resize_image',
         'memex_add_assets',
         'memex_kv_write',
         'memex_kv_get',
@@ -2614,51 +2616,12 @@ def test_list_assets_rejects_invalid_uuid(config, vault_id):
     api.get_note.assert_not_awaited()
 
 
-# -- Handler tests: get_resources (#23) --
-
-
-def test_get_resources_base64_round_trip(config, vault_id):
-    """AC-046: bytes round-trip base64; size_bytes is pre-encode length; mime from path."""
-    api = Mock()
-    raw = b'PNG_FAKE'
-    api.get_resource = AsyncMock(return_value=raw)
-    out = dispatch(
-        'memex_get_resources',
-        {'paths': ['abc/diagram.png']},
-        api=api,
-        config=config,
-        vault_id=vault_id,
-    )
-    data = json.loads(out)
-    result = data['results'][0]
-    assert _b64.b64decode(result['content_b64']) == raw
-    assert result['size_bytes'] == len(raw)
-    assert result['mime_type'] == 'image/png'
-    assert result['filename'] == 'diagram.png'
-    assert result['path'] == 'abc/diagram.png'
-    assert 'error' not in result
-
-
-def test_get_resources_partial_failure_reports_per_path(config, vault_id):
-    """AC-047: per-path partial failure isolation; error entries have no content_b64."""
-    api = Mock()
-    api.get_resource = AsyncMock(
-        side_effect=[b'ok1', FileNotFoundError('missing'), b'ok3'],
-    )
-    out = dispatch(
-        'memex_get_resources',
-        {'paths': ['p1', 'p2', 'p3']},
-        api=api,
-        config=config,
-        vault_id=vault_id,
-    )
-    results = json.loads(out)['results']
-    assert len(results) == 3
-    assert _b64.b64decode(results[0]['content_b64']) == b'ok1'
-    assert results[1]['path'] == 'p2'
-    assert 'error' in results[1]
-    assert 'content_b64' not in results[1]
-    assert _b64.b64decode(results[2]['content_b64']) == b'ok3'
+# -- Handler tests: get_resources --
+# The disk-handoff variant of these tests lives in
+# ``tests/test_handle_get_resources.py``; that suite covers the new
+# response shape (``local_path`` instead of ``content_b64``) and the
+# ``SessionAssetCache`` lifecycle. The legacy base64 round-trip tests were
+# retired with the inline-bytes path in issue #59.
 
 
 # -- Handler tests: add_assets (#24) --
@@ -2911,50 +2874,9 @@ def test_add_assets_rejects_non_string_b64(config, vault_id):
     api.add_note_assets.assert_not_awaited()
 
 
-def test_get_resources_rejects_too_many_paths(config, vault_id):
-    """Enforcing the 50-path cap prevents clients from bypassing the schema limit."""
-    api = Mock()
-    api.get_resource = AsyncMock()
-    out = dispatch(
-        'memex_get_resources',
-        {'paths': [f'p{i}.png' for i in range(51)]},
-        api=api,
-        config=config,
-        vault_id=vault_id,
-    )
-    data = json.loads(out)
-    assert 'error' in data
-    assert 'too many' in data['error'].lower()
-    api.get_resource.assert_not_awaited()
-
-
-def test_get_resources_rejects_oversized_asset(config, vault_id, monkeypatch):
-    """Oversized assets produce a per-path error entry instead of being base64-encoded.
-
-    Uses monkeypatch to shrink the cap so we don't have to allocate ~50 MiB.
-    One good asset and one oversized asset are fetched together to assert the
-    existing per-path failure isolation still holds.
-    """
-    from memex_hermes_plugin.memex import tools as tools_mod
-
-    monkeypatch.setattr(tools_mod, '_MAX_RESOURCE_BYTES', 4, raising=True)
-
-    api = Mock()
-    api.get_resource = AsyncMock(side_effect=[b'ok', b'TOOBIG!'])
-    out = dispatch(
-        'memex_get_resources',
-        {'paths': ['small.png', 'big.png']},
-        api=api,
-        config=config,
-        vault_id=vault_id,
-    )
-    results = json.loads(out)['results']
-    assert len(results) == 2
-    assert 'content_b64' in results[0]
-    assert results[0]['path'] == 'small.png'
-    assert 'error' in results[1]
-    assert 'exceeds max size' in results[1]['error']
-    assert 'content_b64' not in results[1]
+# Note: The disk-handoff equivalents of the legacy "too many paths" and
+# "oversize per-path" tests live in ``tests/test_handle_get_resources.py``;
+# they need a ``SessionAssetCache`` fixture that's not part of this module.
 
 
 # -- Handler tests: kv_write (#25) --

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -2853,9 +2853,9 @@ def test_add_assets_rejects_oversized_asset(config, vault_id, monkeypatch):
     allocate ~50 MiB. The error surfaces which filename tripped the cap so
     the caller can identify the culprit in a multi-asset request.
     """
-    from memex_hermes_plugin.memex import tools as tools_mod
 
-    monkeypatch.setattr(tools_mod, '_MAX_RESOURCE_BYTES', 4, raising=True)
+    monkeypatch.setattr('memex_common.asset_cache.MAX_RESOURCE_BYTES', 4)
+    monkeypatch.setattr('memex_hermes_plugin.memex.tools.MAX_RESOURCE_BYTES', 4)
 
     api = Mock()
     api.add_note_assets = AsyncMock()
@@ -2891,7 +2891,8 @@ def test_add_assets_rejects_oversized_b64_before_decode(config, vault_id, monkey
     """
     from memex_hermes_plugin.memex import tools as tools_mod
 
-    monkeypatch.setattr(tools_mod, '_MAX_RESOURCE_BYTES', 4, raising=True)
+    monkeypatch.setattr('memex_common.asset_cache.MAX_RESOURCE_BYTES', 4)
+    monkeypatch.setattr('memex_hermes_plugin.memex.tools.MAX_RESOURCE_BYTES', 4)
 
     decoded_calls: list[str] = []
 

--- a/packages/mcp/src/memex_mcp/lifespan.py
+++ b/packages/mcp/src/memex_mcp/lifespan.py
@@ -8,6 +8,7 @@ import httpx
 from fastmcp import Context, FastMCP
 from mcp.shared.context import RequestContext
 
+from memex_common.asset_cache import SessionAssetCache
 from memex_common.client import RemoteMemexAPI
 from memex_common.config import MemexConfig
 from memex_mcp.models import AppContext
@@ -32,8 +33,11 @@ async def lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     client = httpx.AsyncClient(base_url=base_url, timeout=120.0, headers=headers)
     api = RemoteMemexAPI(client)
 
+    cache = SessionAssetCache()
+
     app_context = AppContext(config=config)
     app_context._api = api
+    app_context._asset_cache = cache
 
     try:
         vault = await api.get_active_vault()
@@ -44,6 +48,7 @@ async def lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     try:
         yield app_context
     finally:
+        cache.cleanup()
         await client.aclose()
 
 
@@ -53,6 +58,14 @@ def get_api(ctx: Context) -> RemoteMemexAPI:
     """
     app_context: AppContext = cast(RequestContext, ctx.request_context).lifespan_context
     return cast(RemoteMemexAPI, app_context._api)
+
+
+def get_asset_cache(ctx: Context) -> SessionAssetCache:
+    """
+    Get the SessionAssetCache instance from the context.
+    """
+    app_context: AppContext = cast(RequestContext, ctx.request_context).lifespan_context
+    return cast(SessionAssetCache, app_context._asset_cache)
 
 
 def get_config(ctx: Context) -> MemexConfig:

--- a/packages/mcp/src/memex_mcp/models.py
+++ b/packages/mcp/src/memex_mcp/models.py
@@ -11,6 +11,7 @@ import ast
 
 from pydantic import BaseModel, Field, PrivateAttr, field_validator
 
+from memex_common.asset_cache import SessionAssetCache
 from memex_common.client import RemoteMemexAPI
 from memex_common.config import MemexConfig
 from memex_common.schemas import TOCNodeDTO
@@ -30,6 +31,7 @@ class AppContext(BaseModel):
 
     config: MemexConfig = Field(..., description='The Memex configuration settings.')
     _api: RemoteMemexAPI = PrivateAttr()
+    _asset_cache: SessionAssetCache | None = PrivateAttr(default=None)
 
     model_config = {'arbitrary_types_allowed': True}
 

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -76,12 +76,7 @@ from memex_common.schemas import (
 
 _SESSION_DEDUP_TTL = 1800  # 30 minutes
 
-# Per-asset ceiling for memex_get_resources (parity with Hermes AC-011).
 _MAX_RESOURCE_BYTES: Final[int] = 50 * 1024 * 1024
-
-# Hard cap on the number of paths a single memex_get_resources call can
-# request (parity with Hermes). Stops a misbehaving caller from fanning
-# out an unbounded sequence of fetches.
 _MAX_GET_RESOURCES_PATHS: Final[int] = 50
 
 # Link types always inlined in search results (all others available via
@@ -565,11 +560,7 @@ async def _fetch_single_resource(ctx: Context, path: str) -> str:
     api = get_api(ctx)
     local_path, _, size = await cache.get_or_fetch(path, api.get_resource)
     if size > _MAX_RESOURCE_BYTES:
-        # Unlink so the cap can't be bypassed by re-reading the cache file
-        # directly; the LRU entry is left in place but ``get_or_fetch``
-        # re-fetches when the backing file is missing, re-applying the cap.
-        with contextlib.suppress(FileNotFoundError, OSError):
-            os.unlink(local_path)
+        cache.invalidate(path)
         raise ToolError(f'Resource exceeds max size ({size} > {_MAX_RESOURCE_BYTES} bytes)')
     return f'file://{local_path}'
 
@@ -652,9 +643,6 @@ async def memex_resize_image(
     except (FileNotFoundError, OSError) as exc:
         raise ToolError(f'Asset cache tempdir is unavailable: {exc}')
 
-    # ``resolve(strict=True)`` closes a TOCTOU window where a symlink could be
-    # swapped between resolution and the confinement check; raises FileNotFoundError
-    # if the path is missing.
     try:
         resolved_input = Path(local_path).resolve(strict=True)
     except FileNotFoundError:
@@ -665,11 +653,9 @@ async def memex_resize_image(
     if not resolved_input.is_relative_to(cache_root):
         raise ToolError('local_path must point inside the session asset cache')
 
-    # Decompression-bomb protection lives inside ``resize_image`` itself: it
-    # checks ``img.size`` before any pixel decoding. ValueError covers both
-    # the bomb path and format-allowlist rejections.
     try:
-        dest_path, _ = resize_image(
+        dest_path, _ = await asyncio.to_thread(
+            resize_image,
             resolved_input,
             max_width=max_width,
             max_height=max_height,
@@ -678,10 +664,8 @@ async def memex_resize_image(
     except ValueError as exc:
         raise ToolError(str(exc))
 
-    # Defense-in-depth: re-resolve the destination and re-check confinement
-    # in case a symlink was swapped during resize (TOCTOU). Also register
-    # the resized sibling with the LRU so it participates in eviction and
-    # session cleanup.
+    # Re-check confinement post-resize to close the TOCTOU window between
+    # the input resolve and Pillow's internal reopen.
     try:
         resolved_dest = dest_path.resolve(strict=True)
     except (FileNotFoundError, OSError):

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -1,12 +1,15 @@
 "FastMCP Memex server implementation"
 
+import contextlib
 import os
 import pathlib as plb
 import asyncio
 import base64
 import time
+import warnings
 from dataclasses import dataclass, field
-from typing import Annotated, Any
+from pathlib import Path
+from typing import Annotated, Any, Final
 from uuid import UUID
 import mimetypes
 
@@ -16,6 +19,7 @@ import structlog
 from fastmcp import FastMCP, Context
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 from fastmcp.exceptions import ToolError
+from PIL import Image
 
 from memex_common.asset_resize import resize_image
 from fastmcp.utilities.logging import configure_logging
@@ -73,6 +77,17 @@ from memex_common.schemas import (
 
 
 _SESSION_DEDUP_TTL = 1800  # 30 minutes
+
+# Per-asset ceiling for memex_get_resources (parity with Hermes AC-011).
+_MAX_RESOURCE_BYTES: Final[int] = 50 * 1024 * 1024
+
+# Decompression-bomb cap for memex_resize_image. Pillow's default
+# ``MAX_IMAGE_PIXELS`` (~89 MP) only emits a warning; promote the warning to
+# an error so a pathological image fails on ``Image.open`` before we allocate
+# the full pixel buffer. We keep the cap module-local rather than mutating
+# global Pillow state from inside the tool body.
+_MAX_IMAGE_PIXELS: Final[int] = 178956970
+warnings.simplefilter('error', Image.DecompressionBombWarning)
 
 # Link types always inlined in search results (all others available via
 # memex_get_memory_links on demand).
@@ -542,7 +557,14 @@ async def _fetch_single_resource(ctx: Context, path: str) -> str:
     """
     cache = get_asset_cache(ctx)
     api = get_api(ctx)
-    local_path, _, _ = await cache.get_or_fetch(path, api.get_resource)
+    local_path, _, size = await cache.get_or_fetch(path, api.get_resource)
+    if size > _MAX_RESOURCE_BYTES:
+        # Unlink so the cap can't be bypassed by re-reading the cache file
+        # directly; the LRU entry is left in place but ``get_or_fetch``
+        # re-fetches when the backing file is missing, re-applying the cap.
+        with contextlib.suppress(FileNotFoundError, OSError):
+            os.unlink(local_path)
+        raise ToolError(f'Resource exceeds max size ({size} > {_MAX_RESOURCE_BYTES} bytes)')
     return f'file://{local_path}'
 
 
@@ -607,29 +629,70 @@ async def memex_resize_image(
     ],
     max_width: Annotated[int, Field(description='Maximum output width in pixels.')] = 1280,
     max_height: Annotated[int, Field(description='Maximum output height in pixels.')] = 1280,
-    format: Annotated[
+    output_format: Annotated[
         str | None,
         Field(description='Output format override (PNG/JPEG/WEBP/GIF). Defaults to source.'),
     ] = None,
 ) -> str:
     """Resize an image inside the session asset cache. Returns the new path."""
+    if max_width <= 0 or max_height <= 0:
+        raise ToolError('max_width and max_height must be positive')
+
     cache = get_asset_cache(ctx)
-    resolved_input = plb.Path(local_path).resolve()
-    cache_root = cache.tempdir.resolve()
+    cache_root = cache.tempdir.resolve(strict=True)
+
+    # ``resolve(strict=True)`` closes a TOCTOU window where a symlink could be
+    # swapped between resolution and the confinement check; raises FileNotFoundError
+    # if the path is missing.
+    try:
+        resolved_input = Path(local_path).resolve(strict=True)
+    except FileNotFoundError:
+        raise ToolError(f'local_path does not exist: {local_path}')
+    except OSError as exc:
+        raise ToolError(f'cannot access local_path: {exc}')
 
     if not resolved_input.is_relative_to(cache_root):
         raise ToolError('local_path must point inside the session asset cache')
 
+    # Pillow only warns past ``MAX_IMAGE_PIXELS``; the module-level
+    # ``warnings.simplefilter('error', DecompressionBombWarning)`` makes the
+    # warning raise so we catch it via ValueError below.
+    prev_max = Image.MAX_IMAGE_PIXELS
+    Image.MAX_IMAGE_PIXELS = _MAX_IMAGE_PIXELS
     try:
-        dest_path, _ = resize_image(
-            resolved_input,
-            max_width=max_width,
-            max_height=max_height,
-            format=format,
-        )
-    except ValueError as exc:
-        raise ToolError(str(exc))
+        try:
+            dest_path, _ = resize_image(
+                resolved_input,
+                max_width=max_width,
+                max_height=max_height,
+                output_format=output_format,
+            )
+        except Image.DecompressionBombError as exc:
+            raise ToolError('Image is too large to safely decode') from exc
+        except Image.DecompressionBombWarning as exc:
+            raise ToolError('Image is too large to safely decode') from exc
+        except ValueError as exc:
+            raise ToolError(str(exc))
+    finally:
+        Image.MAX_IMAGE_PIXELS = prev_max
 
+    # Defense-in-depth: re-resolve the destination and re-check confinement
+    # in case a symlink was swapped during resize (TOCTOU). Also register
+    # the resized sibling with the LRU so it participates in eviction and
+    # session cleanup.
+    try:
+        resolved_dest = dest_path.resolve(strict=True)
+    except (FileNotFoundError, OSError):
+        with contextlib.suppress(FileNotFoundError, OSError):
+            os.unlink(dest_path)
+        raise ToolError('Resize destination escaped session cache')
+
+    if not resolved_dest.is_relative_to(cache_root):
+        with contextlib.suppress(FileNotFoundError, OSError):
+            os.unlink(dest_path)
+        raise ToolError('Resize destination escaped session cache')
+
+    cache.register(dest_path)
     return str(dest_path)
 
 

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -6,7 +6,7 @@ import asyncio
 import base64
 import time
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Final
+from typing import Annotated, Any
 from uuid import UUID
 import mimetypes
 
@@ -17,7 +17,7 @@ from fastmcp import FastMCP, Context
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 from fastmcp.exceptions import ToolError
 
-from memex_common.asset_cache import MAX_RESOURCE_BYTES
+from memex_common.asset_cache import MAX_GET_RESOURCES_PATHS, MAX_RESOURCE_BYTES
 from memex_common.asset_resize import validate_and_resize
 from fastmcp.utilities.logging import configure_logging
 import json
@@ -74,8 +74,6 @@ from memex_common.schemas import (
 
 
 _SESSION_DEDUP_TTL = 1800  # 30 minutes
-
-_MAX_GET_RESOURCES_PATHS: Final[int] = 50
 
 # Link types always inlined in search results (all others available via
 # memex_get_memory_links on demand).
@@ -586,8 +584,8 @@ async def memex_get_resources(
     ] = None,
 ) -> list[str]:
     """Retrieve file resources. Returns a list of file:// URIs or error strings."""
-    if len(paths) > _MAX_GET_RESOURCES_PATHS:
-        raise ToolError(f'Too many paths requested ({len(paths)} > {_MAX_GET_RESOURCES_PATHS})')
+    if len(paths) > MAX_GET_RESOURCES_PATHS:
+        raise ToolError(f'Too many paths requested ({len(paths)} > {MAX_GET_RESOURCES_PATHS})')
     try:
         api = get_api(ctx)
         vault_id = vault_id or _default_write_vault(ctx)

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -1,13 +1,11 @@
 "FastMCP Memex server implementation"
 
-import contextlib
 import os
 import pathlib as plb
 import asyncio
 import base64
 import time
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Annotated, Any, Final
 from uuid import UUID
 import mimetypes
@@ -19,7 +17,7 @@ from fastmcp import FastMCP, Context
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 from fastmcp.exceptions import ToolError
 
-from memex_common.asset_resize import resize_image
+from memex_common.asset_resize import validate_and_resize
 from fastmcp.utilities.logging import configure_logging
 import json
 
@@ -632,57 +630,21 @@ async def memex_resize_image(
         str | None,
         Field(description='Output format override (PNG/JPEG/WEBP/GIF). Defaults to source.'),
     ] = None,
-) -> str:
-    """Resize an image inside the session asset cache. Returns the new path."""
-    if max_width <= 0 or max_height <= 0:
-        raise ToolError('max_width and max_height must be positive')
-
+) -> dict[str, Any]:
+    """Resize an image inside the session asset cache."""
     cache = get_asset_cache(ctx)
     try:
-        cache_root = cache.tempdir.resolve(strict=True)
-    except (FileNotFoundError, OSError) as exc:
-        raise ToolError(f'Asset cache tempdir is unavailable: {exc}')
-
-    try:
-        resolved_input = Path(local_path).resolve(strict=True)
-    except FileNotFoundError:
-        raise ToolError(f'local_path does not exist: {local_path}')
-    except OSError as exc:
-        raise ToolError(f'cannot access local_path: {exc}')
-
-    if not resolved_input.is_relative_to(cache_root):
-        raise ToolError('local_path must point inside the session asset cache')
-
-    try:
-        dest_path, _ = await asyncio.to_thread(
-            resize_image,
-            resolved_input,
+        dest_path, size = await asyncio.to_thread(
+            validate_and_resize,
+            cache,
+            local_path,
             max_width=max_width,
             max_height=max_height,
             output_format=output_format,
         )
     except ValueError as exc:
         raise ToolError(str(exc))
-
-    # Re-check confinement post-resize to close the TOCTOU window between
-    # the input resolve and Pillow's internal reopen.
-    try:
-        resolved_dest = dest_path.resolve(strict=True)
-    except (FileNotFoundError, OSError):
-        with contextlib.suppress(FileNotFoundError, OSError):
-            os.unlink(dest_path)
-        raise ToolError('Resize destination escaped session cache')
-
-    if not resolved_dest.is_relative_to(cache_root):
-        with contextlib.suppress(FileNotFoundError, OSError):
-            os.unlink(dest_path)
-        raise ToolError('Resize destination escaped session cache')
-
-    try:
-        cache.register(dest_path)
-    except ValueError as exc:
-        raise ToolError(str(exc))
-    return str(dest_path)
+    return {'local_path': str(dest_path), 'size_bytes': size}
 
 
 @mcp.tool(

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -15,14 +15,15 @@ import httpx
 import structlog
 from fastmcp import FastMCP, Context
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
-from fastmcp.utilities.types import Image, Audio, File
 from fastmcp.exceptions import ToolError
+
+from memex_common.asset_resize import resize_image
 from fastmcp.utilities.logging import configure_logging
 import json
 
 from pydantic import BeforeValidator, Field
 
-from memex_mcp.lifespan import lifespan, get_api, get_config
+from memex_mcp.lifespan import lifespan, get_api, get_asset_cache, get_config
 from memex_mcp.models import (
     McpAddAssetsResult,
     McpAddNoteResult,
@@ -533,39 +534,24 @@ async def memex_rename_note(
         raise ToolError(f'Rename note failed: {e}')
 
 
-async def _fetch_single_resource(api: Any, path: str) -> Image | Audio | File | str:
-    """Fetch a single resource by path. Raises on failure."""
-    mime_type, _ = mimetypes.guess_type(path)
-    # SVGs are XML text — Claude's vision API can't process them as images
-    is_raster_image = (
-        mime_type is not None and mime_type.startswith('image/') and mime_type != 'image/svg+xml'
-    )
+async def _fetch_single_resource(ctx: Context, path: str) -> str:
+    """Fetch a single resource and return a ``file://`` URI to a session-cached copy.
 
-    # For local stores, return file:// URI to avoid base64 overhead
-    local_path = api.get_resource_path(path) if hasattr(api, 'get_resource_path') else None
-    if local_path and is_raster_image:
-        return f'file://{local_path}'
-
-    content_bytes = await api.get_resource(path)
-
-    if mime_type:
-        if is_raster_image:
-            return Image(data=content_bytes, format=mime_type.split('/')[-1])
-        elif mime_type.startswith('audio/'):
-            return Audio(data=content_bytes, format=mime_type.split('/')[-1])
-
-    path_obj = plb.Path(path)
-    filename = path_obj.name
-    ext = path_obj.suffix.lstrip('.') if path_obj.suffix else None
-
-    return File(data=content_bytes, name=filename, format=ext)
+    Bytes are written into the session ``SessionAssetCache`` so the agent can
+    ``Read`` the asset directly off disk instead of getting it inlined as base64.
+    """
+    cache = get_asset_cache(ctx)
+    api = get_api(ctx)
+    local_path, _, _ = await cache.get_or_fetch(path, api.get_resource)
+    return f'file://{local_path}'
 
 
 @mcp.tool(
     name='memex_get_resources',
     description=(
         'Retrieve 1+ file attachments (images, audio, documents) by path. '
-        'View or download assets attached to notes. '
+        'Returns local file paths the agent must `Read` directly. '
+        'Use `memex_resize_image` if the asset is too large to forward. '
         'Get paths from memex_list_assets. Accepts a single path or a list.'
     ),
     tags={'assets'},
@@ -581,17 +567,17 @@ async def memex_get_resources(
         str | None,
         Field(description='Vault UUID or name. Omit to use config defaults.'),
     ] = None,
-) -> list[Image | Audio | File | str]:
-    """Retrieve file resources. Returns a list of Image, Audio, File, or error strings."""
+) -> list[str]:
+    """Retrieve file resources. Returns a list of file:// URIs or error strings."""
     try:
         api = get_api(ctx)
         vault_id = vault_id or _default_write_vault(ctx)
         await _resolve_vault_id(api, vault_id)
 
-        results: list[Image | Audio | File | str] = []
+        results: list[str] = []
         for path in paths:
             try:
-                results.append(await _fetch_single_resource(api, path))
+                results.append(await _fetch_single_resource(ctx, path))
             except Exception as exc:
                 results.append(f'Error fetching {path}: {exc}')
 
@@ -600,6 +586,51 @@ async def memex_get_resources(
     except Exception as e:
         logger.error(f'Get resource failed: {e}', exc_info=True)
         raise ToolError(f'Failed to retrieve resources: {e}')
+
+
+@mcp.tool(
+    name='memex_resize_image',
+    description=(
+        'Resize an image previously fetched via `memex_get_resources` so it can '
+        'be forwarded inline. The input MUST be a path under the session asset '
+        'cache; arbitrary filesystem paths are rejected. Returns the resized '
+        'file path. Allowed input formats: PNG, JPEG, WEBP, GIF.'
+    ),
+    tags={'assets'},
+    annotations={'readOnlyHint': False},
+)
+async def memex_resize_image(
+    ctx: Context,
+    local_path: Annotated[
+        str,
+        Field(description='Path returned by memex_get_resources (under session cache).'),
+    ],
+    max_width: Annotated[int, Field(description='Maximum output width in pixels.')] = 1280,
+    max_height: Annotated[int, Field(description='Maximum output height in pixels.')] = 1280,
+    format: Annotated[
+        str | None,
+        Field(description='Output format override (PNG/JPEG/WEBP/GIF). Defaults to source.'),
+    ] = None,
+) -> str:
+    """Resize an image inside the session asset cache. Returns the new path."""
+    cache = get_asset_cache(ctx)
+    resolved_input = plb.Path(local_path).resolve()
+    cache_root = cache.tempdir.resolve()
+
+    if not resolved_input.is_relative_to(cache_root):
+        raise ToolError('local_path must point inside the session asset cache')
+
+    try:
+        dest_path, _ = resize_image(
+            resolved_input,
+            max_width=max_width,
+            max_height=max_height,
+            format=format,
+        )
+    except ValueError as exc:
+        raise ToolError(str(exc))
+
+    return str(dest_path)
 
 
 @mcp.tool(

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -17,6 +17,7 @@ from fastmcp import FastMCP, Context
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 from fastmcp.exceptions import ToolError
 
+from memex_common.asset_cache import MAX_RESOURCE_BYTES
 from memex_common.asset_resize import validate_and_resize
 from fastmcp.utilities.logging import configure_logging
 import json
@@ -74,7 +75,6 @@ from memex_common.schemas import (
 
 _SESSION_DEDUP_TTL = 1800  # 30 minutes
 
-_MAX_RESOURCE_BYTES: Final[int] = 50 * 1024 * 1024
 _MAX_GET_RESOURCES_PATHS: Final[int] = 50
 
 # Link types always inlined in search results (all others available via
@@ -557,9 +557,9 @@ async def _fetch_single_resource(ctx: Context, path: str) -> str:
     cache = get_asset_cache(ctx)
     api = get_api(ctx)
     local_path, _, size = await cache.get_or_fetch(path, api.get_resource)
-    if size > _MAX_RESOURCE_BYTES:
+    if size > MAX_RESOURCE_BYTES:
         cache.invalidate(path)
-        raise ToolError(f'Resource exceeds max size ({size} > {_MAX_RESOURCE_BYTES} bytes)')
+        raise ToolError(f'Resource exceeds max size ({size} > {MAX_RESOURCE_BYTES} bytes)')
     return f'file://{local_path}'
 
 

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -6,7 +6,6 @@ import pathlib as plb
 import asyncio
 import base64
 import time
-import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Annotated, Any, Final
@@ -19,7 +18,6 @@ import structlog
 from fastmcp import FastMCP, Context
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 from fastmcp.exceptions import ToolError
-from PIL import Image
 
 from memex_common.asset_resize import resize_image
 from fastmcp.utilities.logging import configure_logging
@@ -81,13 +79,10 @@ _SESSION_DEDUP_TTL = 1800  # 30 minutes
 # Per-asset ceiling for memex_get_resources (parity with Hermes AC-011).
 _MAX_RESOURCE_BYTES: Final[int] = 50 * 1024 * 1024
 
-# Decompression-bomb cap for memex_resize_image. Pillow's default
-# ``MAX_IMAGE_PIXELS`` (~89 MP) only emits a warning; promote the warning to
-# an error so a pathological image fails on ``Image.open`` before we allocate
-# the full pixel buffer. We keep the cap module-local rather than mutating
-# global Pillow state from inside the tool body.
-_MAX_IMAGE_PIXELS: Final[int] = 178956970
-warnings.simplefilter('error', Image.DecompressionBombWarning)
+# Hard cap on the number of paths a single memex_get_resources call can
+# request (parity with Hermes). Stops a misbehaving caller from fanning
+# out an unbounded sequence of fetches.
+_MAX_GET_RESOURCES_PATHS: Final[int] = 50
 
 # Link types always inlined in search results (all others available via
 # memex_get_memory_links on demand).
@@ -591,6 +586,8 @@ async def memex_get_resources(
     ] = None,
 ) -> list[str]:
     """Retrieve file resources. Returns a list of file:// URIs or error strings."""
+    if len(paths) > _MAX_GET_RESOURCES_PATHS:
+        raise ToolError(f'Too many paths requested ({len(paths)} > {_MAX_GET_RESOURCES_PATHS})')
     try:
         api = get_api(ctx)
         vault_id = vault_id or _default_write_vault(ctx)
@@ -639,7 +636,10 @@ async def memex_resize_image(
         raise ToolError('max_width and max_height must be positive')
 
     cache = get_asset_cache(ctx)
-    cache_root = cache.tempdir.resolve(strict=True)
+    try:
+        cache_root = cache.tempdir.resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise ToolError(f'Asset cache tempdir is unavailable: {exc}')
 
     # ``resolve(strict=True)`` closes a TOCTOU window where a symlink could be
     # swapped between resolution and the confinement check; raises FileNotFoundError
@@ -654,27 +654,18 @@ async def memex_resize_image(
     if not resolved_input.is_relative_to(cache_root):
         raise ToolError('local_path must point inside the session asset cache')
 
-    # Pillow only warns past ``MAX_IMAGE_PIXELS``; the module-level
-    # ``warnings.simplefilter('error', DecompressionBombWarning)`` makes the
-    # warning raise so we catch it via ValueError below.
-    prev_max = Image.MAX_IMAGE_PIXELS
-    Image.MAX_IMAGE_PIXELS = _MAX_IMAGE_PIXELS
+    # Decompression-bomb protection lives inside ``resize_image`` itself: it
+    # checks ``img.size`` before any pixel decoding. ValueError covers both
+    # the bomb path and format-allowlist rejections.
     try:
-        try:
-            dest_path, _ = resize_image(
-                resolved_input,
-                max_width=max_width,
-                max_height=max_height,
-                output_format=output_format,
-            )
-        except Image.DecompressionBombError as exc:
-            raise ToolError('Image is too large to safely decode') from exc
-        except Image.DecompressionBombWarning as exc:
-            raise ToolError('Image is too large to safely decode') from exc
-        except ValueError as exc:
-            raise ToolError(str(exc))
-    finally:
-        Image.MAX_IMAGE_PIXELS = prev_max
+        dest_path, _ = resize_image(
+            resolved_input,
+            max_width=max_width,
+            max_height=max_height,
+            output_format=output_format,
+        )
+    except ValueError as exc:
+        raise ToolError(str(exc))
 
     # Defense-in-depth: re-resolve the destination and re-check confinement
     # in case a symlink was swapped during resize (TOCTOU). Also register
@@ -692,7 +683,10 @@ async def memex_resize_image(
             os.unlink(dest_path)
         raise ToolError('Resize destination escaped session cache')
 
-    cache.register(dest_path)
+    try:
+        cache.register(dest_path)
+    except ValueError as exc:
+        raise ToolError(str(exc))
     return str(dest_path)
 
 

--- a/packages/mcp/tests/conftest.py
+++ b/packages/mcp/tests/conftest.py
@@ -100,12 +100,7 @@ async def _mock_lifespan(_server):
     """No-op lifespan that skips the HTTP health check."""
     ctx = AppContext(config=MemexConfig())
     ctx._api = AsyncMock()
-    ctx._asset_cache = SessionAssetCache()
-    try:
-        yield ctx
-    finally:
-        if ctx._asset_cache is not None:
-            ctx._asset_cache.cleanup()
+    yield ctx
 
 
 @pytest.fixture(autouse=True)

--- a/packages/mcp/tests/conftest.py
+++ b/packages/mcp/tests/conftest.py
@@ -1,10 +1,12 @@
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from fastmcp import Client
 from memex_mcp.server import mcp
 from memex_mcp.models import AppContext
+from memex_common.asset_cache import SessionAssetCache
 from memex_common.config import MemexConfig
 
 
@@ -48,6 +50,33 @@ def mock_api():
 
 
 @pytest.fixture
+def asset_cache(tmp_path: Path):
+    """Real SessionAssetCache rooted in tmp_path, patched in for MCP tools."""
+    cache = SessionAssetCache(tempdir=tmp_path / 'asset-cache')
+    with patch('memex_mcp.server.get_asset_cache', return_value=cache):
+        yield cache
+    cache.cleanup()
+
+
+@pytest.fixture(autouse=True)
+def _autouse_asset_cache(request):
+    """Auto-provide a stub SessionAssetCache for tests that don't request it.
+
+    Tools that fetch resources patch ``get_asset_cache`` and expect a real
+    cache. Tests that don't touch the cache get an isolated tempdir under
+    the pytest tmp factory.
+    """
+    if 'asset_cache' in request.fixturenames:
+        yield
+        return
+    tmp_path_factory = request.getfixturevalue('tmp_path_factory')
+    cache = SessionAssetCache(tempdir=tmp_path_factory.mktemp('mcp-cache'))
+    with patch('memex_mcp.server.get_asset_cache', return_value=cache):
+        yield
+    cache.cleanup()
+
+
+@pytest.fixture
 def mock_config():
     """Mock MemexConfig for tools that use get_config (e.g. vault defaults)."""
     config = MagicMock()
@@ -71,7 +100,12 @@ async def _mock_lifespan(_server):
     """No-op lifespan that skips the HTTP health check."""
     ctx = AppContext(config=MemexConfig())
     ctx._api = AsyncMock()
-    yield ctx
+    ctx._asset_cache = SessionAssetCache()
+    try:
+        yield ctx
+    finally:
+        if ctx._asset_cache is not None:
+            ctx._asset_cache.cleanup()
 
 
 @pytest.fixture(autouse=True)

--- a/packages/mcp/tests/test_edge_cases.py
+++ b/packages/mcp/tests/test_edge_cases.py
@@ -1132,7 +1132,7 @@ class TestUUIDFormats:
 
 
 # Need AsyncMock / MagicMock for vault resolution + resource tests
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1141,56 +1141,38 @@ from unittest.mock import AsyncMock, MagicMock
 
 
 class TestSVGResourceHandling:
-    """SVGs should be returned as File objects, not Image objects."""
+    """All asset fetches now return file:// URIs to a session-cached copy."""
 
     @pytest.mark.asyncio
-    async def test_svg_local_path_not_returned_as_file_uri(self, mock_api, mcp_client):
-        """SVG with local path should NOT get file:// URI (that's for raster images only)."""
-        mock_api.get_resource_path = MagicMock(return_value='/data/images/diagram.svg')
-        mock_api.get_resource.return_value = b'<svg>...</svg>'
+    async def test_svg_returned_as_file_uri(self, mock_api, asset_cache, mcp_client):
+        """SVGs flow through the session cache and come back as file:// URIs."""
+        mock_api.get_resource = AsyncMock(return_value=b'<svg>...</svg>')
 
         result = await mcp_client.call_tool(
             'memex_get_resources', {'paths': ['images/diagram.svg'], 'vault_id': 'test-vault'}
         )
 
-        # Should fall through to get_resource and return as File, not file:// URI
-        contents = result.content
-        assert len(contents) >= 1
-        # Should NOT be a plain text file:// URI
-        text_contents = [c for c in contents if hasattr(c, 'text')]
-        for tc in text_contents:
-            assert 'file://' not in tc.text or 'Error' in tc.text
+        items = parse_tool_result(result)
+        assert isinstance(items, list)
+        assert len(items) == 1
+        assert items[0].startswith('file://')
 
     @pytest.mark.asyncio
-    async def test_svg_remote_returned_as_file_not_image(self, mock_api, mcp_client):
-        """SVG without local path should be returned as File (EmbeddedResource), not Image."""
-        mock_api.get_resource_path = MagicMock(return_value=None)
-        mock_api.get_resource.return_value = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
-
-        result = await mcp_client.call_tool(
-            'memex_get_resources', {'paths': ['assets/chart.svg'], 'vault_id': 'test-vault'}
-        )
-
-        contents = result.content
-        assert len(contents) >= 1
-        # Should be an EmbeddedResource (File), not an Image
-        resource_contents = [c for c in contents if c.type == 'resource']
-        image_contents = [c for c in contents if c.type == 'image']
-        assert len(resource_contents) == 1, 'SVG should be returned as EmbeddedResource'
-        assert len(image_contents) == 0, 'SVG should NOT be returned as Image'
-
-    @pytest.mark.asyncio
-    async def test_png_still_returned_as_image_uri(self, mock_api, mcp_client):
-        """Raster images (PNG) should still get file:// URI treatment."""
-        mock_api.get_resource_path = MagicMock(return_value='/data/images/photo.png')
+    async def test_png_returned_as_file_uri(self, mock_api, asset_cache, mcp_client):
+        """Raster images also become file:// URIs to a cached copy under the session tempdir."""
+        mock_api.get_resource = AsyncMock(return_value=b'\x89PNG\r\n\x1a\n')
 
         result = await mcp_client.call_tool(
             'memex_get_resources', {'paths': ['images/photo.png'], 'vault_id': 'test-vault'}
         )
 
-        texts = [c.text for c in result.content if hasattr(c, 'text')]
-        combined = ' '.join(texts)
-        assert 'file:///data/images/photo.png' in combined
+        from pathlib import Path
+
+        items = parse_tool_result(result)
+        assert isinstance(items, list) and len(items) == 1
+        assert items[0].startswith('file://')
+        local = Path(items[0].removeprefix('file://')).resolve()
+        assert local.is_relative_to(asset_cache.tempdir.resolve())
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/packages/mcp/tests/test_mcp_integration.py
+++ b/packages/mcp/tests/test_mcp_integration.py
@@ -1,6 +1,6 @@
 import datetime as dt
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4, UUID
 
 from fastmcp import Client
@@ -54,7 +54,6 @@ async def test_integration_search_assets_resource(mock_api):
     )
 
     # 3. Setup Resource Data (for Get Resource)
-    mock_api.get_resource_path = MagicMock(return_value='/data/assets/arch.png')
     mock_api.get_resource.return_value = b'fake_image_bytes'
 
     async with Client(mcp) as client:
@@ -73,13 +72,16 @@ async def test_integration_search_assets_resource(mock_api):
         assert any(a['filename'] == 'arch.png' for a in assets_data)
         assert any(a['path'] == 'assets/arch.png' for a in assets_data)
 
-        # Step 3: Get Resource (batch)
-        await client.call_tool(
+        # Step 3: Get Resource (batch) — disk-handoff fetches via api.get_resource
+        get_result = await client.call_tool(
             'memex_get_resources', {'paths': ['assets/arch.png'], 'vault_id': 'test-vault'}
         )
 
-        # Verify it returns file:// URI for local images
-        mock_api.get_resource_path.assert_called_once_with('assets/arch.png')
+        # New disk-handoff: agent gets a file:// URI to a session-cached copy
+        mock_api.get_resource.assert_awaited_once_with('assets/arch.png')
+        items = parse_tool_result(get_result)
+        assert isinstance(items, list)
+        assert any(s.startswith('file://') for s in items)
 
 
 @pytest.mark.asyncio

--- a/packages/mcp/tests/test_resize.py
+++ b/packages/mcp/tests/test_resize.py
@@ -1,0 +1,68 @@
+"""Tests for the memex_resize_image MCP tool."""
+
+import pytest
+from pathlib import Path
+
+from PIL import Image
+from fastmcp.exceptions import ToolError
+
+
+def _write_png(path: Path, size: tuple[int, int] = (2048, 1536)) -> None:
+    """Write a deterministic PNG of ``size`` to ``path``."""
+    Image.new('RGB', size, color=(255, 0, 0)).save(path, format='PNG')
+
+
+@pytest.mark.asyncio
+async def test_resize_writes_smaller_file(asset_cache, mcp_client):
+    """Happy path: resizing a cached PNG produces a smaller sibling file."""
+    src = asset_cache.tempdir / 'big.png'
+    _write_png(src, size=(2048, 1536))
+    src_size = src.stat().st_size
+
+    result = await mcp_client.call_tool(
+        'memex_resize_image',
+        {'local_path': str(src), 'max_width': 512, 'max_height': 512},
+    )
+
+    assert len(result.content) == 1
+    dest_path = Path(result.content[0].text)
+    assert dest_path.exists()
+    assert dest_path.stat().st_size < src_size
+    assert dest_path.is_relative_to(asset_cache.tempdir)
+
+
+@pytest.mark.asyncio
+async def test_resize_rejects_path_outside_tempdir(asset_cache, mcp_client):
+    """AC-009: paths outside the session cache are rejected with ToolError."""
+    with pytest.raises(ToolError, match='session asset cache'):
+        await mcp_client.call_tool(
+            'memex_resize_image',
+            {'local_path': '/etc/passwd'},
+        )
+
+
+@pytest.mark.asyncio
+async def test_resize_rejects_path_via_relative_traversal(asset_cache, tmp_path, mcp_client):
+    """AC-009: a `..` traversal that escapes the cache is rejected after resolve()."""
+    escape_target = tmp_path / 'escape.png'
+    _write_png(escape_target, size=(64, 64))
+    traversal = str(asset_cache.tempdir / '..' / 'escape.png')
+
+    with pytest.raises(ToolError, match='session asset cache'):
+        await mcp_client.call_tool(
+            'memex_resize_image',
+            {'local_path': traversal},
+        )
+
+
+@pytest.mark.asyncio
+async def test_resize_rejects_unsupported_format(asset_cache, mcp_client):
+    """Unsupported source format raises ToolError carrying the helper's message."""
+    svg = asset_cache.tempdir / 'diagram.svg'
+    svg.write_text('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+
+    with pytest.raises(ToolError, match='Unsupported'):
+        await mcp_client.call_tool(
+            'memex_resize_image',
+            {'local_path': str(svg)},
+        )

--- a/packages/mcp/tests/test_resize.py
+++ b/packages/mcp/tests/test_resize.py
@@ -1,5 +1,6 @@
 """Tests for the memex_resize_image MCP tool."""
 
+import json
 import pytest
 from pathlib import Path
 
@@ -25,10 +26,12 @@ async def test_resize_writes_smaller_file(asset_cache, mcp_client):
     )
 
     assert len(result.content) == 1
-    dest_path = Path(result.content[0].text)
+    payload = json.loads(result.content[0].text)
+    dest_path = Path(payload['local_path'])
     assert dest_path.exists()
     assert dest_path.stat().st_size < src_size
     assert dest_path.is_relative_to(asset_cache.tempdir)
+    assert payload['size_bytes'] == dest_path.stat().st_size
 
 
 @pytest.mark.asyncio

--- a/packages/mcp/tests/test_resize_security.py
+++ b/packages/mcp/tests/test_resize_security.py
@@ -13,6 +13,7 @@ Each test in this module proves a specific Phase 3 adversarial finding:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -22,6 +23,10 @@ from fastmcp.exceptions import ToolError
 
 from memex_mcp.server import _MAX_GET_RESOURCES_PATHS, _MAX_RESOURCE_BYTES
 from helpers import parse_tool_result
+
+
+def _resize_payload(result) -> dict:
+    return json.loads(result.content[0].text)
 
 
 def _write_png(path: Path, size: tuple[int, int] = (64, 64)) -> Path:
@@ -157,14 +162,13 @@ async def test_resize_post_check_rejects_dest_outside_cache(asset_cache, mcp_cli
     def _fake_resize(*_args, **_kwargs):
         return rogue, rogue.stat().st_size
 
-    with patch('memex_mcp.server.resize_image', side_effect=_fake_resize):
+    with patch('memex_common.asset_resize.resize_image', side_effect=_fake_resize):
         with pytest.raises(ToolError, match='escaped session cache'):
             await mcp_client.call_tool(
                 'memex_resize_image',
                 {'local_path': str(src), 'max_width': 32, 'max_height': 32},
             )
 
-    # The post-check must unlink the bogus destination so it doesn't linger.
     assert not rogue.exists()
 
 
@@ -180,8 +184,9 @@ async def test_resize_registers_dest_in_cache(asset_cache, mcp_client):
         'memex_resize_image',
         {'local_path': str(src), 'max_width': 64, 'max_height': 64},
     )
-    dest_str = result.content[0].text
-    assert dest_str in asset_cache, f'{dest_str!r} not registered in {asset_cache!r}'
+    payload = _resize_payload(result)
+    assert payload['local_path'] in asset_cache
+    assert payload['size_bytes'] > 0
 
 
 # Finding 11 -----------------------------------------------------------------
@@ -201,6 +206,8 @@ async def test_resize_accepts_output_format_kwarg(asset_cache, mcp_client):
             'output_format': 'JPEG',
         },
     )
-    dest = Path(result.content[0].text)
+    payload = _resize_payload(result)
+    dest = Path(payload['local_path'])
     assert dest.exists()
     assert dest.suffix == '.jpg'
+    assert payload['size_bytes'] == dest.stat().st_size

--- a/packages/mcp/tests/test_resize_security.py
+++ b/packages/mcp/tests/test_resize_security.py
@@ -20,7 +20,7 @@ import pytest
 from PIL import Image
 from fastmcp.exceptions import ToolError
 
-from memex_mcp.server import _MAX_RESOURCE_BYTES
+from memex_mcp.server import _MAX_GET_RESOURCES_PATHS, _MAX_RESOURCE_BYTES
 from helpers import parse_tool_result
 
 
@@ -90,17 +90,31 @@ async def test_resize_rejects_negative_dimensions(asset_cache, mcp_client, mw, m
 
 @pytest.mark.asyncio
 async def test_resize_rejects_decompression_bomb(asset_cache, mcp_client):
-    """Image whose pixel count exceeds ``Image.MAX_IMAGE_PIXELS`` raises a
-    ``DecompressionBombWarning`` that we promote to ``ToolError``."""
-    src = _write_png(asset_cache.tempdir / 'bomb.png', size=(50, 50))  # 2500 px
+    """An image whose pixel count exceeds the shared ``_MAX_DECODED_PIXELS``
+    budget must be rejected by ``resize_image`` before any pixels are
+    decoded — surfacing as a clean ``ToolError`` to the caller."""
+    # 200x200 = 40k pixels, well above the patched cap below.
+    src = _write_png(asset_cache.tempdir / 'bomb.png', size=(200, 200))
 
-    # Temporarily lower the cap so a 2500-pixel image trips the warning.
-    with patch('memex_mcp.server._MAX_IMAGE_PIXELS', 100):
+    with patch('memex_common.asset_resize._MAX_DECODED_PIXELS', 1000):
         with pytest.raises(ToolError, match='too large to safely decode'):
             await mcp_client.call_tool(
                 'memex_resize_image',
                 {'local_path': str(src), 'max_width': 16, 'max_height': 16},
             )
+
+
+@pytest.mark.asyncio
+async def test_get_resources_rejects_too_many_paths(asset_cache, mcp_client):
+    """Parity with Hermes: a paths list above ``_MAX_GET_RESOURCES_PATHS``
+    is rejected up front so a misbehaving caller cannot fan out unbounded
+    fetches."""
+    paths = [f'images/asset-{i}.png' for i in range(_MAX_GET_RESOURCES_PATHS + 1)]
+    with pytest.raises(ToolError, match='Too many paths'):
+        await mcp_client.call_tool(
+            'memex_get_resources',
+            {'paths': paths, 'vault_id': 'test-vault'},
+        )
 
 
 # Finding 10 -----------------------------------------------------------------

--- a/packages/mcp/tests/test_resize_security.py
+++ b/packages/mcp/tests/test_resize_security.py
@@ -21,8 +21,7 @@ import pytest
 from PIL import Image
 from fastmcp.exceptions import ToolError
 
-from memex_common.asset_cache import MAX_RESOURCE_BYTES
-from memex_mcp.server import _MAX_GET_RESOURCES_PATHS
+from memex_common.asset_cache import MAX_GET_RESOURCES_PATHS, MAX_RESOURCE_BYTES
 from helpers import parse_tool_result
 
 
@@ -133,10 +132,10 @@ async def test_resize_rejects_decompression_bomb(asset_cache, mcp_client):
 
 @pytest.mark.asyncio
 async def test_get_resources_rejects_too_many_paths(asset_cache, mcp_client):
-    """Parity with Hermes: a paths list above ``_MAX_GET_RESOURCES_PATHS``
+    """Parity with Hermes: a paths list above ``MAX_GET_RESOURCES_PATHS``
     is rejected up front so a misbehaving caller cannot fan out unbounded
     fetches."""
-    paths = [f'images/asset-{i}.png' for i in range(_MAX_GET_RESOURCES_PATHS + 1)]
+    paths = [f'images/asset-{i}.png' for i in range(MAX_GET_RESOURCES_PATHS + 1)]
     with pytest.raises(ToolError, match='Too many paths'):
         await mcp_client.call_tool(
             'memex_get_resources',

--- a/packages/mcp/tests/test_resize_security.py
+++ b/packages/mcp/tests/test_resize_security.py
@@ -52,6 +52,27 @@ async def test_get_resources_oversize_rejected_after_download(mock_api, asset_ca
     assert str(_MAX_RESOURCE_BYTES) in msg
 
 
+@pytest.mark.asyncio
+async def test_oversize_path_invalidated_so_retry_refetches(mock_api, asset_cache, mcp_client):
+    """A rejected oversize asset must be evicted from the cache; a second
+    call for the same path must re-invoke the underlying fetch rather than
+    serve a stale tracked-but-missing entry."""
+    big_blob = b'\x00' * (_MAX_RESOURCE_BYTES + 1)
+    mock_api.get_resource = AsyncMock(return_value=big_blob)
+
+    await mcp_client.call_tool(
+        'memex_get_resources',
+        {'paths': ['images/huge.bin'], 'vault_id': 'test-vault'},
+    )
+    assert 'images/huge.bin' not in asset_cache
+
+    await mcp_client.call_tool(
+        'memex_get_resources',
+        {'paths': ['images/huge.bin'], 'vault_id': 'test-vault'},
+    )
+    assert mock_api.get_resource.call_count == 2
+
+
 # Finding 2 ------------------------------------------------------------------
 
 

--- a/packages/mcp/tests/test_resize_security.py
+++ b/packages/mcp/tests/test_resize_security.py
@@ -21,7 +21,8 @@ import pytest
 from PIL import Image
 from fastmcp.exceptions import ToolError
 
-from memex_mcp.server import _MAX_GET_RESOURCES_PATHS, _MAX_RESOURCE_BYTES
+from memex_common.asset_cache import MAX_RESOURCE_BYTES
+from memex_mcp.server import _MAX_GET_RESOURCES_PATHS
 from helpers import parse_tool_result
 
 
@@ -39,9 +40,9 @@ def _write_png(path: Path, size: tuple[int, int] = (64, 64)) -> Path:
 
 @pytest.mark.asyncio
 async def test_get_resources_oversize_rejected_after_download(mock_api, asset_cache, mcp_client):
-    """A response exceeding ``_MAX_RESOURCE_BYTES`` is reported as an error
+    """A response exceeding ``MAX_RESOURCE_BYTES`` is reported as an error
     string (the wrapper turns ToolError into an entry in the result list)."""
-    big_blob = b'\x00' * (_MAX_RESOURCE_BYTES + 1)
+    big_blob = b'\x00' * (MAX_RESOURCE_BYTES + 1)
     mock_api.get_resource = AsyncMock(return_value=big_blob)
 
     result = await mcp_client.call_tool(
@@ -54,7 +55,7 @@ async def test_get_resources_oversize_rejected_after_download(mock_api, asset_ca
     msg = items[0]
     assert msg.startswith('Error fetching ')
     assert 'Resource exceeds max size' in msg
-    assert str(_MAX_RESOURCE_BYTES) in msg
+    assert str(MAX_RESOURCE_BYTES) in msg
 
 
 @pytest.mark.asyncio
@@ -62,7 +63,7 @@ async def test_oversize_path_invalidated_so_retry_refetches(mock_api, asset_cach
     """A rejected oversize asset must be evicted from the cache; a second
     call for the same path must re-invoke the underlying fetch rather than
     serve a stale tracked-but-missing entry."""
-    big_blob = b'\x00' * (_MAX_RESOURCE_BYTES + 1)
+    big_blob = b'\x00' * (MAX_RESOURCE_BYTES + 1)
     mock_api.get_resource = AsyncMock(return_value=big_blob)
 
     await mcp_client.call_tool(

--- a/packages/mcp/tests/test_resize_security.py
+++ b/packages/mcp/tests/test_resize_security.py
@@ -154,13 +154,15 @@ async def test_resize_post_check_rejects_dest_outside_cache(asset_cache, mcp_cli
     and unlinks the offending file."""
     src = _write_png(asset_cache.tempdir / 'src.png', size=(64, 64))
 
-    # Drop a real PNG outside the cache that the patched resize_image will
-    # claim to have produced.
     rogue = tmp_path / 'rogue.png'
     _write_png(rogue, size=(16, 16))
     assert rogue.exists()
+    assert not rogue.is_relative_to(asset_cache.tempdir)
+
+    captured: list[Path] = []
 
     def _fake_resize(*_args, **_kwargs):
+        captured.append(rogue)
         return rogue, rogue.stat().st_size
 
     with patch('memex_common.asset_resize.resize_image', side_effect=_fake_resize):
@@ -170,7 +172,11 @@ async def test_resize_post_check_rejects_dest_outside_cache(asset_cache, mcp_cli
                 {'local_path': str(src), 'max_width': 32, 'max_height': 32},
             )
 
+    # The rogue path returned by the patched resize_image is the one that
+    # validate_and_resize must unlink — verify that explicitly.
+    assert captured == [rogue]
     assert not rogue.exists()
+    assert rogue not in asset_cache
 
 
 # Finding 4 ------------------------------------------------------------------

--- a/packages/mcp/tests/test_resize_security.py
+++ b/packages/mcp/tests/test_resize_security.py
@@ -1,0 +1,171 @@
+"""Security/hardening tests for ``memex_get_resources`` and ``memex_resize_image``.
+
+Each test in this module proves a specific Phase 3 adversarial finding:
+
+- Finding 1  : per-asset 50 MiB size cap on get_resources.
+- Finding 2  : ``resolve(strict=True)`` + clean ToolError on missing path.
+- Finding 6  : positive-dimension validation.
+- Finding 7  : decompression-bomb protection.
+- Finding 10 : post-resize TOCTOU re-check.
+- Finding 11 : ``format`` parameter renamed to ``output_format``.
+- Finding 4  : resized destination registered into the LRU cache.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from PIL import Image
+from fastmcp.exceptions import ToolError
+
+from memex_mcp.server import _MAX_RESOURCE_BYTES
+from helpers import parse_tool_result
+
+
+def _write_png(path: Path, size: tuple[int, int] = (64, 64)) -> Path:
+    Image.new('RGB', size, color=(0, 128, 255)).save(path, format='PNG')
+    return path
+
+
+# Finding 1 ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_resources_oversize_rejected_after_download(mock_api, asset_cache, mcp_client):
+    """A response exceeding ``_MAX_RESOURCE_BYTES`` is reported as an error
+    string (the wrapper turns ToolError into an entry in the result list)."""
+    big_blob = b'\x00' * (_MAX_RESOURCE_BYTES + 1)
+    mock_api.get_resource = AsyncMock(return_value=big_blob)
+
+    result = await mcp_client.call_tool(
+        'memex_get_resources',
+        {'paths': ['images/huge.bin'], 'vault_id': 'test-vault'},
+    )
+    items = parse_tool_result(result)
+    assert isinstance(items, list)
+    assert len(items) == 1
+    msg = items[0]
+    assert msg.startswith('Error fetching ')
+    assert 'Resource exceeds max size' in msg
+    assert str(_MAX_RESOURCE_BYTES) in msg
+
+
+# Finding 2 ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resize_rejects_nonexistent_path(asset_cache, mcp_client):
+    """``resolve(strict=True)`` should surface a clean ``ToolError`` instead
+    of leaking ``FileNotFoundError`` from underneath."""
+    missing = asset_cache.tempdir / 'does-not-exist.png'
+    with pytest.raises(ToolError, match='does not exist'):
+        await mcp_client.call_tool(
+            'memex_resize_image',
+            {'local_path': str(missing)},
+        )
+
+
+# Finding 6 ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'mw, mh',
+    [(0, 64), (64, 0), (-1, 64), (64, -1)],
+)
+async def test_resize_rejects_negative_dimensions(asset_cache, mcp_client, mw, mh):
+    """Zero and negative dimensions must be rejected before Pillow is invoked."""
+    src = _write_png(asset_cache.tempdir / 'tiny.png', size=(32, 32))
+    with pytest.raises(ToolError, match='positive'):
+        await mcp_client.call_tool(
+            'memex_resize_image',
+            {'local_path': str(src), 'max_width': mw, 'max_height': mh},
+        )
+
+
+# Finding 7 ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resize_rejects_decompression_bomb(asset_cache, mcp_client):
+    """Image whose pixel count exceeds ``Image.MAX_IMAGE_PIXELS`` raises a
+    ``DecompressionBombWarning`` that we promote to ``ToolError``."""
+    src = _write_png(asset_cache.tempdir / 'bomb.png', size=(50, 50))  # 2500 px
+
+    # Temporarily lower the cap so a 2500-pixel image trips the warning.
+    with patch('memex_mcp.server._MAX_IMAGE_PIXELS', 100):
+        with pytest.raises(ToolError, match='too large to safely decode'):
+            await mcp_client.call_tool(
+                'memex_resize_image',
+                {'local_path': str(src), 'max_width': 16, 'max_height': 16},
+            )
+
+
+# Finding 10 -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resize_post_check_rejects_dest_outside_cache(asset_cache, mcp_client, tmp_path):
+    """If ``resize_image`` (or a symlink swap during it) returns a path
+    outside the session cache, the post-resize confinement check rejects it
+    and unlinks the offending file."""
+    src = _write_png(asset_cache.tempdir / 'src.png', size=(64, 64))
+
+    # Drop a real PNG outside the cache that the patched resize_image will
+    # claim to have produced.
+    rogue = tmp_path / 'rogue.png'
+    _write_png(rogue, size=(16, 16))
+    assert rogue.exists()
+
+    def _fake_resize(*_args, **_kwargs):
+        return rogue, rogue.stat().st_size
+
+    with patch('memex_mcp.server.resize_image', side_effect=_fake_resize):
+        with pytest.raises(ToolError, match='escaped session cache'):
+            await mcp_client.call_tool(
+                'memex_resize_image',
+                {'local_path': str(src), 'max_width': 32, 'max_height': 32},
+            )
+
+    # The post-check must unlink the bogus destination so it doesn't linger.
+    assert not rogue.exists()
+
+
+# Finding 4 ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resize_registers_dest_in_cache(asset_cache, mcp_client):
+    """A successful resize must register the destination in the LRU so it
+    participates in eviction and session cleanup."""
+    src = _write_png(asset_cache.tempdir / 'ok.png', size=(256, 256))
+    result = await mcp_client.call_tool(
+        'memex_resize_image',
+        {'local_path': str(src), 'max_width': 64, 'max_height': 64},
+    )
+    dest_str = result.content[0].text
+    assert dest_str in asset_cache, f'{dest_str!r} not registered in {asset_cache!r}'
+
+
+# Finding 11 -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resize_accepts_output_format_kwarg(asset_cache, mcp_client):
+    """The renamed parameter is the public name; calling with
+    ``output_format`` must succeed end-to-end."""
+    src = _write_png(asset_cache.tempdir / 'src.png', size=(128, 128))
+    result = await mcp_client.call_tool(
+        'memex_resize_image',
+        {
+            'local_path': str(src),
+            'max_width': 32,
+            'max_height': 32,
+            'output_format': 'JPEG',
+        },
+    )
+    dest = Path(result.content[0].text)
+    assert dest.exists()
+    assert dest.suffix == '.jpg'

--- a/packages/mcp/tests/test_resources.py
+++ b/packages/mcp/tests/test_resources.py
@@ -1,89 +1,172 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
+
+from helpers import parse_tool_result
+
+
+def _local_paths(result) -> list[Path]:
+    """Strip file:// prefix and return Path objects from a memex_get_resources result."""
+    items = parse_tool_result(result)
+    assert isinstance(items, list)
+    return [Path(s.removeprefix('file://')) for s in items if s.startswith('file://')]
 
 
 @pytest.mark.asyncio
-async def test_mcp_get_resource_image(mock_api, mcp_client):
-    """Test retrieving an image resource returns file:// URI for local stores."""
-    mock_api.get_resource_path = MagicMock(return_value='/data/images/test.png')
+async def test_mcp_get_resource_image(mock_api, asset_cache, mcp_client):
+    """Disk-handoff: bytes are written to the session cache and a file:// URI is returned."""
+    mock_api.get_resource = AsyncMock(return_value=b'fake-png-bytes')
 
     result = await mcp_client.call_tool(
         'memex_get_resources', {'paths': ['images/test.png'], 'vault_id': 'test-vault'}
     )
 
-    assert len(result.content) == 1
-    content = result.content[0]
-
-    # Local images now return file:// URI as text
-    assert content.type == 'text'
-    assert 'file:///data/images/test.png' in content.text
+    paths = _local_paths(result)
+    assert len(paths) == 1
+    assert paths[0].exists()
+    assert paths[0].read_bytes() == b'fake-png-bytes'
+    mock_api.get_resource.assert_awaited_once_with('images/test.png')
 
 
 @pytest.mark.asyncio
-async def test_mcp_get_resource_text(mock_api, mcp_client):
-    """Test retrieving a text file (should be returned as File/EmbeddedResource)."""
-    mock_api.get_resource_path = MagicMock(return_value=None)
-    mock_api.get_resource.return_value = b'Hello World'
+async def test_mcp_get_resource_text(mock_api, asset_cache, mcp_client):
+    """Non-image assets also flow through the cache and come back as file:// URIs."""
+    mock_api.get_resource = AsyncMock(return_value=b'Hello World')
 
     result = await mcp_client.call_tool(
         'memex_get_resources', {'paths': ['notes/test.txt'], 'vault_id': 'test-vault'}
     )
 
-    # Batch returns a list — first item should be an EmbeddedResource
-    assert len(result.content) >= 1
-    content = result.content[0]
-
-    # FastMCP File -> EmbeddedResource
-    assert content.type == 'resource'
-    assert content.resource.mimeType == 'text/plain'
+    paths = _local_paths(result)
+    assert len(paths) == 1
+    assert paths[0].read_bytes() == b'Hello World'
 
 
 @pytest.mark.asyncio
-async def test_mcp_get_resource_with_vault_id(mock_api, mcp_client):
+async def test_mcp_get_resource_with_vault_id(mock_api, asset_cache, mcp_client):
     """Test memex_get_resources accepts vault_id parameter."""
     vault_id = uuid4()
-
     mock_api.resolve_vault_identifier = AsyncMock(return_value=vault_id)
-    mock_api.get_resource_path = MagicMock(return_value='/data/images/test.png')
+    mock_api.get_resource = AsyncMock(return_value=b'bytes')
 
     result = await mcp_client.call_tool(
         'memex_get_resources', {'paths': ['images/test.png'], 'vault_id': str(vault_id)}
     )
 
-    assert len(result.content) == 1
+    paths = _local_paths(result)
+    assert len(paths) == 1
     mock_api.resolve_vault_identifier.assert_called_once_with(str(vault_id))
 
 
 @pytest.mark.asyncio
-async def test_mcp_get_resource_multiple_paths(mock_api, mcp_client):
+async def test_mcp_get_resource_multiple_paths(mock_api, asset_cache, mcp_client):
     """Batch retrieval of multiple resources."""
-    mock_api.get_resource_path = MagicMock(side_effect=['/data/img1.png', '/data/img2.png'])
+    mock_api.get_resource = AsyncMock(side_effect=[b'one', b'two'])
 
     result = await mcp_client.call_tool(
         'memex_get_resources',
         {'paths': ['images/img1.png', 'images/img2.png'], 'vault_id': 'test-vault'},
     )
 
-    # Should get two file:// URIs
-    texts = [c.text for c in result.content if hasattr(c, 'text')]
-    combined = ' '.join(texts)
-    assert 'file:///data/img1.png' in combined
-    assert 'file:///data/img2.png' in combined
+    paths = _local_paths(result)
+    assert len(paths) == 2
+    assert {p.read_bytes() for p in paths} == {b'one', b'two'}
 
 
 @pytest.mark.asyncio
-async def test_mcp_get_resource_partial_failure(mock_api, mcp_client):
+async def test_mcp_get_resource_partial_failure(mock_api, asset_cache, mcp_client):
     """One failing resource should not prevent others from being returned."""
-    mock_api.get_resource_path = MagicMock(side_effect=['/data/ok.png', None])
-    mock_api.get_resource.side_effect = RuntimeError('not found')
+
+    async def fake_fetch(path: str) -> bytes:
+        if path == 'images/ok.png':
+            return b'ok'
+        raise RuntimeError('not found')
+
+    mock_api.get_resource = AsyncMock(side_effect=fake_fetch)
 
     result = await mcp_client.call_tool(
         'memex_get_resources',
         {'paths': ['images/ok.png', 'images/bad.txt'], 'vault_id': 'test-vault'},
     )
 
-    texts = [c.text for c in result.content if hasattr(c, 'text')]
-    combined = ' '.join(texts)
-    assert 'file:///data/ok.png' in combined
-    assert 'Error fetching' in combined
+    items = parse_tool_result(result)
+    assert isinstance(items, list)
+    assert len(items) == 2
+    assert any(s.startswith('file://') for s in items)
+    assert any('Error fetching' in s for s in items)
+
+
+# ── New disk-handoff tests (AC-003, AC-004, AC-005) ──
+
+
+@pytest.mark.asyncio
+async def test_get_resources_returns_file_uri_paths(mock_api, asset_cache, mcp_client):
+    """AC-003: returned values are file:// strings (not Image/Audio/File objects)."""
+    mock_api.get_resource = AsyncMock(return_value=b'data')
+
+    result = await mcp_client.call_tool(
+        'memex_get_resources', {'paths': ['images/x.png'], 'vault_id': 'test-vault'}
+    )
+
+    items = parse_tool_result(result)
+    assert items == [items[0]]  # single-item list
+    assert isinstance(items[0], str)
+    assert items[0].startswith('file://')
+
+
+@pytest.mark.asyncio
+async def test_get_resources_uses_session_tempdir(mock_api, asset_cache, mcp_client):
+    """AC-003: returned path lives under the session asset cache tempdir."""
+    mock_api.get_resource = AsyncMock(return_value=b'data')
+
+    result = await mcp_client.call_tool(
+        'memex_get_resources', {'paths': ['images/x.png'], 'vault_id': 'test-vault'}
+    )
+
+    paths = _local_paths(result)
+    assert len(paths) == 1
+    local = paths[0].resolve()
+    cache_root = asset_cache.tempdir.resolve()
+    assert local.is_relative_to(cache_root), f'{local} is not under {cache_root}'
+
+
+@pytest.mark.asyncio
+async def test_get_resources_caches_repeat_calls(mock_api, asset_cache, mcp_client):
+    """AC-004: repeat calls for the same path hit the cache and don't re-fetch."""
+    mock_api.get_resource = AsyncMock(return_value=b'data')
+
+    first = await mcp_client.call_tool(
+        'memex_get_resources', {'paths': ['images/x.png'], 'vault_id': 'test-vault'}
+    )
+    second = await mcp_client.call_tool(
+        'memex_get_resources', {'paths': ['images/x.png'], 'vault_id': 'test-vault'}
+    )
+
+    assert mock_api.get_resource.await_count == 1
+    assert parse_tool_result(first) == parse_tool_result(second)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_cleanup_removes_tempdir():
+    """AC-005: exiting the lifespan unlinks the session tempdir.
+
+    Drives the lifespan context manager directly instead of relying on real
+    process atexit firing.
+    """
+    from memex_mcp.lifespan import lifespan
+
+    fake_vault = type('V', (), {'id': 'v', 'name': 'v'})()
+
+    with (
+        patch(
+            'memex_common.client.RemoteMemexAPI.get_active_vault',
+            new=AsyncMock(return_value=fake_vault),
+        ),
+        patch('httpx.AsyncClient.aclose', new=AsyncMock(return_value=None)),
+    ):
+        async with lifespan(server=None) as ctx:
+            tempdir = ctx._asset_cache.tempdir
+            assert tempdir.exists()
+
+    assert not tempdir.exists()

--- a/tests/test_e2e_resources.py
+++ b/tests/test_e2e_resources.py
@@ -108,4 +108,4 @@ def test_resource_empty_path_returns_404(client: TestClient, path: str):
     """An empty/root path must 404 cleanly, not 500 from boto on an empty Key."""
     resp = client.get(f'/api/v1/resources/{path}')
     assert resp.status_code == 404
-    assert 'empty' in resp.json()['detail'].lower()
+    assert resp.json()['detail'] == 'Resource path is empty'

--- a/tests/test_e2e_resources.py
+++ b/tests/test_e2e_resources.py
@@ -102,10 +102,6 @@ def test_resource_not_found(client: TestClient):
     assert resp.status_code == 404
 
 
-@pytest.mark.integration
-@pytest.mark.parametrize('path', ['', '/', '///'])
-def test_resource_empty_path_returns_404(client: TestClient, path: str):
-    """An empty/root path must 404 cleanly, not 500 from boto on an empty Key."""
-    resp = client.get(f'/api/v1/resources/{path}')
-    assert resp.status_code == 404
-    assert resp.json()['detail'] == 'Resource path is empty'
+# AC-001 empty/dot-path 404 coverage lives in
+# ``packages/core/tests/integration/test_server_resources.py`` so it stays
+# co-located with the route module and runs without the ``llm`` marker.

--- a/tests/test_e2e_resources.py
+++ b/tests/test_e2e_resources.py
@@ -100,3 +100,12 @@ def test_resource_not_found(client: TestClient):
     """Test 404 for non-existent resource."""
     resp = client.get('/api/v1/resources/non/existent/path.txt')
     assert resp.status_code == 404
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize('path', ['', '/', '///'])
+def test_resource_empty_path_returns_404(client: TestClient, path: str):
+    """An empty/root path must 404 cleanly, not 500 from boto on an empty Key."""
+    resp = client.get(f'/api/v1/resources/{path}')
+    assert resp.status_code == 404
+    assert 'empty' in resp.json()['detail'].lower()

--- a/uv.lock
+++ b/uv.lock
@@ -3244,6 +3244,7 @@ source = { editable = "packages/hermes-plugin" }
 dependencies = [
     { name = "httpx" },
     { name = "memex-common" },
+    { name = "pillow" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "typer" },
@@ -3261,6 +3262,7 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "memex-common", editable = "packages/common" },
+    { name = "pillow", specifier = ">=10" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "typer", specifier = ">=0.12.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,9 @@ provides-extras = ["mcp", "server", "sync"]
 name = "memex-common"
 source = { editable = "packages/common" }
 dependencies = [
+    { name = "cachetools" },
     { name = "httpx" },
+    { name = "pillow" },
     { name = "platformdirs" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -3067,7 +3069,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cachetools", specifier = ">=5" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "pillow", specifier = ">=10" },
     { name = "platformdirs", specifier = ">=4.5.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },


### PR DESCRIPTION
## Summary

Closes [#59](https://github.com/JasperHG90/memex/issues/59) (and the related [JasperHG90/localstack#3](https://github.com/JasperHG90/localstack/issues/3)). Two distinct asset-retrieval defects:

1. **REST 307 → 500**: `GET /api/v1/resources?paths=…` redirected to `/api/v1/resources/?paths=…`, which then 500'd. Now returns a clean **404** for empty / whitespace / all-slash paths, current-/parent-directory tokens (`.`, `..`), URL-encoded variants (`%2E`, `%2E%2E`, mixed `%2F`), and any input that normalises to root via `posixpath.normpath` (e.g. `foo/..`, `a/b/../..`, `./foo/..`).
2. **Tool-result truncation**: `memex_get_resources` (MCP) and `handle_get_resources` (Hermes plugin) inlined base64 bytes in the tool result, hitting the Hermes harness `tool_output.max_bytes` cap (default 50 KB; observed cutoff ~196 K base64 chars) and silently producing 0-byte files. Memex side now writes bytes via the existing API HTTP client into a per-session LRU-cached tempdir and returns the on-disk path. The agent reads from disk; the harness cap is no longer in the path.

Plus a new `memex_resize_image` tool in both packages (Pillow-backed; path-confined; decompression-bomb-capped) so agents can downscale images before forwarding them onwards (Telegram etc.).

## What changed

| Layer | Change |
|---|---|
| `[core]` | `is_root_key` now anchors on `posixpath.normpath` — rejects empty/dot/URL-encoded/mixed-segment shapes that all collapse to root. Route returns 404, not 500. New integration test file at the AC-001-named path. |
| `[shared]` (`memex_common`) | New `SessionAssetCache` (cachetools LRU, per-key asyncio coalescing, eviction unlinks files, public `register()` for derived siblings). New `resize_image` helper with format allowlist, suffix/format alignment, and a centralized **32 MP** decompression-bomb cap checked from `Image.open` header before any pixels are decoded. |
| `[mcp]` | Lifespan-owned tempdir; `_fetch_single_resource` returns `file://`-prefixed paths. New `memex_resize_image` tool with `Path.resolve(strict=True)` confinement, post-resize TOCTOU re-check, 50 MiB per-asset size cap, **50-path** `_MAX_GET_RESOURCES_PATHS` cap (parity with Hermes). |
| `[hermes-plugin]` | `handle_get_resources` returns `{path, local_path, filename, mime_type, size_bytes}` (no `content_b64`). Provider mints `SessionAssetCache` in `initialize` and clears it on `_atexit_shutdown`. New `memex_resize_image` parallels MCP. |

Adversarial review caught a process-global Pillow state mutation in MCP's first-cut decompression-bomb defense and an asymmetric bomb cap between MCP and Hermes — fixed by centralizing the cap as a `width*height > _MAX_DECODED_PIXELS` check inside `resize_image` itself, eliminating all Pillow `MAX_IMAGE_PIXELS` mutation, `warnings.simplefilter`, and per-tool divergence.

## Tests

- `packages/common/tests/test_asset_cache.py` — 15 cases (LRU, locks, register, eviction, cleanup).
- `packages/common/tests/test_asset_resize.py` — format allowlist, suffix alignment, oversize pixel-budget, boundary case.
- `packages/core/tests/integration/test_server_resources.py` — empty / dot / `?paths=foo` literal reproducer + URL-encoded `%2E`/`%2E%2E` + mixed `%2F`-encoded `foo/..` shapes.
- `packages/core/tests/unit/storage/test_filestore.py` — `ROOT_EQUIVALENT_KEYS` parametrize across all 8 guarded methods (load/exists/is_dir/save/delete/move-src/move-dest/glob); positive + negative `is_root_key` direct tests.
- `packages/mcp/tests/test_resize_security.py` — 11 cases including 50 MiB cap, strict-resolve, dim validation, decompression bomb, post-resize TOCTOU, output_format rename, register, path-list cap.
- `packages/hermes-plugin/tests/test_resize.py` — 12 cases mirroring the MCP set + JSON shape.
- All findings demonstrated fail-before-fix.

## Test posture (per-package)

| Package | Pass | Notes |
|---|---|---|
| `memex_common` | 140 | — |
| `memex_core` (unit + new integration) | 2204 unit + 19 server-resources integration | Pre-existing `tests/integration/memory/...` suite has 47 unrelated failures on this branch AND on `main` — unaffected by this PR. |
| `memex_mcp` | 329 | — |
| `memex_hermes_plugin` | 292 (+ 18 deselected: live integration) | — |

Cross-package collection collisions for `test_resize.py` / `test_config.py` only matter when running `pytest packages/` whole; CI runs per-package.

## Process

- Multi-stream parallel dev with `[shared]` primary + `[core]`/`[mcp]`/`[hermes]` workstreams; integration branch `fix/issue-59-asset-disk-handoff`.
- Two adversarial review cycles. First produced 13 findings → 4 rework tickets all merged. Second cold-read produced 4 majors (all in the bomb-cap defense) + 1 minor (path-list parity gap) → all fixed in commit `e5ba220`.

## Out of scope

- Hermes harness `tool_output.max_bytes` setting in the localstack repo.
- Batch JSON `?paths=…` endpoint.
- Streaming/chunked tool-result handling on the MCP transport.

## Notes

- New deps: `cachetools >= 5` (common), `Pillow` (common). `just audit` could not be run end-to-end on this branch because `pip-audit` is missing from this devcontainer — please run on the merge target.
- Cross-package consistency matrix: MCP and Hermes now share identical error messages for size-cap, escaped-cache, dim-validation, decompression-bomb, and output_format rename.

## Test plan

- [ ] `uv run pytest` per package green
- [ ] `just audit` clean against the new deps on the merge target
- [ ] Manual smoke: `curl -i 'http://localhost:8000/api/v1/resources?paths=foo'` → 307 → 404 (not 500)
- [ ] Manual smoke: localstack agent retrieves rituals-vault diagram via `handle_get_resources`; tool result contains `local_path`, no `content_b64`; agent reads file from disk and forwards to Telegram
- [ ] Manual smoke: `memex_resize_image` on the diagram with `max_width=1024` produces a smaller sibling in the same tempdir; passing `/etc/passwd` returns ToolError

🤖 Generated with [Claude Code](https://claude.com/claude-code)