### PR TITLE
fix(test): asset roundtrip stale assertion (post-PR #61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,724%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,748%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/hermes-plugin/tests/integration/test_live_asset_round_trip.py
+++ b/packages/hermes-plugin/tests/integration/test_live_asset_round_trip.py
@@ -1,8 +1,8 @@
 """Integration test for the asset add → list → get round trip (AC-093).
 
 Exercises the full end-to-end path: real Hermes loader × real Memex FastAPI
-app × real Postgres, asserting byte-level round-trip through
-base64 encoding on the Hermes side.
+app × real Postgres, asserting byte-level round-trip through the
+disk-handoff contract on the Hermes side (PR #61 / issue #59).
 
 Per RFC-015 + POC-002: tools are invoked via
 ``initialized_provider.handle_tool_call(tool_name, args)`` — the canonical
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
@@ -83,10 +84,17 @@ async def test_asset_add_list_get_round_trip(initialized_provider, live_api, liv
     asset_path = asset['path']
 
     # 5. Fetch bytes by path and assert byte-level round-trip equality.
+    #    PR #61 changed the contract to disk-handoff: bytes are NEVER inlined
+    #    as ``content_b64``; agents read each ``local_path`` directly.
     get_raw = initialized_provider.handle_tool_call('memex_get_resources', {'paths': [asset_path]})
     get_data = json.loads(get_raw)
     assert len(get_data['results']) == 1
     result = get_data['results'][0]
     assert 'error' not in result, f'get_resources error: {result!r}'
-    assert base64.b64decode(result['content_b64']) == ASSET_BYTES
+    assert 'content_b64' not in result, 'disk-handoff must never inline bytes'
+    local_path = Path(result['local_path'])
+    assert local_path.exists(), f'local_path does not exist: {local_path}'
+    assert local_path.read_bytes() == ASSET_BYTES
     assert result['size_bytes'] == len(ASSET_BYTES)
+    assert result['filename'] == 'test.png'
+    assert result['mime_type'] == 'image/png'


### PR DESCRIPTION
## Summary

- Updates `packages/hermes-plugin/tests/integration/test_live_asset_round_trip.py:91` to assert `result['local_path']` (read bytes from disk) instead of `result['content_b64']`.
- PR #61 (commit 937287d) changed `memex_get_resources` to disk-handoff — bytes are NEVER inlined as `content_b64` and the result shape is now `{path, local_path, filename, mime_type, size_bytes}`. This integration test wasn't updated and would fail the moment the hermes-integration job actually exercises it (surfaces only after #84 wires the job in).
- Also asserts `'content_b64' not in result` (matches the unit-test invariant in `tests/test_handle_get_resources.py:71`) and the new `filename` / `mime_type` fields.

No production code touched. The badge bump in `README.md` is from the `update test count badge` pre-commit hook; not a manual change.

## Test plan

- [x] `prek run --files packages/hermes-plugin/tests/integration/test_live_asset_round_trip.py` passes (ruff + ruff-format + mypy + AST checks).
- [ ] Hermes-integration job (post #84) green — requires `GEMINI_API_KEY` in CI for the upstream ingest (out of scope here; that's the `dev-ci-hermes-key` ticket).
- [x] New assertion shape matches `handle_get_resources` source at `packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py:2853-2861` and existing unit test at `packages/hermes-plugin/tests/test_handle_get_resources.py:50-79`.

Do not merge — quick code review first.