### PR TITLE
fix(F38): acquire per-entity lock around ConsolidationService loop (CRIT-002)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,305%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,672%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/core/src/memex_core/services/consolidation.py
+++ b/packages/core/src/memex_core/services/consolidation.py
@@ -40,6 +40,12 @@ from memex_core.memory.sql_models import (
     MemoryUnit,
     UnitEntity,
 )
+from sqlalchemy.engine.url import make_url
+
+from memex_core.services.locks import (
+    EntityLockTimeoutError,
+    acquire_entity_lock,
+)
 from memex_core.services.mental_model_cleanup import prune_stale_evidence
 from memex_core.services.reflection import ReflectionService
 from memex_core.storage.metastore import AsyncBaseMetaStoreEngine
@@ -47,6 +53,7 @@ from memex_core.storage.metastore import AsyncBaseMetaStoreEngine
 logger = logging.getLogger('memex.core.services.consolidation')
 
 DEFAULT_TICK_BUDGET = 500
+DEFAULT_ENTITY_LOCK_TIMEOUT_SECONDS = 5.0
 
 
 class ConsolidationService:
@@ -64,11 +71,18 @@ class ConsolidationService:
         config: MemexConfig,
         reflection: ReflectionService,
         contradiction: ContradictionEngine | None,
+        *,
+        entity_lock_timeout_seconds: float = DEFAULT_ENTITY_LOCK_TIMEOUT_SECONDS,
     ) -> None:
         self.metastore = metastore
         self.config = config
         self.reflection = reflection
         self.contradiction = contradiction
+        # Derive a plain `postgresql://` DSN for asyncpg from the SQLAlchemy
+        # connection string (mirrors `services/locks.py::_dsn_from_config`).
+        sa_url = make_url(config.server.meta_store.instance.connection_string)
+        self._dsn = sa_url.set(drivername='postgresql').render_as_string(hide_password=False)
+        self._entity_lock_timeout_seconds = entity_lock_timeout_seconds
 
     # ------------------------------------------------------------------
     # Public API
@@ -92,16 +106,18 @@ class ConsolidationService:
 
         async with self.metastore.session() as session:
             unit_ids = await self.select_diff_units(session, vault_id, last_tick, budget=budget)
-            entity_ids = (
-                await self.resolve_unit_ids_to_entity_ids(session, unit_ids, vault_id)
+            unit_ids_by_entity = (
+                await self._resolve_unit_ids_grouped_by_entity(session, unit_ids, vault_id)
                 if unit_ids
-                else set()
+                else {}
             )
             already_stale_ids = (
                 await self._select_already_stale_ids(session, unit_ids, vault_id)
                 if unit_ids
                 else []
             )
+        entity_ids: set[UUID] = set(unit_ids_by_entity.keys())
+        already_stale_set = set(already_stale_ids)
 
         log = logger.getChild(str(vault_id))
         log.info(
@@ -123,50 +139,82 @@ class ConsolidationService:
                 'entities_reflected': len(entity_ids),
                 'contradictions_run': len(unit_ids),
                 'stale_pruned_candidates': len(already_stale_ids),
+                'entities_deferred': 0,
                 'tick_id': None,
             }
 
         contradictions_run = 0
         entities_reflected = 0
         stale_pruned = 0
+        entities_deferred: list[UUID] = []
         error: str | None = None
 
-        if unit_ids:
+        # Per-entity loop under F9's per-entity advisory lock so this tick
+        # cannot race with `memex_memory_reconsolidate` (LocksService) on the
+        # same MentalModel/MemoryUnits. Contention policy: skip-and-log-deferred
+        # — if another reconsolidation holds the lock, leave the entity for the
+        # next tick rather than block the whole tick. AC-F38-1 step ordering
+        # (contradiction → reflection → prune) is preserved per entity.
+        for eid in entity_ids:
+            entity_unit_ids = unit_ids_by_entity[eid]
+            if not entity_unit_ids:
+                continue
             try:
-                # Step 2: contradiction BEFORE reflection (B1 adjudication).
-                if self.contradiction is not None:
-                    await self.contradiction.detect_contradictions(
-                        session_factory=self.metastore.session_maker(),
-                        document_id=None,
-                        unit_ids=unit_ids,
-                        vault_id=vault_id,
-                    )
-                    contradictions_run = len(unit_ids)
-                else:
-                    log.warning('consolidation.tick.contradiction_disabled')
+                async with acquire_entity_lock(
+                    self._dsn, eid, timeout_seconds=self._entity_lock_timeout_seconds
+                ):
+                    try:
+                        if self.contradiction is not None:
+                            await self.contradiction.detect_contradictions(
+                                session_factory=self.metastore.session_maker(),
+                                document_id=None,
+                                unit_ids=entity_unit_ids,
+                                vault_id=vault_id,
+                            )
+                            contradictions_run += len(entity_unit_ids)
+                        else:
+                            log.warning('consolidation.tick.contradiction_disabled')
 
-                # Step 3: reflection AFTER contradiction.
-                if entity_ids:
-                    requests = [
-                        ReflectionRequest(entity_id=eid, vault_id=vault_id) for eid in entity_ids
-                    ]
-                    await self.reflection.reflect_batch(requests)
-                    entities_reflected = len(entity_ids)
-
-                # Step 4: prune ONLY units already STALE (F38 does NOT stale).
-                if already_stale_ids and entity_ids:
-                    async with self.metastore.session() as session:
-                        await prune_stale_evidence(
-                            session,
-                            entity_ids=entity_ids,
-                            deleted_unit_ids=already_stale_ids,
-                            vault_id=vault_id,
+                        await self.reflection.reflect_batch(
+                            [ReflectionRequest(entity_id=eid, vault_id=vault_id)]
                         )
-                        await session.commit()
-                    stale_pruned = len(already_stale_ids)
-            except Exception as exc:
-                error = f'{type(exc).__name__}: {exc}'
-                log.warning('consolidation.tick.error', extra={'error': error}, exc_info=True)
+                        entities_reflected += 1
+
+                        entity_stale_ids = [
+                            uid for uid in entity_unit_ids if uid in already_stale_set
+                        ]
+                        if entity_stale_ids:
+                            async with self.metastore.session() as session:
+                                await prune_stale_evidence(
+                                    session,
+                                    entity_ids={eid},
+                                    deleted_unit_ids=entity_stale_ids,
+                                    vault_id=vault_id,
+                                )
+                                await session.commit()
+                            stale_pruned += len(entity_stale_ids)
+                    except Exception as exc:
+                        # Per-entity failure should not poison the tick — log
+                        # and move on. Outer `error` captures the first failure
+                        # for the tick-summary row (parity with prior behaviour).
+                        if error is None:
+                            error = f'{type(exc).__name__}: {exc}'
+                        log.warning(
+                            'consolidation.tick.entity_error',
+                            extra={'entity_id': str(eid), 'error': str(exc)},
+                            exc_info=True,
+                        )
+            except EntityLockTimeoutError:
+                entities_deferred.append(eid)
+                log.info(
+                    'consolidation.tick.entity_deferred',
+                    extra={
+                        'entity_id': str(eid),
+                        'reason': 'entity_lock_timeout',
+                        'timeout_seconds': self._entity_lock_timeout_seconds,
+                    },
+                )
+                continue
 
         tick_id = await self._write_tick_summary(
             vault_id=vault_id,
@@ -185,6 +233,7 @@ class ConsolidationService:
                 'vault_id': str(vault_id),
                 'tick_id': str(tick_id),
                 'error': error,
+                'entities_deferred': len(entities_deferred),
             },
         )
 
@@ -195,6 +244,7 @@ class ConsolidationService:
             'entities_reflected': entities_reflected,
             'contradictions_run': contradictions_run,
             'stale_pruned': stale_pruned,
+            'entities_deferred': len(entities_deferred),
             'error': error,
         }
 
@@ -318,6 +368,34 @@ class ConsolidationService:
         )
         result = await session.exec(stmt)
         return {row for row in result.all() if row is not None}
+
+    async def _resolve_unit_ids_grouped_by_entity(
+        self,
+        session: Any,
+        unit_ids: list[UUID],
+        vault_id: UUID,
+    ) -> dict[UUID, list[UUID]]:
+        """Return a {entity_id: [unit_ids]} map for the diff units.
+
+        Used by ``tick()`` to drive a per-entity loop under
+        ``acquire_entity_lock`` so F38 cannot race with F9's
+        ``memex_memory_reconsolidate`` on the same MentalModel. Vault-scoped.
+        """
+        if not unit_ids:
+            return {}
+        stmt = select(UnitEntity.entity_id, UnitEntity.unit_id).where(
+            UnitEntity.unit_id.in_(unit_ids),  # type: ignore[attr-defined]
+            UnitEntity.vault_id == vault_id,
+        )
+        result = await session.exec(stmt)
+        grouped: dict[UUID, list[UUID]] = {}
+        for row in result.all():
+            entity_id = row[0] if isinstance(row, tuple) else row.entity_id
+            unit_id = row[1] if isinstance(row, tuple) else row.unit_id
+            if entity_id is None or unit_id is None:
+                continue
+            grouped.setdefault(entity_id, []).append(unit_id)
+        return grouped
 
     async def _select_already_stale_ids(
         self,

--- a/packages/core/tests/integration/test_int_f38_entity_lock.py
+++ b/packages/core/tests/integration/test_int_f38_entity_lock.py
@@ -1,0 +1,291 @@
+"""F38 ConsolidationService — F9 per-entity advisory-lock integration (CRIT-002).
+
+Phase-3 adversarial review CRITICAL-002 found that F38's tick bypassed F9's
+``acquire_entity_lock`` and could race with ``memex_memory_reconsolidate`` on
+the same MentalModel. These tests lock the contract that:
+
+1. F38's per-entity loop holds the F9 advisory lock for the duration of work
+   on that entity (release on success AND on exception).
+2. Concurrent F9 ``LocksService.reconsolidate_entity`` and F38 ``tick``
+   serialize on the same entity (no overlap window).
+3. When the lock cannot be acquired within the timeout, F38 defers that
+   entity (skip-and-log) instead of blocking the whole tick.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core.memory.sql_models import (
+    AuditLog,
+    ContentStatus,
+    Entity,
+    MemoryUnit,
+    Note,
+    UnitEntity,
+    Vault,
+)
+from memex_core.services.consolidation import ConsolidationService
+from memex_core.services.locks import (
+    acquire_entity_lock,
+)
+
+pytestmark = [pytest.mark.integration]
+
+
+async def _seed_vault(session: AsyncSession) -> UUID:
+    vault_id = uuid4()
+    session.add(Vault(id=vault_id, name=f'v-{vault_id.hex[:8]}', description=''))
+    await session.commit()
+    return vault_id
+
+
+async def _seed_note(session: AsyncSession, vault_id: UUID) -> UUID:
+    note_id = uuid4()
+    session.add(
+        Note(
+            id=note_id,
+            vault_id=vault_id,
+            content_hash=f'h-{note_id.hex[:8]}',
+            original_text='seed note for F38 lock tests',
+            filestore_path=None,
+            assets=[],
+        )
+    )
+    await session.commit()
+    return note_id
+
+
+async def _seed_unit_with_entity(
+    session: AsyncSession,
+    *,
+    vault_id: UUID,
+    note_id: UUID,
+    status: ContentStatus = ContentStatus.ACTIVE,
+) -> tuple[UUID, UUID]:
+    unit_id = uuid4()
+    entity_id = uuid4()
+    session.add(
+        MemoryUnit(
+            id=unit_id,
+            note_id=note_id,
+            vault_id=vault_id,
+            text='seeded fact',
+            fact_type=FactTypes.WORLD,
+            embedding=[0.1] * 384,
+            status=status,
+            event_date=datetime.now(timezone.utc),
+        )
+    )
+    session.add(Entity(id=entity_id, canonical_name=f'E-{entity_id.hex[:6]}'))
+    session.add(UnitEntity(unit_id=unit_id, entity_id=entity_id, vault_id=vault_id))
+    await session.commit()
+    return unit_id, entity_id
+
+
+async def _emit_outcome_audit(
+    session: AsyncSession,
+    *,
+    unit_id: UUID,
+    vault_id: UUID,
+) -> None:
+    session.add(
+        AuditLog(
+            action='outcome.record',
+            resource_type='memory_unit',
+            resource_id=str(unit_id),
+            details={'vault_id': str(vault_id), 'outcome': 'success'},
+        )
+    )
+    await session.commit()
+
+
+def _make_service(
+    metastore,
+    *,
+    contradiction_spy,
+    reflection_spy,
+    config,
+    entity_lock_timeout_seconds: float = 5.0,
+) -> ConsolidationService:
+    refl = MagicMock()
+    refl.reflect_batch = reflection_spy
+    return ConsolidationService(
+        metastore=metastore,
+        config=config,
+        reflection=refl,
+        contradiction=contradiction_spy,
+        entity_lock_timeout_seconds=entity_lock_timeout_seconds,
+    )
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_entity_when_lock_already_held(
+    metastore, memex_config, session, postgres_uri
+):
+    """If another process holds the F9 lock, F38 must skip-and-log (defer)
+    that entity, not block the whole tick."""
+    vault_id = await _seed_vault(session)
+    note_id = await _seed_note(session, vault_id)
+    unit_a, entity_a = await _seed_unit_with_entity(session, vault_id=vault_id, note_id=note_id)
+    unit_b, entity_b = await _seed_unit_with_entity(session, vault_id=vault_id, note_id=note_id)
+    await _emit_outcome_audit(session, unit_id=unit_a, vault_id=vault_id)
+    await _emit_outcome_audit(session, unit_id=unit_b, vault_id=vault_id)
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock()
+    reflection_spy = AsyncMock(return_value=[])
+
+    # Coerce SQLAlchemy DSN to plain postgresql:// for asyncpg.
+    asyncpg_dsn = postgres_uri.replace('+asyncpg', '')
+
+    # Hold the F9 lock on entity_a from a sibling task; F38 should defer it.
+    holder_acquired = asyncio.Event()
+    holder_release = asyncio.Event()
+
+    async def _hold_lock_on_entity_a():
+        async with acquire_entity_lock(asyncpg_dsn, entity_a, timeout_seconds=2.0):
+            holder_acquired.set()
+            await holder_release.wait()
+
+    holder_task = asyncio.create_task(_hold_lock_on_entity_a())
+    await asyncio.wait_for(holder_acquired.wait(), timeout=5.0)
+
+    try:
+        svc = _make_service(
+            metastore,
+            contradiction_spy=contradiction_spy,
+            reflection_spy=reflection_spy,
+            config=memex_config,
+            entity_lock_timeout_seconds=0.5,  # short for fast skip
+        )
+        result = await svc.tick(vault_id)
+    finally:
+        holder_release.set()
+        await holder_task
+
+    # entity_a was deferred; entity_b was processed.
+    assert result['entities_deferred'] == 1, result
+    assert result['entities_reflected'] == 1, result
+    # Reflection should have been called exactly once, for entity_b.
+    assert reflection_spy.await_count == 1
+    called_requests = reflection_spy.await_args_list[0].args[0]
+    assert len(called_requests) == 1
+    assert called_requests[0].entity_id == entity_b
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tick_and_reconsolidate_serialize_on_same_entity(
+    metastore, memex_config, session, postgres_uri
+):
+    """Two concurrent invocations on the same entity must NOT overlap. The
+    second waiter must observe the first's lock until release."""
+    vault_id = await _seed_vault(session)
+    note_id = await _seed_note(session, vault_id)
+    unit_id, entity_id = await _seed_unit_with_entity(session, vault_id=vault_id, note_id=note_id)
+    await _emit_outcome_audit(session, unit_id=unit_id, vault_id=vault_id)
+
+    asyncpg_dsn = postgres_uri.replace('+asyncpg', '')
+
+    # Reflection spy tracks overlap: each call records (start, end). Sleep a
+    # bit inside the body so concurrent calls would overlap if the lock were
+    # missing.
+    overlaps: list[tuple[float, float]] = []
+    in_flight = 0
+    max_in_flight = 0
+    enter_lock = asyncio.Lock()
+
+    async def _reflection_body(_requests):
+        nonlocal in_flight, max_in_flight
+        async with enter_lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        start = asyncio.get_event_loop().time()
+        await asyncio.sleep(0.3)
+        end = asyncio.get_event_loop().time()
+        overlaps.append((start, end))
+        async with enter_lock:
+            in_flight -= 1
+        return []
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock()
+    reflection_spy = AsyncMock(side_effect=_reflection_body)
+
+    svc = _make_service(
+        metastore,
+        contradiction_spy=contradiction_spy,
+        reflection_spy=reflection_spy,
+        config=memex_config,
+        entity_lock_timeout_seconds=10.0,
+    )
+
+    # Mimic an external `memex_memory_reconsolidate` by holding the same
+    # advisory lock and doing equivalent work in parallel with `tick()`.
+    async def _external_reconsolidate():
+        async with acquire_entity_lock(asyncpg_dsn, entity_id, timeout_seconds=10.0):
+            await _reflection_body(None)
+
+    task_a = asyncio.create_task(svc.tick(vault_id))
+    # Slight stagger so the contention is real but deterministic.
+    await asyncio.sleep(0.05)
+    task_b = asyncio.create_task(_external_reconsolidate())
+
+    result, _ = await asyncio.gather(task_a, task_b)
+
+    assert max_in_flight == 1, (
+        f'F38 tick and external reconsolidate ran concurrently on the same '
+        f'entity (max_in_flight={max_in_flight}); F9 lock was bypassed.'
+    )
+    # Verify intervals do not overlap (start of one >= end of other).
+    a, b = overlaps
+    assert a[1] <= b[0] or b[1] <= a[0], f'reflection intervals overlap: {a} vs {b}; lock not held'
+    assert result['entities_reflected'] == 1
+    assert result['entities_deferred'] == 0
+
+
+@pytest.mark.asyncio
+async def test_lock_releases_on_exception_in_tick_body(
+    metastore, memex_config, session, postgres_uri
+):
+    """If reflection raises mid-tick on entity X, the F9 advisory lock for X
+    must still be released (context-manager guarantee). A second acquire
+    after the tick succeeds immediately."""
+    vault_id = await _seed_vault(session)
+    note_id = await _seed_note(session, vault_id)
+    unit_id, entity_id = await _seed_unit_with_entity(session, vault_id=vault_id, note_id=note_id)
+    await _emit_outcome_audit(session, unit_id=unit_id, vault_id=vault_id)
+
+    asyncpg_dsn = postgres_uri.replace('+asyncpg', '')
+
+    class _Boom(RuntimeError):
+        pass
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock()
+    reflection_spy = AsyncMock(side_effect=_Boom('boom'))
+
+    svc = _make_service(
+        metastore,
+        contradiction_spy=contradiction_spy,
+        reflection_spy=reflection_spy,
+        config=memex_config,
+        entity_lock_timeout_seconds=2.0,
+    )
+
+    result = await svc.tick(vault_id)
+
+    # The error should be captured in the tick row; lock must still be free.
+    assert result['error'] is not None
+    assert 'boom' in result['error'] or '_Boom' in result['error']
+
+    # If the lock leaked, this acquire would block until our short timeout.
+    async with acquire_entity_lock(asyncpg_dsn, entity_id, timeout_seconds=0.5):
+        pass  # acquired without timeout — lock was released on exception

--- a/packages/core/tests/unit/test_consolidation_lock.py
+++ b/packages/core/tests/unit/test_consolidation_lock.py
@@ -1,0 +1,200 @@
+"""F38 ConsolidationService — F9 lock-acquire/release contract (CRIT-002 unit).
+
+Source-level + behavioural unit tests verifying that ``tick()`` wraps each
+per-entity iteration in ``acquire_entity_lock`` so F38 cannot race with
+``memex_memory_reconsolidate`` on the same MentalModel.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from memex_core.services import consolidation
+from memex_core.services.consolidation import ConsolidationService
+
+_SOURCE = inspect.getsource(consolidation)
+
+
+def test_tick_imports_and_uses_acquire_entity_lock():
+    """tick() must reference ``acquire_entity_lock`` and ``EntityLockTimeoutError``
+    so the F9 lock cannot be silently removed in a future refactor."""
+    assert 'acquire_entity_lock(' in _SOURCE, (
+        'CRIT-002 regression: ConsolidationService no longer calls acquire_entity_lock — '
+        'F38 would race with memex_memory_reconsolidate on the same MentalModel.'
+    )
+    assert 'EntityLockTimeoutError' in _SOURCE, (
+        'tick() must import EntityLockTimeoutError to handle lock contention'
+    )
+
+
+def test_lock_acquire_is_inside_tick_per_entity_loop():
+    """The acquire_entity_lock call site must live inside ``async def tick``."""
+    src = _SOURCE
+    tick_match = re.search(r'async def tick\b', src)
+    assert tick_match, 'tick() not found in source'
+    # Find the next top-level `async def` after tick to bound the search.
+    tick_start = tick_match.start()
+    next_def = re.search(r'\n    async def\s', src[tick_start + 1 :])
+    tick_end = (tick_start + 1 + next_def.start()) if next_def else len(src)
+    tick_body = src[tick_start:tick_end]
+    assert 'acquire_entity_lock(' in tick_body, (
+        'acquire_entity_lock must be called inside tick(), not at module level'
+    )
+
+
+@pytest.mark.asyncio
+async def test_tick_acquires_and_releases_lock_per_entity(monkeypatch):
+    """Behavioural: each entity yields exactly one matched acquire/release
+    pair; reflection runs only between acquire and release."""
+    vault_id = uuid4()
+    entity_a = uuid4()
+    entity_b = uuid4()
+    unit_a = uuid4()
+    unit_b = uuid4()
+    unit_to_entity = {unit_a: entity_a, unit_b: entity_b}
+
+    events: list[tuple[str, UUID]] = []
+
+    @asynccontextmanager
+    async def _fake_lock(_dsn, eid, *, timeout_seconds):
+        events.append(('acquire', eid))
+        try:
+            yield
+        finally:
+            events.append(('release', eid))
+
+    monkeypatch.setattr(consolidation, 'acquire_entity_lock', _fake_lock)
+
+    metastore = MagicMock()
+
+    # Patch out the DB-touching methods so we do not need a real Postgres.
+    config = MagicMock()
+    config.server.meta_store.instance.connection_string = (
+        'postgresql+asyncpg://x:y@localhost:5432/db'
+    )
+
+    async def _record_contradiction(**kw):
+        # Map unit_id back to entity_id for ordering checks.
+        events.append(('contradiction', unit_to_entity[kw['unit_ids'][0]]))
+
+    async def _record_reflection(reqs):
+        events.append(('reflection', reqs[0].entity_id))
+        return []
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock(side_effect=_record_contradiction)
+    reflection = MagicMock()
+    reflection.reflect_batch = AsyncMock(side_effect=_record_reflection)
+
+    svc = ConsolidationService(
+        metastore=metastore,
+        config=config,
+        reflection=reflection,
+        contradiction=contradiction_spy,
+    )
+
+    # Stub out the diff-selection + grouping + stale-filter so we can drive
+    # the per-entity loop deterministically.
+    svc.get_last_tick_timestamp = AsyncMock(return_value=None)  # type: ignore
+    svc.select_diff_units = AsyncMock(return_value=[unit_a, unit_b])  # type: ignore
+    svc._resolve_unit_ids_grouped_by_entity = AsyncMock(  # type: ignore
+        return_value={entity_a: [unit_a], entity_b: [unit_b]}
+    )
+    svc._select_already_stale_ids = AsyncMock(return_value=[])  # type: ignore
+    svc._write_tick_summary = AsyncMock(return_value=uuid4())  # type: ignore
+
+    # `metastore.session()` is used for diff/staleness reads; return a mocked
+    # async context that yields a sentinel session (we stubbed the methods
+    # that would have used it, so the body is unused).
+    @asynccontextmanager
+    async def _fake_session():
+        yield MagicMock()
+
+    metastore.session = MagicMock(side_effect=_fake_session)
+    metastore.session_maker = MagicMock(return_value=MagicMock())
+
+    result = await svc.tick(vault_id)
+
+    # Both entities processed; no deferrals.
+    assert result['entities_reflected'] == 2
+    assert result['entities_deferred'] == 0
+    assert result['error'] is None
+
+    # Extract acquire/release pairs and verify each entity has exactly one
+    # matched pair, with the inner work happening between them.
+    for eid in (entity_a, entity_b):
+        eid_events = [e for e in events if e[1] == eid]
+        # Expect: acquire, contradiction, reflection, release (in that order).
+        kinds = [k for k, _ in eid_events]
+        assert kinds == ['acquire', 'contradiction', 'reflection', 'release'], (
+            f'lock+work ordering for {eid}: {kinds}'
+        )
+
+
+@pytest.mark.asyncio
+async def test_tick_releases_lock_when_reflection_raises(monkeypatch):
+    """If the inner work raises, the lock is still released by the
+    context-manager — the release event must fire after the exception."""
+    from memex_core.services.consolidation import ConsolidationService
+
+    vault_id = uuid4()
+    entity_id = uuid4()
+    unit_id = uuid4()
+
+    events: list[tuple[str, UUID]] = []
+
+    @asynccontextmanager
+    async def _fake_lock(_dsn, eid, *, timeout_seconds):
+        events.append(('acquire', eid))
+        try:
+            yield
+        finally:
+            events.append(('release', eid))
+
+    monkeypatch.setattr(consolidation, 'acquire_entity_lock', _fake_lock)
+
+    config = MagicMock()
+    config.server.meta_store.instance.connection_string = (
+        'postgresql+asyncpg://x:y@localhost:5432/db'
+    )
+
+    metastore = MagicMock()
+
+    @asynccontextmanager
+    async def _fake_session():
+        yield MagicMock()
+
+    metastore.session = MagicMock(side_effect=_fake_session)
+    metastore.session_maker = MagicMock(return_value=MagicMock())
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock()
+    reflection = MagicMock()
+    reflection.reflect_batch = AsyncMock(side_effect=RuntimeError('boom'))
+
+    svc = ConsolidationService(
+        metastore=metastore,
+        config=config,
+        reflection=reflection,
+        contradiction=contradiction_spy,
+    )
+
+    svc.get_last_tick_timestamp = AsyncMock(return_value=None)  # type: ignore
+    svc.select_diff_units = AsyncMock(return_value=[unit_id])  # type: ignore
+    svc._resolve_unit_ids_grouped_by_entity = AsyncMock(  # type: ignore
+        return_value={entity_id: [unit_id]}
+    )
+    svc._select_already_stale_ids = AsyncMock(return_value=[])  # type: ignore
+    svc._write_tick_summary = AsyncMock(return_value=uuid4())  # type: ignore
+
+    result = await svc.tick(vault_id)
+
+    assert result['error'] is not None and 'boom' in result['error']
+    kinds = [k for k, _ in events]
+    assert kinds == ['acquire', 'release'], f'lock not released on exception: events={events}'


### PR DESCRIPTION
Closes #38. Phase 3 adversarial review CRITICAL-002: F38 ConsolidationService bypassed F9's per-entity advisory lock, racing with `memex_memory_reconsolidate` on the same MentalModel. Wraps per-entity iteration in `acquire_entity_lock(entity_id)`.

## Summary
- `services/consolidation.py::tick()` now iterates entities one at a time, holding the F9 per-entity advisory lock around contradiction -> reflection -> prune for each entity. F38 cannot race with `memex_memory_reconsolidate` on the same MentalModel anymore.
- Lock release is guaranteed on exception via the F9 context-manager; bit-62 disjointness from `MEMEX_LEADER_LOCK_ID` is preserved (the math in `services/locks.py::entity_lock_id` is reused unchanged).
- Contention policy: **skip-and-log-deferred**. If another reconsolidation holds the lock past `entity_lock_timeout_seconds` (default 5s), the entity is left for the next tick rather than blocking the whole tick. New tick result key `entities_deferred` surfaces the count; structured log `consolidation.tick.entity_deferred` carries the `entity_id`.
- Per-entity AC-F38-1 step ordering (contradiction -> reflection -> prune) is preserved; the existing source-level guard in `test_consolidation_writes.py` still passes.

## Test plan
- [x] Unit guard: `pytest packages/core/tests/unit/test_consolidation_lock.py` — source-level guard that the lock import + acquire site live inside `tick()`, behavioural acquire/release ordering with mocked lock, release-on-exception.
- [x] Integration: `pytest packages/core/tests/integration/test_int_f38_entity_lock.py` — real Postgres advisory locks. (a) lock already held by another task -> F38 skips that entity (`entities_deferred=1`) and processes the rest; (b) F38 tick + external `acquire_entity_lock` block on the same entity prove no overlap window (`max_in_flight==1`); (c) exception inside reflection releases the lock so a follow-up acquire returns immediately.
- [x] Regression: existing F38 unit + integration tests pass (`test_consolidation_writes.py`, `test_f38_no_agent_surface.py`, `test_int_f38_tick.py`, `test_int_f38_outcomes_audit.py`).
- [x] F9 lock invariants pass (`test_locks.py`, `test_locks_invariants.py`) — bit-62 disjointness from `MEMEX_LEADER_LOCK_ID` unchanged.

Run all together:
```
uv run pytest \
  packages/core/tests/unit/test_consolidation_lock.py \
  packages/core/tests/unit/test_consolidation_writes.py \
  packages/core/tests/unit/test_f38_no_agent_surface.py \
  packages/core/tests/unit/services/test_locks.py \
  packages/core/tests/unit/services/test_locks_invariants.py \
  packages/core/tests/integration/test_int_f38_tick.py \
  packages/core/tests/integration/test_int_f38_outcomes_audit.py \
  packages/core/tests/integration/test_int_f38_entity_lock.py
```

Generated with Claude Code