### PR TITLE
fix(hermes/prefetch): wait for both layers in consume()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,628%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,530%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/prefetch.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/prefetch.py
@@ -37,6 +37,12 @@ class PrefetchCache:
         self._notes: list[Any] = []
         self._generation: int = 0
         self._pending: set[int] = set()
+        # Per-layer completion signals for the current generation. Both start
+        # set so a fresh cache with no queue() yet treats consume() as idle.
+        self._facts_done: threading.Event = threading.Event()
+        self._notes_done: threading.Event = threading.Event()
+        self._facts_done.set()
+        self._notes_done.set()
 
     def queue(
         self,
@@ -53,6 +59,13 @@ class PrefetchCache:
             self._facts = []
             self._notes = []
             self._pending = {gen}
+            # Replace events so stale completions from prior generations
+            # cannot satisfy this generation's wait. Bind new instances under
+            # the lock and let fetch closures capture them by reference.
+            self._facts_done = threading.Event()
+            self._notes_done = threading.Event()
+            facts_done = self._facts_done
+            notes_done = self._notes_done
 
         vault_ids: list[Any] | None = [vault_id] if vault_id else None
 
@@ -75,6 +88,8 @@ class PrefetchCache:
                         self._facts = list(result or [])
             except Exception as e:
                 logger.debug('Prefetch facts failed: %s', e)
+            finally:
+                facts_done.set()
 
         def _fetch_notes() -> None:
             try:
@@ -93,6 +108,8 @@ class PrefetchCache:
                         self._notes = list(result or [])
             except Exception as e:
                 logger.debug('Prefetch notes failed: %s', e)
+            finally:
+                notes_done.set()
 
         threading.Thread(
             target=_fetch_facts, daemon=True, name=f'memex-prefetch-facts-{gen}'
@@ -104,15 +121,25 @@ class PrefetchCache:
     def consume(self, timeout: float = 3.0) -> str:
         """Wait up to ``timeout`` for the current generation's results, then format.
 
-        Polls at 50ms intervals until both layers have landed or until the
-        deadline passes. Returns '' if nothing arrived. After consumption the
-        buffers are cleared so the next turn starts fresh.
+        Waits for BOTH layers to report completion (success or failure) or for
+        the deadline to pass. Returns whatever populated by then; '' if nothing
+        arrived. After consumption the buffers are cleared so the next turn
+        starts fresh.
+
+        Note on the wait shape: an earlier implementation broke the wait as
+        soon as EITHER layer reported data, then snapshot+cleared. Under load
+        the slow layer's results landed in the cleared buffer for the same
+        generation and were lost on the next ``queue()``. The both-or-deadline
+        wait fixes this; partial results are only returned post-deadline.
         """
+        with self._lock:
+            facts_done = self._facts_done
+            notes_done = self._notes_done
+
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            with self._lock:
-                if self._facts or self._notes:
-                    break
+            if facts_done.is_set() and notes_done.is_set():
+                break
             time.sleep(0.05)
 
         with self._lock:

--- a/packages/hermes-plugin/tests/test_prefetch.py
+++ b/packages/hermes-plugin/tests/test_prefetch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
@@ -87,3 +88,50 @@ def test_slow_fetch_respects_timeout():
     api.search_notes = slow_search
     cache.queue('q', api=api, config=config, vault_id=uuid4())
     assert cache.consume(timeout=0.1) == ''
+
+
+def test_consume_waits_for_both_layers_when_one_is_slow():
+    """Regression: under load the prior consume() exited as soon as EITHER
+    layer landed and cleared the buffers, losing the slower layer. Now
+    consume() waits until both layers have reported completion or until the
+    deadline expires.
+    """
+    cache = PrefetchCache()
+    config = HermesMemexConfig()
+    api = Mock()
+
+    async def slow_facts(*args, **kwargs):
+        await asyncio.sleep(0.2)
+        return [_fact('slow-fact')]
+
+    async def fast_notes(*args, **kwargs):
+        return [_note_result('fast-note')]
+
+    api.search = slow_facts
+    api.search_notes = fast_notes
+    cache.queue('q', api=api, config=config, vault_id=uuid4())
+    text = cache.consume(timeout=2.0)
+    assert 'slow-fact' in text, 'slow layer was lost — early-exit regression'
+    assert 'fast-note' in text
+
+
+def test_consume_returns_partial_after_deadline_does_not_deadlock():
+    """Worst-case: both layers exceed the deadline. consume() must terminate
+    at the deadline and return whatever's populated (or '' if nothing).
+    """
+    cache = PrefetchCache()
+    config = HermesMemexConfig()
+    api = Mock()
+
+    async def hung_search(*args, **kwargs):
+        await asyncio.sleep(5)
+        return []
+
+    api.search = hung_search
+    api.search_notes = hung_search
+    cache.queue('q', api=api, config=config, vault_id=uuid4())
+    started = time.monotonic()
+    text = cache.consume(timeout=0.2)
+    elapsed = time.monotonic() - started
+    assert text == ''
+    assert elapsed < 1.0, f'consume() did not honour deadline: elapsed={elapsed:.3f}s'


### PR DESCRIPTION
Closes #30 prefetch race flake. Drops the early-exit that allowed consume() to return before both cache layers populated.