### PR TITLE
chore: rename internal handlers + Prometheus counter to match tool names (#65)

### DIFF
--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -102,14 +102,10 @@ NOTE_APPEND_DURATION_SECONDS = Histogram(
 )
 
 # Tracks ingestions whose note_key resolves to an existing non-empty note. Lets
-# us see how many callers should migrate to memex_append_note before deprecating
-# the retain-as-overwrite path. NOT an error counter; informational only.
-# TODO(rename): the counter name still reads ``memex_retain_*`` even though all
-# tool surfaces now use ``memex_add_note`` / ``memex_append_note``. Renaming a
-# Prometheus counter is a breaking change for any consumer dashboards, so it's
-# tracked here as a follow-up rather than landed alongside the tool rename.
-NOTE_RETAIN_OVERLAPS_EXISTING_TOTAL = Counter(
-    'memex_retain_with_existing_note_key_total',
+# us see how many callers should migrate to memex_append_note. NOT an error
+# counter; informational only.
+NOTE_ADD_OVERLAPS_EXISTING_TOTAL = Counter(
+    'memex_add_note_with_existing_note_key_total',
     'Ingestions that re-used an existing non-empty note (candidate for memex_append_note).',
     # The label is set by the caller path. Today only ingestion.py emits
     # ``surface='ingest_api'``; ``mcp_add_note`` and ``hermes_add_note`` are

--- a/packages/core/src/memex_core/services/ingestion.py
+++ b/packages/core/src/memex_core/services/ingestion.py
@@ -434,11 +434,11 @@ ingested_at: {now}
                 # the full body.
                 if has_stored_text:
                     try:
-                        from memex_core.metrics import NOTE_RETAIN_OVERLAPS_EXISTING_TOTAL
+                        from memex_core.metrics import NOTE_ADD_OVERLAPS_EXISTING_TOTAL
 
-                        NOTE_RETAIN_OVERLAPS_EXISTING_TOTAL.labels(surface='ingest_api').inc()
+                        NOTE_ADD_OVERLAPS_EXISTING_TOTAL.labels(surface='ingest_api').inc()
                     except Exception:  # pragma: no cover — metrics never block ingest
-                        logger.debug('NOTE_RETAIN_OVERLAPS_EXISTING_TOTAL increment failed')
+                        logger.debug('NOTE_ADD_OVERLAPS_EXISTING_TOTAL increment failed')
 
         # 3. Open Transaction
         # Staging txn_id must be unique per in-flight transaction, not derived from

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -1448,7 +1448,7 @@ def _serialize_kv_entry(entry: Any) -> dict[str, Any]:
 # --- Vault-scoped (Stream 1) ---
 
 
-def handle_recall(
+def handle_memory_search(
     api: MemexAPIProtocol, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
 ) -> str:
     try:
@@ -1484,7 +1484,7 @@ def handle_recall(
     return json.dumps({'count': len(items), 'results': items})
 
 
-def handle_retrieve_notes(
+def handle_note_search(
     api: MemexAPIProtocol, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
 ) -> str:
     try:
@@ -1570,7 +1570,7 @@ def handle_survey(
     )
 
 
-def handle_retain(
+def handle_add_note(
     api: MemexAPIProtocol,
     config: HermesMemexConfig,
     vault_id: UUID | None,
@@ -1615,7 +1615,7 @@ def handle_retain(
     )
 
 
-def handle_append(
+def handle_append_note(
     api: MemexAPIProtocol,
     config: HermesMemexConfig,
     vault_id: UUID | None,
@@ -3016,19 +3016,13 @@ class _AssetCacheHandler(Protocol):
     ) -> str: ...
 
 
-# TODO(rename): handler functions still carry the old verb names
-# (``handle_recall``, ``handle_retrieve_notes``, ``handle_retain``,
-# ``handle_append``) while the tool names mirror MCP (``memex_memory_search``,
-# ``memex_note_search``, ``memex_add_note``, ``memex_append_note``). Renaming
-# the handlers is internal-only churn, deferred to a separate cleanup so this
-# diff stays scoped to the agent-facing rename.
 HANDLERS: dict[str, _StdHandler | _AssetCacheHandler] = {
     # --- Vault-scoped (Stream 1) ---
-    'memex_memory_search': handle_recall,
-    'memex_note_search': handle_retrieve_notes,
+    'memex_memory_search': handle_memory_search,
+    'memex_note_search': handle_note_search,
     'memex_survey': handle_survey,
-    'memex_add_note': handle_retain,
-    'memex_append_note': handle_append,
+    'memex_add_note': handle_add_note,
+    'memex_append_note': handle_append_note,
     'memex_list_entities': handle_list_entities,
     'memex_get_entity_mentions': handle_get_entity_mentions,
     'memex_get_entity_cooccurrences': handle_get_entity_cooccurrences,

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -710,7 +710,7 @@ def test_note_search_schema_declares_vault_ids():
 
 
 def test_note_search_uses_bound_vault_by_default(config, vault_id):
-    """AC-013: ``handle_retrieve_notes`` mirrors memory_search — default is bound vault."""
+    """AC-013: ``handle_note_search`` mirrors memory_search — default is bound vault."""
     api = Mock()
     api.search_notes = AsyncMock(return_value=[])
     dispatch(
@@ -724,7 +724,7 @@ def test_note_search_uses_bound_vault_by_default(config, vault_id):
 
 
 def test_note_search_resolves_vault_names(config, vault_id):
-    """AC-013: ``handle_retrieve_notes`` resolves names via the helper."""
+    """AC-013: ``handle_note_search`` resolves names via the helper."""
     api = Mock()
     resolved = uuid4()
     api.resolve_vault_identifier = AsyncMock(return_value=resolved)
@@ -3334,7 +3334,7 @@ def test_hermes_routes_structured_capture_to_templates_via_gemini():
 
 
 # ---------------------------------------------------------------------------
-# memex_append_note (handle_append) — issue #56
+# memex_append_note (handle_append_note) — issue #56
 # ---------------------------------------------------------------------------
 
 
@@ -3357,7 +3357,7 @@ def test_append_note_schema_is_registered():
 
 
 def test_append_note_dispatches_with_note_key(config, vault_id):
-    """handle_append builds a NoteAppendRequest and forwards it to the API."""
+    """handle_append_note builds a NoteAppendRequest and forwards it to the API."""
     api = Mock()
     note_id = uuid4()
     append_id = uuid4()
@@ -3478,7 +3478,7 @@ def test_append_note_missing_identifier_returns_error(config, vault_id):
 
 
 def test_append_note_api_failure_returns_error(config, vault_id):
-    """If the API raises (e.g. 409 conflict), handle_append returns a tool_error."""
+    """If the API raises (e.g. 409 conflict), handle_append_note returns a tool_error."""
     api = Mock()
     api.append_to_note = AsyncMock(
         side_effect=httpx.HTTPStatusError(


### PR DESCRIPTION
Closes #65.

PR #63 renamed the four divergent Hermes tool names to mirror MCP but deferred the matching internal-symbol renames behind ``TODO(rename)`` markers. This PR lands them outright (no backward-compat shim).

## Summary

- **Handlers** (`packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py`):

  | Old | New |
  |---|---|
  | `handle_recall` | `handle_memory_search` |
  | `handle_retrieve_notes` | `handle_note_search` |
  | `handle_retain` | `handle_add_note` |
  | `handle_append` | `handle_append_note` |

  The `HANDLERS` dispatch dict, the four function definitions, and the test-file docstrings all use the new names. Removed the explanatory `TODO(rename)` block above `HANDLERS`.

- **Prometheus counter** (`packages/core/src/memex_core/metrics.py`):
  - Python const: `NOTE_RETAIN_OVERLAPS_EXISTING_TOTAL` → `NOTE_ADD_OVERLAPS_EXISTING_TOTAL`
  - Metric name: `memex_retain_with_existing_note_key_total` → `memex_add_note_with_existing_note_key_total`
  - Updated the single emit site in `services/ingestion.py`.
  - Removed the `TODO(rename)` comment.

**Breaking change** (per direction): the metric rename has no compat shim or dual-emit. Any downstream dashboard/alert filtering on the old metric name will need to be repointed.

## Test plan

- [x] `uv run pytest packages/hermes-plugin/tests --ignore=tests/integration` → 310 passed
- [x] `uv run pytest packages/core/tests --ignore=tests/integration` → 2237 passed
- [x] `prek run --files <changed>` (ruff, ruff-format, mypy, test count badge) all green
- [ ] Manual: confirm any dashboards filtering on `memex_retain_with_existing_note_key_total` are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)