### PR TITLE
feat(F9): per-vault rate limit on memex_memory_consolidate (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,234%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,308%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -874,11 +874,23 @@ class RemoteMemexAPI:
         *,
         dry_run: bool = False,
     ) -> dict[str, Any]:
-        """F9: vault-wide low-MW unit consolidation."""
-        return await self._post(
-            'memory/consolidate',
-            {'vault_id': str(vault_id), 'dry_run': dry_run},
-        )
+        """F9: vault-wide low-MW unit consolidation.
+
+        On HTTP 429 (per-vault rate limit, RFC-008 line 125), raises a
+        structured ``RateLimitExceeded`` carrying ``retry_after_seconds``
+        so callers can surface the back-off time without re-parsing the
+        body. Mirrors :meth:`summarize_node`.
+        """
+        body = {'vault_id': str(vault_id), 'dry_run': dry_run}
+        response = await self.client.post('memory/consolidate', json=body)
+        if response.status_code == 429:
+            payload = response.json()
+            raise RateLimitExceeded(
+                retry_after_seconds=float(payload.get('retry_after_seconds', 0.0)),
+                message=str(payload.get('message', 'Rate limit exceeded.')),
+            )
+        response.raise_for_status()
+        return response.json()
 
     async def get_memory_links(
         self,

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -850,6 +850,36 @@ class ConsolidationConfig(BaseModel):
     )
 
 
+class ConsolidateRateLimitConfig(BaseModel):
+    """F9: rate-limit config for memex_memory_consolidate (RFC-008 line 125).
+
+    Per-vault token bucket (default 1 call per vault per hour). LLM-intensive
+    workload + mass-mutation guard — reuses F5's TokenBucketRateLimiter
+    primitive. In-process LRU; multi-worker leakage matches F5's documented
+    limitation (advisory, not security gate).
+    """
+
+    enabled: bool = Field(
+        default=True,
+        description='When False, consolidate_vault calls are never rate-limited (set False in tests).',
+    )
+    per_vault_per_seconds: int = Field(
+        default=3600,
+        gt=0,
+        description='Window in seconds across which `burst` calls are allowed per vault (default 1h).',
+    )
+    burst: int = Field(
+        default=1,
+        gt=0,
+        description='Token-bucket capacity. Default 1 = no bursting (1 call per window).',
+    )
+    max_keys: int = Field(
+        default=10000,
+        gt=0,
+        description='LRU eviction cap on tracked vault_id keys.',
+    )
+
+
 class Permission(str, Enum):
     """Granular permissions for API key access control."""
 
@@ -1235,6 +1265,11 @@ class MemoryConfig(BaseModel):
     consolidation: ConsolidationConfig = Field(
         default_factory=ConsolidationConfig,
         description='F38 consolidation orchestrator configuration.',
+    )
+
+    consolidate_rate_limit: ConsolidateRateLimitConfig = Field(
+        default_factory=ConsolidateRateLimitConfig,
+        description='F9: per-vault rate limit for memex_memory_consolidate (RFC-008 line 125).',
     )
 
     circuit_breaker: CircuitBreakerConfig = Field(

--- a/packages/core/src/memex_core/server/memories.py
+++ b/packages/core/src/memex_core/server/memories.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from memex_common.exceptions import MemexError, MemoryUnitNotFoundError
@@ -18,6 +19,7 @@ from memex_core.server.common import (
     get_api,
 )
 from memex_core.services.locks import EntityLockTimeoutError
+from memex_core.services.rate_limit import RateLimitExceededError
 
 logger = logging.getLogger('memex.core.server')
 
@@ -162,19 +164,47 @@ async def reconsolidate_entity(
 @router.post(
     '/memory/consolidate',
     dependencies=[Depends(require_write)],
+    responses={
+        429: {
+            'description': 'Rate limit exceeded for this vault (default 1 call per vault per hour).',
+            'content': {
+                'application/json': {
+                    'example': {
+                        'error': 'rate_limit_exceeded',
+                        'retry_after_seconds': 1234.5,
+                        'message': 'Rate limit exceeded; retry after 1234.50s.',
+                    }
+                }
+            },
+        }
+    },
 )
 async def consolidate_vault(
     request: Annotated[ConsolidateRequest, Body()],
     api: Annotated[MemexAPI, Depends(get_api)],
-) -> dict[str, Any]:
+) -> Any:
     """F9: vault-wide low-MW unit consolidation. RFC-008.
 
     Predicate: mw_score<0.35 AND outcomes>=5 AND !is_deprioritized AND
     created_at<now()-30d. dry_run=true returns preview without writes.
-    Note: rate-limit deferred to task #33.
+
+    Rate-limited per vault (RFC-008 line 125; default 1 call per vault per
+    hour). Translates ``RateLimitExceededError`` into a 429 envelope with a
+    ``Retry-After`` header. Mirrors the F5 summarize-node 429 contract.
     """
     try:
         return await api.consolidate_vault(request.vault_id, dry_run=request.dry_run)
+    except RateLimitExceededError as exc:
+        retry_after = max(0, int(exc.retry_after_seconds + 0.999))
+        return JSONResponse(
+            status_code=429,
+            content={
+                'error': 'rate_limit_exceeded',
+                'retry_after_seconds': exc.retry_after_seconds,
+                'message': str(exc),
+            },
+            headers={'Retry-After': str(retry_after)},
+        )
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, 'Consolidate failed')
 

--- a/packages/core/src/memex_core/services/locks.py
+++ b/packages/core/src/memex_core/services/locks.py
@@ -30,6 +30,7 @@ from sqlalchemy.engine.url import make_url
 from sqlmodel import select
 
 from memex_common.exceptions import MemexError
+from memex_core.services.rate_limit import TokenBucketRateLimiter
 
 if TYPE_CHECKING:
     from memex_core.config import MemexConfig
@@ -184,6 +185,16 @@ class LocksService:
         self.contradiction = contradiction
         self.units = units
         self._dsn = _dsn_from_config(config)
+        # F9 / RFC-008 line 125: per-vault rate limit on memex_memory_consolidate.
+        # Reuses F5's TokenBucketRateLimiter primitive. Default 1 call per vault
+        # per hour (LLM-intensive + mass-mutation guard).
+        consolidate_cfg = config.server.memory.consolidate_rate_limit
+        self._consolidate_limiter = TokenBucketRateLimiter(
+            per_seconds=consolidate_cfg.per_vault_per_seconds,
+            burst=consolidate_cfg.burst,
+            max_keys=consolidate_cfg.max_keys,
+            enabled=consolidate_cfg.enabled,
+        )
 
     async def _resolve_entity_to_unit_ids(
         self,
@@ -342,9 +353,12 @@ class LocksService:
         """Vault-wide low-MW unit consolidation (RFC-008).
 
         Steps:
-            1. Identify candidates by predicate (see `_select_consolidate_candidates`).
-            2. If `dry_run`: return preview, no writes.
-            3. Otherwise: for each candidate, call F4
+            1. Acquire a per-vault rate-limit token (RFC-008 line 125;
+               default 1 call per vault per hour). Skipped on `dry_run`
+               so agents can preview cheaply without burning the bucket.
+            2. Identify candidates by predicate (see `_select_consolidate_candidates`).
+            3. If `dry_run`: return preview, no writes.
+            4. Otherwise: for each candidate, call F4
                `UnitsService.set_unit_deprioritized` and write a
                `MaintenanceProposal` row with `status='resolved'`,
                `rule_name='consolidate_vault_low_mw'`, evidence carrying
@@ -356,10 +370,18 @@ class LocksService:
         Branch B fallback: if `maintenance_proposals` table is missing
         (F6 not deployed), returns the preview shape without proposal
         writes. Branch A is live in this codebase since F6 merged.
+
+        Raises ``RateLimitExceededError`` (with ``retry_after_seconds``)
+        when the per-vault bucket is empty and ``dry_run=False``. The
+        exception is a service-layer signal — surface translation to
+        MCP/HTTP belongs to the calling layer (mirrors F5 summarize_node).
         """
         from sqlalchemy import inspect as sa_inspect
 
         from memex_core.metrics import CONSOLIDATE_TOTAL
+
+        if not dry_run:
+            self._consolidate_limiter.acquire(vault_id)
 
         try:
             candidates = await self._select_consolidate_candidates(vault_id)

--- a/packages/core/tests/unit/conftest.py
+++ b/packages/core/tests/unit/conftest.py
@@ -213,6 +213,13 @@ def mock_config():
     rate_cfg.per_entity_per_seconds = 60
     rate_cfg.burst = 1
     rate_cfg.max_keys = 1000
+    # F9: per-vault consolidate rate limit; mirror the F5 disabled-by-default
+    # convention so unit tests building LocksService don't get throttled.
+    consolidate_cfg = config.server.memory.consolidate_rate_limit
+    consolidate_cfg.enabled = False
+    consolidate_cfg.per_vault_per_seconds = 3600
+    consolidate_cfg.burst = 1
+    consolidate_cfg.max_keys = 1000
     return config
 
 

--- a/packages/core/tests/unit/services/test_consolidate_rate_limit.py
+++ b/packages/core/tests/unit/services/test_consolidate_rate_limit.py
@@ -1,0 +1,162 @@
+"""Task #33 — F9 consolidate-vault rate-limit (RFC-008 line 125).
+
+Per-vault TokenBucket, default 1 call/hour. Reuses F5's
+``TokenBucketRateLimiter`` primitive. These tests verify the
+service-layer wiring and per-vault isolation; the bucket primitive
+itself is exercised in ``test_rate_limit.py``.
+
+Tests:
+- ``test_consolidate_rate_limit_first_call_succeeds_second_blocks``: with
+  burst=1, the second call within the window raises
+  ``RateLimitExceededError`` carrying ``retry_after_seconds``.
+- ``test_consolidate_rate_limit_sliding_1h_window``: after the full
+  ``per_vault_per_seconds`` window elapses, the bucket has refilled and
+  the next call succeeds. Frozen-clock keeps timing deterministic.
+- ``test_consolidate_rate_limit_isolated_per_vault``: a blocked vault
+  does not block other vaults — keys are vault-scoped.
+- ``test_consolidate_rate_limit_dry_run_is_not_charged``: ``dry_run=True``
+  bypasses the limiter so agents can preview cheaply.
+- ``test_consolidate_rate_limit_disabled_via_config``: when
+  ``enabled=False`` the limiter is a passthrough.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from memex_common.config import GLOBAL_VAULT_ID
+from memex_core.memory.contradiction.engine import ContradictionEngine
+from memex_core.services.locks import LocksService
+from memex_core.services.rate_limit import RateLimitExceededError, TokenBucketRateLimiter
+from memex_core.services.reflection import ReflectionService
+from memex_core.services.units import UnitsService
+
+
+class _FrozenClock:
+    """Monotonic clock stub. ``advance(seconds)`` moves it forward."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self._t = start
+
+    def __call__(self) -> float:
+        return self._t
+
+    def advance(self, seconds: float) -> None:
+        self._t += seconds
+
+
+def _make_locks_service(*, enabled: bool, clock: _FrozenClock) -> LocksService:
+    """Build a LocksService whose limiter uses a frozen clock.
+
+    Construction bypasses ``__init__`` (which derives a DSN from a real
+    config) — we only exercise ``consolidate_vault`` and stub out the
+    candidate selector + units dependency, so DSN never gets used.
+    """
+    contradiction = MagicMock(spec=ContradictionEngine)
+    reflection = MagicMock(spec=ReflectionService)
+    units = MagicMock(spec=UnitsService)
+    units.set_unit_deprioritized = AsyncMock(return_value=None)
+
+    svc = LocksService.__new__(LocksService)
+    svc.metastore = MagicMock()
+    svc.config = MagicMock()
+    svc.reflection = reflection
+    svc.contradiction = contradiction
+    svc.units = units
+    svc._dsn = 'postgresql://stub'  # never opened in these tests
+    svc._consolidate_limiter = TokenBucketRateLimiter(
+        per_seconds=3600.0,
+        burst=1,
+        max_keys=1000,
+        enabled=enabled,
+        clock=clock,
+    )
+
+    async def _no_candidates(_vault_id: uuid.UUID) -> list[uuid.UUID]:
+        return []
+
+    svc._select_consolidate_candidates = _no_candidates  # type: ignore[method-assign]
+
+    async def _has_table(_self: LocksService, _inspect: object) -> bool:
+        return False
+
+    svc._has_maintenance_proposals_table = _has_table.__get__(svc, LocksService)  # type: ignore[method-assign]
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_consolidate_rate_limit_first_call_succeeds_second_blocks() -> None:
+    clock = _FrozenClock()
+    svc = _make_locks_service(enabled=True, clock=clock)
+    vault_id = GLOBAL_VAULT_ID
+
+    result = await svc.consolidate_vault(vault_id, dry_run=False)
+    assert result['vault_id'] == str(vault_id)
+    assert result['dry_run'] is False
+
+    with pytest.raises(RateLimitExceededError) as exc:
+        await svc.consolidate_vault(vault_id, dry_run=False)
+    assert exc.value.key == vault_id
+    assert 0 < exc.value.retry_after_seconds <= 3600.0
+
+
+@pytest.mark.asyncio
+async def test_consolidate_rate_limit_sliding_1h_window() -> None:
+    clock = _FrozenClock()
+    svc = _make_locks_service(enabled=True, clock=clock)
+    vault_id = GLOBAL_VAULT_ID
+
+    await svc.consolidate_vault(vault_id, dry_run=False)
+    with pytest.raises(RateLimitExceededError):
+        await svc.consolidate_vault(vault_id, dry_run=False)
+
+    clock.advance(3599.9)
+    with pytest.raises(RateLimitExceededError):
+        await svc.consolidate_vault(vault_id, dry_run=False)
+
+    clock.advance(1.0)
+    await svc.consolidate_vault(vault_id, dry_run=False)
+
+
+@pytest.mark.asyncio
+async def test_consolidate_rate_limit_isolated_per_vault() -> None:
+    clock = _FrozenClock()
+    svc = _make_locks_service(enabled=True, clock=clock)
+    vault_a = uuid.uuid4()
+    vault_b = uuid.uuid4()
+
+    await svc.consolidate_vault(vault_a, dry_run=False)
+    with pytest.raises(RateLimitExceededError):
+        await svc.consolidate_vault(vault_a, dry_run=False)
+
+    await svc.consolidate_vault(vault_b, dry_run=False)
+    with pytest.raises(RateLimitExceededError):
+        await svc.consolidate_vault(vault_b, dry_run=False)
+
+
+@pytest.mark.asyncio
+async def test_consolidate_rate_limit_dry_run_is_not_charged() -> None:
+    clock = _FrozenClock()
+    svc = _make_locks_service(enabled=True, clock=clock)
+    vault_id = GLOBAL_VAULT_ID
+
+    for _ in range(5):
+        result = await svc.consolidate_vault(vault_id, dry_run=True)
+        assert result['dry_run'] is True
+
+    await svc.consolidate_vault(vault_id, dry_run=False)
+    with pytest.raises(RateLimitExceededError):
+        await svc.consolidate_vault(vault_id, dry_run=False)
+
+
+@pytest.mark.asyncio
+async def test_consolidate_rate_limit_disabled_via_config() -> None:
+    clock = _FrozenClock()
+    svc = _make_locks_service(enabled=False, clock=clock)
+    vault_id = GLOBAL_VAULT_ID
+
+    for _ in range(10):
+        await svc.consolidate_vault(vault_id, dry_run=False)

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3873,14 +3873,30 @@ async def memex_memory_consolidate(
         Field(description='If true, return preview without making changes.'),
     ] = False,
 ) -> dict[str, Any]:
-    """F9: vault-wide low-MW unit consolidation."""
+    """F9: vault-wide low-MW unit consolidation.
+
+    Rate-limited per vault (RFC-008 line 125; default 1 call per vault per
+    hour). On 429 the tool returns a structured envelope with
+    ``retry_after_seconds`` rather than raising — mirrors the F5
+    summarize-node contract so agents can back off without retry loops.
+    """
+    from memex_common.client import RateLimitExceeded
+
     try:
         api = get_api(ctx)
         try:
             vault_uuid = UUID(vault_id)
         except ValueError:
             raise ToolError(f'Invalid vault UUID: {vault_id}')
-        return await api.consolidate_vault(vault_uuid, dry_run=dry_run)
+        try:
+            return await api.consolidate_vault(vault_uuid, dry_run=dry_run)
+        except RateLimitExceeded as exc:
+            return {
+                'error': 'rate_limit_exceeded',
+                'vault_id': vault_id,
+                'retry_after_seconds': exc.retry_after_seconds,
+                'message': str(exc),
+            }
     except ToolError:
         raise
     except Exception as e:


### PR DESCRIPTION
RFC-008 line 125: TokenBucket per vault, 1 call/hour. Closes #33. Task #34 (resolved_by column) deferred to follow-up agent.