### PR TITLE
fix(test/F8): restore maintenance_proposals after CASCADE drop (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,234%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,303%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/core/tests/integration/services/test_int_f8_lint_query.py
+++ b/packages/core/tests/integration/services/test_int_f8_lint_query.py
@@ -283,12 +283,22 @@ async def test_vault_scoping(session: AsyncSession, api) -> None:
 
 @pytest.mark.asyncio
 async def test_missing_table_raises_initialization_error(
-    session: AsyncSession, api, metastore
+    session: AsyncSession, api, metastore, engine
 ) -> None:
-    """Drop maintenance_proposals; the next get_findings raises the documented error."""
+    """Drop maintenance_proposals; the next get_findings raises the documented error.
+
+    The table is recreated in ``finally`` so downstream tests in the same
+    session do not observe the simulated uninitialized state.
+    """
+    from sqlmodel import SQLModel
+
     await session.execute(text('DROP TABLE IF EXISTS maintenance_proposals CASCADE'))
     await session.commit()
-
-    with pytest.raises(LintSubsystemNotInitializedError) as ei:
-        await api.lint.get_findings()
-    assert 'alembic upgrade head' in str(ei.value)
+    try:
+        with pytest.raises(LintSubsystemNotInitializedError) as ei:
+            await api.lint.get_findings()
+        assert 'alembic upgrade head' in str(ei.value)
+    finally:
+        table = SQLModel.metadata.tables['maintenance_proposals']
+        async with engine.begin() as conn:
+            await conn.run_sync(lambda sync_conn: table.create(sync_conn, checkfirst=True))


### PR DESCRIPTION
## Summary
- `test_missing_table_raises_initialization_error` (F8) intentionally drops `maintenance_proposals` to assert that an uninitialized lint subsystem raises `LintSubsystemNotInitializedError`. It never recreated the table, so any later test in the same pytest session that touched `maintenance_proposals` failed (e.g. F10 lint-LLM tests, F6 rules, alembic 025).
- Wrap the test body in `try/finally` and recreate the table from `SQLModel.metadata` (`checkfirst=True`) in the cleanup branch. The original assertion is preserved verbatim.

## Test plan
- [x] `pytest packages/core/tests/integration/services/test_int_f8_lint_query.py::test_missing_table_raises_initialization_error` — passes in isolation
- [x] `pytest packages/core/tests/integration/services/test_int_f8_lint_query.py` — 11 passed
- [x] `pytest packages/core/tests/integration/services/test_int_f8_lint_query.py packages/core/tests/integration/services/test_int_f10_lint_llm.py` — 35 passed (F10 was previously broken by the missing table)
- [x] `pytest packages/core/tests/integration/services/` — 49 passed
- [x] `pytest packages/core/tests/integration/services/ -p no:randomly` — 49 passed (no ordering sensitivity)
- [x] `pytest packages/core/tests/integration/services/ packages/core/tests/integration/test_int_f6_rules.py packages/core/tests/integration/test_int_alembic_025.py -p no:randomly` — 64 passed
- [x] ruff check + ruff format clean
- [x] pre-commit hooks (debug, ruff, mypy, badge) green on commit

Resolves task #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)