### PR TITLE
test(hermes-integration): MockDspyLM for wiring tests (#27 unblocker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,724%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,748%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/hermes-plugin/tests/integration/conftest.py
+++ b/packages/hermes-plugin/tests/integration/conftest.py
@@ -25,7 +25,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, AsyncGenerator, Generator, Iterator
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -72,6 +72,86 @@ def _require_prerequisites() -> None:
             'testcontainers Postgres.',
             allow_module_level=False,
         )
+
+
+# ---------------------------------------------------------------------------
+# LLM mocking — make the suite hermetic (no LLM API key required)
+# ---------------------------------------------------------------------------
+#
+# These tests exercise plugin <-> server <-> Postgres wiring, not LLM behaviour.
+# Without a mock, ``ingestion._process_chunk`` calls ``self.memory.retain``,
+# which fans out to ``run_dspy_operation`` for fact extraction; with no API
+# key the call raises ``litellm.AuthenticationError``, the AsyncTransaction
+# rolls back, and the note never persists. The CI ``llm-tests`` job is gated
+# off (no key in secrets), so the only sustainable fix is to mock the LLM.
+#
+# Mirrors the unit-test ``MockDspyLM`` pattern (packages/core/tests/unit/conftest.py
+# and packages/core/tests/fixtures/llm_mocks.py): patches ``run_dspy_operation``
+# at the definition site AND at every module that did
+# ``from memex_core.llm import run_dspy_operation`` (the function reference is
+# captured at import time, so patching only the source is not enough).
+
+
+_RUN_DSPY_IMPORT_SITES: tuple[str, ...] = (
+    'memex_core.llm.run_dspy_operation',
+    'memex_core.memory.extraction.core.run_dspy_operation',
+    'memex_core.memory.extraction.classifier.run_dspy_operation',
+    'memex_core.memory.reflect.reflection.run_dspy_operation',
+    'memex_core.memory.retrieval.expansion.run_dspy_operation',
+    'memex_core.memory.retrieval.temporal_concretizer.run_dspy_operation',
+    'memex_core.memory.contradiction.engine.run_dspy_operation',
+    'memex_core.processing.titles.run_dspy_operation',
+    'memex_core.processing.dates.run_dspy_operation',
+    'memex_core.services.search.run_dspy_operation',
+    'memex_core.services.vault_summary.run_dspy_operation',
+)
+
+
+def _make_empty_extraction_result() -> MagicMock:
+    """Default mock result: an ``ExtractedOutput`` with zero facts.
+
+    Shape mirrors what ``_extract_facts_from_chunk`` and
+    ``extract_facts_from_frontmatter`` consume::
+
+        result.extracted_facts.extracted_facts -> []
+
+    Other call sites read different attributes (``pred.detected_headers``,
+    ``result.classifier`` etc.); ``MagicMock`` returns child mocks for those
+    by default, which is harmless for the wiring tests we care about — they
+    only hit the simple-strategy extraction path with meaningful titles, so
+    no LLM-derived field is ever asserted on.
+    """
+    result = MagicMock()
+    result.extracted_facts.extracted_facts = []
+    return result
+
+
+async def _mock_run_dspy(*args: Any, **kwargs: Any) -> Any:
+    return _make_empty_extraction_result()
+
+
+@pytest.fixture(scope='session', autouse=True)
+def _mock_run_dspy_operation_for_hermes_integration() -> Generator[None, None, None]:
+    """Patch ``run_dspy_operation`` for the entire integration session.
+
+    Session-scoped + autouse so the patch is installed BEFORE the uvicorn
+    server thread starts (the server runs in-process, so module-level
+    patches are visible across threads). Wrapping ``AsyncMock`` per-site
+    keeps each ``patch`` independent — necessary because some of the call
+    sites import the symbol via ``from ... import run_dspy_operation``,
+    binding the reference at import time.
+    """
+    patches = [
+        patch(target, new=AsyncMock(side_effect=_mock_run_dspy))
+        for target in _RUN_DSPY_IMPORT_SITES
+    ]
+    for p in patches:
+        p.start()
+    try:
+        yield
+    finally:
+        for p in patches:
+            p.stop()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/hermes-plugin/tests/integration/test_live_asset_round_trip.py
+++ b/packages/hermes-plugin/tests/integration/test_live_asset_round_trip.py
@@ -1,8 +1,8 @@
 """Integration test for the asset add → list → get round trip (AC-093).
 
 Exercises the full end-to-end path: real Hermes loader × real Memex FastAPI
-app × real Postgres, asserting byte-level round-trip through
-base64 encoding on the Hermes side.
+app × real Postgres, asserting byte-level round-trip through the
+disk-handoff contract on the Hermes side (PR #61 / issue #59).
 
 Per RFC-015 + POC-002: tools are invoked via
 ``initialized_provider.handle_tool_call(tool_name, args)`` — the canonical
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
@@ -83,10 +84,17 @@ async def test_asset_add_list_get_round_trip(initialized_provider, live_api, liv
     asset_path = asset['path']
 
     # 5. Fetch bytes by path and assert byte-level round-trip equality.
+    #    PR #61 changed the contract to disk-handoff: bytes are NEVER inlined
+    #    as ``content_b64``; agents read each ``local_path`` directly.
     get_raw = initialized_provider.handle_tool_call('memex_get_resources', {'paths': [asset_path]})
     get_data = json.loads(get_raw)
     assert len(get_data['results']) == 1
     result = get_data['results'][0]
     assert 'error' not in result, f'get_resources error: {result!r}'
-    assert base64.b64decode(result['content_b64']) == ASSET_BYTES
+    assert 'content_b64' not in result, 'disk-handoff must never inline bytes'
+    local_path = Path(result['local_path'])
+    assert local_path.exists(), f'local_path does not exist: {local_path}'
+    assert local_path.read_bytes() == ASSET_BYTES
     assert result['size_bytes'] == len(ASSET_BYTES)
+    assert result['filename'] == 'test.png'
+    assert result['mime_type'] == 'image/png'


### PR DESCRIPTION
## Summary

Migrates 3 hermes-integration tests off real-LLM dependency to MockDspyLM. Fixes 3 of 4 #84-surfaced failures. The 4th (memory-mode-tools) is a separate Tier-A regression owned by `dev-bug-memory-mode-tools`. Plugin-server-Postgres wiring contract unchanged; LLM behavior was never the SUT.

## What changed

- **`packages/hermes-plugin/tests/integration/conftest.py`** (this PR's commit): adds a session-scoped autouse fixture that patches `run_dspy_operation` at the definition site **and** every call site that imports it via `from ... import` (Python captures the reference at import time, so patching only `memex_core.llm` is not enough). The mock returns an empty `ExtractedOutput`, which short-circuits `extract_and_persist` cleanly: `track_document` records the note and returns, the transaction commits, hermes-side wiring assertions can run.

- **`packages/hermes-plugin/tests/integration/test_live_asset_round_trip.py`** (rebased from `fix/asset-roundtrip-stale-assertion` by `dev-bug-asset-roundtrip-stale`): updates the asset round-trip assertion for the disk-handoff contract (PR #61). Composes with the LLM mock; without both fixes the test fails — first on the LLM dep, then on the stale assertion.

## Why a fixture, not a per-test marker

The 3 tests don't need test-specific golden outputs — they're wiring tests, so an empty extraction is the right default. A session-scoped autouse fixture in the integration conftest patches once, before the in-process uvicorn thread starts, and covers all 17 hermes-integration tests uniformly. No per-test changes; matches the existing `mock_dspy_lm` pattern from `packages/core/tests/unit/conftest.py`.

## Verification

```
$ unset GEMINI_API_KEY GOOGLE_API_KEY ANTHROPIC_API_KEY
$ uv run pytest packages/hermes-plugin/tests/integration/ -v -m hermes_integration -p no:randomly
... 16 passed, 1 failed in 9.53s
```

The only remaining failure is `test_memory_mode_tools_hides_briefing_and_prefetch` — separate Tier-A regression, owned by `dev-bug-memory-mode-tools`, out of scope here.

Pre-fix baseline (memory_augmentation HEAD): 15 passed, 2 failed (asset round-trip + memory-mode-tools).

## Test plan

- [x] All 3 target tests pass with NO LLM API key in env
- [x] Other 13 hermes-integration tests don't regress (16/17 pass; the 1 fail is out-of-scope)
- [x] `prek run --files packages/hermes-plugin/tests/integration/conftest.py` clean (ruff + ruff-format + mypy)
- [ ] CI hermes-integration job (PR #84) passes on this branch

## Coordination

- The 2nd commit on this branch is `a73d849` from `fix/asset-roundtrip-stale-assertion` (rebase-included, not silently dropped). When that branch lands first, this PR will simplify automatically. When this lands first, the other PR becomes a no-op.
- Does NOT touch `test_memory_mode_tools_hides_briefing_and_prefetch` (other agent's scope).
- Production ingestion code is unchanged — the LLM dep is correct in production; only the test path is hermetic now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)