### PR TITLE
refactor(locks): dedup MEMEX_LEADER_LOCK_ID source of truth (HIGH-003)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,305%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,666%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/core/src/memex_core/services/locks.py
+++ b/packages/core/src/memex_core/services/locks.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger('memex.core.services.locks')
 
-LEADER_LOCK_ID: Final[int] = 5432789123456789
 ENTITY_LOCK_HIGH_BIT: Final[int] = 1 << 62
 ENTITY_LOCK_MASK: Final[int] = (1 << 62) - 1
 
@@ -70,8 +69,9 @@ def entity_lock_id(entity_id: uuid.UUID) -> int:
     """Derive a deterministic int64 advisory lock id from an entity UUID.
 
     The high bit is set so the result lives in [2^62, 2^63-1], disjoint from
-    LEADER_LOCK_ID (~2^52). Deterministic by construction — the same UUID
-    yields the same lock_id across processes (no PYTHONHASHSEED dependency).
+    the leader advisory lock (~2^52, defined in ``memex_core.scheduler``).
+    Deterministic by construction — the same UUID yields the same lock_id
+    across processes (no PYTHONHASHSEED dependency).
     """
     raw = int.from_bytes(entity_id.bytes, 'big', signed=False) & ENTITY_LOCK_MASK
     return ENTITY_LOCK_HIGH_BIT | raw

--- a/packages/core/tests/unit/services/test_locks.py
+++ b/packages/core/tests/unit/services/test_locks.py
@@ -1,10 +1,12 @@
 """TC-23-1 — Lock-id derivation + split helper (F9 ship, locked v2 contract).
 
-5 tests:
+6 tests:
 - test_lock_id_deterministic: same UUID -> same int across imports.
 - test_lock_id_within_high_bit_range: bit-mask proof per RFC-005 risk row 2.
 - test_no_collision_with_leader: 1M UUIDs vs MEMEX_LEADER_LOCK_ID.
 - test_split_for_pg_locks_round_trip: (classid << 32) | objid == lock_id.
+- test_leader_lock_id_single_source_of_truth: HIGH-003 dedup guard
+  (scheduler.py is canonical; services/locks.py must not redeclare).
 - (test_split_matches_actual_pg_locks_layout lives in TC-23-2 integration.)
 """
 
@@ -14,9 +16,9 @@ import uuid
 
 import pytest
 
+from memex_core.scheduler import MEMEX_LEADER_LOCK_ID
 from memex_core.services.locks import (
     ENTITY_LOCK_HIGH_BIT,
-    LEADER_LOCK_ID,
     LockIdSplit,
     entity_lock_id,
     split_for_pg_locks,
@@ -36,15 +38,15 @@ def test_lock_id_within_high_bit_range() -> None:
         assert lock_id >= ENTITY_LOCK_HIGH_BIT
         assert lock_id < (1 << 63), 'must fit signed int64'
 
-    assert LEADER_LOCK_ID & ENTITY_LOCK_HIGH_BIT == 0, (
-        'LEADER_LOCK_ID must have bit 62 clear so the disjoint-range invariant holds'
+    assert MEMEX_LEADER_LOCK_ID & ENTITY_LOCK_HIGH_BIT == 0, (
+        'MEMEX_LEADER_LOCK_ID must have bit 62 clear so the disjoint-range invariant holds'
     )
 
 
 @pytest.mark.parametrize('count', [1_000_000])
 def test_no_collision_with_leader(count: int) -> None:
     for _ in range(count):
-        assert entity_lock_id(uuid.uuid4()) != LEADER_LOCK_ID
+        assert entity_lock_id(uuid.uuid4()) != MEMEX_LEADER_LOCK_ID
 
 
 def test_split_for_pg_locks_round_trip() -> None:
@@ -62,3 +64,27 @@ def test_split_for_pg_locks_known_value() -> None:
     split = split_for_pg_locks(0x40000000DEADBEEF)
     assert split.classid == 0x40000000
     assert split.objid == 0xDEADBEEF
+
+
+def test_leader_lock_id_single_source_of_truth() -> None:
+    """HIGH-003 (Phase 3 adversarial review): scheduler.py is the sole
+    runtime definition of the leader advisory-lock ID.
+
+    Pins the AC-X-8 invariant value (5432789123456789) AND ensures
+    ``services/locks.py`` does not redeclare a parallel constant. Any
+    future module re-introducing a local copy is caught by `dir()`
+    scan + value match.
+    """
+    from memex_core import scheduler as scheduler_mod
+    from memex_core.services import locks as locks_mod
+
+    assert scheduler_mod.MEMEX_LEADER_LOCK_ID == 5432789123456789
+
+    # locks.py must not redeclare the constant (under any spelling).
+    forbidden = {'LEADER_LOCK_ID', 'MEMEX_LEADER_LOCK_ID'}
+    leaked = forbidden & set(dir(locks_mod))
+    assert not leaked, (
+        f'services/locks.py must not redeclare leader-lock constants; '
+        f'found: {sorted(leaked)}. The single source of truth is '
+        f'memex_core.scheduler.MEMEX_LEADER_LOCK_ID.'
+    )


### PR DESCRIPTION
Closes #39. Phase 3 adversarial review HIGH-003: services/locks.py and scheduler.py held duplicate constants for the same advisory lock, drift hazard.