### PR TITLE
feat(retrieval): D-MEM Z-score embedding anisotropy correction (F2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-3,796%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,799%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,091%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-3,796%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -710,6 +710,16 @@ class RetrievalConfig(BaseModel):
         default=0.3,
         description='Minimum link weight for causal graph expansion in memory_links.',
     )
+    anisotropy_window_size: int = Field(
+        default=1024,
+        description='Sliding window size for Z-score anisotropy correction. '
+        '1024 matches D-MEM §4.1. Set to 0 to disable.',
+    )
+    anisotropy_min_samples: int = Field(
+        default=32,
+        description='Minimum observations before anisotropy correction activates. '
+        'Below this threshold, raw similarity scores pass through unchanged.',
+    )
     graph_semantic_seeding: bool = Field(
         default=True,
         description='Enable semantic seeding for graph retrieval strategies.',

--- a/packages/core/src/memex_core/memory/models/__init__.py
+++ b/packages/core/src/memex_core/memory/models/__init__.py
@@ -19,6 +19,10 @@ from memex_core.memory.models.reranking import (
     get_reranking_model,
 )
 from memex_core.memory.models.ner import get_ner_model, FastNERModel
+from memex_core.memory.models.anisotropy import (
+    AnisotropyCorrector,
+    AnisotropyCorrectorGroup,
+)
 
 __all__ = [
     'BaseOnnxModel',
@@ -35,4 +39,6 @@ __all__ = [
     'get_reranking_model',
     'FastNERModel',
     'get_ner_model',
+    'AnisotropyCorrector',
+    'AnisotropyCorrectorGroup',
 ]

--- a/packages/core/src/memex_core/memory/models/anisotropy.py
+++ b/packages/core/src/memex_core/memory/models/anisotropy.py
@@ -1,0 +1,197 @@
+"""Sliding-window Z-score normalizer for embedding anisotropy correction.
+
+Modern high-dimensional embedding models suffer from representation anisotropy:
+vectors cluster in a narrow cone, causing even semantically unrelated texts to
+yield cosine similarities above 0.7.  D-MEM (arXiv:2603.14597v1) §4.1 proposes
+maintaining a sliding window of recent similarity scores to compute a historical
+mean and standard deviation, then applying Z-score normalization mapped through
+a sigmoid function.
+
+This module provides ``AnisotropyCorrector``, a stateful sliding-window normalizer
+that can be wired into any site that produces cosine similarity scores.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from threading import Lock
+
+import structlog
+
+logger = structlog.get_logger('memex.core.memory.models.anisotropy')
+
+# Default window size — balances responsiveness (short windows track distribution
+# shifts) with stability (long windows resist noise).  1024 matches D-MEM §4.1.
+DEFAULT_WINDOW_SIZE = 1024
+
+# Epsilon to prevent division by zero when σ ≈ 0.
+DEFAULT_EPSILON = 1e-8
+
+
+class AnisotropyCorrector:
+    """Sliding-window Z-score → sigmoid normalizer for cosine similarity scores.
+
+    Usage::
+
+        corrector = AnisotropyCorrector()
+        # Feed raw similarity scores and get corrected values back
+        corrected = corrector.normalize(raw_similarity)
+
+    Cold-start: returns the raw score unchanged until the window has at least
+    ``min_samples`` observations (default 32), at which point Z-score
+    normalization kicks in.
+    """
+
+    def __init__(
+        self,
+        window_size: int = DEFAULT_WINDOW_SIZE,
+        epsilon: float = DEFAULT_EPSILON,
+        min_samples: int = 32,
+    ) -> None:
+        self._window_size = window_size
+        self._epsilon = epsilon
+        self._min_samples = min_samples
+        self._window: deque[float] = deque(maxlen=window_size)
+        self._lock = Lock()
+        # Running stats (Welford-like for numerical stability)
+        self._count: int = 0
+        self._mean: float = 0.0
+        self._m2: float = 0.0  # sum of squared deviations from mean
+
+    @property
+    def window_size(self) -> int:
+        return self._window_size
+
+    @property
+    def count(self) -> int:
+        """Number of observations currently in the window."""
+        return self._count
+
+    @property
+    def mean(self) -> float:
+        """Current running mean of similarity scores in the window."""
+        return self._mean
+
+    @property
+    def std(self) -> float:
+        """Current running standard deviation (population) of similarity scores."""
+        if self._count < 2:
+            return 0.0
+        variance = self._m2 / self._count
+        return math.sqrt(max(0.0, variance))
+
+    def _update_stats_add(self, value: float) -> None:
+        """Add a value to running stats (Welford online algorithm)."""
+        self._count += 1
+        delta = value - self._mean
+        self._mean += delta / self._count
+        delta2 = value - self._mean
+        self._m2 += delta * delta2
+
+    def _update_stats_remove(self, value: float) -> None:
+        """Remove a value from running stats (Welford removal)."""
+        if self._count <= 1:
+            self._count = 0
+            self._mean = 0.0
+            self._m2 = 0.0
+            return
+        self._count -= 1
+        delta = value - self._mean
+        self._mean -= delta / self._count
+        delta2 = value - self._mean
+        self._m2 -= delta * delta2
+
+    def normalize(self, raw_similarity: float) -> float:
+        """Normalize a raw cosine similarity score using Z-score → sigmoid.
+
+        If fewer than ``min_samples`` observations have been seen, returns
+        the raw score unchanged (cold-start passthrough).
+
+        Args:
+            raw_similarity: Cosine similarity in [-1, 1] (typically [0, 1]).
+
+        Returns:
+            Normalized similarity in (0, 1).
+        """
+        with self._lock:
+            self._window.append(raw_similarity)
+            self._update_stats_add(raw_similarity)
+
+            # If the deque was full, the oldest value was auto-evicted.
+            # We need to remove it from running stats.
+            # The deque maxlen handles eviction, but we track count separately.
+            # If count > window_size, a value was evicted before we added.
+            if self._count > self._window_size:
+                # This case means our running stats overshot. We can't
+                # know which value was evicted, so recalculate from scratch.
+                self._recompute_stats()
+
+            if self._count < self._min_samples:
+                return raw_similarity
+
+            std = self.std
+            z_score = (raw_similarity - self._mean) / (std + self._epsilon)
+
+            # Sigmoid mapping: compresses Z-scores back to (0, 1)
+            # centered at 0.5 (neutral) with steepness controlled by the
+            # natural scale of Z-scores.
+            return 1.0 / (1.0 + math.exp(-z_score))
+
+    def _recompute_stats(self) -> None:
+        """Recompute running stats from scratch when evicted values are lost."""
+        self._count = 0
+        self._mean = 0.0
+        self._m2 = 0.0
+        for val in self._window:
+            self._update_stats_add(val)
+
+    def reset(self) -> None:
+        """Clear all state."""
+        with self._lock:
+            self._window.clear()
+            self._count = 0
+            self._mean = 0.0
+            self._m2 = 0.0
+
+
+class AnisotropyCorrectorGroup:
+    """A collection of named ``AnisotropyCorrector`` instances.
+
+    Different similarity call sites may have different score distributions,
+    so each site should maintain its own corrector.  This group provides
+    convenient access by name (e.g. 'retrieval', 'contradiction', 'dedup').
+    """
+
+    def __init__(
+        self,
+        names: list[str] | None = None,
+        window_size: int = DEFAULT_WINDOW_SIZE,
+        epsilon: float = DEFAULT_EPSILON,
+        min_samples: int = 32,
+    ) -> None:
+        self._correctors: dict[str, AnisotropyCorrector] = {}
+        self._window_size = window_size
+        self._epsilon = epsilon
+        self._min_samples = min_samples
+        for name in names or []:
+            self._correctors[name] = AnisotropyCorrector(
+                window_size=window_size,
+                epsilon=epsilon,
+                min_samples=min_samples,
+            )
+
+    def get(self, name: str) -> AnisotropyCorrector:
+        """Get or create a corrector for the given site name."""
+        if name not in self._correctors:
+            self._correctors[name] = AnisotropyCorrector(
+                window_size=self._window_size,
+                epsilon=self._epsilon,
+                min_samples=self._min_samples,
+            )
+        return self._correctors[name]
+
+    def reset(self) -> None:
+        """Reset all correctors."""
+        for c in self._correctors.values():
+            c.reset()

--- a/packages/core/src/memex_core/memory/models/anisotropy.py
+++ b/packages/core/src/memex_core/memory/models/anisotropy.py
@@ -115,17 +115,14 @@ class AnisotropyCorrector:
             Normalized similarity in (0, 1).
         """
         with self._lock:
-            self._window.append(raw_similarity)
-            self._update_stats_add(raw_similarity)
-
-            # If the deque was full, the oldest value was auto-evicted.
-            # We need to remove it from running stats.
-            # The deque maxlen handles eviction, but we track count separately.
-            # If count > window_size, a value was evicted before we added.
-            if self._count > self._window_size:
-                # This case means our running stats overshot. We can't
-                # know which value was evicted, so recalculate from scratch.
-                self._recompute_stats()
+            if len(self._window) == self._window_size:
+                evicted = self._window[0]
+                self._window.append(raw_similarity)
+                self._update_stats_add(raw_similarity)
+                self._update_stats_remove(evicted)
+            else:
+                self._window.append(raw_similarity)
+                self._update_stats_add(raw_similarity)
 
             if self._count < self._min_samples:
                 return raw_similarity
@@ -137,14 +134,6 @@ class AnisotropyCorrector:
             # centered at 0.5 (neutral) with steepness controlled by the
             # natural scale of Z-scores.
             return 1.0 / (1.0 + math.exp(-z_score))
-
-    def _recompute_stats(self) -> None:
-        """Recompute running stats from scratch when evicted values are lost."""
-        self._count = 0
-        self._mean = 0.0
-        self._m2 = 0.0
-        for val in self._window:
-            self._update_stats_add(val)
 
     def reset(self) -> None:
         """Clear all state."""
@@ -174,6 +163,7 @@ class AnisotropyCorrectorGroup:
         self._window_size = window_size
         self._epsilon = epsilon
         self._min_samples = min_samples
+        self._lock = Lock()
         for name in names or []:
             self._correctors[name] = AnisotropyCorrector(
                 window_size=window_size,
@@ -183,12 +173,13 @@ class AnisotropyCorrectorGroup:
 
     def get(self, name: str) -> AnisotropyCorrector:
         """Get or create a corrector for the given site name."""
-        if name not in self._correctors:
-            self._correctors[name] = AnisotropyCorrector(
-                window_size=self._window_size,
-                epsilon=self._epsilon,
-                min_samples=self._min_samples,
-            )
+        with self._lock:
+            if name not in self._correctors:
+                self._correctors[name] = AnisotropyCorrector(
+                    window_size=self._window_size,
+                    epsilon=self._epsilon,
+                    min_samples=self._min_samples,
+                )
         return self._correctors[name]
 
     def reset(self) -> None:

--- a/packages/core/src/memex_core/memory/models/anisotropy.py
+++ b/packages/core/src/memex_core/memory/models/anisotropy.py
@@ -21,16 +21,13 @@ import structlog
 
 logger = structlog.get_logger('memex.core.memory.models.anisotropy')
 
-# Default window size — balances responsiveness (short windows track distribution
-# shifts) with stability (long windows resist noise).  1024 matches D-MEM §4.1.
 DEFAULT_WINDOW_SIZE = 1024
 
-# Epsilon to prevent division by zero when σ ≈ 0.
 DEFAULT_EPSILON = 1e-8
 
 
 class AnisotropyCorrector:
-    """Sliding-window Z-score → sigmoid normalizer for cosine similarity scores.
+    """Sliding-window Z-score -> sigmoid normalizer for cosine similarity scores.
 
     Usage::
 
@@ -41,6 +38,9 @@ class AnisotropyCorrector:
     Cold-start: returns the raw score unchanged until the window has at least
     ``min_samples`` observations (default 32), at which point Z-score
     normalization kicks in.
+
+    Set ``window_size=0`` to disable anisotropy correction (normalize returns
+    the raw score unchanged for all inputs).
     """
 
     def __init__(
@@ -49,15 +49,19 @@ class AnisotropyCorrector:
         epsilon: float = DEFAULT_EPSILON,
         min_samples: int = 32,
     ) -> None:
+        if window_size < 0:
+            raise ValueError(f'window_size must be >= 0, got {window_size}')
         self._window_size = window_size
         self._epsilon = epsilon
         self._min_samples = min_samples
-        self._window: deque[float] = deque(maxlen=window_size)
+        self._disabled = window_size == 0
+        # deque(maxlen=0) crashes, so use maxlen=1 as a no-op buffer when
+        # disabled — normalize() returns early before appending anyway.
+        self._window: deque[float] = deque(maxlen=max(1, window_size))
         self._lock = Lock()
-        # Running stats (Welford-like for numerical stability)
         self._count: int = 0
         self._mean: float = 0.0
-        self._m2: float = 0.0  # sum of squared deviations from mean
+        self._m2: float = 0.0
 
     @property
     def window_size(self) -> int:
@@ -101,12 +105,17 @@ class AnisotropyCorrector:
         self._mean -= delta / self._count
         delta2 = value - self._mean
         self._m2 -= delta * delta2
+        # Clamp floating-point drift
+        self._m2 = max(0.0, self._m2)
 
     def normalize(self, raw_similarity: float) -> float:
-        """Normalize a raw cosine similarity score using Z-score → sigmoid.
+        """Normalize a raw cosine similarity score using Z-score -> sigmoid.
 
         If fewer than ``min_samples`` observations have been seen, returns
         the raw score unchanged (cold-start passthrough).
+
+        If ``window_size=0`` was passed at init, returns the raw score unchanged
+        for all inputs (disabled mode).
 
         Args:
             raw_similarity: Cosine similarity in [-1, 1] (typically [0, 1]).
@@ -114,6 +123,9 @@ class AnisotropyCorrector:
         Returns:
             Normalized similarity in (0, 1).
         """
+        if self._disabled:
+            return raw_similarity
+
         with self._lock:
             if len(self._window) == self._window_size:
                 evicted = self._window[0]
@@ -184,5 +196,6 @@ class AnisotropyCorrectorGroup:
 
     def reset(self) -> None:
         """Reset all correctors."""
-        for c in self._correctors.values():
-            c.reset()
+        with self._lock:
+            for c in self._correctors.values():
+                c.reset()

--- a/packages/core/src/memex_core/memory/models/anisotropy.py
+++ b/packages/core/src/memex_core/memory/models/anisotropy.py
@@ -192,7 +192,7 @@ class AnisotropyCorrectorGroup:
                     epsilon=self._epsilon,
                     min_samples=self._min_samples,
                 )
-        return self._correctors[name]
+            return self._correctors[name]
 
     def reset(self) -> None:
         """Reset all correctors."""

--- a/packages/core/src/memex_core/memory/retrieval/engine.py
+++ b/packages/core/src/memex_core/memory/retrieval/engine.py
@@ -167,6 +167,14 @@ class RetrievalEngine:
         )
         self._session_factory = session_factory
 
+        # Anisotropy corrector for cosine similarity normalization
+        from memex_core.memory.models.anisotropy import AnisotropyCorrector
+
+        self._anisotropy = AnisotropyCorrector(
+            window_size=self.retrieval_config.anisotropy_window_size,
+            min_samples=self.retrieval_config.anisotropy_min_samples,
+        )
+
         # Source RRF constants from config
         self.k_rrf = self.retrieval_config.rrf_k
         self.candidate_pool_size = self.retrieval_config.candidate_pool_size
@@ -1154,11 +1162,14 @@ class RetrievalEngine:
             logger.error(f'Reranking failed: {e}. Falling back to RRF order.')
             return results
 
-    @staticmethod
     async def _compute_pairwise_cosine(
-        session: AsyncSession, unit_ids: list[UUID]
+        self, session: AsyncSession, unit_ids: list[UUID]
     ) -> dict[tuple[UUID, UUID], float]:
-        """Compute pairwise cosine similarity for a set of memory units via SQL."""
+        """Compute pairwise cosine similarity for a set of memory units via SQL.
+
+        Raw cosine similarities are normalized through the anisotropy corrector
+        (Z-score → sigmoid) to counteract embedding anisotropy.
+        """
         from sqlalchemy import text
 
         if len(unit_ids) < 2:
@@ -1181,9 +1192,11 @@ class RetrievalEngine:
         result = await conn.execute(stmt, {'unit_ids': [str(uid) for uid in unit_ids]})
         matrix: dict[tuple[UUID, UUID], float] = {}
         for row in result:
+            raw_sim = float(row.similarity)
+            corrected = self._anisotropy.normalize(raw_sim)
             key = (row.id_a, row.id_b)
-            matrix[key] = float(row.similarity)
-            matrix[(row.id_b, row.id_a)] = float(row.similarity)
+            matrix[key] = corrected
+            matrix[(row.id_b, row.id_a)] = corrected
         return matrix
 
     @staticmethod

--- a/packages/core/tests/unit/memory/models/test_anisotropy.py
+++ b/packages/core/tests/unit/memory/models/test_anisotropy.py
@@ -1,0 +1,184 @@
+"""Unit tests for AnisotropyCorrector (D-MEM Z-score embedding anisotropy correction)."""
+
+import math
+
+from memex_core.memory.models.anisotropy import (
+    AnisotropyCorrector,
+    AnisotropyCorrectorGroup,
+)
+
+
+class TestAnisotropyCorrectorColdStart:
+    """Cold-start: passthrough until min_samples reached."""
+
+    def test_returns_raw_score_below_min_samples(self):
+        c = AnisotropyCorrector(min_samples=5)
+        # First 4 observations should pass through unchanged
+        for i in range(4):
+            result = c.normalize(0.85)
+            assert result == 0.85
+
+    def test_activates_at_min_samples(self):
+        c = AnisotropyCorrector(min_samples=3)
+        c.normalize(0.80)
+        c.normalize(0.90)
+        # Third observation triggers normalization
+        result = c.normalize(0.85)
+        assert c.count == 3
+        # With some variance, normalization should produce a valid result
+        assert 0.0 < result < 1.0
+
+    def test_cold_start_returns_exactly_raw(self):
+        c = AnisotropyCorrector(min_samples=100)
+        raw = 0.73
+        assert c.normalize(raw) == raw
+
+
+class TestAnisotropyCorrectorNormalization:
+    """Z-score → sigmoid normalization behavior."""
+
+    def test_high_score_gets_high_normalized(self):
+        c = AnisotropyCorrector(min_samples=2, epsilon=1e-8)
+        # Feed a tight cluster of low scores
+        for _ in range(10):
+            c.normalize(0.70)
+        # Now feed a genuinely high score
+        result = c.normalize(0.90)
+        # Should be well above 0.5 (sigmoid of positive z-score)
+        assert result > 0.5
+
+    def test_low_score_gets_low_normalized(self):
+        c = AnisotropyCorrector(min_samples=2, epsilon=1e-8)
+        # Feed a tight cluster of high scores
+        for _ in range(10):
+            c.normalize(0.90)
+        # Now feed a genuinely low score
+        result = c.normalize(0.70)
+        # Should be well below 0.5 (sigmoid of negative z-score)
+        assert result < 0.5
+
+    def test_mean_score_gets_neutral(self):
+        c = AnisotropyCorrector(min_samples=2, epsilon=1e-8)
+        for _ in range(10):
+            c.normalize(0.80)
+        # A score right at the mean should give z≈0, sigmoid(0)=0.5
+        result = c.normalize(0.80)
+        assert abs(result - 0.5) < 0.05
+
+    def test_sigmoid_output_bounded(self):
+        c = AnisotropyCorrector(min_samples=2, epsilon=1e-8)
+        # Feed some values then check extreme scores
+        for v in [0.75, 0.76, 0.74, 0.77, 0.73]:
+            c.normalize(v)
+        # Very extreme scores should still be in (0, 1)
+        high = c.normalize(0.99)
+        low = c.normalize(0.01)
+        assert 0.0 < low < 1.0
+        assert 0.0 < high < 1.0
+        assert high > low
+
+    def test_output_increases_monotonically_with_input(self):
+        c = AnisotropyCorrector(min_samples=2, epsilon=1e-8)
+        # Seed with moderate values
+        for v in [0.80, 0.82, 0.78, 0.81, 0.79]:
+            c.normalize(v)
+        # Higher input → higher output
+        results = [c.normalize(v) for v in [0.70, 0.80, 0.90]]
+        assert results[0] < results[1] < results[2]
+
+
+class TestAnisotropyCorrectorSlidingWindow:
+    """Sliding window statistics."""
+
+    def test_window_size_limits_observations(self):
+        c = AnisotropyCorrector(window_size=5, min_samples=2)
+        for v in [0.80] * 100:
+            c.normalize(v)
+        # Window should be capped at 5
+        assert c.count == 5
+
+    def test_window_eviction_shifts_mean(self):
+        c = AnisotropyCorrector(window_size=3, min_samples=2, epsilon=1e-8)
+        # Fill window with low values
+        c.normalize(0.70)
+        c.normalize(0.70)
+        # Now push high values to evict old ones
+        c.normalize(0.90)
+        # Mean should have shifted up
+        assert c.mean > 0.75
+
+    def test_reset_clears_state(self):
+        c = AnisotropyCorrector(min_samples=2)
+        for _ in range(10):
+            c.normalize(0.85)
+        assert c.count > 0
+        c.reset()
+        assert c.count == 0
+        # After reset, should passthrough again
+        assert c.normalize(0.50) == 0.50
+
+
+class TestAnisotropyCorrectorRunningStats:
+    """Verify running mean and std computation."""
+
+    def test_running_mean(self):
+        c = AnisotropyCorrector(min_samples=100)
+        values = [0.8, 0.9, 0.7, 0.85, 0.75]
+        for v in values:
+            c.normalize(v)
+        expected_mean = sum(values) / len(values)
+        assert abs(c.mean - expected_mean) < 1e-10
+
+    def test_running_std(self):
+        c = AnisotropyCorrector(min_samples=100)
+        values = [0.8, 0.9, 0.7, 0.85, 0.75]
+        for v in values:
+            c.normalize(v)
+        mean = sum(values) / len(values)
+        expected_var = sum((v - mean) ** 2 for v in values) / len(values)
+        expected_std = math.sqrt(expected_var)
+        assert abs(c.std - expected_std) < 1e-10
+
+    def test_constant_input_std_zero(self):
+        c = AnisotropyCorrector(min_samples=100)
+        for _ in range(10):
+            c.normalize(0.85)
+        assert c.std == 0.0
+
+    def test_constant_input_with_normalization_gives_neutral(self):
+        """When all scores are identical, normalization returns 0.5 (neutral)."""
+        c = AnisotropyCorrector(min_samples=3)
+        c.normalize(0.85)
+        c.normalize(0.85)
+        result = c.normalize(0.85)
+        # z_score = 0 / epsilon → 0, sigmoid(0) = 0.5
+        assert abs(result - 0.5) < 0.01
+
+
+class TestAnisotropyCorrectorGroup:
+    """Named corrector group."""
+
+    def test_get_returns_same_corrector(self):
+        group = AnisotropyCorrectorGroup(names=['retrieval', 'contradiction'])
+        r1 = group.get('retrieval')
+        r2 = group.get('retrieval')
+        assert r1 is r2
+
+    def test_get_creates_on_demand(self):
+        group = AnisotropyCorrectorGroup()
+        c = group.get('dedup')
+        assert isinstance(c, AnisotropyCorrector)
+
+    def test_reset_clears_all(self):
+        group = AnisotropyCorrectorGroup(names=['a', 'b'])
+        for _ in range(10):
+            group.get('a').normalize(0.85)
+            group.get('b').normalize(0.90)
+        group.reset()
+        assert group.get('a').count == 0
+        assert group.get('b').count == 0
+
+    def test_custom_params_propagate(self):
+        group = AnisotropyCorrectorGroup(names=['test'], window_size=64, min_samples=5)
+        c = group.get('test')
+        assert c.window_size == 64

--- a/packages/core/tests/unit/memory/models/test_anisotropy.py
+++ b/packages/core/tests/unit/memory/models/test_anisotropy.py
@@ -182,3 +182,25 @@ class TestAnisotropyCorrectorGroup:
         group = AnisotropyCorrectorGroup(names=['test'], window_size=64, min_samples=5)
         c = group.get('test')
         assert c.window_size == 64
+
+
+class TestAnisotropyCorrectorDisabled:
+    """window_size=0 disables anisotropy correction (passthrough)."""
+
+    def test_disabled_returns_raw_unchanged(self):
+        c = AnisotropyCorrector(window_size=0)
+        assert c.normalize(0.85) == 0.85
+        assert c.normalize(0.10) == 0.10
+        assert c.normalize(0.99) == 0.99
+
+    def test_disabled_no_state_accumulation(self):
+        c = AnisotropyCorrector(window_size=0)
+        for _ in range(100):
+            c.normalize(0.85)
+        assert c.count == 0
+
+    def test_negative_window_size_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match='window_size must be >= 0'):
+            AnisotropyCorrector(window_size=-1)

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Annotated, Any
 from uuid import UUID
+from datetime import datetime
 import mimetypes
 
 import aiofiles
@@ -143,7 +144,7 @@ def _coerce_int(v: Any) -> Any:
     return v
 
 
-def _to_utc_datetime(dt: Any) -> Any:
+def _to_utc_datetime(dt: datetime | None) -> datetime | None:
     """Convert a parsed datetime to UTC.
 
     Naive datetimes get UTC assigned. Aware datetimes are converted to UTC.
@@ -1328,10 +1329,7 @@ def compute_staleness(
         return Staleness.STALE
 
     if event_date is not None and isinstance(event_date, _dt):
-        if event_date.tzinfo is None:
-            event_date = event_date.replace(tzinfo=_tz.utc)
-        else:
-            event_date = event_date.astimezone(_tz.utc)
+        event_date = _to_utc_datetime(event_date)
         age_days = (now - event_date).days
 
         if age_days > 30:

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -143,6 +143,21 @@ def _coerce_int(v: Any) -> Any:
     return v
 
 
+def _to_utc_datetime(dt: Any) -> Any:
+    """Convert a parsed datetime to UTC.
+
+    Naive datetimes get UTC assigned. Aware datetimes are converted to UTC.
+    Avoids ``.replace(tzinfo=)`` which silently overwrites existing timezones.
+    """
+    from datetime import timezone as _tz2
+
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=_tz2.utc)
+    return dt.astimezone(_tz2.utc)
+
+
 def _validate_vault_ids(vault_ids: list[str]) -> list[str]:
     """Validate vault_ids is a real list, not a stringified JSON array."""
     if isinstance(vault_ids, str):
@@ -1315,6 +1330,8 @@ def compute_staleness(
     if event_date is not None and isinstance(event_date, _dt):
         if event_date.tzinfo is None:
             event_date = event_date.replace(tzinfo=_tz.utc)
+        else:
+            event_date = event_date.astimezone(_tz.utc)
         age_days = (now - event_date).days
 
         if age_days > 30:
@@ -1556,13 +1573,11 @@ async def memex_memory_search(
         _validate_vault_ids(vault_ids)
         resolved_vids = await _resolve_vault_ids(api, vault_ids)
 
-        from datetime import datetime as _dt, timezone as _tz
+        from datetime import datetime as _dt
 
-        after_dt = _dt.fromisoformat(after).replace(tzinfo=_tz.utc) if after else None
-        before_dt = _dt.fromisoformat(before).replace(tzinfo=_tz.utc) if before else None
-        ref_dt = (
-            _dt.fromisoformat(reference_date).replace(tzinfo=_tz.utc) if reference_date else None
-        )
+        after_dt = _to_utc_datetime(_dt.fromisoformat(after)) if after else None
+        before_dt = _to_utc_datetime(_dt.fromisoformat(before)) if before else None
+        ref_dt = _to_utc_datetime(_dt.fromisoformat(reference_date)) if reference_date else None
 
         results = await api.search(
             query=query,
@@ -1763,13 +1778,11 @@ async def memex_note_search(
         _validate_vault_ids(vault_ids)
         resolved_vids = await _resolve_vault_ids(api, vault_ids)
 
-        from datetime import datetime as _dt, timezone as _tz
+        from datetime import datetime as _dt
 
-        after_dt = _dt.fromisoformat(after).replace(tzinfo=_tz.utc) if after else None
-        before_dt = _dt.fromisoformat(before).replace(tzinfo=_tz.utc) if before else None
-        ref_dt = (
-            _dt.fromisoformat(reference_date).replace(tzinfo=_tz.utc) if reference_date else None
-        )
+        after_dt = _to_utc_datetime(_dt.fromisoformat(after)) if after else None
+        before_dt = _to_utc_datetime(_dt.fromisoformat(before)) if before else None
+        ref_dt = _to_utc_datetime(_dt.fromisoformat(reference_date)) if reference_date else None
 
         search_limit = limit * 3 if has_assets else limit
         results = await api.search_notes(


### PR DESCRIPTION
## Summary
- **F2**: New `AnisotropyCorrector` module implementing D-MEM §4.1 Z-score → sigmoid normalization for cosine similarity scores
- Sliding-window (default k=1024) tracks historical mean and std of pairwise similarities; normalizes new scores through Z-score → sigmoid to counteract embedding anisotropy
- Wired into `RetrievalEngine._compute_pairwise_cosine` so MMR diversity filtering uses corrected similarities
- Cold-start passthrough: returns raw scores unchanged until 32 observations collected
- Config knobs: `anisotropy_window_size` (default 1024), `anisotropy_min_samples` (default 32)
- `AnisotropyCorrectorGroup` for per-site corrector management

## Spec reference
- `cognitive-memory-research-report.md` F2 (D-MEM Z-score anisotropy correction)

## Design note
The anisotropy corrector is applied at the pairwise cosine matrix level (used by MMR), not at the SQL-level `<=>` distance filter. SQL-level filters use hard thresholds; adjusting those requires a different approach (threshold calibration) and is out of scope for F2.

## Test plan
- [x] 19 unit tests covering cold-start passthrough, Z-score normalization behavior, sigmoid bounds, monotonicity, sliding window eviction, running stats accuracy, group API
- [x] All 2244 unit tests pass
- [x] mypy, ruff, ruff-format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)