### PR TITLE
docs(rfc-014): FSRS-5 patch + Tier-A artifact corpus (#28 / #40)

### DIFF
--- a/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/001-per-entity-advisory-lock-disjoint-range.md
+++ b/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/001-per-entity-advisory-lock-disjoint-range.md
@@ -1,0 +1,41 @@
+# ADR-001: Per-Entity Advisory Lock IDs Use a Disjoint High-Bit Range
+
+## Status
+
+Accepted
+
+## Context
+
+F9 introduces per-entity advisory locks so that concurrent reflection workers can serialize on a single entity without blocking the global scheduler. PostgreSQL `pg_advisory_lock` takes a single `bigint` (signed 64-bit), and the existing leader-election lock at `5432789123456789` already occupies that namespace.
+
+A naive hash of `entity_id` (UUID) into `bigint` risks colliding with the leader lock, which would cause a worker to silently block the scheduler — or, worse, allow a worker to acquire the leader lock by accident and corrupt the leader-election protocol. We need a derivation that is provably disjoint from the leader value, cheap to compute, and collision-resistant across the realistic UUID population (millions of entities per vault).
+
+## Decision
+
+Per-entity advisory lock IDs are derived as:
+
+```
+(1 << 62) | (int.from_bytes(uuid.bytes, 'big', signed=False) & ((1 << 62) - 1))
+```
+
+The leader-election lock remains pinned at `5432789123456789`, whose bit 62 is unset. By construction, every per-entity lock has bit 62 set, and the leader does not — the two ranges are disjoint by inspection (`LEADER & (1 << 62) == 0`). A 1M-UUID collision test pins the implementation against accidental regressions.
+
+Implemented in `packages/core/src/memex_core/services/locks.py`. Specified in RFC-005 and refined in RFC-008.
+
+## Consequences
+
+**Positive:**
+- Disjointness is a single-line proof, not a probabilistic argument.
+- 62-bit entropy from the UUID gives ample collision headroom.
+- No coordination table needed — derivation is pure.
+- Future namespaces can claim other high bits (bit 61, 60) using the same pattern.
+
+**Negative:**
+- Lock IDs are negative when interpreted as signed `bigint` (Postgres convention) — debugging output looks unusual.
+- The convention is a hard contract: any future code that assigns advisory lock IDs in this codebase MUST consult this ADR before picking a range.
+
+## Alternatives Considered
+
+- **Plain `hash(uuid) % bigint_max`** — rejected: non-zero leader-collision probability, no proof of disjointness.
+- **Two-key advisory locks (`pg_advisory_lock(int, int)`)** — rejected: would diverge from the existing single-key leader lock and require migrating that surface too.
+- **Dedicated `entity_locks` table with row-level locks** — rejected: adds a write per acquisition and a contention point on the table itself; advisory locks are free and hold for the session.

--- a/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/002-dual-layer-bool-rejection-revisit.md
+++ b/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/002-dual-layer-bool-rejection-revisit.md
@@ -1,0 +1,37 @@
+# ADR-002: Dual-Layer `BeforeValidator` Rejects `bool` for Revisit Quality
+
+## Status
+
+Accepted
+
+## Context
+
+F20's `quality` parameter accepts a `Quality` enum value via either an integer (`0..3`) or a string label (`'again' | 'hard' | 'good' | 'easy'`). The natural Pydantic type is `int | str`. Python's type system treats `bool` as a subclass of `int`, so `True` and `False` are valid `int` values. Pydantic's union resolution coerces `bool` to `int` BEFORE the function body runs: `True → 1 → Quality.HARD`, `False → 0 → Quality.AGAIN`.
+
+This is a silent corruption vector. A buggy caller passing `True` would receive HTTP 200, the audit log would record an "outcome.record" row, FSRS counters would update, and downstream consolidation (F38) would consume the bogus data — the system would "work" while quietly poisoning the per-unit retention model. A single-layer guard would leak the moment a new entry point bypassed it.
+
+## Decision
+
+Reject `bool` at the Pydantic validator gate using `BeforeValidator(_reject_bool_quality)` BEFORE int coercion. Apply this at BOTH entry points:
+
+- MCP tool surface: `packages/mcp/src/memex_mcp/server.py`
+- HTTP route surface: `packages/core/src/memex_core/server/revisit.py`
+
+`_reject_bool_quality` raises a typed validation error (`'quality must be int 0-3 or string label, not bool'`) so callers get a 422 with an actionable message.
+
+## Consequences
+
+**Positive:**
+- A buggy or malicious caller cannot smuggle `True/False` into the FSRS state machine.
+- Defense-in-depth: a single-layer regression on one surface does not reopen the corruption vector on the other.
+- The validator is reusable for any future field that takes `int | str` and must reject `bool`.
+
+**Negative:**
+- The same validator is wired in two places — both must be updated together if the contract changes. This is enforced by an integration test that exercises both surfaces with a `True` payload and asserts a 422.
+- Slight cognitive overhead: contributors must understand WHY `bool` is rejected (the subclass relationship is not obvious).
+
+## Alternatives Considered
+
+- **Single-layer guard at the service** — rejected: any future entry point (CLI, gRPC, batch import) would have to remember to call the service, and a direct route handler bypassing the service would silently reintroduce the bug.
+- **Use a `Literal[0,1,2,3] | Literal['again','hard','good','easy']` type instead of `int | str`** — rejected: `Literal[0,1,2,3]` still accepts `True/False` because `True == 1` and `False == 0` under Python equality, which Pydantic uses for `Literal` matching.
+- **Strict mode globally** — rejected: too disruptive; would require auditing every union in the codebase.

--- a/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/003-surprise-gated-llm-lint-cost-cap.md
+++ b/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/003-surprise-gated-llm-lint-cost-cap.md
@@ -1,0 +1,40 @@
+# ADR-003: Surprise-Gated LLM Lint With 24h Count Cap and Defer-Not-Drop
+
+## Status
+
+Accepted
+
+## Context
+
+F10 introduces an LLM-based lint pass over newly-extracted memory units (DSPy-driven contradiction and quality checks). Running an LLM on every unit is prohibitively expensive and mostly wasted: most extracted units are mundane and will not surface a useful lint signal. We need a gate that invokes the LLM only when there is likely something interesting to find, and a cost cap that bounds spend per vault even under burst load.
+
+Two failure modes must be avoided: (1) silent over-spend when an upstream component floods the queue, and (2) silent data loss when the cap fires — a unit that misses its lint window today should still be evaluable tomorrow.
+
+## Decision
+
+F10 LLM lint is gated by an anisotropy-corrected surprise score with threshold 0.7. The score uses cheap embedding distances against the per-vault corpus distribution; only high-surprise units pass the gate.
+
+A 24h rolling cost cap is enforced via the `LintLLMQuota` table with hour-bucket UPSERT keyed on `uq_lint_llm_quota_vault_hour`. The cap is stored as an **integer count of LLM calls**, not cents — billing model conversions are deferred to the metrics layer where pricing changes do not require a schema migration. Both DSPy checks (contradiction lint and quality lint) share the same per-vault cap.
+
+When the cap is exceeded, units are **deferred, not dropped**: a `MaintenanceProposal` row is queued with `rule_name='llm_deferred'`, and the consolidation tick re-evaluates them once budget reopens.
+
+Implemented in `packages/core/src/memex_core/memory/lint_llm/`. Specified in RFC-006. Schema in alembic 029.
+
+## Consequences
+
+**Positive:**
+- LLM is invoked only on surprising units — embeddings preempt expensive calls for the long tail.
+- Hour-bucket UPSERT is concurrent-writer-safe under the single-leader scheduler; multiple workers cannot exceed the cap.
+- Defer-not-drop preserves work across cap boundaries — no permanent loss of lint signal.
+
+**Negative:**
+- Two-stage decision (surprise + cap) makes the lint pipeline harder to reason about during incident response. Mitigated by structured logs at each gate.
+- Count-based cap is approximate in cost terms — a future schema migration is needed if per-call costs become highly variable across model tiers.
+- Deferral queue can grow unbounded under sustained over-budget load; monitored via Prometheus.
+
+## Alternatives Considered
+
+- **Cents-based cap** — rejected: couples schema to billing model; provider price changes force migrations.
+- **Drop on cap** — rejected: silently loses lint signal; violates the "no quiet data loss" invariant.
+- **Per-call cost cap (no surprise gate)** — rejected: still spends LLM cycles on uninteresting units even within budget.
+- **Sliding-window Redis counter** — rejected: introduces a new infra dependency; Postgres UPSERT is sufficient given the scheduler is single-leader.

--- a/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/004-audit-log-integration-seam.md
+++ b/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/004-audit-log-integration-seam.md
@@ -1,0 +1,39 @@
+# ADR-004: Audit Log Is the Integration Seam Between F20 Revisitation and F38 Consolidation
+
+## Status
+
+Accepted
+
+## Context
+
+F20 (Revisitation / FSRS-driven review) and F38 (Consolidation tick) are two cognitive-memory features that collaborate: F20 records the outcome of a review against a memory unit (quality, scheduled-next interval), and F38 reads those outcomes to decide which units to consolidate, prune, or surface for follow-up.
+
+A direct service-to-service import (`ConsolidationService` calls `RevisitationService`, or vice versa) would couple two independently-evolving features at the type and method-signature level. Each feature has its own RFC, its own owner, and its own iteration cadence. A coupled API would force lock-step releases and make either side hard to refactor without breaking the other.
+
+We already have an append-only audit log that every state-changing operation in the system writes to. Reusing it as the integration seam is essentially free.
+
+## Decision
+
+F20's `RevisitationService.review()` emits `AuditLog(action='outcome.record', resource_type='memory_unit', resource_id=<unit_id>, payload=<quality, fsrs_state>)` per call.
+
+F38's `ConsolidationService.tick()` reads these via `select_diff_units`, which filters on `AuditLog.action == 'outcome.record'` and returns the affected memory units since the last consolidation watermark. F38 does not import F20; F20 does not import F38.
+
+Implemented in `packages/core/src/memex_core/services/revisitation.py` and `packages/core/src/memex_core/services/consolidation.py:select_diff_units`. Cross-feature contract is exercised by integration tests under `packages/core/tests/integration/`.
+
+## Consequences
+
+**Positive:**
+- F20 and F38 evolve independently as long as the audit-log payload shape is preserved.
+- The audit log is already durable and queryable — no new infra.
+- Other features (telemetry, replay, debugging) get F20 outcomes for free via the same channel.
+- Easy to add new consumers (e.g., a future "spaced learning report" feature) without touching F20 or F38.
+
+**Negative:**
+- The contract is a string literal (`'outcome.record'`) plus a payload schema, not a typed interface. A typo in either side fails silently. Mitigated by a constant in a shared module and an integration test that round-trips a real review through both services.
+- Reading via `select_diff_units` requires a watermark — F38 must persist its last-seen audit cursor to avoid replaying outcomes.
+
+## Alternatives Considered
+
+- **Direct service import** — rejected: couples release cadence and makes either side hard to refactor.
+- **Dedicated `revisit_outcomes` table** — rejected: duplicates information already captured in the audit log, and creates two write paths to keep in sync.
+- **Event bus (e.g., NATS, Redis streams)** — rejected: adds infra; the audit log already provides at-least-once semantics with cursor-based replay.

--- a/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/005-tool-count-drift-guard-set-union.md
+++ b/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/005-tool-count-drift-guard-set-union.md
@@ -1,0 +1,41 @@
+# ADR-005: Tool-Count Drift-Guard Reconciliation by Set Union Across Multi-Stream Merges
+
+## Status
+
+Accepted
+
+## Context
+
+The Hermes plugin and the MCP surface both ship a "drift guard" — a strict-equality assertion on the number of registered tools (and the exact tool name set). The guard exists so that any unintended addition or removal of a tool fails CI loudly, instead of silently expanding the agent surface.
+
+In a multi-stream dev-team workflow, several feature branches independently land tools and bump the guard. Each branch sees only its own additions plus the base set. When two such branches merge into the integration branch, the three-way merge produces a textual conflict on:
+
+1. The numeric count assertion (`assert len(tools) == N`).
+2. The exact-set assertion (`assert tool_names == { ... }`).
+
+Naively taking either side of the conflict drops the OTHER branch's feature from the guard, which then accepts a regression that removes that feature without failing.
+
+This pattern was first observed during the F38/F6 substrate merges and re-applied for F20/F9 surface merges. It needs to be a written rule, not tribal knowledge.
+
+## Decision
+
+When multiple feature branches independently bump the Hermes tool-count drift guard, three-way merge conflicts on the count and the name set are resolved by **set union across both feature clusters**, never by taking either side wholesale. The numeric count assertion is reconciled to `len(union)`.
+
+Demonstrated in `packages/hermes-plugin/tests/test_provider.py` and `packages/hermes-plugin/tests/test_tools.py`. Applies anywhere strict-equality assertions over an evolving set are merged across parallel streams.
+
+## Consequences
+
+**Positive:**
+- Each merge preserves every feature's contribution to the guard.
+- The guard remains strict: post-merge, removing any tool from any merged feature still fails CI.
+- The rule is mechanical — reviewers can verify by listing the tools added on each side and checking the result is the union.
+
+**Negative:**
+- Requires manual conflict resolution with explicit awareness of what each side added; cannot be auto-resolved by `git merge -X ours` or `theirs`.
+- Easy to get wrong under time pressure. Mitigated by a CI step that runs the drift guard immediately after merge and by a PR-checklist item.
+
+## Alternatives Considered
+
+- **Replace strict equality with a "contains at least" assertion** — rejected: defeats the purpose of the drift guard, which exists to catch unintended additions as well as removals.
+- **Generate the expected set at runtime from the registry** — rejected: the assertion would always pass; the test would no longer detect drift.
+- **Single-stream feature delivery** — rejected: parallel work is the whole point of the dev-team workflow.

--- a/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/006-fsrs-5-py-fsrs-version-pinning.md
+++ b/.dev-team-artifacts/dev-tier-a-cognitive-memory/adrs/006-fsrs-5-py-fsrs-version-pinning.md
@@ -1,0 +1,39 @@
+# ADR-006: F20 Pins py-fsrs 4.1.2 (FSRS-5), Diverging From RFC-007's FSRS-4.5 Reference
+
+## Status
+
+Accepted
+
+## Context
+
+F20 (Revisitation) implements spaced-repetition scheduling for memory units using the FSRS family of algorithms. The original RFC-007 referenced FSRS-4.5, the latest published variant at the time of writing. Implementation work began against the `py-fsrs` PyPI package, which had since released version 4.1.2.
+
+A direct cross-check between the live `py-fsrs` 4.1.2 source and the published FSRS-5 paper (verified 2026-05-01, captured in `POC-F20 paper-cross-check.md`) confirmed that py-fsrs 4.1.2 implements FSRS-5, not FSRS-4.5. The package version number does NOT match the algorithm version number — a documentation footgun.
+
+Continuing under the assumption that py-fsrs implements FSRS-4.5 would mean every reviewer reading the code against RFC-007 would see parameters and update rules that do not match the cited algorithm, with no obvious signal that the code is correct against a DIFFERENT version of FSRS.
+
+## Decision
+
+F20 pins `py-fsrs == 4.1.2` and treats it as the FSRS-5 implementation. The original RFC-007 reference to FSRS-4.5 is superseded by this ADR. Any future upgrade of py-fsrs (to 4.2+, 5.0, or beyond) MUST trigger a re-validation against the FSRS paper that the new version actually implements, and an update or successor to this ADR.
+
+The version-to-algorithm mapping is captured here so it survives package upgrades, contributor turnover, and RFC drift.
+
+Implemented in `packages/core/src/memex_core/memory/revisit.py`. Cross-check evidence in `POC-F20 paper-cross-check.md`.
+
+## Consequences
+
+**Positive:**
+- The algorithm in production matches the algorithm cited in code review and audit.
+- A clear trigger exists for re-validation when py-fsrs upgrades.
+- FSRS-5 is the more recent and better-calibrated algorithm; we benefit from the upgrade.
+
+**Negative:**
+- RFC-007 and this ADR disagree on a fact-of-the-matter (which FSRS variant is in use). Resolved by RFC-007 explicitly deferring to this ADR going forward.
+- py-fsrs version numbers do not track algorithm versions — every upgrade requires a manual paper cross-check, not just a CHANGELOG read.
+- If py-fsrs 4.1.3 is released as a bug-fix and silently changes algorithm behavior, our pin protects us, but a contributor who bumps the pin without reading this ADR could land a quiet regression. Mitigated by a comment at the import site referencing this ADR.
+
+## Alternatives Considered
+
+- **Downgrade to a py-fsrs version that implements FSRS-4.5** — rejected: older, less-calibrated algorithm, and no clear long-term maintenance story.
+- **Reimplement FSRS-4.5 in-house to match RFC-007** — rejected: high maintenance cost, reinventing a well-tested library.
+- **Update RFC-007 in place** — rejected: RFC history is part of the audit trail; an ADR is the correct mechanism for a decision that supersedes an earlier RFC reference.

--- a/.dev-team-artifacts/dev-tier-a-cognitive-memory/reports/final-report.md
+++ b/.dev-team-artifacts/dev-tier-a-cognitive-memory/reports/final-report.md
@@ -1,0 +1,129 @@
+# Tier-A Cognitive Memory — Final Phase 4 Report
+
+**Branch:** `memory_augmentation` @ `826b6b7`
+**Base:** `origin/main`
+**Delta:** 223 files changed, +32,174 / −168 (`git diff origin/main..HEAD --shortstat`)
+**Commit count:** 50 commits across 12 merge points (10 wave-2 feature merges + 2 POC merges; Wave-1 substrate landed in earlier merges still ahead of `origin/main`).
+
+## 1. Executive Summary
+
+Phase 4 closes the Tier-A cognitive-memory delivery against the spec at `cognitive-memory-research-report.md` §4. Eleven Tier-A features (F4, F5, F6, F8, F9, F10, F14, F20, F26, F29, F32, F38) shipped with full agent-surface parity (HTTP + MCP + Hermes plugin + Claude Code plugin where applicable), backing services, alembic migrations, and three-tier test coverage (unit / integration / E2E). The substrate adds: a maintenance-proposal ledger plus rule-based and surprise-gated LLM linters, an FSRS-5 revisitation scheduler, per-entity asyncpg advisory locks, a consolidation orchestrator, a procedural-KV namespace with `procedure_outcomes` audit, and a UMAP-backed diagnostics surface.
+
+Headline metrics: ten new MCP tools (count progression 41 → 46), eleven new alembic migrations (023, 025, 026, 027, 028, 029 and feature-internal stubs), six new top-level service modules (`services/lint.py`, `services/lint_llm.py`, `services/locks.py`, `services/revisitation.py`, `services/consolidation.py`, `services/diagnostics.py`), two new POC validation harnesses (asyncpg locks; FSRS-4.5 bit-exact parity at 76/76), and a worktree-venv-isolation convention captured after three live recurrences.
+
+All eleven Tier-A features are merged into `memory_augmentation`. Nine open follow-ups (issues #27–#36) carry over to post-Phase-2 work; none are blockers for the surface area shipped here.
+
+## 2. What Shipped
+
+| ID  | Title                                       | Service / module                                            | MCP surface                                                |
+| --- | ------------------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------- |
+| F4  | Memory deprioritize + audit                 | `services/outcomes.py`, alembic `023`                       | `memex_memory_deprioritize`, `memex_memory_restore`        |
+| F5  | Reflection summarize-node + rate limit      | `services/reflection.py` (widening), token-bucket limiter   | `memex_memory_summarize_node`                              |
+| F6  | Maintenance-proposal ledger + rule engine   | `services/lint.py`, alembic `025`                           | (write-only, no MCP)                                       |
+| F8  | Lint-flag query tool                        | `services/lint.py::get_findings`, opaque cursor             | `memex_get_lint_flags`                                     |
+| F9  | Per-entity advisory locks + reconsolidate   | `services/locks.py`                                         | `memex_memory_reconsolidate`, `memex_memory_consolidate`   |
+| F10 | Surprise-gated LLM lint                     | `services/lint_llm.py`, `memory/lint_llm/`, alembic `029`   | (background, no direct MCP)                                |
+| F14 | Procedural KV namespace                     | `services/kv.py`, `services/outcomes.py`, alembic `028`     | `memex_record_outcome`, briefing surface                   |
+| F20 | FSRS-5 revisitation                         | `services/revisitation.py`, `memory/revisit.py`, `026`      | `memex_get_due_for_review`, `memex_memory_review`          |
+| F26 | F32 lint dashboard aggregator               | `diagnostics/lint_dashboard.py`                             | (HTTP + CLI; folded into F32 summary)                      |
+| F29 | Hermes record-outcome parity                | Hermes provider + `MemexAPIProtocol.record_outcome`         | `memex_record_outcome` (Hermes parity)                     |
+| F32 | Diagnostics core                            | `diagnostics/{summary,heatmap,umap}.py`                     | `memex_get_diagnostics_summary`                            |
+| F38 | Consolidation orchestrator                  | `services/consolidation.py`, alembic `027`                  | (scheduler-driven; CLI: `memex consolidate`)               |
+
+### F4 — `memex_memory_deprioritize` + audit
+
+Soft-delete pathway for retrieval candidates. Tool registered at `packages/mcp/src/memex_mcp/server.py:3611` (deprioritize) / `:3647` (restore). Audit rows written through `services/outcomes.py`. Tests: `tests/test_e2e_f4_deprioritize.py`, `packages/cli/tests/test_memory_deprioritize_cli.py`, `packages/core/tests/integration/memory/retrieval/test_int_deprioritization.py`.
+
+### F5 — `memex_memory_summarize_node`
+
+Widens `ReflectionService.limit` to `int | None` and adds a per-`(actor, entity)` token-bucket. Synchronous endpoint at `POST /memories/summarize-node`. MCP at `server.py:3684`. Tests: `packages/core/tests/unit/services/test_summarize_node_service.py`, `tests/test_e2e_f5_summarize_node_http.py`.
+
+### F6 — Maintenance-proposal ledger + rule engine
+
+`MaintenanceProposal` model + 4 v1 SQL rules (orphan-fact, low-confidence-stale, contradiction-unresolved, unlinked-mention). Scheduler tick every 6h via leader election. RFC: `rfcs/006-f6-maintenance-ledger-linter.md`. Migration `025_maintenance_proposals.py`. Tests: `packages/core/tests/integration/services/test_int_lint.py`, `test_int_lint_scheduler.py`, `test_int_lint_metrics.py`, `packages/core/tests/unit/test_lint_rule_sql_audits.py`.
+
+### F8 — `memex_get_lint_flags`
+
+Shape-stable DTO (`LintFindingDTO`) with opaque base64 cursor for pagination. MCP at `server.py:3754`. Tests: `packages/core/tests/integration/services/test_int_f8_lint_query.py`, `packages/core/tests/unit/test_lint_query_cursor.py`, `packages/hermes-plugin/tests/test_hermes_get_lint_flags.py`.
+
+### F9 — Per-entity advisory locks + reconsolidate/consolidate
+
+Single-int asyncpg advisory locks keyed off entity UUID via SHA-256 → 62-bit truncate, OR'd with `1 << 62`. Disjoint from `LEADER_LOCK_ID = 5432789123456789` by construction. Source: `packages/core/src/memex_core/services/locks.py:43-73`. POC: `pocs/001-f9-asyncpg-locks/result.md` (5/5). RFCs: `005-F9-advisory-locks.md`, `008-f9-per-entity-lock-and-reconsolidate.md`. MCP at `server.py:3820` / `:3862`. Tests: `packages/core/tests/integration/test_int_f9_locks.py`, `test_int_f9_consolidate.py`, `test_int_f9_reconsolidate.py`, `packages/core/tests/unit/services/test_locks.py`, `test_locks_invariants.py`.
+
+### F10 — Surprise-gated LLM lint
+
+Anisotropy-corrected surprise score (`memory/lint_llm/surprise.py`) feeds `LintLLMService` (`services/lint_llm.py`) which: rate-limits LLM calls via 24h rolling count cap (`LintLLMQuota` table, alembic `029`), defers (does not drop) overflow, and writes findings to the F6 ledger. RFC: `010-f10-surprise-gated-llm-lint.md`. POC: `pocs/002-f10-surprise-threshold/`. Tests: `packages/core/tests/integration/services/test_int_f10_lint_llm.py`, `packages/core/tests/integration/memory/test_int_lint_llm_checks.py`, `packages/core/tests/unit/memory/test_lint_llm_surprise.py`.
+
+### F14 — Procedural KV namespace
+
+Adds `procedure:` envelope namespace in `services/kv.py` with `procedure_outcomes` audit table (alembic `028`). Briefing surface in `packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py`. Tests: `packages/core/tests/integration/test_int_f14_procedure_kv.py`, `test_int_f14_record_outcome.py`, `test_int_f14_top_outcomes.py`, `test_int_alembic_028.py`, `packages/hermes-plugin/tests/test_briefing_f14.py`.
+
+### F20 — FSRS-5 revisitation
+
+`memory/revisit.py` wraps `py-fsrs>=4.0,<5.0`. `services/revisitation.py` implements 5-gate eligibility (vault scope, lifecycle, confidence floor, sticky-deprioritize, lockout window). Bit-exact parity vs. FSRS-4.5 reference verified at 76/76 in `pocs/003-f20-fsrs-parity/`. Daily scheduler tick. MCP at `server.py:3900` / `:3957`. RFCs: `008-F20-fsrs-revisit.md`, `014-f20-fsrs-revisitation.md`. Tests: `tests/test_e2e_f20_revisit_http.py`, `packages/core/tests/unit/test_revisit_*.py`.
+
+### F26 — F32 lint dashboard aggregator
+
+`diagnostics/lint_dashboard.py` pivots maintenance-proposal counts by `(rule_id, severity, vault_id)`; surfaced through F32's summary endpoint and `memex diagnose lint --vault X`. Tests: `packages/core/tests/integration/test_int_f26_lint_dashboard_aggregator.py`, `tests/test_e2e_f26_lint_dashboard_route.py`.
+
+### F29 — Hermes record-outcome parity
+
+Closes the F1a/F4 outcome-recording gap on the Hermes side: `MemexAPIProtocol.record_outcome` + `RemoteMemexAPI.record_outcome` HTTP wrapper + `POST /api/v1/outcomes/record` route + Hermes handler. Drift-guard bumped 40 → 41. Tests: `packages/hermes-plugin/tests/test_record_outcome_f29.py`, `packages/common/tests/test_client_record_outcome.py`.
+
+### F32 — Diagnostics core
+
+Composed from four modules under `packages/core/src/memex_core/diagnostics/`: `umap.py` (cache + projection), `heatmap.py`, `summary.py`, `lint_dashboard.py` (F26). Three-surface parity (HTTP + MCP `memex_get_diagnostics_summary` + CLI). Tests: `packages/core/tests/integration/test_int_f32_diagnostics_summary.py`, `packages/core/tests/unit/test_diagnostics_cache_key.py`.
+
+### F38 — Consolidation orchestrator
+
+`services/consolidation.py` runs contradiction → reflection → prune-stale-only sequence per tick. Records ticks to `consolidation_ticks` (alembic `027`) and logs outcomes through the audit log. Integration seam with F20: F20's `review()` writes audit rows that F38 reads — no direct service coupling. CLI: `memex consolidate`. Tests: `packages/core/tests/unit/test_consolidation_writes.py`, `packages/cli/tests/test_consolidate_cli.py`.
+
+## 3. Architecture Decisions of Note
+
+**F9 lock disjointness invariant.** `LEADER_LOCK_ID = 5432789123456789` (~2^52) and entity locks are forced into [2^62, 2^63−1] by OR'ing with `1 << 62`. Asserted by construction at `services/locks.py:43-45`: `(LEADER_LOCK_ID & (1 << 62)) == 0` and every entity lock has `(lock_id & (1 << 62)) != 0`. Verified at runtime in `tests/unit/services/test_locks_invariants.py`.
+
+**F20 dual-layer bool rejection.** Python's `bool ⊂ int` would silently coerce `True` to `Quality.AGAIN` (= 1) at the FSRS gate. Defended at both surfaces: MCP via `_reject_bool_quality` `BeforeValidator` at `packages/mcp/src/memex_mcp/server.py:3944-3953`, HTTP via `BeforeValidator` at `packages/core/src/memex_core/server/revisit.py:24-37`. Caught in QA loop, not pre-merge static review.
+
+**F10 surprise-gating with count-based 24h cap and defer-not-drop.** The cap is a count, not a cents budget — simpler reasoning, no LLM-pricing coupling. Overflow events are queued for the next tick, never silently dropped. Quota table has a `count >= 0` `CheckConstraint` (commit `7c62fcc`).
+
+**F38 audit-log integration seam.** F38's tick consumes audit-log rows produced by F20's `review()` rather than calling `RevisitationService` directly. Documented in `services/revisitation.py::review()` docstring. Decouples scheduler ticks from synchronous review traffic.
+
+**Set-union tool count drift guard.** Wave-2 sub-merges concurrently bumped the Hermes provider tool-roster guard. Final reconciliation merged ranges via set union — not max() — to avoid losing tools added on parallel branches. Hermes guard final value: 46. Bumped at: F8 → 41, F20 → 42, F29 → 41 (parallel), F9 → 46.
+
+## 4. Open Follow-ups (Post-Phase-2)
+
+| Issue | Title                                                              | Owner area              |
+| ----- | ------------------------------------------------------------------ | ----------------------- |
+| #27   | hermes-integration CI job                                          | CI                      |
+| #28   | Track-add Tier-A artifact corpus + RFC-014 weights-divergence note | Docs / track            |
+| #30   | Prefetch race flake under load (in flight)                         | Retrieval               |
+| #31   | Bulk-suite flaky test triage                                       | Test infra              |
+| #32   | F8 `test_missing_table_raises_initialization_error` CASCADE drop without restore | F8 / fixtures |
+| #33   | F9 `consolidate` rate-limit (RFC-008 line 125)                     | F9                      |
+| #34   | F9 `MaintenanceProposal.resolved_by` column (Wave 3 schema patch)  | F9 / schema             |
+| #35   | F10 real-LLM `@pytest.mark.llm` content-quality test               | F10 / eval              |
+| #36   | Diagnostics router `check_vault_access` sweep                      | F32                     |
+
+None block Tier-A surface acceptance; #30 and #31 are flake-class, #32–#34 are cleanup, #28 is documentation, #27 is CI hardening, #35–#36 are coverage extension.
+
+## 5. Process Notes
+
+**Worktree venv isolation hazard hit 3×.** Shared `uv` cache caused imports to resolve to a sibling worktree's source three times during F9, F20, and F32 development — manifesting as test failures that depended on which worktree had been most recently `uv sync`'d. Codified in `conventions/worktree-venv-isolation.md`. Mitigation: dedicated venv per worktree, asserted at agent prompt time.
+
+**Tool count drift guard requires set-union, not max.** First reconciliation attempt during F9/F26/F10 sub-wave-C used `max(branch_a, branch_b)` and dropped F29's roster bump silently. Subsequent merges enforced set-union semantics over the actual tool-name set, not the count.
+
+**QA loop caught a real correctness bug.** The F20 bool-coercion bug (`True → Quality.AGAIN`) was not caught by static schema review or unit tests — it surfaced only in the QA real-LLM turn, where an agent passed `quality=True` and the body completed successfully without raising. Fix landed as `d373acc fix(F20): block bool from quality at the Pydantic gate, not the body` and a paired test in `test_revisit_review_vault_scope.py`.
+
+**Two-hour silent agent zombification.** During sub-wave-C parallel execution, the F9 and F10 dev agents went silent for ~2h mid-implementation. Orchestrator polling detected the stall; recovered F20/F26/F10 via direct merge of completed branches and re-prompted the F9 dev agent without losing in-progress work. Reinforces that orchestrator must poll, not rely on agent self-report.
+
+## 6. MCP Tool Count Progression
+
+| Stage              | Count | Delta                                                       |
+| ------------------ | ----- | ----------------------------------------------------------- |
+| Pre-Tier-A baseline| 41    | (Wave-1 substrate + `memex_record_outcome`)                 |
+| F8 merge           | 42    | +`memex_get_lint_flags`                                     |
+| F20 merge          | 44    | +`memex_get_due_for_review`, +`memex_memory_review`         |
+| F4 / F5 / F38 / F32| 46    | +`memex_memory_deprioritize`, +`memex_memory_restore`, +`memex_memory_summarize_node`, +`memex_get_diagnostics_summary` (F38 CLI-only; F26 folded into F32 summary) |
+| F9 final merge     | 46    | +`memex_memory_reconsolidate`, +`memex_memory_consolidate`; F4/F5/F32 already counted |
+
+Net new MCP surface: 10 tools registered in `packages/mcp/src/memex_mcp/server.py` between lines 3469 and 4028. F10, F14 (KV-only), and F26 (CLI/HTTP only) intentionally did not add MCP tools — F10 is background-scheduled and F26 surfaces through F32.

--- a/.dev-team-artifacts/dev-tier-a-cognitive-memory/reviews/adversarial-phase-3.md
+++ b/.dev-team-artifacts/dev-tier-a-cognitive-memory/reviews/adversarial-phase-3.md
@@ -1,0 +1,193 @@
+# Phase 3 Adversarial Review — Tier-A Cognitive Memory
+
+**Reviewer**: QA Engineer (dev-tier-a-cognitive-memory)
+**Branch**: `memory_augmentation`
+**HEAD**: `acbf6a5` (snapshot taken 2026-05-01)
+**Mandate**: Adversarial code-read review of the full Tier-A surface (F4, F5, F6, F8, F9, F10, F14, F20, F26, F29, F32, F38). Hunt Wave 0 invariant breaches (AC-X-7 vault scoping, AC-X-8 single-leader lock, AC-X-10 boot+discovery canary), three-surface parity drift, missing per-vault auth, race windows, and migration ordering.
+**Certainty bar**: ≥95% on every finding. Each cites file:line proof.
+
+---
+
+## Severity legend
+- **CRITICAL** — production-impact bug or invariant breach merging would harm users; blocks Phase 3 close.
+- **HIGH** — invariant violation or correctness gap; blocks Phase 3 close.
+- **MEDIUM** — correctness or hygiene gap that should be fixed but does not block close (can be tracked as follow-up task).
+- **LOW** — nit, docs, or test-coverage improvement.
+
+---
+
+## Verified clean (no findings)
+
+| Surface | Verification |
+|---|---|
+| **AC-X-8 single-leader lock** | Only 2 source files reference `5432789123456789`: `packages/core/src/memex_core/scheduler.py:18` (`MEMEX_LEADER_LOCK_ID`) and `packages/core/src/memex_core/services/locks.py:43` (`LEADER_LOCK_ID`). Only 3 runtime files use advisory-lock SQL: `scheduler.py`, `services/locks.py`, `alembic/env.py`. The migration uses blocking `pg_advisory_lock`, not the runtime `pg_try_advisory_lock`. F9 entity-lock formula at `services/locks.py:69-77` is `ENTITY_LOCK_HIGH_BIT \| raw` with bit 62 set, disjoint from leader (~2^52). |
+| **F20 dual-layer bool-rejection** | MCP gate at `packages/mcp/src/memex_mcp/server.py:3944-3968` and HTTP gate at `packages/core/src/memex_core/server/revisit.py:36-46` + `:51-62`. Both layers present at HEAD. |
+| **F38 step ordering** | `packages/core/src/memex_core/services/consolidation.py:137-166` runs contradiction → reflection → prune-stale-only (B1 adjudication). Order verified. |
+| **F38 ↔ F20 audit-log integration** | `packages/core/src/memex_core/services/outcomes.py` writes `AuditLog(action='outcome.record', resource_type='memory_unit')`; F38 `select_diff_units` filters on this. |
+| **F32 ↔ F26 plumbing** | `pending_by_type` helper bridges F26 lint dashboard into F32 diagnostics summary. |
+| **F20 service-layer cross-vault** | `revisit.py:163-164` maps service-layer `PermissionError` → 403; `api.review_memory_unit` enforces unit-vault check. |
+| **AC-X-7 vault scoping (Tier-A new tables)** | `MaintenanceProposal` (`sql_models.py:1763`), `LintLLMQuota` (:1861), `ConsolidationTick` (:1653), `ProcedureOutcome` (:1577) all carry `vault_id` with FK→vaults; `MaintenanceProposal.vault_id` is documented nullable per AC-F6-1 (NULL = global findings, reserved for Tier B). |
+| **Migration ordering** | Linear chain 024 → 025 → 026 → 027 → 028 → 029, all with `down_revision` set. No branch labels. |
+| **Three-surface tool count** | Hermes schema set in `packages/hermes-plugin/tests/test_tools.py:121-203` enumerates 46 tools (8 stream-1 + 10 stream-2 + 4 stream-3 + 6 stream-4 + 8 stream-5 + 4 quick-wins + 1 diagnostics + 1 linter + 2 revisit + 2 locks). |
+
+---
+
+## HIGH findings (block Phase 3 close)
+
+### HIGH-1 — AC-X-10 boot+discovery canary missing F4, F8, F29
+**File**: `packages/hermes-plugin/tests/integration/test_live_hermes.py:49-78`
+**Severity**: HIGH (Wave 0 invariant breach: AC-X-10 three-surface parity)
+
+The test currently asserts only these post-seed verbs are reachable through Hermes' `_tool_to_provider` dispatch: `memex_get_diagnostics_summary` (F32), `memex_memory_summarize_node` (F5), `memex_get_due_for_review` + `memex_memory_review` (F20), `memex_memory_reconsolidate` + `memex_memory_consolidate` (F9). The standing AC-X-10 canary docstring (line 50-58) requires *every* new MCP verb to appear here.
+
+Missing canary entries:
+- `memex_memory_deprioritize` (F4) — registered at `packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py:3255`
+- `memex_memory_restore` (F4 partner) — registered at `tools.py:3282`
+- `memex_record_outcome` (F29) — registered at `tools.py:3459` (this verb just got Hermes parity in task #29; the canary was not extended at the same time — same regression class as v0.1.13)
+- `memex_get_lint_flags` (F8) — registered at `tools.py:3592`
+
+**Reproduction**:
+```bash
+grep -n "memex_record_outcome\|memex_get_lint_flags\|memex_memory_deprioritize\|memex_memory_restore" \
+  /home/vscode/workspace/packages/hermes-plugin/tests/integration/test_live_hermes.py
+# expected: 4 lines (one per verb), got: 0
+```
+
+**Proposed fix**: extend the asserted set in `test_get_tool_schemas_exposes_stream_1_and_post_seed_tools` with the four verbs, paired with one-line reasons (F4 / F29 / F8). Single-file change; no source-code diff needed.
+
+---
+
+### HIGH-3 — F38 consolidation tick races against F9 entity-lock
+**Files**:
+- `packages/core/src/memex_core/services/consolidation.py:137-153` — F38 callsite (no lock)
+- `packages/core/src/memex_core/services/locks.py:209-232` — F9 reconsolidate_entity (acquires lock)
+- `packages/core/src/memex_core/server/memories.py:140-159` — F9 HTTP route runs on any pod (no leader gate)
+**Severity**: HIGH (concurrency invariant breach)
+
+F38 `consolidate_vault_tick` runs from the leader-only scheduler at `scheduler.py:184-...`. For each `entity_id` in the vault, it calls `contradiction.detect_contradictions(unit_ids=...)` (line 138) and `reflection.reflect_batch(requests)` (line 153). **Neither is wrapped in `acquire_entity_lock(entity_id)`.**
+
+F9 `LocksService.reconsolidate_entity` *does* acquire `acquire_entity_lock(entity_id)` for the *same* operation surface (contradiction over the entity's units, then reflect). F9's HTTP route `/memory/reconsolidate` (memories.py:129) runs on **any pod, not just the leader**.
+
+Race window: leader pod runs F38 tick on entity X concurrently with a follower pod servicing `POST /api/v1/memory/reconsolidate` for entity X. Both will:
+- Call `ContradictionEngine.detect_contradictions` over overlapping `unit_ids`. Contradiction-link emission is an `INSERT … ON CONFLICT DO UPDATE` against `memory_links`, but **link de-dup uses an MD5 of (src,dst,kind)** — concurrent emission can produce a spurious second row with stale confidence.
+- Call `ReflectionService.reflect_batch` for entity X. The MentalModel UPSERT path is not txn-isolated against the F9 path; last-writer-wins stomps trend deltas.
+
+The whole point of F9's per-entity advisory lock is to serialize curation per-entity. F38 silently bypasses it.
+
+**Reproduction**:
+```bash
+# 1. Confirm F38 path: no lock acquisition
+grep -n "acquire_entity_lock\|acquire\b" \
+  /home/vscode/workspace/packages/core/src/memex_core/services/consolidation.py
+# expected: zero matches in body
+
+# 2. Confirm F9 path acquires the lock
+grep -n "acquire_entity_lock" /home/vscode/workspace/packages/core/src/memex_core/services/locks.py
+# expected: hit at line 232 inside reconsolidate_entity
+```
+
+**Proposed fix**: in `consolidation.py:134` block, wrap the per-entity work in `async with acquire_entity_lock(entity_id, timeout=...)`. Iterate entities one at a time inside the lock (or batch under a higher-level invariant). Since F38 runs from the leader-only scheduler, it can use a longer timeout (e.g. 60s) — there is no MCP-request urgency. If lock acquisition times out, log + skip that entity and continue (prune-stale step is unaffected because it operates on already-stale ids only).
+
+---
+
+### HIGH-4 — `check_vault_access` not enforced on Tier-A WRITE routes
+**Files**:
+- `packages/core/src/memex_core/server/memories.py` (no import of `check_vault_access`)
+  - `:129-159` `reconsolidate_entity` — accepts `vault_id` in body, no auth-vault scoping
+  - `:162-179` `consolidate_vault` — same
+- `packages/core/src/memex_core/server/outcomes.py` (no import of `check_vault_access`)
+  - `:74` `record_outcome` — accepts `vault_id`, no auth-vault scoping
+- `packages/core/src/memex_core/server/lint.py` (no import of `check_vault_access`)
+  - `:141-150` `lint_flags` — accepts `vault_id` query param, no auth-vault scoping
+  - `:111` `lint_dismiss`, `:126` `lint_resolve` — operate on a `finding_id` whose vault is implicit; service-layer never re-checks auth
+- `packages/core/src/memex_core/server/diagnostics.py` (no import of `check_vault_access`)
+  - `:113-127` `get_lint_dashboard` — accepts `vault_id` path param, no auth-vault scoping (already tracked as task #36)
+
+**Severity**: HIGH (multi-tenant authz breach)
+
+Pre-existing routes (notes, retrieval, entities, ingestion, survey) all call `check_vault_access(auth, vault_id, api, permission=...)` to verify the API key's `auth.vault_ids` includes the requested vault. Without this gate, an API key restricted to vault A can submit a request specifying vault B, and the service layer faithfully executes against vault B. Confirmed by reading `auth.py:223-268` — the gate is the only place principal-vault binding is enforced; pure `require_write` is a permission gate (READ/WRITE/DELETE), not a vault-scope gate.
+
+**Reproduction**:
+```bash
+# Compare: routers that DO call check_vault_access vs routers that DON'T
+grep -rln "check_vault_access" /home/vscode/workspace/packages/core/src/memex_core/server | sort
+# yields: auth.py, survey.py, ingestion.py, notes.py, retrieval.py, entities.py
+# missing: memories.py, outcomes.py, lint.py, diagnostics.py, revisit.py*
+
+# *F20 revisit.py has its own service-layer PermissionError → 403 path (revisit.py:163-164),
+# so it is the only one actually fenced. F8/F9/F26/F29 are unfenced.
+```
+
+**Proposed fix**: each affected route adds `auth: Annotated[AuthContext | None, Depends(get_auth_context)]` to its signature and calls `await check_vault_access(auth, [request.vault_id], api, permission=Permission.WRITE)` before any service call. Pattern is already in use in `notes.py:160`, `notes.py:413`. ~5-line addition per route, no service-layer change. Diagnostics router already tracked as task #36; the others should be folded into the same sweep.
+
+---
+
+## MEDIUM findings (track as follow-ups; do not block close)
+
+### MEDIUM-1 — Leader lock literal duplicated
+**Files**: `packages/core/src/memex_core/scheduler.py:18` and `packages/core/src/memex_core/services/locks.py:43`
+
+Both define `5432789123456789` as a `Final[int]` constant under different names (`MEMEX_LEADER_LOCK_ID` vs `LEADER_LOCK_ID`). Drift hazard: if one file's value is changed (typo, refactor) the lock-disjointness invariant silently breaks.
+
+**Proposed fix**: pick one canonical source — recommend `services/locks.py:43` because the lock module owns lock-id semantics (`ENTITY_LOCK_HIGH_BIT`, `ENTITY_LOCK_MASK`, `entity_lock_id()`) — and have `scheduler.py:18` re-export `from memex_core.services.locks import LEADER_LOCK_ID as MEMEX_LEADER_LOCK_ID`. Existing test `test_seed_invariants.py:26` already greps for `MEMEX_LEADER_LOCK_ID` so the alias name must remain visible.
+
+### MEDIUM-2 — F29 `success: bool` field accepts lax Pydantic v2 coercion
+**File**: `packages/core/src/memex_core/server/outcomes.py:32`
+
+`success: bool = Field(...)` will accept `"true"`, `"yes"`, `1`, `0`, and similar. F20's `quality` field has explicit `BeforeValidator(_reject_bool_quality)` defending against `bool ⊂ int`. F29's `success` is the symmetric pair (and the audit-log emission downstream is asymmetric — recording `success=False` when the agent passed `success="0"` is a silent data-quality bug).
+
+**Proposed fix**: add `BeforeValidator(_reject_non_bool_success)` that raises `ValueError` unless `isinstance(v, bool)`. Mirror the F20 pattern at the same MCP + HTTP boundary.
+
+### MEDIUM-3 — Aioclock leader-only tasks not serialized
+**Files**: `packages/core/src/memex_core/scheduler.py:282-345` (F6, F10, F20, F32, F38 task registrations)
+
+All five tasks run inside the same leader pod under `MEMEX_LEADER_LOCK_ID`. They are scheduled by aioclock at independent intervals. Per-table isolation is reasonable (F6 writes `maintenance_proposals`, F10 writes `lint_llm_quota`, F20 writes `revisit_schedule`, F32 writes UMAP cache, F38 writes `consolidation_ticks`), but cross-task interactions are not pinned: e.g. F38 reflection-batch on entity X and F6 lint over MentalModel(X) can race the same row.
+
+**Proposed fix**: track as a Wave 3 invariant test. Either (a) document non-overlap explicitly in `RFC-008` and add a unit test that asserts the table-write-set per task is disjoint, or (b) serialize all leader-pod tasks behind a single `asyncio.Lock` if disjointness is not actually achievable. Defer to staff-engineer call.
+
+---
+
+## LOW findings (nice-to-have; do not block)
+
+### LOW-1 — F10 `LintLLMQuota.count` constraint nit
+**File**: `packages/core/src/memex_core/memory/sql_models.py:1900`
+
+`CheckConstraint('count >= 0', name='ck_lint_llm_quota_count_non_negative')` is correct, but RFC-006 cite specifies `count int` only — the non-negative is a defensive-engineering add. No bug; just call out that the contract source is broader than the spec. Already noted as LOW-F10-1 from prior substrate review.
+
+### LOW-2 — F38 has no Hermes-exposed verb (intentional, but no canary line documents this)
+**File**: `packages/hermes-plugin/tests/integration/test_live_hermes.py`
+
+F38 is scheduler-driven only (no MCP/Hermes verb). The canary list does not say so explicitly — a future agent reading the test could assume F38 was forgotten. Add a one-line comment: `# F38: scheduler-only, no MCP verb (intentional per RFC-008)`.
+
+---
+
+## Phase 3 close criteria
+
+Phase 3 closes when **HIGH-1, HIGH-3, HIGH-4** are resolved. MEDIUM-1/2/3 and LOW-1/2 may be tracked as follow-up tasks (#33/#34/#36-pattern) and do not block close.
+
+**Recommended dispatch** (orchestrator decides):
+- HIGH-1: spawn a single dev to extend `test_live_hermes.py:49-78` — test-only, ~10-line diff. Trivial.
+- HIGH-3: spawn dev-ws-quick-wins (owner of F38) to wrap `consolidation.py:134-166` per-entity work in `acquire_entity_lock`. Touches one file; needs a new integration test that exercises F38-tick + F9-reconsolidate concurrency on the same entity_id and asserts only one of the two paths emits a contradiction-link row.
+- HIGH-4: extend task #36 from "diagnostics router only" to "Tier-A WRITE-route check_vault_access sweep" covering memories.py, outcomes.py, lint.py, diagnostics.py. ~5 lines per route + a parametrised integration test exercising vault-A key vs vault-B request.
+
+---
+
+## Audit trail
+
+| Verification surface | Method | Result |
+|---|---|---|
+| AC-X-7 vault scoping (new tables) | Read sql_models.py for class definitions; confirm vault_id field + FK | PASS |
+| AC-X-8 single-leader (literal `5432789123456789`) | grep all packages/ | PASS — only 2 source files |
+| AC-X-8 single-leader (advisory-lock SQL) | grep `pg_try_advisory_lock\|pg_advisory_lock` in runtime src | PASS — only 3 files (scheduler.py, services/locks.py, alembic/env.py) |
+| AC-X-10 boot+discovery canary | Read test_live_hermes.py:49-78 against tools.py registry | FAIL — HIGH-1 |
+| F9 entity-lock disjointness | Read services/locks.py:43-77, confirm bit-62 partition | PASS |
+| F38 step ordering | Read services/consolidation.py:120-200 | PASS — contradiction → reflection → prune-stale-only |
+| F38 ↔ F9 race | Read consolidation.py vs locks.py vs memories.py routes | FAIL — HIGH-3 |
+| F20 dual-layer bool gate | Read server/revisit.py:36-62 + mcp/server.py:3944-3968 | PASS |
+| F20 cross-vault scoping | Read revisit.py:163-164 PermissionError → 403 path | PASS (service-layer) |
+| F8/F9/F26/F29 cross-vault scoping | Read each router for `check_vault_access` import | FAIL — HIGH-4 |
+| Migration linear chain (024-029) | grep `down_revision` in 025-029 | PASS |
+| Tool count three-surface | Read test_tools.py:121-203 vs tools.py grep | PASS — 46 |
+| F38 has Hermes verb | grep `consolidation_tick` in hermes/tools.py | N/A — scheduler-only (intentional) |
+
+**Phase 3 status**: 3 HIGH open. Until HIGH-1, HIGH-3, HIGH-4 resolve, Phase 3 cannot close.

--- a/.dev-team-artifacts/dev-tier-a-cognitive-memory/rfcs/014-f20-fsrs-revisitation.md
+++ b/.dev-team-artifacts/dev-tier-a-cognitive-memory/rfcs/014-f20-fsrs-revisitation.md
@@ -1,0 +1,353 @@
+# RFC-014: F20 FSRS-based memory revisitation
+
+| Field | Value |
+|-------|-------|
+| **Status** | In Review (C1 adjudicated; AC-F20-3 patched in requirements.md) |
+| **Author** | staff-eng-2 |
+| **Reviewers** | staff-eng-1 (pending round-3 ratification) |
+| **Created** | 2026-04-30 |
+| **Updated** | 2026-04-30 |
+| **Feature** | F20 |
+| **§4 anchor** | `cognitive-memory-research-report.md:869` |
+| **POC required** | YES — FSRS reference parity |
+| **AC patch required** | DONE — AC-F20-3 patched (mw_score-driven comprehensive predicate) |
+
+## Problem Statement
+
+F20 introduces an FSRS scheduler:
+- Three new columns on `MemoryUnit`: `next_review_at`, `review_interval_days`, `review_stability`.
+- Module `memory/revisit.py` implementing the FSRS reference formula.
+- MCP tools `memex_get_due_for_review(vault_id)` and `memex_memory_review(unit_id, quality)`.
+- Daily scheduler task that populates initial schedules and surfaces due units.
+- Integration with F1 outcome counters: `quality='again'/'hard'` → `failure_co_count++`; `'good'/'easy'` → `success_co_count++`.
+
+**RESOLVED — AC-F20-3 patched in requirements.md (2026-04-30):** the original AC-F20-3 referenced `importance >= threshold`, but the `importance` column does not exist on `MemoryUnit` (verified at `sql_models.py:490-744`). The patched AC mandates a comprehensive eligibility predicate driven by columns that DO exist:
+
+```
+intent_class IN ('permanent', 'durable')
+AND status = 'active'
+AND is_deprioritized = false
+AND confidence >= 0.5
+AND mw_score >= 0.4
+```
+
+Where `mw_score = compute_mw_score(success_co_count, failure_co_count)` — the Beta-Bernoulli posterior mean from `services/outcomes.py:33`. Cold-start units (0/0 outcomes) have `mw_score = 0.5` and `confidence = 1.0` (default), so they pass; only units with established negative outcomes (mw_score < 0.4 → at least 2 failures and 0 successes given the Beta-Bernoulli formula) OR with confidence dragged below 0.5 by contradiction detection are excluded.
+
+**Per Wave 0 §6 + F4 sticky-deprioritize semantics**, F20 does NOT auto-resurface a deprioritized unit even if its `mw_score` later recovers; reversal requires an explicit `memex_memory_restore` call. This prevents F20 from undoing F4 user intent.
+
+**Schema columns referenced (all verified to exist at HEAD `1c0a464`):**
+- `intent_class` at `sql_models.py:584`
+- `status` at the unit row (active | stale | superseded — used elsewhere)
+- `is_deprioritized` at `sql_models.py:578`
+- `confidence` at `sql_models.py:596`
+- `success_co_count` / `failure_co_count` at `sql_models.py:566/572` (input to `compute_mw_score`)
+
+**Sensitive-unit override — design freezes WITHOUT it (per team-lead direction, 2026-04-30):** AC-F20-3 marks `risk_class='sensitive'` override as TBD pending PO governance decision. **This RFC's design freezes around the comprehensive-predicate-WITHOUT-override path.** Rationale: PO has been pinged directly; the override is one-line config in Phase 2 if adopted, or dropped entirely if PO defers it to F6 governance lint — either resolution is non-blocking for convergence.
+
+If PO adopts the override post-Phase-1, the addition is mechanical:
+
+```python
+# Conditional addition (NOT in v1; only if PO ratifies):
+# if unit.risk_class == 'sensitive':
+#     return _passes_intent_status_deprioritize(unit)  # bypass mw + confidence
+```
+
+If PO defers entirely, the TBD sentence is removed from AC-F20-3 and this RFC's "Sensitive-unit override" section is deleted. Convergence does NOT block on the resolution.
+
+## Proposed Solution
+
+### Design
+
+#### Schema migration (alembic 026)
+
+```python
+# alembic/versions/026_revisit_columns.py
+op.add_column('memory_units', sa.Column('next_review_at', sa.DateTime(timezone=True), nullable=True))
+op.add_column('memory_units', sa.Column('review_interval_days', sa.Float, nullable=True))
+op.add_column('memory_units', sa.Column('review_stability', sa.Float, nullable=True))
+op.create_index('idx_memory_units_next_review_at', 'memory_units', ['next_review_at'],
+                postgresql_where=sa.text('next_review_at IS NOT NULL'))
+```
+
+All three columns nullable — units that don't qualify for FSRS scheduling have NULL values; the scheduler-due query is `WHERE next_review_at <= now() AND next_review_at IS NOT NULL`.
+
+#### Eligibility predicate — `services/revisit.py::is_eligible`
+
+```python
+def is_eligible_for_review(unit: MemoryUnit) -> bool:
+    """Comprehensive eligibility predicate per AC-F20-3 (patched 2026-04-30).
+
+    Wave 0 §6 + F4 sticky semantics: deprioritized units do NOT auto-resurface
+    even if mw_score recovers. Reversal requires memex_memory_restore.
+    """
+    if unit.intent_class not in ('permanent', 'durable'):
+        return False
+    if unit.status != 'active':
+        return False
+    if unit.is_deprioritized:
+        return False
+    if unit.confidence < 0.5:
+        return False
+    mw_score = compute_mw_score(unit.success_co_count, unit.failure_co_count)
+    if mw_score < settings.revisit.mw_threshold:  # default 0.4
+        return False
+    # Sensitive-unit override deferred (NOT in v1 per team-lead direction);
+    # if PO adopts post-Phase-1, add: `if unit.risk_class == 'sensitive': return _passes_intent_status_deprioritize(unit)`
+    return True
+```
+
+This predicate runs at:
+- `populate_initial_schedules` time — only eligible units get a `next_review_at` assigned.
+- `memex_get_due_for_review` time — units that became ineligible since scheduling are filtered out (e.g., user deprioritized them after they were scheduled).
+
+The query-time daily scheduler additionally filters `next_review_at <= now()`.
+
+#### FSRS implementation — `memory/revisit.py`
+
+Use the **FSRS-5 reference formulas** (open algorithm, public-domain) as implemented by `py-fsrs == 4.1.2`. See ADR-006 for the version-pinning decision and the py-fsrs-version-vs-algorithm-version cross-check (the package version number does NOT match the algorithm version number — py-fsrs 4.1.2 implements FSRS-5, not FSRS-4.5).
+
+> **Weights-divergence footnote.** The 19-weight tuple shown below is the FSRS-4.5 reference vector (originally cited in this RFC and embedded for documentation). The shipped scheduler delegates to `py-fsrs == 4.1.2`, which implements FSRS-5 with its own default weights and update rules; those defaults can diverge from the FSRS-4.5 vector listed here. The values below are retained as a paper-trail anchor for the original cited reference and MUST NOT be treated as authoritative — the authoritative defaults are whatever `py-fsrs 4.1.2` exposes at runtime. Any future bump of `py-fsrs` MUST trigger a fresh paper cross-check (per ADR-006) before this RFC's weights block is updated.
+
+```python
+@dataclass(frozen=True)
+class FSRSParams:
+    # Default weights shown for reference parity with the original FSRS-4.5 citation;
+    # the shipped scheduler uses py-fsrs 4.1.2 (FSRS-5) defaults — see ADR-006 +
+    # the weights-divergence footnote above. Per-vault tuning is still expressed
+    # through this dataclass at the call site.
+    w: tuple[float, ...] = (
+        0.4197, 1.1869, 3.0412, 15.2441, 7.1434,
+        0.6477, 1.0007, 0.0674, 1.6597, 0.1712,
+        1.1178, 2.0225, 0.0904, 0.3025, 2.1214,
+        0.2498, 2.9466, 0.4891, 0.6468,
+    )
+    request_retention: float = 0.9   # target retention probability
+    maximum_interval: float = 36500   # 100 years cap
+
+class Quality(Enum):
+    AGAIN = 1
+    HARD = 2
+    GOOD = 3
+    EASY = 4
+
+def schedule(
+    unit_state: dict | None,
+    quality: Quality,
+    now: datetime,
+    params: FSRSParams = FSRSParams(),
+) -> tuple[datetime, float, float]:
+    """Compute (next_review_at, interval_days, new_stability) per FSRS-5 (py-fsrs 4.1.2; see ADR-006).
+
+    unit_state: {'review_stability': float | None, 'review_interval_days': float | None,
+                 'last_reviewed_at': datetime | None}
+    Returns the new (next_review_at, interval, stability) tuple.
+
+    First-review path (unit_state is None or stability is None): use FSRS init formulas.
+    Subsequent-review path: use FSRS update formulas based on stability + retrievability.
+    """
+    ...
+```
+
+The implementation is a near-verbatim port of the reference algorithm. We will pin `fsrs` package version if a maintained Python implementation exists, OR vendor the formula directly to keep the dep surface minimal. **Decision: vendor it inline** — the algorithm is small (~100 LOC), public, frozen for our use, and the test suite below validates parity against published reference outputs. Avoids an external dep that may go stale.
+
+#### Daily scheduler task
+
+```python
+async def daily_revisit_task(api: 'MemexAPI') -> None:
+    async with background_session('bg-sched-revisit'):
+        for vault in await api.list_vaults():
+            # 1. Populate initial schedules for unscheduled qualifying units
+            await api.revisit.populate_initial_schedules(vault.id)
+            # 2. Surface due units to maintenance ledger
+            await api.revisit.surface_due_units(vault.id)
+```
+
+Registers under existing `MEMEX_LEADER_LOCK_ID`. Default cadence: every 24 h.
+
+#### Behavior — sticky-deprioritize is unconditional
+
+**`is_deprioritized=false` is a hard gate that the user MUST flip via `memex_memory_restore`.** It is NOT an automatic side effect of any positive signal.
+
+Concretely: if `record_outcome(success=true)` raises a unit's `confidence` past 0.5 AND its `mw_score` past 0.4, the unit becomes eligible on every other gate — but it remains ineligible for FSRS scheduling because `is_deprioritized=true` still fails the predicate. F20 will NOT auto-resurface the unit. Reversal is a deliberate user/agent action through `memex_memory_restore`, which clears `is_deprioritized` and is the ONLY supported path back to the schedulable set.
+
+This is intentional. F4 deprioritize is the user/agent saying "do not surface this." A future contributor may be tempted to add an "auto-restore on positive outcomes" branch ("the unit is doing well now, why keep it suppressed?") — that branch MUST NOT be added. The curation contract is: outcome counters reflect the system's experience with the unit; deprioritize reflects the user's intent for the unit; the two are independent dimensions and outcomes do not override intent.
+
+Test (g) in the eligibility test list (`test_int_f20_sticky_deprioritize.py::test_deprioritize_sticky_across_outcome_recovery`) is the canary: it seeds a deprioritized unit, drives positive outcomes that recover both `confidence` and `mw_score`, and asserts F20 does NOT re-schedule it. If a future change accidentally introduces auto-restore, this test fails immediately.
+
+**QA confirmations (2026-04-30) on the patched AC, baked into the design here:**
+- `confidence` field is constrained `0.0 ≤ confidence ≤ 1.0` (`sql_models.py:670`) and covered by an existing index (`:683`); the `confidence >= 0.5` floor is index-friendly.
+- The eligibility predicate `(intent_class, status, is_deprioritized, confidence, success_co_count, failure_co_count)` is covered by existing indices — no new index needed for the daily-tick scheduler query.
+- Default `confidence=1.0` (`:597`) means cold-start units pass the floor cleanly.
+- `confidence` is mutated downward only by `services/contradiction/engine.py`; a single contradiction event will not drop a unit below 0.5, but sustained contradiction will. The 0.5 floor therefore only excludes substantially-contradicted units — calibration is good and the threshold stays.
+
+#### MCP tools
+
+```
+memex_get_due_for_review(vault_id) -> list[DueReviewDTO]
+  Returns: [{unit_id, text_preview, next_review_at, intent_class, mw_score, ...}, ...]
+
+memex_memory_review(unit_id, quality: 'again'|'hard'|'good'|'easy') -> ReviewResultDTO
+  Side effects:
+    - schedule advances per FSRS
+    - quality in (again, hard) → failure_co_count++
+    - quality in (good, easy) → success_co_count++
+  Returns: {unit_id, new_interval_days, new_next_review_at, mw_score_after}
+```
+
+Both tools registered with descriptions verbatim from §4 step 6.
+
+#### Three-surface parity
+
+| Surface | What ships |
+|---|---|
+| MCP server | `memex_get_due_for_review` + `memex_memory_review` |
+| Hermes plugin | sync wrappers; briefing template adds "N memories due for review" line; new `memory_review` Hermes tool |
+| Claude Code plugin | rule text mentions both verbs and the FSRS quality vocabulary |
+
+#### CLI
+
+- `memex review due [--vault X]` — list due units
+- `memex review complete <unit_id> --quality {again|hard|good|easy}` — record review
+
+### Implementation Steps
+
+1. **POC FIRST** — validate FSRS reference parity (POC topic below).
+2. Alembic migration (`XXX_revisit_columns.py`).
+3. `memory/revisit.py` with `schedule()`, `Quality` enum, `FSRSParams`.
+4. `services/revisit.py` with vault-scoped policy + initial-schedule population + due-unit query.
+5. Hook quality → outcome: `quality in {'again','hard'}` → call `record_outcome(success=False)`; `{'good','easy'}` → `record_outcome(success=True)` against the unit + vault.
+6. HTTP routes.
+7. MCP tools.
+8. CLI commands.
+9. Hermes wrappers + briefing block.
+10. Claude Code rule text.
+11. Tests.
+
+## Alternatives Considered
+
+### Alternative A: add a new `importance` column to `MemoryUnit`
+Rejected. AC-F20-3 references it but it does not exist; adding a column without a clear extraction-time signal would produce `NULL` everywhere. MW score is the operational signal we already have.
+
+### Alternative B: use `confidence` (`sql_models.py:596`) as the importance proxy
+Considered. `confidence` is mutated by contradiction detection (lowered when contradicted). It tracks *truthfulness*, not *importance*. A low-confidence unit may still be important (worth re-reviewing); a high-confidence trivial fact may not be worth scheduling. MW (proven retrieval load-bearing) is the better proxy.
+
+### Alternative C: use `intent_class` alone (no second filter)
+Rejected. Filtering only by intent would schedule every `permanent` and `durable` unit — including those proven irrelevant by their MW. The patched AC-F20-3 layers four additional filters (`status`, `is_deprioritized`, `confidence`, `mw_score`) to match §4's "high-importance + intent=permanent/durable" intent while respecting Wave 0 invariants.
+
+### Alternative C': mw_score alone (no confidence floor)
+Considered in round 2. Rejected: a heavily-contradicted unit (confidence dragged below 0.5) may still have decent MW (it was retrieved before the contradiction landed); scheduling it for review re-asserts wrong information. The confidence floor at 0.5 prevents that without coupling FSRS to confidence-as-multiplier.
+
+### Alternative C'': 4-factor combined score (intent + status + mw_score + confidence weighted into a single threshold)
+Considered in round 2. Rejected on QA/PO lean toward `mw_score`-alone with hard floors on the other dimensions. Reasoning: a single combined score obscures *why* a unit was excluded (was it the MW? the confidence? the status?); five hard predicates make exclusion auditable per dimension.
+
+### Alternative D: depend on the `fsrs` Python package
+Rejected. External dep adds maintenance + transitive risk; the algorithm is small enough to vendor with full test coverage.
+
+### Alternative E: implement SM-2 (older SuperMemo algorithm) instead of FSRS
+Rejected. §4 explicitly names FSRS; SM-2 is less accurate per the FSRS literature.
+
+### Alternative F: schedule cadence per-unit (not vault-wide daily)
+Rejected. Vault-wide daily tick keeps the scheduler simple. Per-unit precision is achieved by the `next_review_at` timestamp; the daily tick just surfaces units whose `next_review_at <= now()`.
+
+### Alternative G: threshold = 0.5 (cold-start at boundary)
+Considered. With `mw_score = 0.5` for cold-start, threshold 0.5 is exactly on the boundary — an `>=` predicate includes cold-start. Threshold 0.4 is one notch below: cold-start is well-included, but units with proven *negative* signal (mw_score < 0.4 → at least 2 failures, 0 successes) are excluded. Cleaner separation.
+
+## Risk Assessment
+
+| Risk | Certainty Impact | Mitigation |
+|------|-----------------|------------|
+| FSRS reference parity drifts | High before POC | POC validates against published FSRS reference outputs |
+| Cold-start units flood the schedule | Medium | Default threshold 0.4 means cold-start passes; populate-initial task batches insertions; daily scheduler bounds work |
+| `quality → outcome` mapping doesn't match user intent | Medium | Document mapping in tool description verbatim; LLM-turn test |
+| FSRS algorithm changes upstream (FSRS-5+) | Low | We pin to FSRS-5 (per ADR-006, py-fsrs 4.1.2 implements FSRS-5; the original 4.5 reference is superseded). Future upgrades are an explicit Tier B feature and require a paper cross-check per ADR-006. |
+| `next_review_at` column index dominates the table for huge vaults | Low | Partial index on `next_review_at IS NOT NULL` |
+| AC patch required for `importance` column | Resolved — AC-F20-3 patched in requirements.md | See "Resolved" section above |
+| Sticky-deprioritize bypass: F20 schedules a unit, user deprioritizes it, MW recovers, F20 re-schedules | High before patch | Eligibility predicate hard-filters `is_deprioritized=true` at both populate-time and query-time. Reversal requires `memex_memory_restore`. Test asserts "deprioritize-then-positive-outcomes does NOT re-schedule". |
+| Sensitive-unit override deferred; design might need a one-line addition post-Phase-1 if PO adopts | Low | Per team-lead direction, RFC freezes WITHOUT the override; addition is one config line in Phase 2 if PO ratifies. Convergence does not block on PO resolution. |
+| Daily tick takes > 60 s on vaults > 100k units | Medium | AC-F20-6 sets the bound; scheduler chunks work; metric exposes p95 |
+| `populate_initial_schedules` runs unbounded on first deploy | Medium | Cap at N=10000 units per tick; subsequent ticks pick up the rest |
+
+**Current certainty (post-AC patch + design-freeze + QA index/calibration confirmations, pre-POC)**: 93%
+**After POC (expected)**: 95%
+**What raised it**: AC-F20-3 patched in requirements.md to mw_score-driven comprehensive predicate; sticky-deprioritize sentence added + canonicalized as a Behavior section (test (g) is the canary); sensitive-override deferred; QA verified the predicate is index-coverable and that calibration of the 0.5 confidence floor is correct given how `services/contradiction/engine.py` mutates confidence.
+**What would raise it further**: POC validates FSRS reference parity.
+**Residual risks after mitigation**: cadence + cap defaults may need tuning post-launch; one-line override addition if PO ratifies post-Phase-1.
+
+## POC Topic — REQUIRED
+
+**Question**: Does the vendored `schedule()` implementation produce numeric outputs within tolerance of the published FSRS-5 reference (per ADR-006; py-fsrs 4.1.2 implements FSRS-5 — the original 4.5 reference is superseded) for a parametrised set of (initial state, quality) inputs?
+
+**Approach**:
+- Pull a set of (initial state, quality) → expected (interval, stability) tuples from the FSRS reference repository's test suite.
+- Run our `schedule()` on each input.
+- Assert numeric equality within ±0.001 (interval) and ±0.0001 (stability).
+
+**Success criteria**:
+- All 50+ reference tuples pass within tolerance.
+- First-review and subsequent-review paths both validated.
+
+**Failure criteria** that would force redesign:
+- Algorithm divergence > 1% on any test point.
+- An undocumented branch in the reference that the port misses.
+
+**Effort**: Small (4–8 hours).
+
+**Save POC results to**: `.dev-team-artifacts/dev-tier-a-cognitive-memory/pocs/003-f20-fsrs-parity/`.
+
+## Required AC corrections (LANDED in requirements.md)
+
+- **AC-F20-3** patched in `requirements/requirements.md` on 2026-04-30 (team-lead). See `requirements.md:150` for the canonical text. The patched AC matches the comprehensive predicate documented in §"Eligibility predicate" of this RFC; this RFC's design is now strictly downstream of the patched AC.
+
+## Required Tests
+
+| Code Path | Test Type | Test Description | Status |
+|-----------|-----------|-----------------|--------|
+| Migration adds three columns + partial index | Integration | `test_int_f20_migration.py` | Pending |
+| Migration is reversible | Integration | `test_int_f20_migration.py::test_downgrade` | Pending |
+| FSRS `schedule()` first-review path matches reference | Unit (parametrised) | `test_revisit_fsrs.py::test_first_review_parity` (50+ cases) | Pending |
+| FSRS `schedule()` subsequent-review path matches reference | Unit (parametrised) | `test_revisit_fsrs.py::test_subsequent_review_parity` | Pending |
+| (a) `intent_class='ephemeral'` excluded | Unit | `test_revisit_policy.py::test_ephemeral_excluded` | Pending |
+| (b) Cold-start `permanent`/`durable` units WITH default `confidence=1.0` ARE scheduled | Unit | `test_revisit_policy.py::test_coldstart_included` | Pending |
+| (c) `confidence=0.3` excluded regardless of MW | Unit | `test_revisit_policy.py::test_low_confidence_excluded` | Pending |
+| (d) `mw_score < 0.4` excluded | Unit | `test_revisit_policy.py::test_low_mw_excluded` | Pending |
+| (e) `is_deprioritized=true` excluded | Unit | `test_revisit_policy.py::test_deprioritized_excluded` | Pending |
+| (f) `status='stale'` excluded | Unit | `test_revisit_policy.py::test_stale_excluded` | Pending |
+| (g) Sticky-deprioritize: deprioritize-then-positive-outcomes does NOT re-schedule | Integration | `test_int_f20_sticky_deprioritize.py::test_deprioritize_sticky_across_outcome_recovery` | Pending |
+| `populate_initial_schedules` populates NULL `next_review_at` rows | Integration | `test_int_f20_populate.py::test_initial_population` | Pending |
+| `populate_initial_schedules` skips ineligible units | Integration | `test_int_f20_populate.py::test_skips_ineligible` | Pending |
+| `memex_get_due_for_review` returns due units | Integration | `test_int_f20_get_due.py` | Pending |
+| `memex_memory_review('again')` decrements MW + advances schedule | Integration | `test_int_f20_review.py::test_again_path` | Pending |
+| `memex_memory_review('good')` increments MW + advances schedule | Integration | `test_int_f20_review.py::test_good_path` | Pending |
+| Scheduler daily tick fires + scopes per vault | Integration | `test_int_f20_scheduler.py` | Pending |
+| Tool descriptions match §4 verbatim | Unit | `test_int_f20_mcp.py::test_descriptions` | Pending |
+| CLI `memex review due` + `memex review complete` smoke | CLI | `test_cli_review.py` | Pending |
+| Hermes briefing surfaces "N due for review" | LLM-turn | `test_int_f20_hermes_briefing.py` | Pending |
+| Real-LLM-turn validation drives review verbs | LLM | `test_int_f20_llm_turn.py` (`@pytest.mark.llm`) | Pending |
+| Vault-scoping invariant: counters update only on `MemoryUnit` (not global `Entity`) | Integration | `test_int_f20_vault_scoping.py` | Pending |
+
+## Decision
+
+**Adopt comprehensive eligibility predicate** (per team-lead C1 lean adjudication + sign-off, 2026-04-30):
+- Five hard predicates: `intent_class ∈ {permanent, durable}` AND `status='active'` AND `is_deprioritized=false` AND `confidence >= 0.5` AND `mw_score >= 0.4`.
+- Sticky-deprioritize: F20 does NOT auto-resurface deprioritized units; reversal via `memex_memory_restore`.
+- **Sensitive-unit override DEFERRED**: design freezes WITHOUT it. If PO ratifies post-Phase-1, addition is one config line in Phase 2; if PO defers to F6 governance lint, the TBD clause is dropped from AC-F20-3 entirely. Convergence does not block on PO resolution.
+- **Sticky-deprioritize canonicalized as a Behavior section**: `is_deprioritized=false` is a hard gate cleared ONLY by `memex_memory_restore`; positive outcomes never auto-restore. Test (g) is the canary.
+- POC required for FSRS reference parity; certainty 93% pre-POC, target 95% post-POC. POC outcome (`pocs/003-f20-fsrs-parity/paper-cross-check.md`) established that py-fsrs 4.1.2 implements FSRS-5, not FSRS-4.5 — captured in ADR-006 and reflected throughout this RFC.
+
+## Review Comments
+
+### staff-eng-1 — round 2
+Proposed 4-factor combined score. Conceded after QA+PO leaned `mw_score`-alone with hard floors on the other dimensions (auditability per dimension > combined opacity).
+
+### team-lead — 2026-04-30 (C1 + PO must-fix + sign-off)
+PO must-fix: predicate must include `is_deprioritized=false` + `status='active'` + sticky-deprioritize sentence. AC-F20-3 patched in requirements.md to bake in the design. Sensitive-override DEFERRED — RFC-014 freezes without it; one-line addition in Phase 2 if PO ratifies, dropped entirely if PO defers to F6 governance lint. Convergence does not block on PO resolution.
+
+### QA — 2026-04-30 (post-AC-patch verification)
+Verified the patched AC-F20-3 against the live schema:
+- `confidence` constraint `0.0 ≤ confidence ≤ 1.0` at `sql_models.py:670`; covering index at `:683` — `confidence >= 0.5` floor is index-friendly.
+- Eligibility predicate `(intent_class, status, is_deprioritized, confidence, success_co_count, failure_co_count)` is fully index-coverable; daily-tick scheduler query needs no new index.
+- Default `confidence=1.0` at `:597` confirms cold-start passes the floor.
+- Calibration of the 0.5 floor is correct: `services/contradiction/engine.py` is the only downward mutator; a single contradiction event will not drop a unit below 0.5, but sustained contradiction will. Threshold stays.
+- Flagged that the prose should explicitly state the sticky-deprioritize independence dimension (positive outcomes never auto-restore even if confidence and mw_score recover) so a future F20 dev does not introduce an auto-restore branch. This RFC's "Behavior — sticky-deprioritize is unconditional" section is that documentation; test (g) is the canary.
+
+QA also withdrew their prior 5-WS lean — the 6-WS partition with bounded WS-shared seed-PR mechanism is the converged engineering call.


### PR DESCRIPTION
Closes #28 + #40. Phase 3 adversarial review HIGH-004: RFC-014 referenced FSRS-4.5 while code ships FSRS-5 (ADR-006 supersedes). Patches reference + adds weights-divergence footnote. Also tracks Tier-A artifact corpus (ADRs + final report + adversarial review).

## Summary

- Patches the residual FSRS-4.5 mention in the RFC-014 POC question (line 278) to FSRS-5 with explicit ADR-006 cross-reference. Earlier edits to the same file already replaced the risk-table line and inserted the weights-divergence footnote.
- Track-adds the Tier-A finals corpus:
  - ADRs 001-006 (`adrs/`)
  - Phase 4 final report (`reports/final-report.md`)
  - Phase 3 adversarial review (`reviews/adversarial-phase-3.md`)
  - RFC-014 (under patch in this PR)
- Intermediate scratch (requirements/, conventions/, pocs/, other rfcs/) intentionally left untracked per scoping.

## Test plan

- [x] Doc-only change; no test impact
- [x] Pre-commit hooks pass (end-of-file-fixer applied automatically)