### PR TITLE
test(hermes): extend AC-X-10 boot+discovery canary to F4/F8/F29 (HIGH-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,305%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,665%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/hermes-plugin/tests/integration/test_live_hermes.py
+++ b/packages/hermes-plugin/tests/integration/test_live_hermes.py
@@ -76,6 +76,10 @@ def test_get_tool_schemas_exposes_stream_1_and_post_seed_tools(initialized_provi
     assert 'memex_memory_review' in names  # F20 — WRITE verb (FSRS-5 schedule advance)
     assert 'memex_memory_reconsolidate' in names  # F9 — entity-scoped curation
     assert 'memex_memory_consolidate' in names  # F9 — vault-scoped curation
+    assert 'memex_memory_deprioritize' in names  # F4 — soft-deprioritize WRITE verb
+    assert 'memex_memory_restore' in names  # F4 — restore partner of deprioritize
+    assert 'memex_record_outcome' in names  # F29 — outcome telemetry WRITE verb
+    assert 'memex_get_lint_flags' in names  # F8 — memory-hygiene lint READ verb
 
 
 def test_get_tool_schemas_at_registration_time(loaded_provider):


### PR DESCRIPTION
## Summary

Closes Phase 3 adversarial review HIGH-1 (`.dev-team-artifacts/dev-tier-a-cognitive-memory/reviews/adversarial-phase-3.md` line 37).

The AC-X-10 boot+discovery canary at `packages/hermes-plugin/tests/integration/test_live_hermes.py:49-78` missed four MCP verbs added during Tier-A but never wired into the assertion list:

- `memex_memory_deprioritize` (F4) — registered at `tools.py:3255`
- `memex_memory_restore` (F4 partner) — registered at `tools.py:3282`
- `memex_record_outcome` (F29) — registered at `tools.py:3459`
- `memex_get_lint_flags` (F8) — registered at `tools.py:3592`

Same regression class as v0.1.13: a refactor moves schema registration somewhere that imports correctly but is never picked up by Hermes' loader. The boot+discovery canary is the only assertion that verifies registration is reachable through `_tool_to_provider` dispatch — its docstring (lines 50-58) requires every new MCP verb to appear here.

Test-only diff (4 added lines, mirroring existing `assert 'memex_X' in names` pattern). README badge update is auto-applied by the `update test count badge` pre-commit hook.

## Test plan

- [ ] `uv run pytest packages/hermes-plugin/tests/integration/test_live_hermes.py::test_get_tool_schemas_exposes_stream_1_and_post_seed_tools -m hermes_integration -v` (requires Docker + `uv sync --group hermes-integration`)
- [ ] Pre-commit (`prek run --files packages/hermes-plugin/tests/integration/test_live_hermes.py`) — already verified locally, all hooks Passed
- [ ] CI: hermes integration suite green on memory_augmentation merge

Do not merge — qa-adversarial-2 verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)