### PR TITLE
Slice 2 — Foundations + F4 + F5 + F32 (Wave-0 prework, deprioritize/restore, summarize_node, diagnostics)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,4 +199,26 @@ recordings/cli/.casts/
 # Test artifacts from mocked cache_dir paths
 MagicMock/
 
-.dev-team-artifacts
+# Dev-team artifacts: per-team. Sibling teams' dirs and transient state are ignored;
+# this team's permanent artifacts (POCs, RFCs, requirements, ADRs, reports, research,
+# conventions, ac-traceability) are tracked because they are referenced by acceptance
+# criteria and the final design doc. Enumerate siblings here instead of using a parent
+# .dev-team-artifacts/ exclude — git does not evaluate child re-includes when a parent
+# directory is excluded by a non-negated rule.
+.dev-team-artifacts/dev-contradiction-relations/
+.dev-team-artifacts/dev-doc-drift/
+.dev-team-artifacts/dev-hermes-mcp-parity/
+.dev-team-artifacts/dev-memex-features/
+.dev-team-artifacts/dev-remove-page-index/
+.dev-team-artifacts/dev-session-briefing/
+.dev-team-artifacts/dev-vault-fixes/
+.dev-team-artifacts/extraction-wedge-fix/
+.dev-team-artifacts/memex-poc-planning/
+.dev-team-artifacts/.active-team
+.dev-team-artifacts/.DS_Store
+.dev-team-artifacts/dev-tier-a-cognitive-memory/dashboard.html
+.dev-team-artifacts/dev-tier-a-cognitive-memory/events.jsonl
+.dev-team-artifacts/dev-tier-a-cognitive-memory/.lock
+.dev-team-artifacts/dev-tier-a-cognitive-memory/state.json
+.dev-team-artifacts/dev-tier-a-cognitive-memory/progress.md
+.dev-team-artifacts/dev-tier-a-cognitive-memory/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -199,26 +199,4 @@ recordings/cli/.casts/
 # Test artifacts from mocked cache_dir paths
 MagicMock/
 
-# Dev-team artifacts: per-team. Sibling teams' dirs and transient state are ignored;
-# this team's permanent artifacts (POCs, RFCs, requirements, ADRs, reports, research,
-# conventions, ac-traceability) are tracked because they are referenced by acceptance
-# criteria and the final design doc. Enumerate siblings here instead of using a parent
-# .dev-team-artifacts/ exclude — git does not evaluate child re-includes when a parent
-# directory is excluded by a non-negated rule.
-.dev-team-artifacts/dev-contradiction-relations/
-.dev-team-artifacts/dev-doc-drift/
-.dev-team-artifacts/dev-hermes-mcp-parity/
-.dev-team-artifacts/dev-memex-features/
-.dev-team-artifacts/dev-remove-page-index/
-.dev-team-artifacts/dev-session-briefing/
-.dev-team-artifacts/dev-vault-fixes/
-.dev-team-artifacts/extraction-wedge-fix/
-.dev-team-artifacts/memex-poc-planning/
-.dev-team-artifacts/.active-team
-.dev-team-artifacts/.DS_Store
-.dev-team-artifacts/dev-tier-a-cognitive-memory/dashboard.html
-.dev-team-artifacts/dev-tier-a-cognitive-memory/events.jsonl
-.dev-team-artifacts/dev-tier-a-cognitive-memory/.lock
-.dev-team-artifacts/dev-tier-a-cognitive-memory/state.json
-.dev-team-artifacts/dev-tier-a-cognitive-memory/progress.md
-.dev-team-artifacts/dev-tier-a-cognitive-memory/.DS_Store
+.dev-team-artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,8 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv-*
+.ws-env
 env/
 venv/
 ENV/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,251%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,255%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,315%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,319%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,298%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,299%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,309%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,315%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,329%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,333%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,333%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,331%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,255%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,266%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,319%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,327%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,305%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,309%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,299%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,305%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,327%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,329%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,229%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,246%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,295%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,297%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,266%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,269%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,246%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,251%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,269%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,295%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,297%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,298%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/claude-code-plugin/skills/recall/SKILL.md
+++ b/packages/claude-code-plugin/skills/recall/SKILL.md
@@ -36,4 +36,12 @@ F32: WS-diagnostics (get_diagnostics_summary surfacing)
 # --- F20 --- (filled by WS-revisit)
 
 # --- F32 --- (filled by WS-diagnostics)
+4. **Vault diagnostics** (when the user asks "how is this vault doing?",
+   "what's in vault X?", "check vault health", or wants visualisation):
+   call `memex_get_diagnostics_summary(vault_id=...)` to surface unit
+   counts by status (active / stale / deprioritized), pending lint counts
+   by type, cluster_count (null when the UMAP manifold cache is cold),
+   avg MW score, and top retrieved entities. For full JSON or visual
+   plots, point the user to the CLI: `memex diagnostics manifold |
+   retrieval | summary --vault X`.
 -->

--- a/packages/claude-code-plugin/skills/recall/SKILL.md
+++ b/packages/claude-code-plugin/skills/recall/SKILL.md
@@ -24,3 +24,16 @@ You have been invoked via the `/recall` slash command.
    - Summarize the findings in a clear, readable format.
    - Include source Note IDs so the user can drill deeper with `memex_read_note`.
    - If no results are found, tell the user and suggest alternative queries.
+
+<!--
+Tier A — /recall verb extensions
+F8:  WS-linter      (get_lint_flags surfacing)
+F20: WS-revisit     (get_due_for_review surfacing)
+F32: WS-diagnostics (get_diagnostics_summary surfacing)
+
+# --- F8 ---  (filled by WS-linter)
+
+# --- F20 --- (filled by WS-revisit)
+
+# --- F32 --- (filled by WS-diagnostics)
+-->

--- a/packages/claude-code-plugin/skills/remember/SKILL.md
+++ b/packages/claude-code-plugin/skills/remember/SKILL.md
@@ -37,3 +37,22 @@ You have been invoked via the `/remember` slash command.
 
 5. **Confirm to the user.**
    After calling the tool, briefly confirm what was saved and mention the title.
+
+<!--
+Tier A — /remember verb extensions
+F4:  WS-quick-wins  (memory_deprioritize/restore disclosure)
+F5:  WS-quick-wins  (memory_summarize_node disclosure)
+F9:  WS-locks       (memory_reconsolidate, memory_consolidate disclosure)
+F14: WS-quick-wins  (procedural KV capture surfacing)
+F20: WS-revisit     (memory_review disclosure)
+
+# --- F4 ---  (filled by WS-quick-wins)
+
+# --- F5 ---  (filled by WS-quick-wins)
+
+# --- F9 ---  (filled by WS-locks)
+
+# --- F14 --- (filled by WS-quick-wins)
+
+# --- F20 --- (filled by WS-revisit)
+-->

--- a/packages/claude-code-plugin/skills/remember/SKILL.md
+++ b/packages/claude-code-plugin/skills/remember/SKILL.md
@@ -52,6 +52,26 @@ that contaminates retrieval, prefer the **NON-DESTRUCTIVE** verb:
   it removes the unit from the entity graph and is irreversible. Prefer
   deprioritize unless the unit MUST leave the graph entirely.
 
+## Synchronously consolidating mid-conversation (summarize_node vs reflect)
+
+When you notice mid-conversation that retrieved facts about a topic are
+conflicting, incomplete, or scattered, you can ask Memex to consolidate them
+into a coherent mental model **before continuing**:
+
+- `memex_memory_summarize_node(entity_id, scope)` triggers reflection
+  **synchronously**. `scope='incremental'` (default) consolidates only new
+  evidence; `scope='full'` re-evaluates all evidence on the entity (capped
+  at the most-recent 1000 units). The tool returns the updated mental model
+  in the same turn, so you can act on it immediately.
+- Background `reflect` (the existing scheduler-driven path) is the **default**:
+  it runs asynchronously when leader-elected and is the cheaper option.
+
+`summarize_node` is rate-limited to **1 call per (entity, vault) per 60
+seconds**. If you hit the limit, the response includes `retry_after_seconds`;
+do not retry-loop. Reach for `summarize_node` only when an in-session reason
+exists (a contradiction signal, a user-driven question that depends on the
+consolidated view); otherwise let background reflection do its work.
+
 <!--
 Tier A — /remember verb extensions
 F4:  WS-quick-wins  (memory_deprioritize/restore disclosure)

--- a/packages/claude-code-plugin/skills/remember/SKILL.md
+++ b/packages/claude-code-plugin/skills/remember/SKILL.md
@@ -38,6 +38,20 @@ You have been invoked via the `/remember` slash command.
 5. **Confirm to the user.**
    After calling the tool, briefly confirm what was saved and mention the title.
 
+## Curating memory after the fact (deprioritize vs archive)
+
+When a previously-saved memory turns out to be misleading, outdated, or noise
+that contaminates retrieval, prefer the **NON-DESTRUCTIVE** verb:
+
+- `memex_memory_deprioritize(unit_id, reason)` lowers the unit's retrieval
+  rank without removing it from the entity graph. The unit remains accessible
+  via `include_deprioritized=true` retrieval. Use the `reason` field liberally
+  ("user confirmed issue fixed", "superseded by v2.3 release") — it is logged
+  to `audit_logs` as the audit trail. Reversible via `memex_memory_restore`.
+- Archive (CLI-only, `memex memory delete`) is the **DESTRUCTIVE** counterpart:
+  it removes the unit from the entity graph and is irreversible. Prefer
+  deprioritize unless the unit MUST leave the graph entirely.
+
 <!--
 Tier A — /remember verb extensions
 F4:  WS-quick-wins  (memory_deprioritize/restore disclosure)
@@ -46,7 +60,7 @@ F9:  WS-locks       (memory_reconsolidate, memory_consolidate disclosure)
 F14: WS-quick-wins  (procedural KV capture surfacing)
 F20: WS-revisit     (memory_review disclosure)
 
-# --- F4 ---  (filled by WS-quick-wins)
+# --- F4 ---  (filled by WS-quick-wins — see "Curating memory after the fact" section above)
 
 # --- F5 ---  (filled by WS-quick-wins)
 

--- a/packages/cli/src/memex_cli/diagnose.py
+++ b/packages/cli/src/memex_cli/diagnose.py
@@ -1,0 +1,90 @@
+"""F32 — `memex diagnostics` CLI subgroup.
+
+Subcommands:
+- manifold   — emit UMAP projection JSON (or 202 task info)
+- retrieval  — emit top-N entities heatmap JSON
+- summary    — emit full diagnostics summary JSON
+
+NOTE: there is intentionally NO `lint` subcommand in this module — that ships
+in #26 (last in sub-wave C, after F6's MaintenanceProposal table is merged).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+import typer
+from rich.console import Console
+
+from memex_cli.utils import async_command, get_api_context, handle_api_error
+from memex_common.config import MemexConfig
+
+console = Console()
+
+app = typer.Typer(
+    name='diagnostics',
+    help='F32 — Diagnostics (UMAP manifold, retrieval heatmap, vault summary).',
+    no_args_is_help=True,
+)
+
+
+@app.command('manifold')
+@async_command
+async def manifold_cmd(
+    ctx: typer.Context,
+    vault: Annotated[str, typer.Option('--vault', help='Vault name or ID.')],
+    force_refresh: Annotated[
+        bool, typer.Option('--force-refresh', help='Force recompute, ignore cache.')
+    ] = False,
+):
+    """Print the UMAP manifold JSON. 202 task info if cache is cold."""
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            vault_id = await api.resolve_vault_identifier(vault)
+            status_code, payload = await api.get_diagnostics_manifold(
+                vault_id, force_refresh=force_refresh
+            )
+        except Exception as e:
+            handle_api_error(e)
+            return
+    payload['_http_status'] = status_code
+    console.print_json(json.dumps(payload, default=str))
+
+
+@app.command('retrieval')
+@async_command
+async def retrieval_cmd(
+    ctx: typer.Context,
+    vault: Annotated[str, typer.Option('--vault', help='Vault name or ID.')],
+    top_n: Annotated[int, typer.Option('--top-n', help='Number of entities to return.')] = 50,
+):
+    """Print the top-N entity outcome heatmap JSON."""
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            vault_id = await api.resolve_vault_identifier(vault)
+            payload = await api.get_diagnostics_retrieval(vault_id, top_n=top_n)
+        except Exception as e:
+            handle_api_error(e)
+            return
+    console.print_json(json.dumps(payload, default=str))
+
+
+@app.command('summary')
+@async_command
+async def summary_cmd(
+    ctx: typer.Context,
+    vault: Annotated[str, typer.Option('--vault', help='Vault name or ID.')],
+):
+    """Print the full diagnostics summary JSON (synchronous, no UMAP block)."""
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            vault_id = await api.resolve_vault_identifier(vault)
+            payload = await api.get_diagnostics_summary(vault_id)
+        except Exception as e:
+            handle_api_error(e)
+            return
+    console.print_json(json.dumps(payload, default=str))

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -166,6 +166,55 @@ async def view_memory(
                 console.print(f'[dim]Source:[/dim] {source}')
 
 
+@app.command('deprioritize')
+@async_command
+async def deprioritize_memory(
+    ctx: typer.Context,
+    unit_id: Annotated[str, typer.Argument(help='UUID of the memory unit to deprioritize.')],
+    reason: Annotated[
+        str,
+        typer.Option('--reason', '-r', help='Why this unit is being deprioritized.'),
+    ] = 'manual',
+):
+    """
+    Deprioritize a memory unit (non-destructive). The unit remains accessible via
+    `include_deprioritized=true` retrieval. Use `memex memory restore <id>` to undo.
+    """
+    config: MemexConfig = ctx.obj
+    uuid_obj = parse_uuid(unit_id, 'memory unit')
+
+    async with get_api_context(config) as api:
+        try:
+            unit = await api.deprioritize_memory_unit(uuid_obj, reason=reason)
+        except Exception as e:
+            handle_api_error(e)
+            return
+
+    console.print(
+        f'[green]Memory unit {unit.id} deprioritized.[/green]  reason=[dim]{reason}[/dim]'
+    )
+
+
+@app.command('restore')
+@async_command
+async def restore_memory(
+    ctx: typer.Context,
+    unit_id: Annotated[str, typer.Argument(help='UUID of the memory unit to restore.')],
+):
+    """Restore a deprioritized memory unit (flips ``is_deprioritized`` back to false)."""
+    config: MemexConfig = ctx.obj
+    uuid_obj = parse_uuid(unit_id, 'memory unit')
+
+    async with get_api_context(config) as api:
+        try:
+            unit = await api.restore_memory_unit(uuid_obj)
+        except Exception as e:
+            handle_api_error(e)
+            return
+
+    console.print(f'[green]Memory unit {unit.id} restored.[/green]')
+
+
 @app.command('delete')
 @async_command
 async def delete_memory(

--- a/packages/cli/src/memex_cli/utils.py
+++ b/packages/cli/src/memex_cli/utils.py
@@ -40,6 +40,7 @@ LAZY_SUBCOMMANDS: dict[str, str] = {
     'briefing': 'memex_cli.session:app',
     'setup': 'memex_cli.setup_claude_code:app',
     'report-bug': 'memex_cli.report_bug:app',
+    'diagnostics': 'memex_cli.diagnose:app',
 }
 
 

--- a/packages/cli/tests/test_diagnose.py
+++ b/packages/cli/tests/test_diagnose.py
@@ -1,0 +1,77 @@
+"""F32 CLI — `memex diagnostics ...` smoke tests (Test 10).
+
+Verifies:
+- `--help` lists the three F32 subcommands (manifold, retrieval, summary).
+- 'lint' is NOT in the help (carve verification — lint dashboard is #26 scope).
+- `manifold --help` and `retrieval --help` emit usable help text.
+- Each command emits JSON shape when invoked against a mocked api.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import json
+
+from memex_cli.diagnose import app as diagnose_app
+
+
+def test_help_lists_subcommands_no_lint(runner):
+    result = runner.invoke(diagnose_app, ['--help'])
+    assert result.exit_code == 0
+    assert 'manifold' in result.output
+    assert 'retrieval' in result.output
+    assert 'summary' in result.output
+    # Carve verification: F32 lint dashboard is task #26, not in this PR.
+    assert 'lint' not in result.output
+
+
+def test_manifold_help_and_json_shape(runner, mock_api, monkeypatch, mock_config):
+    """`memex diagnostics manifold --help` works, and the command emits JSON."""
+    help_result = runner.invoke(diagnose_app, ['manifold', '--help'])
+    assert help_result.exit_code == 0
+    assert '--vault' in help_result.output
+    assert '--force-refresh' in help_result.output
+
+    fake_vault = uuid4()
+    payload = {
+        'vault_id': str(fake_vault),
+        'task_id': 'cafef00d',
+    }
+    mock_api.resolve_vault_identifier = AsyncMock(return_value=fake_vault)
+    mock_api.get_diagnostics_manifold = AsyncMock(return_value=(202, payload))
+
+    monkeypatch.setattr('memex_cli.diagnose.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(diagnose_app, ['manifold', '--vault', str(fake_vault)], obj=mock_config)
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed['vault_id'] == str(fake_vault)
+    assert parsed['_http_status'] == 202
+
+
+def test_retrieval_help_and_json_shape(runner, mock_api, monkeypatch, mock_config):
+    """`memex diagnostics retrieval --help` works, and the command emits JSON."""
+    help_result = runner.invoke(diagnose_app, ['retrieval', '--help'])
+    assert help_result.exit_code == 0
+    assert '--vault' in help_result.output
+    assert '--top-n' in help_result.output
+
+    fake_vault = uuid4()
+    payload = {
+        'vault_id': str(fake_vault),
+        'top_n': 50,
+        'entities': [],
+        'as_of': '2026-04-30T00:00:00Z',
+    }
+    mock_api.resolve_vault_identifier = AsyncMock(return_value=fake_vault)
+    mock_api.get_diagnostics_retrieval = AsyncMock(return_value=payload)
+
+    monkeypatch.setattr('memex_cli.diagnose.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(diagnose_app, ['retrieval', '--vault', str(fake_vault)], obj=mock_config)
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed['vault_id'] == str(fake_vault)
+    assert parsed['top_n'] == 50

--- a/packages/cli/tests/test_int_f32_claude_code_rule.py
+++ b/packages/cli/tests/test_int_f32_claude_code_rule.py
@@ -5,6 +5,9 @@ the Claude Code plugin. F32 is surfaced via /recall (vault diagnostics is a
 read action). This test asserts that at least one SKILL.md mentions the verb
 ``memex_get_diagnostics_summary`` together with at least one of the documented
 diagnostic keywords (cluster count, MW score, top entities).
+
+The negative-grep test below codifies the architectural rule that
+diagnostics is a *read* action (recall), not a capture action (remember).
 """
 
 from __future__ import annotations
@@ -39,4 +42,18 @@ def test_rule_text_describes_verb():
     assert has_context, (
         'memex_get_diagnostics_summary mentioned but no diagnostic keyword '
         '(cluster count / MW score / top entities) appears alongside it.'
+    )
+
+
+def test_remember_skill_does_not_contain_diagnostics_verb():
+    """Diagnostics is a read action; belongs in recall/SKILL.md, NOT remember/SKILL.md.
+
+    Codifies the architectural call so future refactors can't silently un-make it.
+    """
+    skill_path = _PACKAGES_DIR / 'claude-code-plugin' / 'skills' / 'remember' / 'SKILL.md'
+    assert skill_path.exists(), f'SKILL.md not found at {skill_path}'
+    text = skill_path.read_text()
+    assert 'memex_get_diagnostics_summary' not in text, (
+        'Diagnostics verb leaked into remember/SKILL.md — it is a read action, '
+        'belongs in recall only. Move it back.'
     )

--- a/packages/cli/tests/test_int_f32_claude_code_rule.py
+++ b/packages/cli/tests/test_int_f32_claude_code_rule.py
@@ -1,0 +1,42 @@
+"""F32 Claude Code skill — verb description grep (Test 9).
+
+The recall and remember SKILL.md files are the agent-facing entry points for
+the Claude Code plugin. F32 is surfaced via /recall (vault diagnostics is a
+read action). This test asserts that at least one SKILL.md mentions the verb
+``memex_get_diagnostics_summary`` together with at least one of the documented
+diagnostic keywords (cluster count, MW score, top entities).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_PACKAGES_DIR = Path(__file__).resolve().parents[2]
+SKILL_FILES = [
+    _PACKAGES_DIR / 'claude-code-plugin' / 'skills' / 'recall' / 'SKILL.md',
+    _PACKAGES_DIR / 'claude-code-plugin' / 'skills' / 'remember' / 'SKILL.md',
+]
+
+
+def test_rule_text_describes_verb():
+    mentions = []
+    for path in SKILL_FILES:
+        assert path.exists(), f'SKILL.md not found at {path}'
+        text = path.read_text()
+        if 'memex_get_diagnostics_summary' in text:
+            mentions.append((path, text))
+
+    assert mentions, (
+        'Neither recall/SKILL.md nor remember/SKILL.md mentions '
+        'memex_get_diagnostics_summary. F32 verb must be surfaced.'
+    )
+
+    # At least one mention must include a documented keyword.
+    keyword_pat = re.compile(r'cluster.?count|MW.?score|top.?(retrieved.?)?entit', re.IGNORECASE)
+    has_context = any(keyword_pat.search(text) for _, text in mentions)
+    assert has_context, (
+        'memex_get_diagnostics_summary mentioned but no diagnostic keyword '
+        '(cluster count / MW score / top entities) appears alongside it.'
+    )

--- a/packages/cli/tests/test_memory_deprioritize_cli.py
+++ b/packages/cli/tests/test_memory_deprioritize_cli.py
@@ -1,0 +1,82 @@
+"""F4 — CLI tests for `memex memory deprioritize` and `memex memory restore`.
+
+T5 (CLI half): the Typer commands exist, dispatch to the API client correctly,
+and surface success messages.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from memex_cli.memory import app
+from memex_common.schemas import MemoryUnitDTO
+
+
+def _fake_unit(unit_id: str, *, is_deprioritized: bool = True) -> MemoryUnitDTO:
+    return MemoryUnitDTO(
+        id=unit_id,
+        text='example',
+        fact_type='observation',
+        confidence=1.0,
+        is_deprioritized=is_deprioritized,
+    )
+
+
+def test_deprioritize_command_invokes_api(runner, mock_api, mock_config, monkeypatch):
+    unit_id = str(uuid4())
+    mock_api.deprioritize_memory_unit.return_value = _fake_unit(unit_id)
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(
+        app, ['deprioritize', unit_id, '--reason', 'wrong about deploy'], obj=mock_config
+    )
+    assert result.exit_code == 0, result.stdout
+    assert 'deprioritized' in result.stdout.lower()
+
+    mock_api.deprioritize_memory_unit.assert_called_once()
+    args, kwargs = mock_api.deprioritize_memory_unit.call_args
+    assert str(args[0]) == unit_id
+    assert kwargs.get('reason') == 'wrong about deploy'
+
+
+def test_restore_command_invokes_api(runner, mock_api, mock_config, monkeypatch):
+    unit_id = str(uuid4())
+    mock_api.restore_memory_unit.return_value = _fake_unit(unit_id, is_deprioritized=False)
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(app, ['restore', unit_id], obj=mock_config)
+    assert result.exit_code == 0, result.stdout
+    assert 'restored' in result.stdout.lower()
+
+    mock_api.restore_memory_unit.assert_called_once()
+
+
+def test_deprioritize_default_reason_is_manual(runner, mock_api, mock_config, monkeypatch):
+    """Sanity: when --reason is omitted the CLI sends 'manual' (not None)."""
+    unit_id = str(uuid4())
+    mock_api.deprioritize_memory_unit.return_value = _fake_unit(unit_id)
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(app, ['deprioritize', unit_id], obj=mock_config)
+    assert result.exit_code == 0
+    assert mock_api.deprioritize_memory_unit.call_args.kwargs.get('reason') == 'manual'
+
+
+def test_deprioritize_help_lists_command():
+    """`memex memory deprioritize --help` returns clean."""
+    from typer.testing import CliRunner
+
+    cli = CliRunner()
+    res = cli.invoke(app, ['deprioritize', '--help'])
+    assert res.exit_code == 0
+    assert 'deprioritize' in res.stdout.lower()
+
+
+def test_restore_help_lists_command():
+    """`memex memory restore --help` returns clean."""
+    from typer.testing import CliRunner
+
+    cli = CliRunner()
+    res = cli.invoke(app, ['restore', '--help'])
+    assert res.exit_code == 0
+    assert 'restore' in res.stdout.lower()

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -705,6 +705,16 @@ class RemoteMemexAPI:
                 return False
             raise
 
+    async def deprioritize_memory_unit(self, unit_id: UUID, reason: str) -> MemoryUnitDTO:
+        """Deprioritize a memory unit (non-destructive). See F4."""
+        result = await self._post(f'memories/{unit_id}/deprioritize', {'reason': reason})
+        return MemoryUnitDTO(**result)
+
+    async def restore_memory_unit(self, unit_id: UUID) -> MemoryUnitDTO:
+        """Restore a previously-deprioritized memory unit. See F4."""
+        result = await self._post(f'memories/{unit_id}/restore', {})
+        return MemoryUnitDTO(**result)
+
     async def get_memory_links(
         self,
         unit_id: UUID,

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -512,6 +512,34 @@ class RemoteMemexAPI:
                 return False
             raise
 
+    # --- Diagnostics (F32) ---
+    async def get_diagnostics_summary(self, vault_id: UUID | str) -> dict[str, Any]:
+        """Fetch the F32 diagnostics summary for a vault."""
+        return await self._get(f'diagnostics/summary/{vault_id}')
+
+    async def get_diagnostics_retrieval(
+        self, vault_id: UUID | str, top_n: int = 50
+    ) -> dict[str, Any]:
+        """Fetch the F32 retrieval heatmap (top-N entities by outcome volume)."""
+        return await self._get(f'diagnostics/retrieval/{vault_id}', params={'top_n': top_n})
+
+    async def get_diagnostics_manifold(
+        self,
+        vault_id: UUID | str,
+        force_refresh: bool = False,
+    ) -> tuple[int, dict[str, Any]]:
+        """Fetch the F32 UMAP manifold. Returns (status_code, payload).
+
+        200 → warm cache hit (payload is the manifold).
+        202 → cold compute kicked off (payload contains task_id).
+        501 → umap-learn not installed.
+        """
+        params = {'force_refresh': 'true'} if force_refresh else None
+        response = await self.client.get(f'diagnostics/manifold/{vault_id}', params=params)
+        if response.status_code == 501:
+            response.raise_for_status()
+        return response.status_code, response.json()
+
     # --- Stats & Overview ---
     async def get_stats_counts(
         self,

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -54,6 +54,18 @@ from memex_common.schemas import (
 logger = logging.getLogger('memex.common.client')
 
 
+class RateLimitExceeded(Exception):
+    """Raised when a rate-limited Memex endpoint returns HTTP 429.
+
+    Carries ``retry_after_seconds`` parsed from the server's envelope so
+    surface adapters (MCP/Hermes) can present a structured back-off hint.
+    """
+
+    def __init__(self, retry_after_seconds: float, message: str) -> None:
+        self.retry_after_seconds = retry_after_seconds
+        super().__init__(message)
+
+
 class RemoteMemexAPI:
     """
     Client for interacting with a remote Memex server via REST.
@@ -754,6 +766,32 @@ class RemoteMemexAPI:
             {'requests': [r.model_dump(mode='json') for r in requests]},
         )
         return [ReflectionResultDTO(**r) for r in result]
+
+    async def summarize_node(
+        self,
+        entity_id: UUID,
+        *,
+        scope: str = 'incremental',
+        vault_id: UUID | None = None,
+    ) -> ReflectionResultDTO:
+        """F5: synchronous on-demand reflection (rate-limited per (entity, vault)).
+
+        On HTTP 429, raises a structured ``RateLimitExceeded`` carrying
+        ``retry_after_seconds`` so callers can surface the back-off time
+        without re-parsing the body.
+        """
+        body: dict[str, Any] = {'entity_id': str(entity_id), 'scope': scope}
+        if vault_id is not None:
+            body['vault_id'] = str(vault_id)
+        response = await self.client.post('memories/summarize-node', json=body)
+        if response.status_code == 429:
+            payload = response.json()
+            raise RateLimitExceeded(
+                retry_after_seconds=float(payload.get('retry_after_seconds', 0.0)),
+                message=str(payload.get('message', 'Rate limit exceeded.')),
+            )
+        response.raise_for_status()
+        return ReflectionResultDTO(**response.json())
 
     async def get_reflection_queue_batch(self, limit: int = 10) -> list[ReflectionQueueDTO]:
         """Fetch items from the reflection queue."""

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -385,6 +385,35 @@ class DocSearchStrategiesConfig(BaseModel):
     temporal: bool = Field(default=True, description='Enable temporal search strategy.')
 
 
+class SummarizeNodeRateLimitConfig(BaseModel):
+    """F5: rate-limit config for memex_memory_summarize_node.
+
+    Token bucket per (entity_id, vault_id), in-process LRU. Multi-worker
+    leakage is accepted in v1 (advisory limit, not security gate); F9's
+    distributed lock will close the cross-process gap.
+    """
+
+    enabled: bool = Field(
+        default=True,
+        description='When False, summarize_node calls are never rate-limited (set False in tests).',
+    )
+    per_entity_per_seconds: int = Field(
+        default=60,
+        gt=0,
+        description='Window in seconds across which `burst` calls are allowed per (entity, vault).',
+    )
+    burst: int = Field(
+        default=1,
+        gt=0,
+        description='Token-bucket capacity. Default 1 = no bursting (1 call per window).',
+    )
+    max_keys: int = Field(
+        default=10000,
+        gt=0,
+        description='LRU eviction cap on tracked (entity_id, vault_id) keys.',
+    )
+
+
 class ReflectionConfig(BaseModel):
     """Configuration for the Hindsight Reflection Engine."""
 
@@ -457,6 +486,10 @@ class ReflectionConfig(BaseModel):
             'Seconds after which a PROCESSING item is considered stale and reset to PENDING. '
             'Prevents items from being stuck forever when reflection fails mid-flight.'
         ),
+    )
+    summarize_node_rate_limit: 'SummarizeNodeRateLimitConfig' = Field(
+        default_factory=lambda: SummarizeNodeRateLimitConfig(),
+        description='F5: per-(entity, vault) rate limit for memex_memory_summarize_node.',
     )
 
     @model_validator(mode='after')

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -309,8 +309,12 @@ class ReflectionRequest(VaultMixin):
     """
 
     entity_id: UUID = Field(description='The UUID of the entity to reflect upon.')
-    limit_recent_memories: int = Field(
-        default=20, description='Number of recent memories to consider.'
+    limit_recent_memories: int | None = Field(
+        default=20,
+        description=(
+            'Number of recent memories to consider. None means no per-request cap '
+            "(F5 'full' scope); the engine still enforces MAX_FULL_SCOPE_UNITS=1000."
+        ),
     )
 
 

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -67,6 +67,7 @@ gcs = ["gcsfs>=2024.6.0"]
 cloud = ["s3fs>=2024.6.0", "gcsfs>=2024.6.0"]
 gpu = ["onnxruntime-gpu==1.23.0"]
 dev-server = ["uvicorn>=0.40.0"]
+diagnostics = ["umap-learn>=0.5,<1.0"]
 tracing = [
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",

--- a/packages/core/src/memex_core/alembic/versions/025_maintenance_proposals.py
+++ b/packages/core/src/memex_core/alembic/versions/025_maintenance_proposals.py
@@ -1,0 +1,26 @@
+"""F6 maintenance_proposals — STUB; filled by WS-linter.
+
+Tier A seed stub — body intentionally raises so any feature workstream that
+forgets to replace it before shipping fails CI loud. `alembic check` validates
+the chain without invoking upgrade()/downgrade(), so this stub passes chain
+integrity checks while remaining unrunnable.
+
+Revision ID: 025_maintenance_proposals
+Revises: 024_intent_risk_classifier
+Create Date: 2026-04-30
+"""
+
+from typing import Sequence, Union
+
+revision: str = '025_maintenance_proposals'
+down_revision: Union[str, None] = '024_intent_risk_classifier'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    raise NotImplementedError('F6: filled in WS-linter PR')
+
+
+def downgrade() -> None:
+    raise NotImplementedError('F6: filled in WS-linter PR')

--- a/packages/core/src/memex_core/alembic/versions/025_maintenance_proposals.py
+++ b/packages/core/src/memex_core/alembic/versions/025_maintenance_proposals.py
@@ -10,12 +10,10 @@ Revises: 024_intent_risk_classifier
 Create Date: 2026-04-30
 """
 
-from typing import Sequence, Union
-
 revision: str = '025_maintenance_proposals'
-down_revision: Union[str, None] = '024_intent_risk_classifier'
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = '024_intent_risk_classifier'
+branch_labels: str | list[str] | None = None
+depends_on: str | list[str] | None = None
 
 
 def upgrade() -> None:

--- a/packages/core/src/memex_core/alembic/versions/026_revisit_columns.py
+++ b/packages/core/src/memex_core/alembic/versions/026_revisit_columns.py
@@ -10,12 +10,10 @@ Revises: 025_maintenance_proposals
 Create Date: 2026-04-30
 """
 
-from typing import Sequence, Union
-
 revision: str = '026_revisit_columns'
-down_revision: Union[str, None] = '025_maintenance_proposals'
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = '025_maintenance_proposals'
+branch_labels: str | list[str] | None = None
+depends_on: str | list[str] | None = None
 
 
 def upgrade() -> None:

--- a/packages/core/src/memex_core/alembic/versions/026_revisit_columns.py
+++ b/packages/core/src/memex_core/alembic/versions/026_revisit_columns.py
@@ -1,0 +1,26 @@
+"""F20 revisit_columns — STUB; filled by WS-revisit.
+
+Tier A seed stub — body intentionally raises so any feature workstream that
+forgets to replace it before shipping fails CI loud. `alembic check` validates
+the chain without invoking upgrade()/downgrade(), so this stub passes chain
+integrity checks while remaining unrunnable.
+
+Revision ID: 026_revisit_columns
+Revises: 025_maintenance_proposals
+Create Date: 2026-04-30
+"""
+
+from typing import Sequence, Union
+
+revision: str = '026_revisit_columns'
+down_revision: Union[str, None] = '025_maintenance_proposals'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    raise NotImplementedError('F20: filled in WS-revisit PR')
+
+
+def downgrade() -> None:
+    raise NotImplementedError('F20: filled in WS-revisit PR')

--- a/packages/core/src/memex_core/alembic/versions/027_consolidation_ticks.py
+++ b/packages/core/src/memex_core/alembic/versions/027_consolidation_ticks.py
@@ -10,12 +10,10 @@ Revises: 026_revisit_columns
 Create Date: 2026-04-30
 """
 
-from typing import Sequence, Union
-
 revision: str = '027_consolidation_ticks'
-down_revision: Union[str, None] = '026_revisit_columns'
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = '026_revisit_columns'
+branch_labels: str | list[str] | None = None
+depends_on: str | list[str] | None = None
 
 
 def upgrade() -> None:

--- a/packages/core/src/memex_core/alembic/versions/027_consolidation_ticks.py
+++ b/packages/core/src/memex_core/alembic/versions/027_consolidation_ticks.py
@@ -1,0 +1,26 @@
+"""F38 consolidation_ticks — STUB; filled by WS-quick-wins.
+
+Tier A seed stub — body intentionally raises so any feature workstream that
+forgets to replace it before shipping fails CI loud. `alembic check` validates
+the chain without invoking upgrade()/downgrade(), so this stub passes chain
+integrity checks while remaining unrunnable.
+
+Revision ID: 027_consolidation_ticks
+Revises: 026_revisit_columns
+Create Date: 2026-04-30
+"""
+
+from typing import Sequence, Union
+
+revision: str = '027_consolidation_ticks'
+down_revision: Union[str, None] = '026_revisit_columns'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    raise NotImplementedError('F38: filled in WS-quick-wins PR')
+
+
+def downgrade() -> None:
+    raise NotImplementedError('F38: filled in WS-quick-wins PR')

--- a/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
+++ b/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
@@ -1,0 +1,26 @@
+"""F14 procedure_outcomes — STUB; filled by WS-quick-wins.
+
+Tier A seed stub — body intentionally raises so any feature workstream that
+forgets to replace it before shipping fails CI loud. `alembic check` validates
+the chain without invoking upgrade()/downgrade(), so this stub passes chain
+integrity checks while remaining unrunnable.
+
+Revision ID: 028_procedure_outcomes
+Revises: 027_consolidation_ticks
+Create Date: 2026-04-30
+"""
+
+from typing import Sequence, Union
+
+revision: str = '028_procedure_outcomes'
+down_revision: Union[str, None] = '027_consolidation_ticks'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    raise NotImplementedError('F14: filled in WS-quick-wins PR')
+
+
+def downgrade() -> None:
+    raise NotImplementedError('F14: filled in WS-quick-wins PR')

--- a/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
+++ b/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
@@ -10,12 +10,10 @@ Revises: 027_consolidation_ticks
 Create Date: 2026-04-30
 """
 
-from typing import Sequence, Union
-
 revision: str = '028_procedure_outcomes'
-down_revision: Union[str, None] = '027_consolidation_ticks'
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = '027_consolidation_ticks'
+branch_labels: str | list[str] | None = None
+depends_on: str | list[str] | None = None
 
 
 def upgrade() -> None:

--- a/packages/core/src/memex_core/alembic/versions/029_lint_llm_quota.py
+++ b/packages/core/src/memex_core/alembic/versions/029_lint_llm_quota.py
@@ -10,12 +10,10 @@ Revises: 028_procedure_outcomes
 Create Date: 2026-04-30
 """
 
-from typing import Sequence, Union
-
 revision: str = '029_lint_llm_quota'
-down_revision: Union[str, None] = '028_procedure_outcomes'
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = '028_procedure_outcomes'
+branch_labels: str | list[str] | None = None
+depends_on: str | list[str] | None = None
 
 
 def upgrade() -> None:

--- a/packages/core/src/memex_core/alembic/versions/029_lint_llm_quota.py
+++ b/packages/core/src/memex_core/alembic/versions/029_lint_llm_quota.py
@@ -1,0 +1,26 @@
+"""F10 lint_llm_quota — STUB; filled by WS-linter.
+
+Tier A seed stub — body intentionally raises so any feature workstream that
+forgets to replace it before shipping fails CI loud. `alembic check` validates
+the chain without invoking upgrade()/downgrade(), so this stub passes chain
+integrity checks while remaining unrunnable.
+
+Revision ID: 029_lint_llm_quota
+Revises: 028_procedure_outcomes
+Create Date: 2026-04-30
+"""
+
+from typing import Sequence, Union
+
+revision: str = '029_lint_llm_quota'
+down_revision: Union[str, None] = '028_procedure_outcomes'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    raise NotImplementedError('F10: filled in WS-linter PR')
+
+
+def downgrade() -> None:
+    raise NotImplementedError('F10: filled in WS-linter PR')

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1163,9 +1163,9 @@ class MemexAPI:
 
         if scope not in ('incremental', 'full'):
             raise ValueError(f"scope must be 'incremental' or 'full', got {scope!r}")
-        return await self._reflection.summarize_node(
-            entity_id, scope=cast(SummarizeScope, scope), vault_id=vault_id
-        )
+        # The preceding guard validates scope at runtime; narrow to SummarizeScope (Literal) for mypy.
+        narrowed: SummarizeScope = scope  # type: ignore[assignment]
+        return await self._reflection.summarize_node(entity_id, scope=narrowed, vault_id=vault_id)
 
     async def record_outcome(
         self,

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1146,6 +1146,27 @@ class MemexAPI:
         """Reflect on multiple entities. Delegates to ReflectionService."""
         return await self._reflection.reflect_batch(requests)
 
+    async def summarize_node(
+        self,
+        entity_id: UUID,
+        *,
+        scope: str = 'incremental',
+        vault_id: UUID | None = None,
+    ) -> ReflectionResult:
+        """F5: synchronous on-demand reflection (rate-limited per entity, vault).
+
+        Delegates to :meth:`ReflectionService.summarize_node`. Surfaces a
+        ``RateLimitExceededError`` upward; surface adapters (MCP/Hermes/HTTP)
+        translate to their own envelope.
+        """
+        from memex_core.services.reflection import SummarizeScope
+
+        if scope not in ('incremental', 'full'):
+            raise ValueError(f"scope must be 'incremental' or 'full', got {scope!r}")
+        return await self._reflection.summarize_node(
+            entity_id, scope=cast(SummarizeScope, scope), vault_id=vault_id
+        )
+
     async def record_outcome(
         self,
         unit_ids: list[str],

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -59,6 +59,7 @@ from memex_core.memory.entity_resolver import EntityResolver
 from memex_core.memory.extraction.core import ExtractSemanticFacts
 from memex_core.processing.files import FileContentProcessor
 from memex_core.processing.batch import JobManager
+from memex_core.services.diagnostics import DiagnosticsService
 from memex_core.services.entities import EntityService
 from memex_core.services.ingestion import IngestionService
 from memex_core.services.kv import KVService
@@ -497,6 +498,11 @@ class MemexAPI:
             filestore=self.filestore,
             config=self.config,
         )
+        self._diagnostics = DiagnosticsService(
+            metastore=self.metastore,
+            filestore=self.filestore,
+            config=self.config,
+        )
 
         from memex_core.services.session_briefing import SessionBriefingService
 
@@ -540,6 +546,10 @@ class MemexAPI:
         resolve note identifiers prior to invoking a higher-level facade
         (e.g. for vault-access auth checks)."""
         return self._notes
+
+    @property
+    def diagnostics(self) -> DiagnosticsService:
+        return self._diagnostics
 
     @property
     def embedder(self) -> EmbeddingsModel:

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -69,6 +69,7 @@ from memex_core.services.outcomes import OutcomeService
 from memex_core.services.reflection import ReflectionService
 from memex_core.services.search import SearchService
 from memex_core.services.stats import StatsService
+from memex_core.services.units import UnitsService
 from memex_core.services.vault_summary import VaultSummaryService
 from memex_core.services.vaults import VaultService, _VAULT_RESOLUTION_CACHE
 
@@ -503,6 +504,11 @@ class MemexAPI:
             filestore=self.filestore,
             config=self.config,
         )
+        self._units = UnitsService(
+            metastore=self.metastore,
+            filestore=self.filestore,
+            config=self.config,
+        )
 
         from memex_core.services.session_briefing import SessionBriefingService
 
@@ -537,6 +543,7 @@ class MemexAPI:
             self._ingestion,
             self._search,
             self._lineage,
+            self._units,
         ):
             svc._audit_service = self._audit_svc  # type: ignore[attr-defined]
 
@@ -974,6 +981,36 @@ class MemexAPI:
     async def delete_memory_unit(self, unit_id: UUID) -> bool:
         """Delete a memory unit. Delegates to StatsService."""
         return await self._stats.delete_memory_unit(unit_id)
+
+    async def deprioritize_memory_unit(
+        self,
+        unit_id: UUID,
+        reason: str,
+        *,
+        actor: str | None = None,
+        background_tasks: Any | None = None,
+    ) -> Any:
+        """Deprioritize a memory unit (non-destructive). Delegates to UnitsService."""
+        return await self._units.set_unit_deprioritized(
+            unit_id,
+            reason,
+            actor=actor,
+            background_tasks=background_tasks,
+        )
+
+    async def restore_memory_unit(
+        self,
+        unit_id: UUID,
+        *,
+        actor: str | None = None,
+        background_tasks: Any | None = None,
+    ) -> Any:
+        """Restore a deprioritized memory unit. Delegates to UnitsService."""
+        return await self._units.restore_unit(
+            unit_id,
+            actor=actor,
+            background_tasks=background_tasks,
+        )
 
     async def retrieve(self, request: RetrievalRequest) -> tuple[list[MemoryUnit], Any]:
         """Retrieve memories using TEMPR Recall. Delegates to SearchService."""

--- a/packages/core/src/memex_core/diagnostics/__init__.py
+++ b/packages/core/src/memex_core/diagnostics/__init__.py
@@ -1,0 +1,23 @@
+from memex_core.diagnostics.heatmap import compute_heatmap
+from memex_core.diagnostics.summary import compute_diagnostics_summary
+from memex_core.diagnostics.umap import (
+    DEFAULT_UMAP_PARAMS,
+    UMAPNotInstalledError,
+    cache_key,
+    cache_path_for,
+    compute_manifold,
+    load_cached_manifold,
+    warm_cache_hit,
+)
+
+__all__ = [
+    'DEFAULT_UMAP_PARAMS',
+    'UMAPNotInstalledError',
+    'cache_key',
+    'cache_path_for',
+    'compute_diagnostics_summary',
+    'compute_heatmap',
+    'compute_manifold',
+    'load_cached_manifold',
+    'warm_cache_hit',
+]

--- a/packages/core/src/memex_core/diagnostics/heatmap.py
+++ b/packages/core/src/memex_core/diagnostics/heatmap.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from sqlalchemy import desc, func, select
+
+from memex_core.memory.sql_models import Entity, UnitEntity
+
+if TYPE_CHECKING:
+    from memex_core.storage.metastore import MetaStore
+
+logger = logging.getLogger('memex.core.diagnostics.heatmap')
+
+
+async def compute_heatmap(
+    metastore: 'MetaStore',
+    vault_id: UUID,
+    top_n: int = 50,
+) -> dict[str, Any]:
+    volume = (UnitEntity.success_co_count + UnitEntity.failure_co_count).label('volume')
+    avg_mw = func.avg(
+        (UnitEntity.success_co_count + 1.0)
+        / (UnitEntity.success_co_count + UnitEntity.failure_co_count + 2.0)
+    ).label('avg_mw')
+
+    async with metastore.session() as sess:
+        stmt = (
+            select(
+                Entity.id,
+                Entity.name,
+                func.sum(volume).label('volume'),
+                avg_mw,
+            )
+            .join(UnitEntity, UnitEntity.entity_id == Entity.id)
+            .where(UnitEntity.vault_id == vault_id)
+            .group_by(Entity.id, Entity.name)
+            .order_by(desc('volume'), desc('avg_mw'))
+            .limit(top_n)
+        )
+        rows = (await sess.exec(stmt)).all()
+
+    entities = [
+        {
+            'entity_id': str(r[0]),
+            'name': r[1],
+            'volume': int(r[2] or 0),
+            'avg_mw_score': float(r[3] or 0.5),
+        }
+        for r in rows
+    ]
+    return {
+        'vault_id': str(vault_id),
+        'as_of': datetime.now(timezone.utc).isoformat(),
+        'top_n': top_n,
+        'entities': entities,
+    }

--- a/packages/core/src/memex_core/diagnostics/heatmap.py
+++ b/packages/core/src/memex_core/diagnostics/heatmap.py
@@ -30,13 +30,13 @@ async def compute_heatmap(
         stmt = (
             select(
                 Entity.id,
-                Entity.name,
+                Entity.canonical_name,
                 func.sum(volume).label('volume'),
                 avg_mw,
             )
             .join(UnitEntity, UnitEntity.entity_id == Entity.id)
             .where(UnitEntity.vault_id == vault_id)
-            .group_by(Entity.id, Entity.name)
+            .group_by(Entity.id, Entity.canonical_name)
             .order_by(desc('volume'), desc('avg_mw'))
             .limit(top_n)
         )

--- a/packages/core/src/memex_core/diagnostics/summary.py
+++ b/packages/core/src/memex_core/diagnostics/summary.py
@@ -90,7 +90,8 @@ async def _avg_mw_score(metastore: 'MetaStore', vault_id: UUID) -> float:
     )
     async with metastore.session() as sess:
         row = (await sess.exec(stmt)).one()
-    val = row[0] if not isinstance(row, tuple) else row[0]
+    # .one() always returns a Row tuple; row[0] is the avg() scalar (None for empty).
+    val = row[0]
     return float(val) if val is not None else 0.5
 
 

--- a/packages/core/src/memex_core/diagnostics/summary.py
+++ b/packages/core/src/memex_core/diagnostics/summary.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from sqlalchemy import case, func, select
+
+from memex_core.diagnostics.heatmap import compute_heatmap
+from memex_core.diagnostics.umap import (
+    load_cached_manifold,
+)
+from memex_core.memory.sql_models import ContentStatus, MemoryUnit
+
+if TYPE_CHECKING:
+    from memex_core.storage.filestore import FileStore
+    from memex_core.storage.metastore import MetaStore
+
+logger = logging.getLogger('memex.core.diagnostics.summary')
+
+
+async def compute_diagnostics_summary(
+    metastore: 'MetaStore',
+    filestore: 'FileStore',
+    vault_id: UUID,
+    *,
+    pending_compute: bool = False,
+) -> dict[str, Any]:
+    unit_counts = await _unit_counts_by_state(metastore, vault_id)
+    avg_mw = await _avg_mw_score(metastore, vault_id)
+    manifold_status, cluster_count = await _manifold_status(filestore, vault_id, pending_compute)
+    heatmap = await compute_heatmap(metastore, vault_id, top_n=5)
+
+    return {
+        'vault_id': str(vault_id),
+        'as_of': datetime.now(timezone.utc).isoformat(),
+        'manifold_status': manifold_status,
+        'unit_counts': unit_counts,
+        'lint_pending_by_type': {},
+        'cluster_count': cluster_count,
+        'avg_mw_score': avg_mw,
+        'top_5_retrieved_entities': heatmap['entities'],
+    }
+
+
+async def _unit_counts_by_state(metastore: 'MetaStore', vault_id: UUID) -> dict[str, int]:
+    active_expr = case(
+        (
+            (MemoryUnit.status == ContentStatus.ACTIVE) & (MemoryUnit.is_deprioritized.is_(False)),
+            1,
+        ),
+        else_=0,
+    )
+    deprioritized_expr = case(
+        (
+            (MemoryUnit.status == ContentStatus.ACTIVE) & (MemoryUnit.is_deprioritized.is_(True)),
+            1,
+        ),
+        else_=0,
+    )
+    stale_expr = case(
+        ((MemoryUnit.status == ContentStatus.STALE), 1),
+        else_=0,
+    )
+    stmt = select(
+        func.coalesce(func.sum(active_expr), 0),
+        func.coalesce(func.sum(deprioritized_expr), 0),
+        func.coalesce(func.sum(stale_expr), 0),
+    ).where(MemoryUnit.vault_id == vault_id)
+    async with metastore.session() as sess:
+        row = (await sess.exec(stmt)).one()
+    return {
+        'active': int(row[0] or 0),
+        'deprioritized': int(row[1] or 0),
+        'stale': int(row[2] or 0),
+    }
+
+
+async def _avg_mw_score(metastore: 'MetaStore', vault_id: UUID) -> float:
+    stmt = select(
+        func.avg(
+            (MemoryUnit.success_co_count + 1.0)
+            / (MemoryUnit.success_co_count + MemoryUnit.failure_co_count + 2.0)
+        )
+    ).where(
+        MemoryUnit.vault_id == vault_id,
+        MemoryUnit.status == ContentStatus.ACTIVE,
+    )
+    async with metastore.session() as sess:
+        row = (await sess.exec(stmt)).one()
+    val = row[0] if not isinstance(row, tuple) else row[0]
+    return float(val) if val is not None else 0.5
+
+
+async def _manifold_status(
+    filestore: 'FileStore',
+    vault_id: UUID,
+    pending_compute: bool,
+) -> tuple[str, int | None]:
+    if pending_compute:
+        return 'pending', None
+    cached = await load_cached_manifold(filestore, vault_id)
+    if cached is None:
+        return 'absent', None
+    return 'ready', cached.get('cluster_count')

--- a/packages/core/src/memex_core/diagnostics/summary.py
+++ b/packages/core/src/memex_core/diagnostics/summary.py
@@ -86,6 +86,7 @@ async def _avg_mw_score(metastore: 'MetaStore', vault_id: UUID) -> float:
     ).where(
         MemoryUnit.vault_id == vault_id,
         MemoryUnit.status == ContentStatus.ACTIVE,
+        MemoryUnit.is_deprioritized.is_(False),
     )
     async with metastore.session() as sess:
         row = (await sess.exec(stmt)).one()

--- a/packages/core/src/memex_core/diagnostics/umap.py
+++ b/packages/core/src/memex_core/diagnostics/umap.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from opentelemetry import trace
+from sqlalchemy import func, select
+
+from memex_core.memory.sql_models import MemoryUnit
+from memex_core.metrics import (
+    DIAGNOSTICS_CACHE_HITS_TOTAL,
+    DIAGNOSTICS_CACHE_MISSES_TOTAL,
+    DIAGNOSTICS_MANIFOLD_COMPUTE_SECONDS,
+)
+
+if TYPE_CHECKING:
+    from memex_core.storage.filestore import FileStore
+    from memex_core.storage.metastore import MetaStore
+
+logger = logging.getLogger('memex.core.diagnostics.umap')
+tracer = trace.get_tracer('memex.diagnostics')
+
+DEFAULT_UMAP_PARAMS: dict[str, Any] = {
+    'n_neighbors': 15,
+    'min_dist': 0.1,
+    'metric': 'cosine',
+    'n_components': 2,
+    'random_state': 42,
+}
+
+
+class UMAPNotInstalledError(RuntimeError):
+    """Raised when umap-learn is requested but the optional extra is missing."""
+
+
+def cache_key(
+    vault_id: UUID,
+    unit_count: int,
+    last_updated_at: datetime | None,
+    params: dict[str, Any] | None = None,
+) -> str:
+    p = dict(DEFAULT_UMAP_PARAMS)
+    if params:
+        p.update(params)
+    payload = json.dumps(
+        {
+            'vault_id': str(vault_id),
+            'unit_count': int(unit_count),
+            'last_updated_at': last_updated_at.isoformat() if last_updated_at else None,
+            'params': p,
+        },
+        sort_keys=True,
+        separators=(',', ':'),
+    )
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+
+
+def cache_path_for(vault_id: UUID) -> str:
+    return f'vaults/{vault_id}/diagnostics/manifold.json'
+
+
+async def _vault_unit_signature(
+    metastore: 'MetaStore',
+    vault_id: UUID,
+) -> tuple[int, datetime | None]:
+    async with metastore.session() as sess:
+        stmt = select(
+            func.count(MemoryUnit.id),
+            func.max(MemoryUnit.updated_at),
+        ).where(MemoryUnit.vault_id == vault_id)
+        row = (await sess.exec(stmt)).one()
+    count = int(row[0] or 0)
+    last = row[1]
+    return count, last
+
+
+async def load_cached_manifold(
+    filestore: 'FileStore',
+    vault_id: UUID,
+) -> dict[str, Any] | None:
+    key = cache_path_for(vault_id)
+    if not await filestore.exists(key):
+        return None
+    raw = await filestore.load(key)
+    return json.loads(raw.decode('utf-8'))
+
+
+async def compute_manifold(
+    metastore: 'MetaStore',
+    filestore: 'FileStore',
+    vault_id: UUID,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    try:
+        import umap  # noqa: F401  — lazy import per [diagnostics] extra
+    except ImportError as e:
+        raise UMAPNotInstalledError(
+            'umap-learn is not installed; install memex[diagnostics] to enable manifold endpoints.'
+        ) from e
+
+    p = dict(DEFAULT_UMAP_PARAMS)
+    if params:
+        p.update(params)
+
+    unit_count, last_updated_at = await _vault_unit_signature(metastore, vault_id)
+    key_hash = cache_key(vault_id, unit_count, last_updated_at, p)
+
+    span_attrs = {
+        'vault_id': str(vault_id),
+        'n_units': unit_count,
+        'cache_key': key_hash,
+    }
+    with tracer.start_as_current_span('memex.diagnostics.compute_manifold', attributes=span_attrs):
+        with DIAGNOSTICS_MANIFOLD_COMPUTE_SECONDS.labels(vault_id=str(vault_id)).time():
+            DIAGNOSTICS_CACHE_MISSES_TOTAL.labels(vault_id=str(vault_id)).inc()
+
+            embeddings, unit_ids = await _load_embeddings(metastore, vault_id)
+            if not embeddings:
+                payload = {
+                    'vault_id': str(vault_id),
+                    'cache_key': key_hash,
+                    'computed_at': datetime.now(timezone.utc).isoformat(),
+                    'n_units': 0,
+                    'umap_params': p,
+                    'points': [],
+                    'cluster_count': None,
+                }
+            else:
+                import numpy as np
+                from umap import UMAP
+
+                arr = np.asarray(embeddings, dtype=float)
+                reducer = UMAP(**p)
+                projected = reducer.fit_transform(arr)
+                points = [
+                    {'unit_id': str(uid), 'x': float(projected[i, 0]), 'y': float(projected[i, 1])}
+                    for i, uid in enumerate(unit_ids)
+                ]
+                payload = {
+                    'vault_id': str(vault_id),
+                    'cache_key': key_hash,
+                    'computed_at': datetime.now(timezone.utc).isoformat(),
+                    'n_units': len(points),
+                    'umap_params': p,
+                    'points': points,
+                    'cluster_count': None,
+                }
+
+            data = json.dumps(payload).encode('utf-8')
+            await filestore.save(cache_path_for(vault_id), data)
+            return payload
+
+
+async def _load_embeddings(
+    metastore: 'MetaStore',
+    vault_id: UUID,
+) -> tuple[list[list[float]], list[UUID]]:
+    async with metastore.session() as sess:
+        stmt = (
+            select(MemoryUnit.id, MemoryUnit.embedding)
+            .where(MemoryUnit.vault_id == vault_id)
+            .where(MemoryUnit.embedding.is_not(None))
+        )
+        rows = (await sess.exec(stmt)).all()
+    embeddings: list[list[float]] = []
+    unit_ids: list[UUID] = []
+    for unit_id, emb in rows:
+        if emb is None:
+            continue
+        embeddings.append(list(emb))
+        unit_ids.append(unit_id)
+    return embeddings, unit_ids
+
+
+async def warm_cache_hit(
+    filestore: 'FileStore',
+    metastore: 'MetaStore',
+    vault_id: UUID,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    cached = await load_cached_manifold(filestore, vault_id)
+    if cached is None:
+        return None
+    unit_count, last_updated_at = await _vault_unit_signature(metastore, vault_id)
+    expected = cache_key(vault_id, unit_count, last_updated_at, params)
+    if cached.get('cache_key') != expected:
+        return None
+    DIAGNOSTICS_CACHE_HITS_TOTAL.labels(vault_id=str(vault_id)).inc()
+    return cached

--- a/packages/core/src/memex_core/memory/reflect/models.py
+++ b/packages/core/src/memex_core/memory/reflect/models.py
@@ -11,8 +11,13 @@ class ReflectionRequest(BaseModel):
     """
 
     entity_id: UUID = Field(description='The UUID of the entity to reflect upon.')
-    limit_recent_memories: int = Field(
-        default=20, description='Number of recent memories to consider.'
+    limit_recent_memories: int | None = Field(
+        default=20,
+        description=(
+            'Number of recent memories to consider. None means no per-request cap '
+            "(F5 'full' scope); the engine still enforces MAX_FULL_SCOPE_UNITS=1000 "
+            'as a hard ceiling on the SQL fetch.'
+        ),
     )
     vault_id: UUID = Field(
         default=GLOBAL_VAULT_ID,

--- a/packages/core/src/memex_core/memory/reflect/reflection.py
+++ b/packages/core/src/memex_core/memory/reflect/reflection.py
@@ -50,6 +50,13 @@ from memex_core.memory.formatting import format_for_embedding
 
 logger = logging.getLogger('memex.core.memory.reflect.reflection')
 
+# F5: hard ceiling on per-entity recent-memory fetch when ReflectionRequest
+# carries limit_recent_memories=None (scope='full'). Caps per-call LLM cost
+# so a busy entity with thousands of units cannot saturate the prompt budget
+# on a single agent-triggered reflection. The rate limit guards call
+# *frequency*; this constant guards per-call *size*.
+MAX_FULL_SCOPE_UNITS = 1000
+
 
 def get_reflection_engine(
     session: AsyncSession,
@@ -145,7 +152,22 @@ class ReflectionEngine:
             # 1.1 Batch Load Data for this Vault (Serial DB Access)
             models_map = await self._batch_get_or_create_models(entity_ids, vault_id=vault_id)
             entities_map = await self._batch_get_entities(entity_ids)
-            memories_map = await self._batch_fetch_recent_memories(entity_ids, vault_id=vault_id)
+            # F5 mixed-limit batch semantics: a single SQL fetch sized to the
+            # most-permissive limit in the batch (or unbounded → MAX_FULL_SCOPE_UNITS
+            # ceiling) so per-request slicing in _process_entity_reflection yields
+            # correct semantics without multiple roundtrips.
+            batch_limit = (
+                None
+                if any(r.limit_recent_memories is None for r in v_requests)
+                else max(
+                    r.limit_recent_memories
+                    for r in v_requests
+                    if r.limit_recent_memories is not None
+                )
+            )
+            memories_map = await self._batch_fetch_recent_memories(
+                entity_ids, vault_id=vault_id, limit_per_entity=batch_limit
+            )
 
             # 1.2 Concurrent Processing for this Vault
             results = await asyncio.gather(
@@ -190,11 +212,20 @@ class ReflectionEngine:
         async with sem:
             try:
                 entity = entities_map.get(eid)
+                # F5 per-request slice: memories_map carries the batch's
+                # most-permissive fetch; honour each request's own limit here.
+                # None means unbounded (already capped at MAX_FULL_SCOPE_UNITS by SQL).
+                fetched = memories_map.get(eid, [])
+                recent_memories = (
+                    fetched
+                    if req.limit_recent_memories is None
+                    else fetched[: req.limit_recent_memories]
+                )
                 return await self._reflect_entity_internal(
                     entity_id=eid,
                     mental_model=models_map[eid],
                     entity=entity,
-                    recent_memories=memories_map.get(eid, []),
+                    recent_memories=recent_memories,
                     db_lock=db_lock,
                     vault_id=req.vault_id,
                 )
@@ -494,12 +525,18 @@ class ReflectionEngine:
         self,
         entity_ids: list[UUID],
         vault_id: UUID = GLOBAL_VAULT_ID,
-        limit_per_entity: int = 20,
+        limit_per_entity: int | None = 20,
     ) -> dict[UUID, list[MemoryUnit]]:
         """
         Fetch recent memories for multiple entities in one go using Window Function.
         Vault scoping follows "Fall-through" logic: (vault_id == active OR vault_id == Global).
+
+        ``limit_per_entity=None`` requests an unbounded fetch ('full' scope from F5);
+        the engine still applies ``MAX_FULL_SCOPE_UNITS`` as a hard ceiling so per-call
+        LLM cost stays bounded.
         """
+
+        effective_limit = MAX_FULL_SCOPE_UNITS if limit_per_entity is None else limit_per_entity
 
         # 1. Base query for units associated with these entities
         subq_base = (
@@ -528,7 +565,7 @@ class ReflectionEngine:
         query = (
             select(MemoryUnit, subq.c.entity_id)
             .join(subq, col(subq.c.unit_id) == col(MemoryUnit.id))
-            .where(subq.c.rn <= limit_per_entity)
+            .where(subq.c.rn <= effective_limit)
             .options(defer(MemoryUnit.embedding))  # type: ignore
         )
 

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -70,6 +70,16 @@ CIRCUIT_BREAKER_REJECTIONS_TOTAL = Counter(
 )
 
 # ---------------------------------------------------------------------------
+# Audit-log metrics (cross-cutting; populated by AuditService._persist)
+# ---------------------------------------------------------------------------
+
+MEMEX_AUDIT_LOG_TOTAL = Counter(
+    'memex_audit_log_total',
+    'Audit log entries written, by action.',
+    ['action'],
+)
+
+# ---------------------------------------------------------------------------
 # Extraction-pipeline in-flight gauges (wedge diagnostics)
 # ---------------------------------------------------------------------------
 

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -163,3 +163,26 @@ CLASSIFIER_BLOCKED_TOTAL = Counter(
     'Facts refused at ingestion because the classifier flagged risk_class=safety.',
     ['vault_id'],
 )
+
+# ---------------------------------------------------------------------------
+# Diagnostics metrics (F32)
+# ---------------------------------------------------------------------------
+
+DIAGNOSTICS_MANIFOLD_COMPUTE_SECONDS = Histogram(
+    'memex_diagnostics_manifold_compute_seconds',
+    'Wall-clock duration of UMAP manifold compute (seconds), per vault.',
+    ['vault_id'],
+    buckets=(0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0),
+)
+
+DIAGNOSTICS_CACHE_HITS_TOTAL = Counter(
+    'memex_diagnostics_cache_hits_total',
+    'Manifold cache hits (cache_key matched live signature) by vault.',
+    ['vault_id'],
+)
+
+DIAGNOSTICS_CACHE_MISSES_TOTAL = Counter(
+    'memex_diagnostics_cache_misses_total',
+    'Manifold cache misses (no cache or cache_key drift) by vault.',
+    ['vault_id'],
+)

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -130,6 +130,22 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
     async def run_kv_ttl_cleanup():
         await periodic_kv_ttl_cleanup_task(api)
 
+    # ============================================================
+    # Tier A — Scheduler tasks (under MEMEX_LEADER_LOCK_ID)
+    # F6 lint task:                WS-linter
+    # F20 revisit seed task:       WS-revisit
+    # F32 diagnostics refresh:     WS-diagnostics
+    # F38 consolidation tick:      WS-quick-wins
+    # ============================================================
+
+    # --- F6 lint ---       (filled by WS-linter)
+
+    # --- F20 revisit ---   (filled by WS-revisit)
+
+    # --- F32 diagnostics --- (filled by WS-diagnostics)
+
+    # --- F38 consolidation --- (filled by WS-quick-wins)
+
     # asyncpg requires a plain postgresql:// DSN (no +asyncpg driver suffix)
     sa_url = make_url(config.server.meta_store.instance.connection_string)
     dsn = sa_url.set(drivername='postgresql').render_as_string(hide_password=False)

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -91,6 +91,22 @@ async def periodic_kv_ttl_cleanup_task(api: 'MemexAPI'):
             logger.error(f'Scheduler: KV TTL cleanup failed: {e}', exc_info=True)
 
 
+async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
+    """F32: weekly UMAP manifold refresh per vault under leader lock."""
+    async with background_session('bg-sched-diagnostics-refresh'):
+        try:
+            vaults = await api.list_vaults()
+            for vault in vaults:
+                try:
+                    await api.diagnostics.get_or_compute_manifold(vault.id, force_refresh=True)
+                except Exception as e:
+                    logger.warning(
+                        f'Scheduler: Manifold compute failed for vault {vault.name}: {e}'
+                    )
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.error(f'Scheduler: Diagnostics refresh failed: {e}', exc_info=True)
+
+
 async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI'):
     """
     Leader election loop using Postgres Advisory Locks.
@@ -143,6 +159,9 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
     # --- F20 revisit ---   (filled by WS-revisit)
 
     # --- F32 diagnostics --- (filled by WS-diagnostics)
+    @clock.task(trigger=Every(seconds=7 * 86400))
+    async def run_diagnostics_refresh():
+        await periodic_diagnostics_refresh_task(api)
 
     # --- F38 consolidation --- (filled by WS-quick-wins)
 

--- a/packages/core/src/memex_core/server/__init__.py
+++ b/packages/core/src/memex_core/server/__init__.py
@@ -27,6 +27,7 @@ except ImportError:
 from memex_core.logging_config import configure_logging
 from memex_core.server.audit import router as audit_router
 from memex_core.server.auth import auth_middleware, setup_auth
+from memex_core.server.diagnostics import router as diagnostics_router
 from memex_core.server.rate_limit import setup_rate_limiting
 from memex_core.services.audit import AuditService
 from memex_core.server.kv import router as kv_router
@@ -335,3 +336,4 @@ app.include_router(kv_router)
 app.include_router(survey_router)
 app.include_router(vault_summary_router)
 app.include_router(session_briefing_router)
+app.include_router(diagnostics_router)

--- a/packages/core/src/memex_core/server/diagnostics.py
+++ b/packages/core/src/memex_core/server/diagnostics.py
@@ -1,0 +1,109 @@
+"""F32 — Diagnostics endpoints (manifold + retrieval heatmap + summary).
+
+Routes:
+- GET /diagnostics/manifold/{vault_id}              — 200 (warm) | 202 (cold) | 501 (umap missing)
+- GET /diagnostics/manifold/{vault_id}/status       — 200 (done) | 202 (still computing) | 404
+- GET /diagnostics/retrieval/{vault_id}             — 200 with heatmap JSON
+- GET /diagnostics/summary/{vault_id}               — 200 with full summary
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
+
+from memex_core.api import MemexAPI
+from memex_core.diagnostics import compute_heatmap
+from memex_core.diagnostics.umap import UMAPNotInstalledError
+from memex_core.server.auth import require_read
+from memex_core.server.common import _handle_error, get_api
+
+logger = logging.getLogger('memex.core.server.diagnostics')
+
+router = APIRouter(prefix='/api/v1/diagnostics', dependencies=[Depends(require_read)])
+
+_UMAP_MISSING_DETAIL = 'umap-learn not installed; install memex[diagnostics]'
+
+
+def _ensure_umap_available() -> None:
+    try:
+        import umap  # noqa: F401
+    except ImportError as e:
+        raise HTTPException(status_code=501, detail=_UMAP_MISSING_DETAIL) from e
+
+
+@router.get('/manifold/{vault_id}')
+async def get_manifold(
+    vault_id: UUID,
+    api: Annotated[MemexAPI, Depends(get_api)],
+    force_refresh: bool = Query(False, alias='force_refresh'),
+) -> JSONResponse:
+    """Returns the cached UMAP projection if warm, or 202 with a task_id on cold.
+
+    Returns 501 if `umap-learn` is not installed.
+    """
+    _ensure_umap_available()
+    try:
+        status, payload = await api.diagnostics.get_or_compute_manifold(
+            vault_id, force_refresh=force_refresh
+        )
+    except UMAPNotInstalledError as e:
+        raise HTTPException(status_code=501, detail=_UMAP_MISSING_DETAIL) from e
+    except Exception as e:
+        raise _handle_error(e, 'Failed to get manifold')
+
+    if status == 'ready':
+        return JSONResponse(content=payload, status_code=200)
+    if status == 'computing':
+        return JSONResponse(content=payload, status_code=202)
+    raise HTTPException(status_code=500, detail=f'Unexpected manifold status: {status}')
+
+
+@router.get('/manifold/{vault_id}/status')
+async def get_manifold_status(
+    vault_id: UUID,
+    task_id: Annotated[str, Query(...)],
+    api: Annotated[MemexAPI, Depends(get_api)],
+) -> JSONResponse:
+    """Polling endpoint for an in-flight manifold compute."""
+    try:
+        status, payload = await api.diagnostics.get_manifold_status(vault_id, task_id)
+    except Exception as e:
+        raise _handle_error(e, 'Failed to query manifold status')
+
+    if status == 'ready':
+        return JSONResponse(content=payload, status_code=200)
+    if status == 'computing':
+        return JSONResponse(content=payload, status_code=202)
+    if status == 'unavailable':
+        raise HTTPException(status_code=501, detail=_UMAP_MISSING_DETAIL)
+    raise HTTPException(status_code=404, detail='No manifold task or cache for this vault/task_id.')
+
+
+@router.get('/retrieval/{vault_id}')
+async def get_retrieval_heatmap(
+    vault_id: UUID,
+    api: Annotated[MemexAPI, Depends(get_api)],
+    top_n: int = Query(50, ge=1, le=500),
+) -> dict[str, Any]:
+    """Top-N entities by outcome volume — independent of UMAP cache."""
+    try:
+        return await compute_heatmap(api.metastore, vault_id, top_n=top_n)
+    except Exception as e:
+        raise _handle_error(e, 'Failed to compute retrieval heatmap')
+
+
+@router.get('/summary/{vault_id}')
+async def get_diagnostics_summary(
+    vault_id: UUID,
+    api: Annotated[MemexAPI, Depends(get_api)],
+) -> dict[str, Any]:
+    """High-level diagnostics summary (synchronous, no UMAP block)."""
+    try:
+        return await api.diagnostics.get_summary(vault_id)
+    except Exception as e:
+        raise _handle_error(e, 'Failed to compute diagnostics summary')

--- a/packages/core/src/memex_core/server/diagnostics.py
+++ b/packages/core/src/memex_core/server/diagnostics.py
@@ -81,7 +81,11 @@ async def get_manifold_status(
         return JSONResponse(content=payload, status_code=202)
     if status == 'unavailable':
         raise HTTPException(status_code=501, detail=_UMAP_MISSING_DETAIL)
-    raise HTTPException(status_code=404, detail='No manifold task or cache for this vault/task_id.')
+    if status == 'absent':
+        raise HTTPException(
+            status_code=404, detail='No manifold task or cache for this vault/task_id.'
+        )
+    raise HTTPException(status_code=500, detail=f'Unexpected manifold status: {status}')
 
 
 @router.get('/retrieval/{vault_id}')

--- a/packages/core/src/memex_core/server/memories.py
+++ b/packages/core/src/memex_core/server/memories.py
@@ -4,10 +4,11 @@ import logging
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 
-from memex_common.exceptions import MemexError
-from memex_core.server.auth import require_delete, require_read
+from memex_common.exceptions import MemexError, MemoryUnitNotFoundError
+from memex_core.server.auth import require_delete, require_read, require_write
 from memex_common.schemas import MemoryLinkDTO, MemoryUnitDTO
 
 from memex_core.api import MemexAPI
@@ -43,6 +44,57 @@ async def delete_memory_unit(id: UUID, api: Annotated[MemexAPI, Depends(get_api)
         return {'status': 'success'}
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, 'Memory unit deletion failed')
+
+
+class DeprioritizeRequest(BaseModel):
+    reason: str = Field(..., description='Why this unit was deprioritized (logged to audit_logs).')
+
+
+@router.post(
+    '/memories/{id}/deprioritize',
+    response_model=MemoryUnitDTO,
+    dependencies=[Depends(require_write)],
+)
+async def deprioritize_memory_unit(
+    id: UUID,
+    request: DeprioritizeRequest,
+    background_tasks: BackgroundTasks,
+    api: Annotated[MemexAPI, Depends(get_api)],
+):
+    """Deprioritize a memory unit (non-destructive — flips ``is_deprioritized=True``).
+
+    Per Wave 0 §6 #12: this is the NON-destructive curation verb. Archive
+    remains the destructive counterpart.
+    """
+    try:
+        unit = await api.deprioritize_memory_unit(
+            id, reason=request.reason, background_tasks=background_tasks
+        )
+        return build_memory_unit_dto(unit)
+    except MemoryUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
+        raise _handle_error(e, f'Failed to deprioritize memory unit {id}')
+
+
+@router.post(
+    '/memories/{id}/restore',
+    response_model=MemoryUnitDTO,
+    dependencies=[Depends(require_write)],
+)
+async def restore_memory_unit(
+    id: UUID,
+    background_tasks: BackgroundTasks,
+    api: Annotated[MemexAPI, Depends(get_api)],
+):
+    """Restore a deprioritized memory unit (flips ``is_deprioritized=False``)."""
+    try:
+        unit = await api.restore_memory_unit(id, background_tasks=background_tasks)
+        return build_memory_unit_dto(unit)
+    except MemoryUnitNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
+        raise _handle_error(e, f'Failed to restore memory unit {id}')
 
 
 @router.get(

--- a/packages/core/src/memex_core/server/reflection.py
+++ b/packages/core/src/memex_core/server/reflection.py
@@ -4,7 +4,8 @@ from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel, Field
 
 from memex_common.config import GLOBAL_VAULT_ID
 from memex_core.server.auth import require_delete, require_write
@@ -25,8 +26,26 @@ from memex_core.server.common import (
     ndjson_response,
     resolve_vault_ids,
 )
+from memex_core.services.rate_limit import RateLimitExceededError
 
 router = APIRouter(prefix='/api/v1')
+
+
+class SummarizeNodeRequest(BaseModel):
+    """F5: synchronous summarize-node endpoint body."""
+
+    entity_id: UUID = Field(..., description='Entity UUID to reflect on.')
+    scope: Literal['incremental', 'full'] = Field(
+        default='incremental',
+        description=(
+            "'incremental' (default — only new evidence) or 'full' "
+            '(re-evaluate all evidence; engine caps at MAX_FULL_SCOPE_UNITS=1000).'
+        ),
+    )
+    vault_id: UUID | None = Field(
+        default=None,
+        description='Vault UUID; defaults to the global vault when omitted.',
+    )
 
 
 @router.post(
@@ -54,6 +73,65 @@ async def reflect(
         )
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, 'Reflection failed')
+
+
+@router.post(
+    '/memories/summarize-node',
+    response_model=ReflectionResultDTO,
+    dependencies=[Depends(require_write)],
+    responses={
+        429: {
+            'description': 'Rate limit exceeded for this (entity_id, vault_id).',
+            'content': {
+                'application/json': {
+                    'example': {
+                        'error': 'rate_limit_exceeded',
+                        'retry_after_seconds': 42.5,
+                        'message': 'Rate limit exceeded; retry after 42.50s.',
+                    }
+                }
+            },
+        }
+    },
+)
+async def summarize_node(
+    request: Annotated[SummarizeNodeRequest, Body()],
+    api: Annotated[MemexAPI, Depends(get_api)],
+):
+    """F5: synchronously consolidate memories on an entity into its mental model.
+
+    Mirrors §4 F5's synchronous contract — does NOT use BackgroundTasks. Per RFC-002,
+    rate-limited per (entity_id, vault_id) at the service layer; the endpoint is a
+    thin transport that translates ``RateLimitExceededError`` into a 429 envelope
+    with a ``Retry-After`` header.
+    """
+    try:
+        result = await api.summarize_node(
+            request.entity_id,
+            scope=request.scope,
+            vault_id=request.vault_id,
+        )
+    except RateLimitExceededError as exc:
+        retry_after = max(0, int(exc.retry_after_seconds + 0.999))
+        return JSONResponse(
+            status_code=429,
+            content={
+                'error': 'rate_limit_exceeded',
+                'retry_after_seconds': exc.retry_after_seconds,
+                'message': str(exc),
+            },
+            headers={'Retry-After': str(retry_after)},
+        )
+    except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
+        raise _handle_error(e, 'Summarize-node reflection failed')
+
+    from memex_common.schemas import ObservationDTO
+
+    return ReflectionResultDTO(
+        entity_id=result.entity_id,
+        new_observations=[ObservationDTO(**obs.model_dump()) for obs in result.new_observations],
+        status='completed',
+    )
 
 
 @router.post(

--- a/packages/core/src/memex_core/server/reflection.py
+++ b/packages/core/src/memex_core/server/reflection.py
@@ -12,6 +12,7 @@ from memex_core.server.auth import require_delete, require_write
 from memex_common.exceptions import MemexError
 from memex_common.schemas import (
     DeadLetterItemDTO,
+    ObservationDTO,
     ReflectionQueueDTO,
     ReflectionRequest as ReflectionDTO,
     ReflectionResultDTO,
@@ -124,8 +125,6 @@ async def summarize_node(
         )
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, 'Summarize-node reflection failed')
-
-    from memex_common.schemas import ObservationDTO
 
     return ReflectionResultDTO(
         entity_id=result.entity_id,

--- a/packages/core/src/memex_core/services/audit.py
+++ b/packages/core/src/memex_core/services/audit.py
@@ -69,8 +69,14 @@ class AuditService:
                 await session.commit()
         except (SQLAlchemyError, OSError, RuntimeError):
             logger.exception('Failed to write audit log entry: action=%s', entry.action)
+            return
         except Exception:
             logger.exception('Unexpected error writing audit log entry: action=%s', entry.action)
+            return
+
+        from memex_core.metrics import MEMEX_AUDIT_LOG_TOTAL
+
+        MEMEX_AUDIT_LOG_TOTAL.labels(action=entry.action).inc()
 
     # ------------------------------------------------------------------
     # Read (query)

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -54,11 +54,19 @@ class DiagnosticsService(BaseService):
         *,
         force_refresh: bool = False,
     ) -> tuple[str, dict[str, Any] | None]:
-        """Returns (status, payload). status ∈ {'ready', 'computing', 'unavailable'}.
+        """Returns (status, payload). status ∈ {'ready', 'computing', 'unavailable', 'absent'}.
 
         - 'ready' → payload is the cached manifold dict (200 OK).
         - 'computing' → payload includes task_id (202 Accepted).
         - 'unavailable' → umap-learn not installed (501 Not Implemented).
+        - 'absent' → no in-flight task and no cached manifold (404 Not Found);
+          only emitted by :meth:`get_manifold_status`, never by this method.
+
+        Note: ``force_refresh=True`` skips the warm-cache check but does NOT
+        cancel an in-flight compute. If a task is already running for this
+        vault, the existing task's id is returned. Cancellation is avoided
+        because the in-flight task may have side effects (cache writes,
+        metrics, traces) that should complete.
         """
         if not force_refresh:
             cached = await warm_cache_hit(self.filestore, self.metastore, vault_id)

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from uuid import UUID
+
+from memex_core.config import MemexConfig
+from memex_core.diagnostics.summary import compute_diagnostics_summary
+from memex_core.diagnostics.umap import (
+    UMAPNotInstalledError,
+    compute_manifold,
+    warm_cache_hit,
+)
+from memex_core.services.base import BaseService
+from memex_core.storage.filestore import BaseAsyncFileStore
+from memex_core.storage.metastore import AsyncBaseMetaStoreEngine
+
+logger = logging.getLogger('memex.core.services.diagnostics')
+
+
+class DiagnosticsService(BaseService):
+    """Owns the in-process pending-task registry for cold-cache UMAP compute.
+
+    Concurrent cold requests for the same vault share a single asyncio.Task;
+    exactly one compute fires per cold-cache window. Restart loses the
+    registry — next request triggers a fresh compute (cache file persists).
+    """
+
+    def __init__(
+        self,
+        metastore: AsyncBaseMetaStoreEngine,
+        filestore: BaseAsyncFileStore,
+        config: MemexConfig,
+    ) -> None:
+        super().__init__(metastore=metastore, filestore=filestore, config=config)
+        self._pending: dict[str, asyncio.Task[dict[str, Any]]] = {}
+        self._registry_lock = asyncio.Lock()
+
+    async def get_summary(self, vault_id: UUID) -> dict[str, Any]:
+        async with self._registry_lock:
+            pending = self._pending.get(str(vault_id))
+            in_flight = pending is not None and not pending.done()
+        return await compute_diagnostics_summary(
+            self.metastore,
+            self.filestore,
+            vault_id,
+            pending_compute=in_flight,
+        )
+
+    async def get_or_compute_manifold(
+        self,
+        vault_id: UUID,
+        *,
+        force_refresh: bool = False,
+    ) -> tuple[str, dict[str, Any] | None]:
+        """Returns (status, payload). status ∈ {'ready', 'computing', 'unavailable'}.
+
+        - 'ready' → payload is the cached manifold dict (200 OK).
+        - 'computing' → payload includes task_id (202 Accepted).
+        - 'unavailable' → umap-learn not installed (501 Not Implemented).
+        """
+        if not force_refresh:
+            cached = await warm_cache_hit(self.filestore, self.metastore, vault_id)
+            if cached is not None:
+                return 'ready', cached
+
+        async with self._registry_lock:
+            key = str(vault_id)
+            existing = self._pending.get(key)
+            if existing is not None and not existing.done():
+                return 'computing', {'task_id': _task_id_for(existing)}
+            task = asyncio.create_task(self._compute_and_cache(vault_id))
+            self._pending[key] = task
+
+            def _on_done(_t: asyncio.Task[dict[str, Any]], k: str = key) -> None:
+                self._clear_registry(k)
+
+            task.add_done_callback(_on_done)
+            return 'computing', {'task_id': _task_id_for(task)}
+
+    async def get_manifold_status(
+        self,
+        vault_id: UUID,
+        task_id: str,
+    ) -> tuple[str, dict[str, Any] | None]:
+        """Polling endpoint for an in-flight compute.
+
+        Returns ('ready', payload) when done + cached, ('computing', {task_id}) if still running,
+        or ('absent', None) if no matching task and no cached file.
+        """
+        async with self._registry_lock:
+            pending = self._pending.get(str(vault_id))
+        if pending is not None and _task_id_for(pending) == task_id:
+            if pending.done():
+                try:
+                    payload = pending.result()
+                except UMAPNotInstalledError:
+                    return 'unavailable', None
+                except Exception as e:
+                    logger.exception('Manifold compute failed for vault %s: %s', vault_id, e)
+                    return 'absent', None
+                return 'ready', payload
+            return 'computing', {'task_id': task_id}
+        cached = await warm_cache_hit(self.filestore, self.metastore, vault_id)
+        if cached is not None:
+            return 'ready', cached
+        return 'absent', None
+
+    async def _compute_and_cache(self, vault_id: UUID) -> dict[str, Any]:
+        return await compute_manifold(self.metastore, self.filestore, vault_id)
+
+    def _clear_registry(self, key: str) -> None:
+        self._pending.pop(key, None)
+
+    async def shutdown(self) -> None:
+        """Cancel all in-flight tasks; intended for app shutdown."""
+        async with self._registry_lock:
+            tasks = list(self._pending.values())
+            self._pending.clear()
+        for t in tasks:
+            t.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _task_id_for(task: asyncio.Task[Any]) -> str:
+    return f'{id(task):x}'

--- a/packages/core/src/memex_core/services/rate_limit.py
+++ b/packages/core/src/memex_core/services/rate_limit.py
@@ -1,0 +1,103 @@
+"""In-process token-bucket rate limiter (F5).
+
+Per-key token bucket with monotonic-clock refill. Designed for advisory
+limits, not security gates: multi-worker leakage is accepted in v1
+(F9 introduces distributed locking; F38 will reuse this primitive).
+
+Reusable across F5, F9, F10, F20 per RFC-002.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+class RateLimitExceededError(Exception):
+    """Raised when a rate-limited operation is attempted before the bucket has refilled.
+
+    ``retry_after_seconds`` is the suggested back-off; service callers surface it
+    structurally to clients (MCP tools, Hermes handlers).
+    """
+
+    def __init__(self, key: object, retry_after_seconds: float, *, message: str | None = None):
+        self.key = key
+        self.retry_after_seconds = retry_after_seconds
+        super().__init__(
+            message or f'Rate limit exceeded for {key!r}; retry after {retry_after_seconds:.2f}s.'
+        )
+
+
+@dataclass
+class _Bucket:
+    tokens: float
+    last_refill: float
+
+
+class TokenBucketRateLimiter:
+    """LRU token-bucket keyed by an arbitrary hashable.
+
+    Each key gets a bucket of capacity ``burst`` that refills at
+    ``burst / per_seconds`` tokens per second. ``acquire(key)`` consumes
+    one token or raises ``RateLimitExceededError``.
+
+    Thread-safe via a single mutex (in-process; multi-worker leakage is
+    documented in RFC-002 and acknowledged in PR body per AC-F5-4).
+    """
+
+    def __init__(
+        self,
+        *,
+        per_seconds: float,
+        burst: int = 1,
+        max_keys: int = 10000,
+        enabled: bool = True,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if per_seconds <= 0:
+            raise ValueError('per_seconds must be > 0')
+        if burst <= 0:
+            raise ValueError('burst must be > 0')
+        if max_keys <= 0:
+            raise ValueError('max_keys must be > 0')
+        self._per_seconds = float(per_seconds)
+        self._burst = float(burst)
+        self._refill_rate = self._burst / self._per_seconds
+        self._max_keys = max_keys
+        self._enabled = enabled
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._buckets: OrderedDict[object, _Bucket] = OrderedDict()
+
+    def acquire(self, key: object) -> None:
+        """Consume one token for ``key`` or raise ``RateLimitExceededError``."""
+        if not self._enabled:
+            return
+        now = self._clock()
+        with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = _Bucket(tokens=self._burst, last_refill=now)
+                self._buckets[key] = bucket
+                self._buckets.move_to_end(key)
+                self._evict_if_needed()
+            else:
+                self._buckets.move_to_end(key)
+                elapsed = max(0.0, now - bucket.last_refill)
+                bucket.tokens = min(self._burst, bucket.tokens + elapsed * self._refill_rate)
+                bucket.last_refill = now
+
+            if bucket.tokens >= 1.0:
+                bucket.tokens -= 1.0
+                return
+
+            deficit = 1.0 - bucket.tokens
+            retry_after = deficit / self._refill_rate
+            raise RateLimitExceededError(key, retry_after_seconds=retry_after)
+
+    def _evict_if_needed(self) -> None:
+        while len(self._buckets) > self._max_keys:
+            self._buckets.popitem(last=False)

--- a/packages/core/src/memex_core/services/rate_limit.py
+++ b/packages/core/src/memex_core/services/rate_limit.py
@@ -9,7 +9,7 @@ Reusable across F5, F9, F10, F20 per RFC-002.
 
 from __future__ import annotations
 
-import threading
+import asyncio
 import time
 from collections import OrderedDict
 from collections.abc import Callable
@@ -44,8 +44,10 @@ class TokenBucketRateLimiter:
     ``burst / per_seconds`` tokens per second. ``acquire(key)`` consumes
     one token or raises ``RateLimitExceededError``.
 
-    Thread-safe via a single mutex (in-process; multi-worker leakage is
-    documented in RFC-002 and acknowledged in PR body per AC-F5-4).
+    Mutual exclusion uses ``asyncio.Lock`` to honour the project-wide
+    asyncio convention (multi-worker leakage is documented in RFC-002 and
+    acknowledged in the PR body per AC-F5-4). Hold time is microseconds —
+    dict lookup plus arithmetic — so contention is negligible.
     """
 
     def __init__(
@@ -69,15 +71,15 @@ class TokenBucketRateLimiter:
         self._max_keys = max_keys
         self._enabled = enabled
         self._clock = clock
-        self._lock = threading.Lock()
+        self._lock = asyncio.Lock()
         self._buckets: OrderedDict[object, _Bucket] = OrderedDict()
 
-    def acquire(self, key: object) -> None:
+    async def acquire(self, key: object) -> None:
         """Consume one token for ``key`` or raise ``RateLimitExceededError``."""
         if not self._enabled:
             return
         now = self._clock()
-        with self._lock:
+        async with self._lock:
             bucket = self._buckets.get(key)
             if bucket is None:
                 bucket = _Bucket(tokens=self._burst, last_refill=now)

--- a/packages/core/src/memex_core/services/reflection.py
+++ b/packages/core/src/memex_core/services/reflection.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 import dspy
 
+from memex_common.config import GLOBAL_VAULT_ID
 from memex_core.config import MemexConfig
 from memex_core.context import background_session
 from memex_core.memory.engine import MemoryEngine
@@ -21,9 +22,15 @@ from memex_core.memory.reflect.queue_service import ReflectionQueueService
 from memex_core.memory.sql_models import Observation
 from memex_core.memory.models.protocols import EmbeddingsModel
 from memex_core.services.audit import AuditService, audit_event
+from memex_core.services.rate_limit import (
+    TokenBucketRateLimiter,
+)
 from memex_core.storage.metastore import AsyncBaseMetaStoreEngine
 
 logger = logging.getLogger('memex.core.services.reflection')
+
+
+SummarizeScope = Literal['incremental', 'full']
 
 
 class ReflectionService:
@@ -53,6 +60,13 @@ class ReflectionService:
         self.queue_service = queue_service
         self.embedding_model = embedding_model
         self._reflection_lock = asyncio.Lock()
+        rate_limit_cfg = config.server.memory.reflection.summarize_node_rate_limit
+        self._summarize_node_limiter = TokenBucketRateLimiter(
+            per_seconds=rate_limit_cfg.per_entity_per_seconds,
+            burst=rate_limit_cfg.burst,
+            max_keys=rate_limit_cfg.max_keys,
+            enabled=rate_limit_cfg.enabled,
+        )
 
     async def background_reflect(self, request: ReflectionRequest) -> None:
         """Run reflection in the background, ensuring serialization via lock."""
@@ -128,6 +142,36 @@ class ReflectionService:
                 new_observations=[Observation(**o) for o in mental_model.observations],
                 updated_model=mental_model,
             )
+
+    async def summarize_node(
+        self,
+        entity_id: UUID,
+        *,
+        scope: SummarizeScope = 'incremental',
+        vault_id: UUID | None = None,
+    ) -> ReflectionResult:
+        """F5: synchronous on-demand reflection for a single entity.
+
+        Wraps :meth:`reflect` with a per-(entity_id, vault_id) token-bucket
+        rate limit. ``scope='incremental'`` (default) honours the standard
+        20-unit window; ``scope='full'`` re-evaluates all evidence on the
+        entity (capped at MAX_FULL_SCOPE_UNITS by the engine).
+
+        Raises ``RateLimitExceededError`` (with ``retry_after_seconds``) if
+        the bucket is empty for this (entity, vault) key. The exception is a
+        service-layer signal — surface translation to MCP/HTTP belongs to
+        the calling layer.
+        """
+        effective_vault = vault_id or GLOBAL_VAULT_ID
+        self._summarize_node_limiter.acquire((entity_id, effective_vault))
+
+        limit_recent = None if scope == 'full' else 20
+        request = ReflectionRequest(
+            entity_id=entity_id,
+            vault_id=effective_vault,
+            limit_recent_memories=limit_recent,
+        )
+        return await self.reflect(request)
 
     async def reflect_batch(self, requests: list[ReflectionRequest]) -> list[ReflectionResult]:
         """

--- a/packages/core/src/memex_core/services/reflection.py
+++ b/packages/core/src/memex_core/services/reflection.py
@@ -171,7 +171,17 @@ class ReflectionService:
             vault_id=effective_vault,
             limit_recent_memories=limit_recent,
         )
-        return await self.reflect(request)
+        result = await self.reflect(request)
+        audit_event(
+            self._audit_service,
+            'memory_summarize_node',
+            'entity',
+            str(entity_id),
+            scope=scope,
+            vault_id=str(effective_vault),
+            observation_count=len(result.new_observations),
+        )
+        return result
 
     async def reflect_batch(self, requests: list[ReflectionRequest]) -> list[ReflectionResult]:
         """

--- a/packages/core/src/memex_core/services/reflection.py
+++ b/packages/core/src/memex_core/services/reflection.py
@@ -163,7 +163,7 @@ class ReflectionService:
         the calling layer.
         """
         effective_vault = vault_id or GLOBAL_VAULT_ID
-        self._summarize_node_limiter.acquire((entity_id, effective_vault))
+        await self._summarize_node_limiter.acquire((entity_id, effective_vault))
 
         limit_recent = None if scope == 'full' else 20
         request = ReflectionRequest(

--- a/packages/core/src/memex_core/services/units.py
+++ b/packages/core/src/memex_core/services/units.py
@@ -1,0 +1,95 @@
+"""Memory unit curation service — non-destructive verbs (F4)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from memex_common.exceptions import MemoryUnitNotFoundError
+from memex_core.context import get_actor, get_session_id
+from memex_core.services.base import BaseService
+
+logger = logging.getLogger('memex.core.services.units')
+
+
+class UnitsService(BaseService):
+    """Memory unit curation: deprioritize / restore.
+
+    Non-destructive counterpart to deletion (`StatsService.delete_memory_unit`).
+    Per Wave 0 §6 #12: deprioritize is the NON-destructive verb; archive
+    remains the destructive cleanup. They coexist.
+    """
+
+    async def set_unit_deprioritized(
+        self,
+        unit_id: UUID,
+        reason: str,
+        *,
+        actor: str | None = None,
+        background_tasks: Any | None = None,
+    ) -> Any:
+        """Flip ``MemoryUnit.is_deprioritized`` to True and record an audit event.
+
+        Does NOT cascade to MentalModels; does NOT call ``prune_stale_evidence``.
+        The retrieval-time filter (F1b) honours the flag — see
+        ``memory/retrieval/strategies.py:93-95``.
+        """
+        return await self._flip_deprioritized(
+            unit_id,
+            value=True,
+            action='memory_deprioritize',
+            details={'reason': reason},
+            actor=actor,
+            background_tasks=background_tasks,
+        )
+
+    async def restore_unit(
+        self,
+        unit_id: UUID,
+        *,
+        actor: str | None = None,
+        background_tasks: Any | None = None,
+    ) -> Any:
+        """Flip ``MemoryUnit.is_deprioritized`` back to False (restore) and audit."""
+        return await self._flip_deprioritized(
+            unit_id,
+            value=False,
+            action='memory_restore',
+            details=None,
+            actor=actor,
+            background_tasks=background_tasks,
+        )
+
+    async def _flip_deprioritized(
+        self,
+        unit_id: UUID,
+        *,
+        value: bool,
+        action: str,
+        details: dict[str, Any] | None,
+        actor: str | None,
+        background_tasks: Any | None,
+    ) -> Any:
+        from memex_core.memory.sql_models import MemoryUnit
+
+        async with self.metastore.session() as session:
+            unit = await session.get(MemoryUnit, unit_id)
+            if unit is None:
+                raise MemoryUnitNotFoundError(f'Memory unit {unit_id} not found.')
+            unit.is_deprioritized = value
+            session.add(unit)
+            await session.commit()
+            await session.refresh(unit)
+
+        if self._audit_service is not None:
+            self._audit_service.log(
+                action=action,
+                actor=actor if actor is not None else get_actor(),
+                resource_type='memory_unit',
+                resource_id=str(unit_id),
+                session_id=get_session_id(),
+                details=details,
+                background_tasks=background_tasks,
+            )
+        return unit

--- a/packages/core/tests/integration/_alembic_test_helpers.py
+++ b/packages/core/tests/integration/_alembic_test_helpers.py
@@ -39,8 +39,14 @@ def sync_url(asyncpg_url: str) -> str:
     return urlunparse(parsed._replace(scheme=scheme))
 
 
-async def alembic_upgrade(db_url: str, target: str = 'head') -> None:
-    """Run ``alembic upgrade <target>`` against ``db_url``."""
+async def alembic_upgrade(db_url: str, target: str = '024_intent_risk_classifier') -> None:
+    """Run ``alembic upgrade <target>`` against ``db_url``.
+
+    Default pinned to ``024_intent_risk_classifier`` (Wave 1 head). Tier A
+    seed PR introduced revisions 025-029 as NIE stubs; each Tier A feature
+    test (``test_int_alembic_NNN.py``) bumps its own target when the matching
+    stub body lands.
+    """
     cfg = alembic_cfg_for(db_url)
     await asyncio.to_thread(command.upgrade, cfg, target)
 

--- a/packages/core/tests/integration/test_int_alembic_021.py
+++ b/packages/core/tests/integration/test_int_alembic_021.py
@@ -206,8 +206,9 @@ async def test_existing_rows_have_empty_keys_after_upgrade(fresh_db_url: str) ->
     finally:
         await engine.dispose()
 
-    # Now upgrade to head (i.e., apply 021).
-    await _alembic_upgrade(fresh_db_url, target='head')
+    # Now upgrade past 020 to apply 021 (target pinned to Wave 1 head; Tier A
+    # NIE stubs at 025-029 must not run from this fixture).
+    await _alembic_upgrade(fresh_db_url, target='024_intent_risk_classifier')
 
     engine = create_async_engine(fresh_db_url, poolclass=NullPool)
     try:

--- a/packages/core/tests/integration/test_int_f32_concurrent_cold.py
+++ b/packages/core/tests/integration/test_int_f32_concurrent_cold.py
@@ -8,14 +8,17 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
-from sqlmodel.ext.asyncio.session import AsyncSession
 
-from memex_common.types import FactTypes
-from memex_core.config import MemexConfig
-from memex_core.diagnostics import umap as umap_mod
-from memex_core.diagnostics.umap import cache_path_for
-from memex_core.memory.sql_models import MemoryUnit, Note, Vault
-from memex_core.services.diagnostics import DiagnosticsService
+pytest.importorskip('umap')
+
+from sqlmodel.ext.asyncio.session import AsyncSession  # noqa: E402
+
+from memex_common.types import FactTypes  # noqa: E402
+from memex_core.config import MemexConfig  # noqa: E402
+from memex_core.diagnostics import umap as umap_mod  # noqa: E402
+from memex_core.diagnostics.umap import cache_path_for  # noqa: E402
+from memex_core.memory.sql_models import MemoryUnit, Note, Vault  # noqa: E402
+from memex_core.services.diagnostics import DiagnosticsService  # noqa: E402
 
 
 async def _seed_minimal_vault(session: AsyncSession) -> Vault:

--- a/packages/core/tests/integration/test_int_f32_concurrent_cold.py
+++ b/packages/core/tests/integration/test_int_f32_concurrent_cold.py
@@ -1,0 +1,138 @@
+"""F32 concurrent cold-path + restart-recovery integration tests (Tests 3, 3b)."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core.config import MemexConfig
+from memex_core.diagnostics import umap as umap_mod
+from memex_core.diagnostics.umap import cache_path_for
+from memex_core.memory.sql_models import MemoryUnit, Note, Vault
+from memex_core.services.diagnostics import DiagnosticsService
+
+
+async def _seed_minimal_vault(session: AsyncSession) -> Vault:
+    vault = Vault(name=f'F32-conc-{uuid4().hex[:8]}')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+
+    note = Note(id=uuid4(), vault_id=vault.id, content_hash='h', original_text='seed')
+    session.add(note)
+    await session.commit()
+
+    now = datetime.now(timezone.utc)
+    units = [
+        MemoryUnit(
+            id=uuid4(),
+            vault_id=vault.id,
+            note_id=note.id,
+            text=f'unit {i}',
+            fact_type=FactTypes.WORLD,
+            status='active',
+            event_date=now,
+            embedding=[0.1 * (i + 1)] * 384,
+        )
+        for i in range(4)
+    ]
+    session.add_all(units)
+    await session.commit()
+    return vault
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrent_cold_requests_share_task(
+    session: AsyncSession,
+    metastore,
+    filestore,
+    memex_config: MemexConfig,
+    monkeypatch,
+):
+    """Two concurrent cold GETs yield the same task_id and exactly ONE compute."""
+    vault = await _seed_minimal_vault(session)
+
+    counter = {'count': 0}
+    real_compute = umap_mod.compute_manifold
+
+    async def counting_compute(*args, **kwargs):
+        counter['count'] += 1
+        return await real_compute(*args, **kwargs)
+
+    monkeypatch.setattr(
+        'memex_core.services.diagnostics.compute_manifold',
+        functools.partial(counting_compute),
+    )
+
+    service = DiagnosticsService(metastore=metastore, filestore=filestore, config=memex_config)
+    try:
+        results = await asyncio.gather(
+            service.get_or_compute_manifold(vault.id),
+            service.get_or_compute_manifold(vault.id),
+        )
+        statuses = [r[0] for r in results]
+        task_ids = [r[1]['task_id'] for r in results]
+        assert statuses == ['computing', 'computing']
+        assert task_ids[0] == task_ids[1]
+
+        # Wait for the in-flight task to settle.
+        pending = list(service._pending.values())
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+        assert counter['count'] == 1
+    finally:
+        await service.shutdown()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_restart_loses_registry_fresh_task_id(
+    session: AsyncSession,
+    metastore,
+    filestore,
+    memex_config: MemexConfig,
+):
+    """A new DiagnosticsService instance has an empty registry; cold call fires fresh task."""
+    vault = await _seed_minimal_vault(session)
+
+    service_a = DiagnosticsService(metastore=metastore, filestore=filestore, config=memex_config)
+    try:
+        status_a, payload_a = await service_a.get_or_compute_manifold(vault.id)
+        assert status_a == 'computing'
+        task_a = payload_a['task_id']
+
+        # Wait for service A's compute to finish + cache file to land.
+        deadline = asyncio.get_event_loop().time() + 120.0
+        while asyncio.get_event_loop().time() < deadline:
+            if await filestore.exists(cache_path_for(vault.id)):
+                break
+            await asyncio.sleep(0.05)
+        else:
+            raise TimeoutError('cache did not warm in time')
+    finally:
+        await service_a.shutdown()
+
+    # New service instance with the same metastore/filestore → registry is empty
+    # but the cache file persists, so a fresh GET hits warm_cache_hit and returns ready.
+    service_b = DiagnosticsService(metastore=metastore, filestore=filestore, config=memex_config)
+    try:
+        # Querying status with the OLD task_id on the new instance should fall
+        # back to the cache (registry is empty) and return 'ready'.
+        status_b, payload_b = await service_b.get_manifold_status(vault.id, task_a)
+        assert status_b == 'ready'
+        assert payload_b is not None
+
+        # And get_or_compute_manifold on a warm cache returns ready immediately.
+        status_c, payload_c = await service_b.get_or_compute_manifold(vault.id)
+        assert status_c == 'ready'
+        assert payload_c is not None
+    finally:
+        await service_b.shutdown()

--- a/packages/core/tests/integration/test_int_f32_diagnostics_summary.py
+++ b/packages/core/tests/integration/test_int_f32_diagnostics_summary.py
@@ -1,0 +1,148 @@
+"""F32 diagnostics summary — integration tests (Test 1, 1b)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core.config import MemexConfig
+from memex_core.memory.sql_models import MemoryUnit, Note, Vault
+from memex_core.services.diagnostics import DiagnosticsService
+
+
+async def _seed_vault_with_units(
+    session: AsyncSession, *, n_active: int, n_stale: int, n_deprioritized: int
+) -> Vault:
+    vault = Vault(name=f'F32-test-{uuid4().hex[:8]}')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+
+    note = Note(
+        id=uuid4(),
+        vault_id=vault.id,
+        content_hash='hash',
+        original_text='seed note',
+    )
+    session.add(note)
+    await session.commit()
+
+    now = datetime.now(timezone.utc)
+    units: list[MemoryUnit] = []
+    for _ in range(n_active):
+        units.append(
+            MemoryUnit(
+                id=uuid4(),
+                vault_id=vault.id,
+                note_id=note.id,
+                text='active unit',
+                fact_type=FactTypes.WORLD,
+                status='active',
+                is_deprioritized=False,
+                event_date=now,
+                embedding=[0.1] * 384,
+                success_co_count=2,
+                failure_co_count=1,
+            )
+        )
+    for _ in range(n_stale):
+        units.append(
+            MemoryUnit(
+                id=uuid4(),
+                vault_id=vault.id,
+                note_id=note.id,
+                text='stale unit',
+                fact_type=FactTypes.WORLD,
+                status='stale',
+                is_deprioritized=False,
+                event_date=now,
+                embedding=[0.1] * 384,
+                success_co_count=0,
+                failure_co_count=0,
+            )
+        )
+    for _ in range(n_deprioritized):
+        units.append(
+            MemoryUnit(
+                id=uuid4(),
+                vault_id=vault.id,
+                note_id=note.id,
+                text='deprioritized unit',
+                fact_type=FactTypes.WORLD,
+                status='active',
+                is_deprioritized=True,
+                event_date=now,
+                embedding=[0.1] * 384,
+                success_co_count=1,
+                failure_co_count=3,
+            )
+        )
+    session.add_all(units)
+    await session.commit()
+    return vault
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_returns_all_fields_with_cluster_count_null(
+    session: AsyncSession,
+    metastore,
+    filestore,
+    memex_config: MemexConfig,
+):
+    """Cold-cache summary returns all documented keys; cluster_count is null;
+    manifold_status ∈ {'pending','absent'}; unit_counts has active/stale/deprioritized."""
+    vault = await _seed_vault_with_units(session, n_active=3, n_stale=1, n_deprioritized=2)
+
+    service = DiagnosticsService(metastore=metastore, filestore=filestore, config=memex_config)
+    summary = await service.get_summary(vault.id)
+
+    assert summary['vault_id'] == str(vault.id)
+    assert 'as_of' in summary
+    assert summary['manifold_status'] in {'pending', 'absent'}
+    assert summary['cluster_count'] is None
+
+    counts = summary['unit_counts']
+    assert set(counts.keys()) == {'active', 'stale', 'deprioritized'}
+    assert counts['active'] == 3
+    assert counts['stale'] == 1
+    assert counts['deprioritized'] == 2
+
+    assert 'lint_pending_by_type' in summary
+    assert summary['lint_pending_by_type'] == {}
+    assert 'avg_mw_score' in summary
+    assert isinstance(summary['avg_mw_score'], float)
+    assert 'top_5_retrieved_entities' in summary
+    assert isinstance(summary['top_5_retrieved_entities'], list)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize('with_f6_seed', [False, True])
+async def test_lint_pending_by_type_pre_post_f6(
+    session: AsyncSession,
+    metastore,
+    filestore,
+    memex_config: MemexConfig,
+    with_f6_seed: bool,
+):
+    """Pre-F6: lint_pending_by_type is {} (key always present).
+    Post-F6: skipped until MaintenanceProposal lands."""
+    if with_f6_seed:
+        try:
+            from memex_core.memory.sql_models import MaintenanceProposal  # noqa: F401
+        except ImportError:
+            pytest.skip('MaintenanceProposal table absent; F6 not yet shipped')
+
+    vault = await _seed_vault_with_units(session, n_active=1, n_stale=0, n_deprioritized=0)
+
+    service = DiagnosticsService(metastore=metastore, filestore=filestore, config=memex_config)
+    summary = await service.get_summary(vault.id)
+
+    assert 'lint_pending_by_type' in summary
+    if not with_f6_seed:
+        assert summary['lint_pending_by_type'] == {}

--- a/packages/core/tests/integration/test_int_f32_endpoints.py
+++ b/packages/core/tests/integration/test_int_f32_endpoints.py
@@ -1,0 +1,103 @@
+"""F32 HTTP endpoints — integration tests (Tests 4b, 5).
+
+- 4b: GET /diagnostics/retrieval/{vault_id} returns heatmap JSON.
+- 5:  Endpoints return 501 when umap-learn is unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Generator
+from unittest.mock import patch
+from urllib.parse import urlparse
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from testcontainers.postgres import PostgresContainer
+
+
+def _build_env_vars(container: PostgresContainer, tmp_path) -> dict[str, str]:
+    dsn = container.get_connection_url()
+    parsed = urlparse(dsn)
+    return {
+        'MEMEX_LOAD_LOCAL_CONFIG': 'false',
+        'MEMEX_LOAD_GLOBAL_CONFIG': 'false',
+        'MEMEX_SERVER__META_STORE__TYPE': 'postgres',
+        'MEMEX_SERVER__META_STORE__INSTANCE__HOST': parsed.hostname or 'localhost',
+        'MEMEX_SERVER__META_STORE__INSTANCE__PORT': str(parsed.port or 5432),
+        'MEMEX_SERVER__META_STORE__INSTANCE__DATABASE': parsed.path.lstrip('/'),
+        'MEMEX_SERVER__META_STORE__INSTANCE__USER': parsed.username or 'test',
+        'MEMEX_SERVER__META_STORE__INSTANCE__PASSWORD': parsed.password or 'test',
+        'MEMEX_SERVER__MEMORY__REFLECTION__BACKGROUND_REFLECTION_ENABLED': 'false',
+        'MEMEX_SERVER__FILE_STORE__TYPE': 'local',
+        'MEMEX_SERVER__FILE_STORE__ROOT': str(tmp_path),
+    }
+
+
+@pytest.fixture
+def f32_client(
+    postgres_container: PostgresContainer,
+    tmp_path,
+) -> Generator[TestClient, None, None]:
+    """TestClient with the full lifespan, auth disabled, FileStore in tmp_path."""
+    env = _build_env_vars(postgres_container, tmp_path)
+    from memex_core.server import app
+
+    with patch.dict(os.environ, env):
+        with TestClient(app) as c:
+            yield c
+
+
+def _seed_vault_via_api(client: TestClient) -> UUID:
+    """Create a vault via the running API and return its id."""
+    resp = client.post('/api/v1/vaults', json={'name': f'F32-ep-{uuid4().hex[:8]}'})
+    assert resp.status_code in (200, 201), resp.text
+    body = resp.json()
+    return UUID(body['id'])
+
+
+@pytest.mark.integration
+def test_retrieval_endpoint_returns_heatmap_json(f32_client: TestClient):
+    """GET /api/v1/diagnostics/retrieval/{vault_id} returns 200 with heatmap shape."""
+    vault_id = _seed_vault_via_api(f32_client)
+    resp = f32_client.get(f'/api/v1/diagnostics/retrieval/{vault_id}')
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body['vault_id'] == str(vault_id)
+    assert 'as_of' in body
+    assert body['top_n'] == 50
+    assert isinstance(body['entities'], list)
+
+
+@pytest.mark.integration
+def test_endpoints_return_501_when_umap_unavailable(
+    postgres_container: PostgresContainer,
+    tmp_path,
+):
+    """Patch the umap import to fail; GET /diagnostics/manifold/... → 501."""
+    env = _build_env_vars(postgres_container, tmp_path)
+    from memex_core.server import app
+
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'umap':
+            raise ImportError('umap-learn not installed')
+        return real_import(name, *args, **kwargs)
+
+    # Pre-pop any cached umap module so the import is forced.
+    sys.modules.pop('umap', None)
+
+    with patch.dict(os.environ, env):
+        with patch('builtins.__import__', side_effect=fake_import):
+            with TestClient(app) as c:
+                resp = c.post('/api/v1/vaults', json={'name': f'F32-501-{uuid4().hex[:8]}'})
+                assert resp.status_code in (200, 201), resp.text
+                vault_id = UUID(resp.json()['id'])
+
+                resp2 = c.get(f'/api/v1/diagnostics/manifold/{vault_id}')
+                assert resp2.status_code == 501, resp2.text
+                assert 'umap-learn' in json.dumps(resp2.json()).lower()

--- a/packages/core/tests/integration/test_int_f32_heatmap.py
+++ b/packages/core/tests/integration/test_int_f32_heatmap.py
@@ -1,0 +1,105 @@
+"""F32 heatmap — integration test (Test 4)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core.diagnostics import compute_heatmap
+from memex_core.diagnostics.umap import cache_path_for
+from memex_core.memory.sql_models import (
+    Entity,
+    MemoryUnit,
+    Note,
+    UnitEntity,
+    Vault,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_top_50_entities_no_manifold_dep(
+    session: AsyncSession,
+    metastore,
+    filestore,
+):
+    """Seed 60 entities with varied (success, failure) counts on a single MemoryUnit.
+    Expect top-50 returned ordered by volume DESC. No manifold cache file written."""
+    vault = Vault(name=f'F32-heatmap-{uuid4().hex[:8]}')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+
+    note = Note(
+        id=uuid4(),
+        vault_id=vault.id,
+        content_hash='hash',
+        original_text='heatmap seed',
+    )
+    session.add(note)
+    await session.commit()
+
+    now = datetime.now(timezone.utc)
+    unit = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault.id,
+        note_id=note.id,
+        text='unit',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        is_deprioritized=False,
+        event_date=now,
+        embedding=[0.1] * 384,
+    )
+    session.add(unit)
+    await session.commit()
+
+    n_entities = 60
+    entities: list[Entity] = []
+    for i in range(n_entities):
+        entities.append(Entity(canonical_name=f'E{i:03d}'))
+    session.add_all(entities)
+    await session.commit()
+    for e in entities:
+        await session.refresh(e)
+
+    links: list[UnitEntity] = []
+    for i, e in enumerate(entities):
+        # Volume = success + failure spans 1..120 with varied success/failure mix
+        success = i + 1
+        failure = n_entities - i
+        links.append(
+            UnitEntity(
+                unit_id=unit.id,
+                entity_id=e.id,
+                vault_id=vault.id,
+                success_co_count=success,
+                failure_co_count=failure,
+            )
+        )
+    session.add_all(links)
+    await session.commit()
+
+    result = await compute_heatmap(metastore, vault.id, top_n=50)
+
+    assert result['vault_id'] == str(vault.id)
+    assert result['top_n'] == 50
+    out = result['entities']
+    assert len(out) == 50
+
+    volumes = [row['volume'] for row in out]
+    assert volumes == sorted(volumes, reverse=True)
+
+    # Highest-volume entity expected: success_co_count + failure_co_count maximal.
+    # success = i+1, failure = 60-i → volume = 61 for every i. With ties the
+    # secondary sort is avg_mw DESC, where avg_mw = (i+2) / 63 — so the entity
+    # with the largest i (E059) wins. Just assert the volume is the maximal 61.
+    assert out[0]['volume'] == 61
+
+    # No manifold cache file written by the heatmap path.
+    manifold_path = cache_path_for(vault.id)
+    assert not await filestore.exists(manifold_path)

--- a/packages/core/tests/integration/test_int_f32_metrics.py
+++ b/packages/core/tests/integration/test_int_f32_metrics.py
@@ -1,0 +1,60 @@
+"""F32 Prometheus metrics — integration test (Test 6)."""
+
+from __future__ import annotations
+
+import os
+from typing import Generator
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+from testcontainers.postgres import PostgresContainer
+
+
+def _build_env_vars(container: PostgresContainer, tmp_path) -> dict[str, str]:
+    dsn = container.get_connection_url()
+    parsed = urlparse(dsn)
+    return {
+        'MEMEX_LOAD_LOCAL_CONFIG': 'false',
+        'MEMEX_LOAD_GLOBAL_CONFIG': 'false',
+        'MEMEX_SERVER__META_STORE__TYPE': 'postgres',
+        'MEMEX_SERVER__META_STORE__INSTANCE__HOST': parsed.hostname or 'localhost',
+        'MEMEX_SERVER__META_STORE__INSTANCE__PORT': str(parsed.port or 5432),
+        'MEMEX_SERVER__META_STORE__INSTANCE__DATABASE': parsed.path.lstrip('/'),
+        'MEMEX_SERVER__META_STORE__INSTANCE__USER': parsed.username or 'test',
+        'MEMEX_SERVER__META_STORE__INSTANCE__PASSWORD': parsed.password or 'test',
+        'MEMEX_SERVER__MEMORY__REFLECTION__BACKGROUND_REFLECTION_ENABLED': 'false',
+        'MEMEX_SERVER__FILE_STORE__TYPE': 'local',
+        'MEMEX_SERVER__FILE_STORE__ROOT': str(tmp_path),
+    }
+
+
+@pytest.fixture
+def metrics_client(
+    postgres_container: PostgresContainer,
+    tmp_path,
+) -> Generator[TestClient, None, None]:
+    env = _build_env_vars(postgres_container, tmp_path)
+    from memex_core.server import app
+
+    with patch.dict(os.environ, env):
+        with TestClient(app) as c:
+            yield c
+
+
+@pytest.mark.integration
+def test_prometheus_counters_emitted(metrics_client: TestClient):
+    """The three F32 metrics are registered and exposed at /api/v1/metrics."""
+    # Touch the module so the collectors register against the global registry,
+    # even before any compute fires.
+    import memex_core.metrics  # noqa: F401
+
+    resp = metrics_client.get('/api/v1/metrics')
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Each metric has at least a HELP line registered, even with zero observations.
+    assert 'memex_diagnostics_manifold_compute_seconds' in body
+    assert 'memex_diagnostics_cache_hits_total' in body
+    assert 'memex_diagnostics_cache_misses_total' in body

--- a/packages/core/tests/integration/test_int_f32_scheduler.py
+++ b/packages/core/tests/integration/test_int_f32_scheduler.py
@@ -1,0 +1,53 @@
+"""F32 scheduler — leader-lock task registration (Test 7).
+
+Per RFC-009 + AC-X-8 (single-leader invariant): the F32 weekly manifold
+refresh registers under the existing ``MEMEX_LEADER_LOCK_ID`` advisory lock,
+not a new one. This test verifies the task registration is reachable on the
+scheduler module, that ``periodic_diagnostics_refresh_task`` exists, and that
+``run_diagnostics_refresh`` appears as a registered ``@clock.task`` line under
+the existing leader-lock loop.
+
+Note: the lock-site invariant ("only MEMEX_LEADER_LOCK_ID is used at runtime")
+is enforced by the seed PR's ``test_runtime_advisory_lock_invariant_pre_f9``;
+this test is the F32 task-registration cousin of that invariant.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from memex_core import scheduler
+
+
+@pytest.mark.integration
+def test_diagnostics_refresh_registered_under_leader_lock():
+    # 1. The helper exists and is async.
+    assert hasattr(scheduler, 'periodic_diagnostics_refresh_task')
+    assert inspect.iscoroutinefunction(scheduler.periodic_diagnostics_refresh_task)
+
+    # 2. The helper uses background_session (cooperates with the runtime
+    #    background-session contract that other periodic tasks share).
+    src_helper = inspect.getsource(scheduler.periodic_diagnostics_refresh_task)
+    assert 'background_session' in src_helper
+    assert "'bg-sched-diagnostics-refresh'" in src_helper
+
+    # 3. The leader-lock loop registers a task named ``run_diagnostics_refresh``
+    #    via ``@clock.task`` with a weekly Every() trigger, and that task body
+    #    awaits the helper. We assert the registration shape on the source of
+    #    ``run_scheduler_with_leader_election`` — the lock-site itself uses
+    #    MEMEX_LEADER_LOCK_ID (verified by the seed PR's pre-F9 invariant test).
+    src_loop = inspect.getsource(scheduler.run_scheduler_with_leader_election)
+    assert 'run_diagnostics_refresh' in src_loop
+    assert 'periodic_diagnostics_refresh_task(api)' in src_loop
+    assert 'Every(seconds=7 * 86400)' in src_loop
+
+    # 4. AC-X-8 invariant cousin: the F32 task does NOT introduce its own
+    #    advisory-lock id. Only ``MEMEX_LEADER_LOCK_ID`` is referenced inside
+    #    the loop function — no other ``advisory_lock`` calls.
+    assert src_loop.count('MEMEX_LEADER_LOCK_ID') >= 1
+    # No new pg_try_advisory_lock or pg_advisory_unlock calls beyond the
+    # existing leader loop's pair — simple word-count assertion.
+    assert src_loop.count('pg_try_advisory_lock') == 1
+    assert src_loop.count('pg_advisory_unlock') == 1

--- a/packages/core/tests/integration/test_int_f32_umap_cache.py
+++ b/packages/core/tests/integration/test_int_f32_umap_cache.py
@@ -1,0 +1,132 @@
+"""F32 UMAP cache — cold/warm/status integration tests (Test 2)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core.config import MemexConfig
+from memex_core.diagnostics.umap import cache_path_for
+from memex_core.memory.sql_models import MemoryUnit, Note, Vault
+from memex_core.services.diagnostics import DiagnosticsService
+
+
+async def _seed_minimal_vault(session: AsyncSession) -> Vault:
+    vault = Vault(name=f'F32-cache-{uuid4().hex[:8]}')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+
+    note = Note(id=uuid4(), vault_id=vault.id, content_hash='h', original_text='seed')
+    session.add(note)
+    await session.commit()
+
+    now = datetime.now(timezone.utc)
+    units = [
+        MemoryUnit(
+            id=uuid4(),
+            vault_id=vault.id,
+            note_id=note.id,
+            text=f'unit {i}',
+            fact_type=FactTypes.WORLD,
+            status='active',
+            event_date=now,
+            embedding=[0.1 * (i + 1)] * 384,
+        )
+        for i in range(5)
+    ]
+    session.add_all(units)
+    await session.commit()
+    return vault
+
+
+async def _wait_for_cache(filestore, vault_id, timeout: float = 5.0) -> None:
+    path = cache_path_for(vault_id)
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if await filestore.exists(path):
+            return
+        await asyncio.sleep(0.05)
+    raise TimeoutError(f'Cache file did not appear: {path}')
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_cold_kicks_off_compute_returns_task_id(
+    session: AsyncSession,
+    metastore,
+    filestore,
+    memex_config: MemexConfig,
+):
+    """First request on cold cache returns ('computing', {task_id})."""
+    vault = await _seed_minimal_vault(session)
+    service = DiagnosticsService(metastore=metastore, filestore=filestore, config=memex_config)
+    try:
+        status, payload = await service.get_or_compute_manifold(vault.id)
+        assert status == 'computing'
+        assert 'task_id' in payload
+        assert isinstance(payload['task_id'], str)
+    finally:
+        await service.shutdown()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_warm_after_compute_returns_ready(
+    session: AsyncSession,
+    metastore,
+    filestore,
+    memex_config: MemexConfig,
+):
+    """After compute completes, second call returns ('ready', cached_payload)."""
+    vault = await _seed_minimal_vault(session)
+    service = DiagnosticsService(metastore=metastore, filestore=filestore, config=memex_config)
+    try:
+        status1, _ = await service.get_or_compute_manifold(vault.id)
+        assert status1 == 'computing'
+
+        await _wait_for_cache(filestore, vault.id, timeout=120.0)
+
+        status2, payload2 = await service.get_or_compute_manifold(vault.id)
+        assert status2 == 'ready'
+        assert payload2 is not None
+        assert payload2['vault_id'] == str(vault.id)
+        assert 'cache_key' in payload2
+        assert 'points' in payload2
+    finally:
+        await service.shutdown()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_status_returns_ready_after_compute(
+    session: AsyncSession,
+    metastore,
+    filestore,
+    memex_config: MemexConfig,
+):
+    """status endpoint backing returns 'ready' once compute is done."""
+    vault = await _seed_minimal_vault(session)
+    service = DiagnosticsService(metastore=metastore, filestore=filestore, config=memex_config)
+    try:
+        status1, payload1 = await service.get_or_compute_manifold(vault.id)
+        assert status1 == 'computing'
+        task_id = payload1['task_id']
+
+        await _wait_for_cache(filestore, vault.id, timeout=120.0)
+        await asyncio.sleep(0.1)
+
+        # status() with the original task_id should resolve to ready (the
+        # task ran to completion and registry callback cleared it; the cache
+        # file exists, so warm_cache_hit returns the payload).
+        status2, payload2 = await service.get_manifold_status(vault.id, task_id)
+        assert status2 == 'ready'
+        assert payload2 is not None
+        assert payload2['vault_id'] == str(vault.id)
+    finally:
+        await service.shutdown()

--- a/packages/core/tests/integration/test_migrations.py
+++ b/packages/core/tests/integration/test_migrations.py
@@ -178,16 +178,20 @@ class TestMigration002:
         await engine.dispose()
 
     @pytest.mark.asyncio
-    async def test_full_upgrade_to_head(self, clean_db, postgres_uri):
-        """Running upgrade to head from scratch works end-to-end."""
-        _run_alembic(postgres_uri, 'upgrade', 'head')
+    async def test_full_upgrade_to_pre_tier_a_baseline(self, clean_db, postgres_uri):
+        """Running upgrade through the pre-Tier-A chain end-to-end works.
+
+        Pinned to ``024_intent_risk_classifier`` (Wave 1 head). Tier A seed PR
+        introduced revisions 025-029 as NIE stubs; running ``upgrade head``
+        here would crash on the first stub. Each Tier A feature PR adds its
+        own ``test_int_alembic_NNN.py`` to exercise its filled-in body.
+        """
+        _run_alembic(postgres_uri, 'upgrade', '024_intent_risk_classifier')
 
         engine = create_async_engine(postgres_uri, poolclass=NullPool)
         async with engine.connect() as conn:
-            from memex_core.migration import get_expected_head
-
             result = await conn.execute(text('SELECT version_num FROM alembic_version'))
-            assert result.scalar() == get_expected_head()
+            assert result.scalar() == '024_intent_risk_classifier'
         await engine.dispose()
 
     @pytest.mark.asyncio

--- a/packages/core/tests/unit/conftest.py
+++ b/packages/core/tests/unit/conftest.py
@@ -206,6 +206,13 @@ def mock_config():
     config.server.memory.extraction.model.model = 'test-model'
     config.server.logging.level = 'WARNING'
     config.server.logging.json_output = False
+    # F5: real ints so TokenBucketRateLimiter validation passes; disabled
+    # so unit tests don't get throttled across iterations.
+    rate_cfg = config.server.memory.reflection.summarize_node_rate_limit
+    rate_cfg.enabled = False
+    rate_cfg.per_entity_per_seconds = 60
+    rate_cfg.burst = 1
+    rate_cfg.max_keys = 1000
     return config
 
 

--- a/packages/core/tests/unit/memory/reflect/test_reflection_engine_batch.py
+++ b/packages/core/tests/unit/memory/reflect/test_reflection_engine_batch.py
@@ -20,6 +20,15 @@ def engine(mock_session):
     return ReflectionEngine(session=mock_session, config=mock_config, embedder=MagicMock())
 
 
+@pytest.fixture
+def engine_relaxed_config(mock_session):
+    """Engine with a real default MemexConfig so deep attribute access works
+    (e.g. ``config.server.memory.reflection.max_concurrency``). The defaults
+    leave the reflection model as None, so the LM-init path is skipped.
+    """
+    return ReflectionEngine(session=mock_session, config=MemexConfig(), embedder=MagicMock())
+
+
 @pytest.mark.asyncio
 async def test_batch_fetch_recent_memories_sql_structure(engine, mock_session):
     """
@@ -53,6 +62,152 @@ async def test_batch_fetch_recent_memories_sql_structure(engine, mock_session):
 
     # Inspect the call args to sanity check logic (hard to verify exact SQL string with mocks,
     # but we check if it didn't crash during construction)
+
+
+@pytest.mark.asyncio
+async def test_batch_fetch_recent_memories_unbounded_caps_at_max_full_scope(
+    engine_relaxed_config, mock_session
+):
+    engine = engine_relaxed_config
+    """TC3 (CONCERN-2): limit_per_entity=None caps at MAX_FULL_SCOPE_UNITS in SQL.
+
+    The outer query's `WHERE rn <= effective_limit` clause must use 1000
+    when the caller requests 'no per-request cap' (F5 scope='full').
+    """
+    from memex_core.memory.reflect.reflection import MAX_FULL_SCOPE_UNITS
+
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    mock_session.exec.return_value = mock_result
+
+    await engine._batch_fetch_recent_memories([uuid4()], limit_per_entity=None)
+
+    mock_session.exec.assert_called_once()
+    query = mock_session.exec.call_args.args[0]
+    compiled = query.compile(compile_kwargs={'literal_binds': True})
+    rendered = str(compiled).replace('\n', ' ')
+    assert f'rn <= {MAX_FULL_SCOPE_UNITS}' in rendered, (
+        f'expected SQL to bind rn <= {MAX_FULL_SCOPE_UNITS}; got: {rendered}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_reflect_batch_derives_max_limit_for_mixed_batch(engine_relaxed_config, mock_session):
+    engine = engine_relaxed_config
+    """TC2.5 (CONCERN-1): mixed-limit batch picks the most-permissive limit.
+
+    Two requests in the same batch, one with limit=20 and one with limit=None,
+    must produce a single SQL fetch with the unbounded path
+    (which is then capped at MAX_FULL_SCOPE_UNITS by the engine).
+    """
+    from memex_core.memory.reflect.models import ReflectionRequest
+    from memex_core.memory.reflect.reflection import MAX_FULL_SCOPE_UNITS
+
+    eid_a, eid_b = uuid4(), uuid4()
+    requests = [
+        ReflectionRequest(entity_id=eid_a, limit_recent_memories=20),
+        ReflectionRequest(entity_id=eid_b, limit_recent_memories=None),
+    ]
+
+    captured_limits: list[int | None] = []
+
+    async def _fake_fetch(entity_ids, vault_id=None, limit_per_entity=20):
+        captured_limits.append(limit_per_entity)
+        return {eid: [] for eid in entity_ids}
+
+    engine._batch_fetch_recent_memories = _fake_fetch  # type: ignore[method-assign]
+    engine._batch_get_or_create_models = AsyncMock(
+        return_value={eid_a: MagicMock(), eid_b: MagicMock()}
+    )
+    engine._batch_get_entities = AsyncMock(return_value={})
+    # Stub the per-entity processing path so the test focuses on the batch fetch.
+    engine._process_entity_reflection = AsyncMock(return_value=None)
+
+    await engine.reflect_batch(requests)
+
+    assert captured_limits == [None], (
+        f'Expected single fetch with limit=None (unbounded → capped at {MAX_FULL_SCOPE_UNITS}); '
+        f'got {captured_limits}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_reflect_batch_max_when_all_bounded(engine_relaxed_config, mock_session):
+    engine = engine_relaxed_config
+    """When all requests carry int limits, the batch fetch uses max(limits)."""
+    from memex_core.memory.reflect.models import ReflectionRequest
+
+    eid_a, eid_b = uuid4(), uuid4()
+    requests = [
+        ReflectionRequest(entity_id=eid_a, limit_recent_memories=20),
+        ReflectionRequest(entity_id=eid_b, limit_recent_memories=50),
+    ]
+
+    captured_limits: list[int | None] = []
+
+    async def _fake_fetch(entity_ids, vault_id=None, limit_per_entity=20):
+        captured_limits.append(limit_per_entity)
+        return {eid: [] for eid in entity_ids}
+
+    engine._batch_fetch_recent_memories = _fake_fetch  # type: ignore[method-assign]
+    engine._batch_get_or_create_models = AsyncMock(
+        return_value={eid_a: MagicMock(), eid_b: MagicMock()}
+    )
+    engine._batch_get_entities = AsyncMock(return_value={})
+    engine._process_entity_reflection = AsyncMock(return_value=None)
+    await engine.reflect_batch(requests)
+
+    assert captured_limits == [50]
+
+
+@pytest.mark.asyncio
+async def test_process_entity_reflection_slices_per_request(engine):
+    """TC2.5 slice-side: per-request limit is honoured even when the batch
+    fetch returned more units than the smaller request's limit allows.
+    """
+    from memex_core.memory.reflect.models import ReflectionRequest
+
+    eid = uuid4()
+    units = [MagicMock(name=f'u{i}') for i in range(30)]
+    memories_map = {eid: units}
+
+    captured = {}
+
+    async def _fake_internal(
+        *, entity_id, mental_model, entity, recent_memories, db_lock, vault_id
+    ):
+        captured['recent_memories'] = recent_memories
+        return MagicMock()
+
+    engine._reflect_entity_internal = _fake_internal  # type: ignore[method-assign]
+
+    import asyncio
+
+    sem = asyncio.Semaphore(1)
+    db_lock = asyncio.Lock()
+
+    req = ReflectionRequest(entity_id=eid, limit_recent_memories=20)
+    await engine._process_entity_reflection(
+        req=req,
+        models_map={eid: MagicMock()},
+        entities_map={},
+        memories_map=memories_map,
+        sem=sem,
+        db_lock=db_lock,
+    )
+    assert len(captured['recent_memories']) == 20
+
+    # And with limit=None, the full pre-capped fetch is passed through.
+    req_full = ReflectionRequest(entity_id=eid, limit_recent_memories=None)
+    await engine._process_entity_reflection(
+        req=req_full,
+        models_map={eid: MagicMock()},
+        entities_map={},
+        memories_map=memories_map,
+        sem=sem,
+        db_lock=db_lock,
+    )
+    assert len(captured['recent_memories']) == 30
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/unit/services/test_rate_limit.py
+++ b/packages/core/tests/unit/services/test_rate_limit.py
@@ -1,0 +1,92 @@
+"""Unit tests for TokenBucketRateLimiter (F5 TC1).
+
+Frozen-clock pattern per TS guidance: a list-based clock advances only when
+the test code chooses, so refill timing is deterministic regardless of
+wall-clock variance.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memex_core.services.rate_limit import RateLimitExceededError, TokenBucketRateLimiter
+
+
+class _FrozenClock:
+    """Monotonic clock stub. ``advance(seconds)`` moves it forward."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self._t = start
+
+    def __call__(self) -> float:
+        return self._t
+
+    def advance(self, seconds: float) -> None:
+        self._t += seconds
+
+
+def test_bucket_drain_and_refill():
+    """Bucket allows `burst` calls then blocks; refills after per_seconds elapses."""
+    clock = _FrozenClock()
+    limiter = TokenBucketRateLimiter(per_seconds=60.0, burst=1, clock=clock)
+
+    limiter.acquire('entity-A')
+
+    with pytest.raises(RateLimitExceededError) as exc:
+        limiter.acquire('entity-A')
+    assert 0 < exc.value.retry_after_seconds <= 60.0
+    assert exc.value.key == 'entity-A'
+
+    clock.advance(60.0)
+    limiter.acquire('entity-A')
+
+
+def test_per_key_isolation():
+    """A blocked key does not block other keys."""
+    clock = _FrozenClock()
+    limiter = TokenBucketRateLimiter(per_seconds=60.0, burst=1, clock=clock)
+
+    limiter.acquire(('entity-A', 'vault-X'))
+    with pytest.raises(RateLimitExceededError):
+        limiter.acquire(('entity-A', 'vault-X'))
+
+    limiter.acquire(('entity-B', 'vault-X'))
+    limiter.acquire(('entity-A', 'vault-Y'))
+
+
+def test_enabled_false_is_passthrough():
+    """When enabled=False, acquire never raises."""
+    clock = _FrozenClock()
+    limiter = TokenBucketRateLimiter(per_seconds=60.0, burst=1, enabled=False, clock=clock)
+    for _ in range(100):
+        limiter.acquire('entity-A')
+
+
+def test_burst_capacity_allows_back_to_back_calls_within_window():
+    """burst=N permits N back-to-back calls before blocking."""
+    clock = _FrozenClock()
+    limiter = TokenBucketRateLimiter(per_seconds=60.0, burst=3, clock=clock)
+    limiter.acquire('A')
+    limiter.acquire('A')
+    limiter.acquire('A')
+    with pytest.raises(RateLimitExceededError):
+        limiter.acquire('A')
+
+
+def test_lru_eviction_caps_tracked_keys():
+    """Once max_keys is exceeded, oldest key is evicted; eviction does not raise."""
+    clock = _FrozenClock()
+    limiter = TokenBucketRateLimiter(per_seconds=60.0, burst=1, max_keys=2, clock=clock)
+    limiter.acquire('A')
+    limiter.acquire('B')
+    limiter.acquire('C')
+    limiter.acquire('A')
+
+
+def test_invalid_config_raises():
+    with pytest.raises(ValueError):
+        TokenBucketRateLimiter(per_seconds=0)
+    with pytest.raises(ValueError):
+        TokenBucketRateLimiter(per_seconds=60, burst=0)
+    with pytest.raises(ValueError):
+        TokenBucketRateLimiter(per_seconds=60, max_keys=0)

--- a/packages/core/tests/unit/services/test_rate_limit.py
+++ b/packages/core/tests/unit/services/test_rate_limit.py
@@ -25,62 +25,67 @@ class _FrozenClock:
         self._t += seconds
 
 
-def test_bucket_drain_and_refill():
+@pytest.mark.asyncio
+async def test_bucket_drain_and_refill():
     """Bucket allows `burst` calls then blocks; refills after per_seconds elapses."""
     clock = _FrozenClock()
     limiter = TokenBucketRateLimiter(per_seconds=60.0, burst=1, clock=clock)
 
-    limiter.acquire('entity-A')
+    await limiter.acquire('entity-A')
 
     with pytest.raises(RateLimitExceededError) as exc:
-        limiter.acquire('entity-A')
+        await limiter.acquire('entity-A')
     assert 0 < exc.value.retry_after_seconds <= 60.0
     assert exc.value.key == 'entity-A'
 
     clock.advance(60.0)
-    limiter.acquire('entity-A')
+    await limiter.acquire('entity-A')
 
 
-def test_per_key_isolation():
+@pytest.mark.asyncio
+async def test_per_key_isolation():
     """A blocked key does not block other keys."""
     clock = _FrozenClock()
     limiter = TokenBucketRateLimiter(per_seconds=60.0, burst=1, clock=clock)
 
-    limiter.acquire(('entity-A', 'vault-X'))
+    await limiter.acquire(('entity-A', 'vault-X'))
     with pytest.raises(RateLimitExceededError):
-        limiter.acquire(('entity-A', 'vault-X'))
+        await limiter.acquire(('entity-A', 'vault-X'))
 
-    limiter.acquire(('entity-B', 'vault-X'))
-    limiter.acquire(('entity-A', 'vault-Y'))
+    await limiter.acquire(('entity-B', 'vault-X'))
+    await limiter.acquire(('entity-A', 'vault-Y'))
 
 
-def test_enabled_false_is_passthrough():
+@pytest.mark.asyncio
+async def test_enabled_false_is_passthrough():
     """When enabled=False, acquire never raises."""
     clock = _FrozenClock()
     limiter = TokenBucketRateLimiter(per_seconds=60.0, burst=1, enabled=False, clock=clock)
     for _ in range(100):
-        limiter.acquire('entity-A')
+        await limiter.acquire('entity-A')
 
 
-def test_burst_capacity_allows_back_to_back_calls_within_window():
+@pytest.mark.asyncio
+async def test_burst_capacity_allows_back_to_back_calls_within_window():
     """burst=N permits N back-to-back calls before blocking."""
     clock = _FrozenClock()
     limiter = TokenBucketRateLimiter(per_seconds=60.0, burst=3, clock=clock)
-    limiter.acquire('A')
-    limiter.acquire('A')
-    limiter.acquire('A')
+    await limiter.acquire('A')
+    await limiter.acquire('A')
+    await limiter.acquire('A')
     with pytest.raises(RateLimitExceededError):
-        limiter.acquire('A')
+        await limiter.acquire('A')
 
 
-def test_lru_eviction_caps_tracked_keys():
+@pytest.mark.asyncio
+async def test_lru_eviction_caps_tracked_keys():
     """Once max_keys is exceeded, oldest key is evicted; eviction does not raise."""
     clock = _FrozenClock()
     limiter = TokenBucketRateLimiter(per_seconds=60.0, burst=1, max_keys=2, clock=clock)
-    limiter.acquire('A')
-    limiter.acquire('B')
-    limiter.acquire('C')
-    limiter.acquire('A')
+    await limiter.acquire('A')
+    await limiter.acquire('B')
+    await limiter.acquire('C')
+    await limiter.acquire('A')
 
 
 def test_invalid_config_raises():

--- a/packages/core/tests/unit/services/test_summarize_node_service.py
+++ b/packages/core/tests/unit/services/test_summarize_node_service.py
@@ -1,0 +1,103 @@
+"""Unit tests for ReflectionService.summarize_node (F5 service-layer).
+
+Covers TC4 (rate-limit error path) at the unit level. TC2/TC3/TC2.5
+remain in integration tests against a real DB. The unit test asserts
+the service produces a service-layer ``RateLimitExceededError`` (NOT a
+fastapi HTTPException) per RFC-002 alt-D rejection.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from memex_core.services.rate_limit import (
+    RateLimitExceededError,
+    TokenBucketRateLimiter,
+)
+
+
+@pytest.fixture
+def reflection_service(mock_metastore, mock_config):
+    """Build a ReflectionService with the rate limiter forced ON.
+
+    The default ``mock_config`` disables the limiter for tests that don't
+    care about throttling. Tests that DO care (TC4) toggle it on by
+    swapping in a real, enabled bucket on the constructed service.
+    """
+    from memex_core.services.reflection import ReflectionService
+
+    svc = ReflectionService(
+        metastore=mock_metastore,
+        config=mock_config,
+        lm=MagicMock(),
+        memory=MagicMock(),
+        extraction=MagicMock(),
+        queue_service=MagicMock(),
+        embedding_model=MagicMock(),
+    )
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_summarize_node_passes_through_when_rate_limit_disabled(reflection_service):
+    """TC sanity: with the limiter disabled (default), summarize_node delegates to reflect."""
+    expected = MagicMock()
+    reflection_service.reflect = AsyncMock(return_value=expected)
+    entity_id = uuid4()
+    result = await reflection_service.summarize_node(entity_id, scope='incremental')
+    assert result is expected
+    reflection_service.reflect.assert_awaited_once()
+    assert reflection_service.reflect.await_args is not None
+    request_arg = reflection_service.reflect.await_args.args[0]
+    assert request_arg.entity_id == entity_id
+    assert request_arg.limit_recent_memories == 20
+
+
+@pytest.mark.asyncio
+async def test_summarize_node_full_scope_passes_none_limit(reflection_service):
+    """scope='full' translates to limit_recent_memories=None on the request."""
+    reflection_service.reflect = AsyncMock(return_value=MagicMock())
+    entity_id = uuid4()
+    await reflection_service.summarize_node(entity_id, scope='full')
+    assert reflection_service.reflect.await_args is not None
+    request_arg = reflection_service.reflect.await_args.args[0]
+    assert request_arg.limit_recent_memories is None
+
+
+@pytest.mark.asyncio
+async def test_summarize_node_rate_limit_exceeded_raises_with_retry_after(reflection_service):
+    """TC4: second back-to-back call raises RateLimitExceededError with retry_after_seconds."""
+    reflection_service.reflect = AsyncMock(return_value=MagicMock())
+
+    # Swap in an enabled limiter that will reject the second call.
+    reflection_service._summarize_node_limiter = TokenBucketRateLimiter(
+        per_seconds=60.0, burst=1, enabled=True
+    )
+
+    entity_id = uuid4()
+    vault_id = uuid4()
+    await reflection_service.summarize_node(entity_id, scope='incremental', vault_id=vault_id)
+
+    with pytest.raises(RateLimitExceededError) as exc:
+        await reflection_service.summarize_node(entity_id, scope='incremental', vault_id=vault_id)
+    assert 0 < exc.value.retry_after_seconds <= 60.0
+    assert exc.value.key == (entity_id, vault_id)
+    assert reflection_service.reflect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_summarize_node_rate_limit_keys_per_entity_and_vault(reflection_service):
+    """Two distinct (entity, vault) keys do not throttle each other."""
+    reflection_service.reflect = AsyncMock(return_value=MagicMock())
+    reflection_service._summarize_node_limiter = TokenBucketRateLimiter(
+        per_seconds=60.0, burst=1, enabled=True
+    )
+
+    eid_a, eid_b = uuid4(), uuid4()
+    vault = uuid4()
+    await reflection_service.summarize_node(eid_a, scope='incremental', vault_id=vault)
+    await reflection_service.summarize_node(eid_b, scope='incremental', vault_id=vault)
+    assert reflection_service.reflect.await_count == 2

--- a/packages/core/tests/unit/services/test_units_service.py
+++ b/packages/core/tests/unit/services/test_units_service.py
@@ -1,0 +1,137 @@
+"""Unit tests for UnitsService (F4 — deprioritize / restore).
+
+T3: AuditService.log is called with the exact contract AC-F4-2 specifies.
+No DB; the metastore is a stand-in async context manager that yields a
+`session` whose `.get()` returns a real `MemoryUnit` row built in-memory.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from memex_core.memory.sql_models import MemoryUnit
+from memex_core.services.units import UnitsService
+
+
+class _StubMetastore:
+    """Minimal async metastore: ``async with metastore.session()`` yields a stub session."""
+
+    def __init__(self, unit: MemoryUnit | None) -> None:
+        self._unit = unit
+        self.added: list[MemoryUnit] = []
+        self.commits = 0
+        self.refreshes = 0
+
+    @asynccontextmanager
+    async def session(self):
+        meta = self
+
+        class _StubSession:
+            async def get(self, model, unit_id):
+                return meta._unit
+
+            def add(self, obj):
+                meta.added.append(obj)
+
+            async def commit(self):
+                meta.commits += 1
+
+            async def refresh(self, obj):
+                meta.refreshes += 1
+
+        yield _StubSession()
+
+
+def _make_service(unit: MemoryUnit | None) -> tuple[UnitsService, _StubMetastore, MagicMock]:
+    metastore = _StubMetastore(unit)
+    service = UnitsService.__new__(UnitsService)
+    service.metastore = metastore  # type: ignore[assignment]
+    service.filestore = None  # type: ignore[assignment]
+    service.config = None  # type: ignore[assignment]
+    audit_mock = MagicMock()
+    service._audit_service = audit_mock  # type: ignore[attr-defined]
+    return service, metastore, audit_mock
+
+
+@pytest.mark.asyncio
+async def test_set_unit_deprioritized_writes_audit_with_exact_kwargs():
+    """T3: AuditService.log called once with action='memory_deprioritize',
+    resource_type='memory_unit', correct resource_id, details, and
+    background_tasks forwarded.
+
+    session_id is populated from the request-scoped ContextVar — assert it
+    is forwarded (any value), but don't pin a specific value here.
+    """
+    unit_id = uuid4()
+    unit = MemoryUnit(
+        id=unit_id,
+        vault_id=uuid4(),
+        type='fact',
+        text='example',
+        is_deprioritized=False,
+    )
+    service, metastore, audit_mock = _make_service(unit)
+    bg_tasks = MagicMock()
+
+    result = await service.set_unit_deprioritized(
+        unit_id, reason='it was wrong', actor='agent:claude', background_tasks=bg_tasks
+    )
+
+    assert result.is_deprioritized is True
+    assert metastore.commits == 1
+    assert audit_mock.log.call_count == 1
+    kwargs = audit_mock.log.call_args.kwargs
+    assert kwargs['action'] == 'memory_deprioritize'
+    assert kwargs['actor'] == 'agent:claude'
+    assert kwargs['resource_type'] == 'memory_unit'
+    assert kwargs['resource_id'] == str(unit_id)
+    assert kwargs['details'] == {'reason': 'it was wrong'}
+    assert kwargs['background_tasks'] is bg_tasks
+    assert 'session_id' in kwargs
+
+
+@pytest.mark.asyncio
+async def test_restore_unit_writes_audit_without_reason():
+    """T3 (restore variant): AuditService.log called with action='memory_restore'
+    and details=None (no reason for restore).
+    """
+    unit_id = uuid4()
+    unit = MemoryUnit(
+        id=unit_id,
+        vault_id=uuid4(),
+        type='fact',
+        text='example',
+        is_deprioritized=True,
+    )
+    service, metastore, audit_mock = _make_service(unit)
+    bg_tasks = MagicMock()
+
+    result = await service.restore_unit(unit_id, actor='agent:claude', background_tasks=bg_tasks)
+
+    assert result.is_deprioritized is False
+    assert metastore.commits == 1
+    assert audit_mock.log.call_count == 1
+    kwargs = audit_mock.log.call_args.kwargs
+    assert kwargs['action'] == 'memory_restore'
+    assert kwargs['actor'] == 'agent:claude'
+    assert kwargs['resource_type'] == 'memory_unit'
+    assert kwargs['resource_id'] == str(unit_id)
+    assert kwargs['details'] is None
+    assert kwargs['background_tasks'] is bg_tasks
+
+
+@pytest.mark.asyncio
+async def test_set_unit_deprioritized_raises_when_unit_missing():
+    """Unit not found → raises MemoryUnitNotFoundError; no audit row written."""
+    from memex_common.exceptions import MemoryUnitNotFoundError
+
+    service, _, audit_mock = _make_service(None)
+    with pytest.raises(MemoryUnitNotFoundError):
+        await service.set_unit_deprioritized(
+            uuid4(), reason='ignored', actor='x', background_tasks=None
+        )
+    audit_mock.log.assert_not_called()

--- a/packages/core/tests/unit/test_diagnostics_cache_key.py
+++ b/packages/core/tests/unit/test_diagnostics_cache_key.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from memex_core.diagnostics import cache_key
+
+
+def test_cache_key_invalidates_on_ingestion():
+    vault_id = uuid4()
+    t0 = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+    t1 = t0 + timedelta(seconds=1)
+
+    k_before = cache_key(vault_id, 10, t0)
+    k_after = cache_key(vault_id, 11, t1)
+
+    assert k_before != k_after
+    assert len(k_before) == 64
+    assert len(k_after) == 64
+
+
+def test_cache_key_per_vault():
+    vault_a = uuid4()
+    vault_b = uuid4()
+    t = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+    assert cache_key(vault_a, 10, t) != cache_key(vault_b, 10, t)
+
+
+def test_cache_key_count_zero():
+    vault_id = uuid4()
+    t = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+    k_empty = cache_key(vault_id, 0, None)
+    k_one = cache_key(vault_id, 1, t)
+
+    assert k_empty != k_one
+    assert len(k_empty) == 64
+
+
+def test_cache_key_deterministic():
+    vault_id = uuid4()
+    t = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+    k1 = cache_key(vault_id, 5, t)
+    k2 = cache_key(vault_id, 5, t)
+
+    assert k1 == k2
+
+
+def test_cache_key_param_change_invalidates():
+    vault_id = uuid4()
+    t = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+    k_default = cache_key(vault_id, 10, t)
+    k_alt = cache_key(vault_id, 10, t, params={'n_neighbors': 30})
+
+    assert k_default != k_alt

--- a/packages/core/tests/unit/test_seed_alembic_stubs.py
+++ b/packages/core/tests/unit/test_seed_alembic_stubs.py
@@ -1,0 +1,78 @@
+"""Unit-level guards for the Tier A seed-PR alembic substrate.
+
+Covers:
+- TC-11-1: chain integrity via ScriptDirectory.walk_revisions() (no DB).
+- TC-11-2: each 025-029 stub raises NotImplementedError on upgrade()/downgrade().
+- TC-11-4: each stub module imports cleanly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib as plb
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+_PACKAGE_ROOT = plb.Path(__file__).resolve().parents[2] / 'src' / 'memex_core'
+_ALEMBIC_INI = _PACKAGE_ROOT / 'alembic.ini'
+_VERSIONS_DIR = _PACKAGE_ROOT / 'alembic' / 'versions'
+
+_TIER_A_STUBS: list[tuple[str, str, str]] = [
+    ('025_maintenance_proposals', '024_intent_risk_classifier', 'F6'),
+    ('026_revisit_columns', '025_maintenance_proposals', 'F20'),
+    ('027_consolidation_ticks', '026_revisit_columns', 'F38'),
+    ('028_procedure_outcomes', '027_consolidation_ticks', 'F14'),
+    ('029_lint_llm_quota', '028_procedure_outcomes', 'F10'),
+]
+
+
+def _load_stub(name: str):
+    src = _VERSIONS_DIR / f'{name}.py'
+    spec = importlib.util.spec_from_file_location(name, src)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_seed_chain_is_linear_and_correct() -> None:
+    cfg = Config(str(_ALEMBIC_INI))
+    cfg.set_main_option('script_location', str(_PACKAGE_ROOT / 'alembic'))
+    sd = ScriptDirectory.from_config(cfg)
+
+    heads = sd.get_heads()
+    assert heads == ['029_lint_llm_quota'], f'Expected single head 029, got {heads}'
+
+    walk = list(sd.walk_revisions())
+    top5 = [(r.revision, r.down_revision) for r in walk[:5]]
+    expected_top5 = [
+        ('029_lint_llm_quota', '028_procedure_outcomes'),
+        ('028_procedure_outcomes', '027_consolidation_ticks'),
+        ('027_consolidation_ticks', '026_revisit_columns'),
+        ('026_revisit_columns', '025_maintenance_proposals'),
+        ('025_maintenance_proposals', '024_intent_risk_classifier'),
+    ]
+    assert top5 == expected_top5, f'Tier A chain mismatch: got {top5}'
+
+
+@pytest.mark.parametrize('rev,down,fid', _TIER_A_STUBS)
+def test_each_stub_raises_not_implemented(rev: str, down: str, fid: str) -> None:
+    mod = _load_stub(rev)
+    assert mod.revision == rev
+    assert mod.down_revision == down
+    with pytest.raises(NotImplementedError, match=fid):
+        mod.upgrade()
+    with pytest.raises(NotImplementedError, match=fid):
+        mod.downgrade()
+
+
+def test_all_stubs_importable() -> None:
+    for rev, _down, _fid in _TIER_A_STUBS:
+        mod = _load_stub(rev)
+        assert hasattr(mod, 'upgrade')
+        assert hasattr(mod, 'downgrade')
+        assert hasattr(mod, 'revision')
+        assert hasattr(mod, 'down_revision')

--- a/packages/core/tests/unit/test_seed_invariants.py
+++ b/packages/core/tests/unit/test_seed_invariants.py
@@ -1,0 +1,66 @@
+"""TC-11-5 (revised) + TC-11-6: Tier A seed invariants.
+
+- Runtime advisory-lock count: exactly one MEMEX_LEADER_LOCK_ID call site
+  in the runtime path pre-F9. F9 will add exactly one more (entity_lock_id).
+  The migration lock at alembic/env.py is excluded by inspection.
+- Default-target pin guard: no test fixture invokes alembic upgrade with
+  target='head' under Tier A NIE stubs (would crash on revision 025).
+"""
+
+from __future__ import annotations
+
+import pathlib as plb
+
+
+_REPO_ROOT = plb.Path(__file__).resolve().parents[4]
+_CORE_RUNTIME = _REPO_ROOT / 'packages' / 'core' / 'src' / 'memex_core'
+_TEST_DIRS = [
+    _REPO_ROOT / 'tests',
+    _REPO_ROOT / 'packages' / 'core' / 'tests',
+]
+
+
+def test_runtime_advisory_lock_invariant_pre_f9() -> None:
+    runtime_files = [p for p in _CORE_RUNTIME.rglob('*.py') if 'alembic' not in p.parts]
+    leader_sites = [
+        p for p in runtime_files if 'MEMEX_LEADER_LOCK_ID' in p.read_text(encoding='utf-8')
+    ]
+    assert len(leader_sites) == 1, (
+        f'Expected exactly 1 leader-lock call site pre-F9, got {len(leader_sites)}: '
+        f'{[str(p.relative_to(_REPO_ROOT)) for p in leader_sites]}'
+    )
+    assert leader_sites[0].name == 'scheduler.py'
+
+
+def test_no_test_fixture_forces_upgrade_to_head() -> None:
+    self_path = plb.Path(__file__).resolve()
+    offenders: list[str] = []
+    for test_dir in _TEST_DIRS:
+        if not test_dir.exists():
+            continue
+        for p in test_dir.rglob('*.py'):
+            if '__pycache__' in p.parts or p.resolve() == self_path:
+                continue
+            text = p.read_text(encoding='utf-8')
+            for needle in (
+                "target='head'",
+                'target="head"',
+                "'upgrade', 'head'",
+                '"upgrade", "head"',
+            ):
+                if needle in text:
+                    offenders.append(f'{p.relative_to(_REPO_ROOT)} :: {needle!r}')
+    assert not offenders, (
+        f'Tier A NIE-stubs at revisions 025-029 will crash any fixture that '
+        f"upgrades to head; pin to '024_intent_risk_classifier' (or the "
+        f"feature-test's own revision). Offenders: {offenders}"
+    )
+
+
+def test_alembic_helper_default_pinned_to_024() -> None:
+    helper = _REPO_ROOT / 'packages' / 'core' / 'tests' / 'integration' / '_alembic_test_helpers.py'
+    text = helper.read_text(encoding='utf-8')
+    assert "target: str = '024_intent_risk_classifier'" in text, (
+        '_alembic_test_helpers.alembic_upgrade default target must be pinned to '
+        "'024_intent_risk_classifier' under Tier A NIE stubs"
+    )

--- a/packages/core/tests/unit/test_seed_labelled_spans.py
+++ b/packages/core/tests/unit/test_seed_labelled_spans.py
@@ -1,0 +1,88 @@
+"""TC-11-3: Tier A labelled-span markers exist verbatim in shared files.
+
+Pure unit test — read each shared file and assert the expected marker text
+is present. Catches regressions where a feature WS accidentally deletes
+another WS's labelled block.
+"""
+
+from __future__ import annotations
+
+import pathlib as plb
+
+import pytest
+
+
+_REPO_ROOT = plb.Path(__file__).resolve().parents[4]
+
+
+_FILE_MARKERS: dict[str, list[str]] = {
+    'packages/mcp/src/memex_mcp/server.py': [
+        '# Tier A — Tool registry',
+        '# --- F4 ---',
+        '# --- F5 ---',
+        '# --- F8 ---',
+        '# --- F9 ---',
+        '# --- F20 ---',
+        '# --- F32 ---',
+    ],
+    'packages/core/src/memex_core/scheduler.py': [
+        '# Tier A — Scheduler tasks (under MEMEX_LEADER_LOCK_ID)',
+        '# --- F6 lint ---',
+        '# --- F20 revisit ---',
+        '# --- F32 diagnostics ---',
+        '# --- F38 consolidation ---',
+    ],
+    'packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py': [
+        '# Tier A — Hermes sync wrappers',
+        '# --- F4 ---',
+        '# --- F5 ---',
+        '# --- F8 ---',
+        '# --- F9 ---',
+        '# --- F20 ---',
+        '# --- F32 ---',
+    ],
+    'packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py': [
+        '# Tier A — Briefing blocks',
+        '# --- F6 ---',
+        '# --- F14 ---',
+        '# --- F20 ---',
+        '# --- F32 ---',
+    ],
+    'packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py': [
+        '# Tier A — Prompt-fragment templates',
+        '# --- F4 ---',
+        '# --- F5 ---',
+        '# --- F8 ---',
+        '# --- F9 ---',
+        '# --- F20 ---',
+        '# --- F32 ---',
+    ],
+    'packages/claude-code-plugin/skills/recall/SKILL.md': [
+        'Tier A — /recall verb extensions',
+        '# --- F8 ---',
+        '# --- F20 ---',
+        '# --- F32 ---',
+    ],
+    'packages/claude-code-plugin/skills/remember/SKILL.md': [
+        'Tier A — /remember verb extensions',
+        '# --- F4 ---',
+        '# --- F5 ---',
+        '# --- F9 ---',
+        '# --- F14 ---',
+        '# --- F20 ---',
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    'rel_path,markers',
+    list(_FILE_MARKERS.items()),
+    ids=list(_FILE_MARKERS.keys()),
+)
+def test_marker_text_present(rel_path: str, markers: list[str]) -> None:
+    src = (_REPO_ROOT / rel_path).read_text(encoding='utf-8')
+    for marker in markers:
+        assert marker in src, (
+            f'{rel_path}: missing labelled-span marker {marker!r} — '
+            'Tier A discipline broken; another WS likely deleted this block'
+        )

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -162,7 +162,17 @@ Match the tool to the query type:
 - **Templates for structured captures** → `memex_list_templates` to see slugs,
   `memex_get_template(slug)` for the markdown scaffold, then `memex_add_note(...,
   template=slug)` so the note is tagged for filtering. Prefer a template for
-  ADRs, retros, technical briefs, RFCs, or any note with clear sections."""
+  ADRs, retros, technical briefs, RFCs, or any note with clear sections.
+- **Curating memory** — when a memory unit turns out to be misleading, outdated,
+  or noise that contaminates retrieval:
+    - `memex_memory_deprioritize(unit_id, reason=...)` is the NON-DESTRUCTIVE
+      verb. The unit stays on the entity graph and remains recallable via
+      `include_deprioritized=true`; only its retrieval rank drops. Pair with
+      `memex_record_outcome(success=false, ...)` when the agent itself
+      discovered the unit was wrong. Reversible via `memex_memory_restore`.
+    - Archive (CLI-only) is the DESTRUCTIVE counterpart — it removes the unit
+      from the entity graph and is irreversible. Prefer deprioritize unless
+      the unit MUST leave the graph entirely (e.g. PII the user wants gone)."""
 
 
 def format_briefing_block(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -172,12 +172,14 @@ def format_briefing_block(
     project_id: str,
     session_note_key: str,
     kv_instructions_if_no_vault: bool,
+    diagnostics_summary: dict[str, Any] | None = None,
 ) -> str:
     """Compose the Memex system-prompt block.
 
     Includes vault/project metadata, the session note key, routing guidance
-    for tool selection, and the fetched briefing markdown. If no vault is
-    resolved, appends guidance on how to bind one via the KV store.
+    for tool selection, the fetched briefing markdown, and (optionally) the
+    F32 diagnostics summary block. If no vault is resolved, appends guidance
+    on how to bind one via the KV store.
     """
     lines = ['## Memex Memory']
     if vault_id:
@@ -207,6 +209,9 @@ def format_briefing_block(
 
     lines.append('\n' + _ROUTING_GUIDE)
 
+    if diagnostics_summary:
+        lines.append('\n' + _render_diagnostics_block(diagnostics_summary))
+
     if briefing:
         lines.append('\n---\n')
         lines.append(briefing)
@@ -231,4 +236,34 @@ __all__ = ['BriefingCache', 'format_briefing_block']
 
 # --- F20 --- (filled by WS-revisit)
 
+
 # --- F32 --- (filled by WS-diagnostics)
+def _render_diagnostics_block(summary: dict[str, Any]) -> str:
+    """Render the F32 diagnostics summary as a compact markdown block.
+
+    Includes manifold_status, unit_counts, avg_mw_score, and top entity names —
+    at least three documented fields per AC-F32-6.
+    """
+    counts = summary.get('unit_counts') or {}
+    active = counts.get('active', 0)
+    stale = counts.get('stale', 0)
+    deprioritized = counts.get('deprioritized', 0)
+    manifold_status = summary.get('manifold_status', 'absent')
+    avg_mw = summary.get('avg_mw_score', 0.0)
+    cluster_count = summary.get('cluster_count')
+    top_entities = summary.get('top_5_retrieved_entities') or []
+    names = [e.get('name', '?') for e in top_entities[:5]]
+
+    lines = [
+        '### Memex diagnostics',
+        f'- Manifold status: `{manifold_status}` · cluster_count: `{cluster_count}`',
+        f'- Units: `{active}` active · `{stale}` stale · `{deprioritized}` deprioritized',
+        f'- Avg MW score: `{avg_mw:.2f}`',
+    ]
+    if names:
+        lines.append('- Top entities: ' + ', '.join(f'`{n}`' for n in names))
+    lines.append(
+        'Surface via `memex_get_diagnostics_summary(vault_id=...)` for details, '
+        'or run `memex diagnostics manifold|retrieval|summary --vault X` for full JSON.'
+    )
+    return '\n'.join(lines)

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -172,7 +172,19 @@ Match the tool to the query type:
       discovered the unit was wrong. Reversible via `memex_memory_restore`.
     - Archive (CLI-only) is the DESTRUCTIVE counterpart — it removes the unit
       from the entity graph and is irreversible. Prefer deprioritize unless
-      the unit MUST leave the graph entirely (e.g. PII the user wants gone)."""
+      the unit MUST leave the graph entirely (e.g. PII the user wants gone).
+- **Synchronously consolidating mid-conversation** — when retrieved facts about
+  a topic are conflicting, incomplete, or scattered, you can ask Memex to
+  consolidate them BEFORE continuing:
+    - `memex_memory_summarize_node(entity_id, scope='incremental'|'full')` is
+      the SYNCHRONOUS counterpart to background `reflect`. `'incremental'`
+      (default) consolidates only new evidence; `'full'` re-evaluates all
+      evidence (capped at the most-recent 1000 units). Returns the updated
+      mental model in the same turn so the agent can act on it.
+    - Background `reflect` (scheduler-driven) is the cheaper default. Reach
+      for `summarize_node` only with an in-session reason.
+    - Rate-limited per (entity, vault). On rejection the response includes
+      `retry_after_seconds`; do NOT retry-loop."""
 
 
 def format_briefing_block(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -215,3 +215,20 @@ def format_briefing_block(
 
 
 __all__ = ['BriefingCache', 'format_briefing_block']
+
+
+# ============================================================
+# Tier A — Briefing blocks
+# F6:  pending lint count                 (WS-linter)
+# F14: procedural observations            (WS-quick-wins)
+# F20: N memories due for review          (WS-revisit)
+# F32: diagnostic summary                 (WS-diagnostics)
+# ============================================================
+
+# --- F6 ---  (filled by WS-linter)
+
+# --- F14 --- (filled by WS-quick-wins)
+
+# --- F20 --- (filled by WS-revisit)
+
+# --- F32 --- (filled by WS-diagnostics)

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
@@ -39,3 +39,10 @@ __all__ = [
 # --- F20 --- (filled by WS-revisit)
 
 # --- F32 --- (filled by WS-diagnostics)
+DIAGNOSTICS_SUMMARY_PROMPT_FRAGMENT = (
+    'Diagnostics: call `memex_get_diagnostics_summary(vault_id=...)` to inspect '
+    "a vault's health — unit counts by status (active/stale/deprioritized), "
+    'pending lint counts by type, cluster_count (null when manifold cache is '
+    'cold), avg MW score, and top retrieved entities. Synchronous; surfaces '
+    'F32 manifold status without waiting on UMAP compute.'
+)

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
@@ -16,3 +16,26 @@ __all__ = [
     'HERMES_SESSION_TEMPLATE',
     'HERMES_USER_NOTE_TEMPLATE',
 ]
+
+
+# ============================================================
+# Tier A — Prompt-fragment templates
+# F4:  WS-quick-wins  (deprioritize/restore disclosure)
+# F5:  WS-quick-wins  (summarize_node prompt)
+# F8:  WS-linter      (get_lint_flags discoverability)
+# F9:  WS-locks       (reconsolidate/consolidate disclosure)
+# F20: WS-revisit     (memory_review prompt)
+# F32: WS-diagnostics (diagnostics_summary disclosure)
+# ============================================================
+
+# --- F4 ---  (filled by WS-quick-wins)
+
+# --- F5 ---  (filled by WS-quick-wins)
+
+# --- F8 ---  (filled by WS-linter)
+
+# --- F9 ---  (filled by WS-locks)
+
+# --- F20 --- (filled by WS-revisit)
+
+# --- F32 --- (filled by WS-diagnostics)

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3173,3 +3173,26 @@ __all__ = [
     'KV_SEARCH_SCHEMA',
     'KV_WRITE_SCHEMA',
 ]
+
+
+# ============================================================
+# Tier A — Hermes sync wrappers
+# F4:  WS-quick-wins  (handle_memory_deprioritize, handle_memory_restore)
+# F5:  WS-quick-wins  (handle_memory_summarize_node)
+# F8:  WS-linter      (handle_get_lint_flags)
+# F9:  WS-locks       (handle_memory_reconsolidate, handle_memory_consolidate)
+# F20: WS-revisit     (handle_get_due_for_review, handle_memory_review)
+# F32: WS-diagnostics (handle_get_diagnostics_summary)
+# ============================================================
+
+# --- F4 ---  (filled by WS-quick-wins)
+
+# --- F5 ---  (filled by WS-quick-wins)
+
+# --- F8 ---  (filled by WS-linter)
+
+# --- F9 ---  (filled by WS-locks)
+
+# --- F20 --- (filled by WS-revisit)
+
+# --- F32 --- (filled by WS-diagnostics)

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -99,6 +99,7 @@ class MemexAPIProtocol(Protocol):
     async def get_lineage(self, *args: Any, **kwargs: Any) -> Any: ...
     async def deprioritize_memory_unit(self, *args: Any, **kwargs: Any) -> Any: ...
     async def restore_memory_unit(self, *args: Any, **kwargs: Any) -> Any: ...
+    async def summarize_node(self, *args: Any, **kwargs: Any) -> Any: ...
 
     # Vaults
     async def list_vaults(self, *args: Any, **kwargs: Any) -> Any: ...
@@ -3327,6 +3328,103 @@ ALL_SCHEMAS.extend([MEMORY_DEPRIORITIZE_SCHEMA, MEMORY_RESTORE_SCHEMA])
 
 
 # --- F5 ---  (filled by WS-quick-wins)
+
+MEMORY_SUMMARIZE_NODE_SCHEMA: dict[str, Any] = {
+    'name': 'memex_memory_summarize_node',
+    'description': (
+        'Trigger reflection synchronously on an entity to consolidate scattered or '
+        'conflicting memories into a coherent mental model BEFORE continuing. '
+        'Synchronous in-session counterpart to background reflect (queued, scheduler-driven). '
+        'Rate-limited per (entity, vault); on rejection the response carries '
+        "'retry_after_seconds' — do not retry-loop. Use sparingly; reflection is LLM-intensive."
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'entity_id': {
+                'type': 'string',
+                'description': 'Entity UUID to reflect on.',
+            },
+            'scope': {
+                'type': 'string',
+                'enum': ['incremental', 'full'],
+                'description': (
+                    "'incremental' (default — only new evidence) or 'full' "
+                    '(re-evaluate all evidence; capped at 1000 most-recent units).'
+                ),
+            },
+            'vault_id': {
+                'type': 'string',
+                'description': 'Vault UUID; defaults to the global vault when omitted.',
+            },
+        },
+        'required': ['entity_id'],
+    },
+}
+
+
+def handle_memory_summarize_node(
+    api: MemexAPIProtocol,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+    args: dict[str, Any],
+) -> str:
+    from memex_common.client import RateLimitExceeded
+
+    try:
+        raw_entity_id = _require(args, 'entity_id')
+    except ValueError as e:
+        return tool_error(str(e))
+    try:
+        entity_uuid = UUID(str(raw_entity_id))
+    except ValueError:
+        return tool_error(f'Invalid entity UUID: {raw_entity_id}')
+
+    scope = args.get('scope', 'incremental')
+    if scope not in ('incremental', 'full'):
+        return tool_error(f"scope must be 'incremental' or 'full', got {scope!r}")
+
+    raw_vault = args.get('vault_id')
+    target_vault: UUID | None
+    if raw_vault is None:
+        target_vault = vault_id
+    else:
+        try:
+            target_vault = UUID(str(raw_vault))
+        except ValueError:
+            return tool_error(f'Invalid vault UUID: {raw_vault}')
+
+    try:
+        result = run_sync(
+            api.summarize_node(entity_uuid, scope=scope, vault_id=target_vault),
+            timeout=120.0,
+        )
+    except RateLimitExceeded as exc:
+        return json.dumps(
+            {
+                'error': 'rate_limit_exceeded',
+                'entity_id': str(entity_uuid),
+                'retry_after_seconds': exc.retry_after_seconds,
+                'message': str(exc),
+            }
+        )
+    except Exception as e:
+        logger.warning('memex_memory_summarize_node failed: %s', e)
+        return tool_error(f'summarize_node failed: {e}')
+
+    return json.dumps(
+        {
+            'entity_id': str(getattr(result, 'entity_id', entity_uuid)),
+            'observation_count': len(getattr(result, 'new_observations', []) or []),
+            'status': getattr(result, 'status', 'completed'),
+            'scope': scope,
+        }
+    )
+
+
+HANDLERS['memex_memory_summarize_node'] = handle_memory_summarize_node
+ALL_SCHEMAS.append(MEMORY_SUMMARIZE_NODE_SCHEMA)
+
 
 # --- F8 ---  (filled by WS-linter)
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -97,6 +97,8 @@ class MemexAPIProtocol(Protocol):
     async def get_memory_unit(self, *args: Any, **kwargs: Any) -> Any: ...
     async def get_memory_links(self, *args: Any, **kwargs: Any) -> Any: ...
     async def get_lineage(self, *args: Any, **kwargs: Any) -> Any: ...
+    async def deprioritize_memory_unit(self, *args: Any, **kwargs: Any) -> Any: ...
+    async def restore_memory_unit(self, *args: Any, **kwargs: Any) -> Any: ...
 
     # Vaults
     async def list_vaults(self, *args: Any, **kwargs: Any) -> Any: ...
@@ -1331,6 +1333,7 @@ ALL_SCHEMAS: list[dict[str, Any]] = [
     KV_LIST_SCHEMA,
     # --- F32 diagnostics ---
     GET_DIAGNOSTICS_SUMMARY_SCHEMA,
+    # --- Tier A schemas appended at module bottom (F4 / F5 / F8 / F9 / F20 / F32) ---
 ]
 
 
@@ -3127,6 +3130,7 @@ HANDLERS: dict[str, _StdHandler | _AssetCacheHandler] = {
     'memex_kv_get': handle_kv_get,
     'memex_kv_search': handle_kv_search,
     'memex_kv_list': handle_kv_list,
+    # --- Tier A handlers appended at module bottom (F4 / F5 / F8 / F9 / F20 / F32) ---
 }
 
 
@@ -3201,6 +3205,9 @@ __all__ = [
     'KV_WRITE_SCHEMA',
     # --- F32 diagnostics ---
     'GET_DIAGNOSTICS_SUMMARY_SCHEMA',
+    # --- F4 (WS-quick-wins) ---
+    'MEMORY_DEPRIORITIZE_SCHEMA',
+    'MEMORY_RESTORE_SCHEMA',
 ]
 
 
@@ -3215,6 +3222,109 @@ __all__ = [
 # ============================================================
 
 # --- F4 ---  (filled by WS-quick-wins)
+
+MEMORY_DEPRIORITIZE_SCHEMA: dict[str, Any] = {
+    'name': 'memex_memory_deprioritize',
+    'description': (
+        "Lower a memory unit's retrieval rank without deleting it (NON-DESTRUCTIVE). "
+        'Use when a memory is misleading, outdated, or noise that contaminates retrieval. '
+        'Companion to memex_memory_restore. Contrast with archive (destructive) — '
+        'prefer deprioritize unless the unit must leave the entity graph entirely.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'unit_id': {
+                'type': 'string',
+                'description': 'Memory unit UUID.',
+            },
+            'reason': {
+                'type': 'string',
+                'description': (
+                    'Brief text explanation logged to audit_logs (e.g., '
+                    "'user confirmed issue fixed', 'superseded by v2.3 release')."
+                ),
+            },
+        },
+        'required': ['unit_id', 'reason'],
+    },
+}
+
+MEMORY_RESTORE_SCHEMA: dict[str, Any] = {
+    'name': 'memex_memory_restore',
+    'description': (
+        'Restore a previously-deprioritized memory unit. Flips is_deprioritized '
+        'back to false; the unit re-enters default-scope retrieval. Writes an '
+        'audit_logs row.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'unit_id': {
+                'type': 'string',
+                'description': 'Memory unit UUID.',
+            },
+        },
+        'required': ['unit_id'],
+    },
+}
+
+
+def handle_memory_deprioritize(
+    api: MemexAPIProtocol,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+    args: dict[str, Any],
+) -> str:
+    try:
+        raw_unit_id = _require(args, 'unit_id')
+        reason = _require(args, 'reason')
+    except ValueError as e:
+        return tool_error(str(e))
+    try:
+        uuid_obj = UUID(str(raw_unit_id))
+    except ValueError:
+        return tool_error(f'Invalid memory unit UUID: {raw_unit_id}')
+    try:
+        result = run_sync(api.deprioritize_memory_unit(uuid_obj, reason=reason), timeout=30.0)
+    except Exception as e:
+        logger.warning('memex_memory_deprioritize failed: %s', e)
+        return tool_error(f'Deprioritize failed: {e}')
+    return json.dumps(
+        {
+            'unit_id': str(getattr(result, 'id', uuid_obj)),
+            'is_deprioritized': True,
+            'reason': reason,
+        }
+    )
+
+
+def handle_memory_restore(
+    api: MemexAPIProtocol,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+    args: dict[str, Any],
+) -> str:
+    try:
+        raw_unit_id = _require(args, 'unit_id')
+    except ValueError as e:
+        return tool_error(str(e))
+    try:
+        uuid_obj = UUID(str(raw_unit_id))
+    except ValueError:
+        return tool_error(f'Invalid memory unit UUID: {raw_unit_id}')
+    try:
+        result = run_sync(api.restore_memory_unit(uuid_obj), timeout=30.0)
+    except Exception as e:
+        logger.warning('memex_memory_restore failed: %s', e)
+        return tool_error(f'Restore failed: {e}')
+    return json.dumps({'unit_id': str(getattr(result, 'id', uuid_obj)), 'is_deprioritized': False})
+
+
+HANDLERS['memex_memory_deprioritize'] = handle_memory_deprioritize
+HANDLERS['memex_memory_restore'] = handle_memory_restore
+ALL_SCHEMAS.extend([MEMORY_DEPRIORITIZE_SCHEMA, MEMORY_RESTORE_SCHEMA])
+
 
 # --- F5 ---  (filled by WS-quick-wins)
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -114,6 +114,9 @@ class MemexAPIProtocol(Protocol):
     async def kv_list(self, *args: Any, **kwargs: Any) -> Any: ...
     async def kv_search(self, *args: Any, **kwargs: Any) -> Any: ...
 
+    # F32 — Diagnostics
+    async def get_diagnostics_summary(self, *args: Any, **kwargs: Any) -> Any: ...
+
 
 # ---------------------------------------------------------------------------
 # Vault resolution helpers (Stream 1)
@@ -1260,6 +1263,28 @@ KV_LIST_SCHEMA: dict[str, Any] = {
     },
 }
 
+# --- F32 — Diagnostics ---
+
+GET_DIAGNOSTICS_SUMMARY_SCHEMA: dict[str, Any] = {
+    'name': 'memex_get_diagnostics_summary',
+    'description': (
+        'Vault diagnostics summary: unit counts by status (active/stale/deprioritized), '
+        'lint pending counts by type, cluster_count (null on cold cache), avg MW score, '
+        'and top-5 retrieved entities. Synchronous — surfaces F32 manifold status without '
+        'waiting on UMAP compute.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'vault_id': {
+                'type': 'string',
+                'description': 'Vault UUID or name.',
+            },
+        },
+        'required': ['vault_id'],
+    },
+}
+
 
 ALL_SCHEMAS: list[dict[str, Any]] = [
     # --- Vault-scoped (Stream 1) ---
@@ -1304,6 +1329,8 @@ ALL_SCHEMAS: list[dict[str, Any]] = [
     KV_GET_SCHEMA,
     KV_SEARCH_SCHEMA,
     KV_LIST_SCHEMA,
+    # --- F32 diagnostics ---
+    GET_DIAGNOSTICS_SUMMARY_SCHEMA,
 ]
 
 
@@ -3172,6 +3199,8 @@ __all__ = [
     'KV_LIST_SCHEMA',
     'KV_SEARCH_SCHEMA',
     'KV_WRITE_SCHEMA',
+    # --- F32 diagnostics ---
+    'GET_DIAGNOSTICS_SUMMARY_SCHEMA',
 ]
 
 
@@ -3195,4 +3224,30 @@ __all__ = [
 
 # --- F20 --- (filled by WS-revisit)
 
+
 # --- F32 --- (filled by WS-diagnostics)
+def handle_get_diagnostics_summary(
+    api: MemexAPIProtocol,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+    args: dict[str, Any],
+) -> str:
+    """Sync wrapper around RemoteMemexAPI.get_diagnostics_summary."""
+    raw = args.get('vault_id')
+    if not raw and vault_id is None:
+        return tool_error('No vault specified and no session-bound vault.')
+
+    try:
+        if raw:
+            target = run_sync(api.resolve_vault_identifier(raw), timeout=10.0)
+        else:
+            target = vault_id
+        summary = run_sync(api.get_diagnostics_summary(target), timeout=30.0)
+    except Exception as e:
+        logger.warning('memex_get_diagnostics_summary failed: %s', e)
+        return tool_error(f'Diagnostics summary failed: {e}')
+
+    return json.dumps(summary)
+
+
+HANDLERS['memex_get_diagnostics_summary'] = handle_get_diagnostics_summary

--- a/packages/hermes-plugin/tests/integration/test_live_hermes.py
+++ b/packages/hermes-plugin/tests/integration/test_live_hermes.py
@@ -46,8 +46,15 @@ def test_initialize_resolves_vault_and_fetches_real_briefing(
     assert initialized_provider._session_note_key in block
 
 
-def test_get_tool_schemas_exposes_stream_1_tools(initialized_provider):
-    """The 8 Stream-1 tools must always be exposed (others are mode-dependent)."""
+def test_get_tool_schemas_exposes_stream_1_and_diagnostics_tools(initialized_provider):
+    """The 8 Stream-1 tools + F32 diagnostics verb must always be exposed.
+
+    The diagnostics-verb assertion guards against the v0.1.13-regression
+    pattern: a future refactor could move schema registration to a place
+    that imports correctly but is never picked up by Hermes' loader. The
+    boot+discovery path is the only assertion that verifies registration
+    is *reachable* through ``_tool_to_provider`` dispatch.
+    """
     names = {s['name'] for s in initialized_provider.get_tool_schemas()}
     assert {
         'memex_memory_search',
@@ -59,6 +66,7 @@ def test_get_tool_schemas_exposes_stream_1_tools(initialized_provider):
         'memex_get_entity_mentions',
         'memex_get_entity_cooccurrences',
     } <= names
+    assert 'memex_get_diagnostics_summary' in names
 
 
 def test_get_tool_schemas_at_registration_time(loaded_provider):

--- a/packages/hermes-plugin/tests/integration/test_live_hermes.py
+++ b/packages/hermes-plugin/tests/integration/test_live_hermes.py
@@ -46,14 +46,16 @@ def test_initialize_resolves_vault_and_fetches_real_briefing(
     assert initialized_provider._session_note_key in block
 
 
-def test_get_tool_schemas_exposes_stream_1_and_diagnostics_tools(initialized_provider):
-    """The 8 Stream-1 tools + F32 diagnostics verb must always be exposed.
+def test_get_tool_schemas_exposes_stream_1_and_post_seed_tools(initialized_provider):
+    """The 8 Stream-1 tools + every post-seed MCP verb must always be exposed.
 
-    The diagnostics-verb assertion guards against the v0.1.13-regression
-    pattern: a future refactor could move schema registration to a place
-    that imports correctly but is never picked up by Hermes' loader. The
-    boot+discovery path is the only assertion that verifies registration
-    is *reachable* through ``_tool_to_provider`` dispatch.
+    Standing AC-X-10 three-surface-parity canary: every new MCP verb must
+    appear here as part of its ship's TC matrix. Guards against the
+    v0.1.13-regression pattern where a refactor could move schema
+    registration to a place that imports correctly but is never picked up
+    by Hermes' loader. The boot+discovery path is the only assertion that
+    verifies registration is *reachable* through ``_tool_to_provider``
+    dispatch.
     """
     names = {s['name'] for s in initialized_provider.get_tool_schemas()}
     assert {
@@ -67,6 +69,9 @@ def test_get_tool_schemas_exposes_stream_1_and_diagnostics_tools(initialized_pro
         'memex_get_entity_cooccurrences',
     } <= names
     assert 'memex_get_diagnostics_summary' in names
+    assert (
+        'memex_memory_summarize_node' in names
+    )  # F5 — new MCP verb, must be reachable through dispatch
 
 
 def test_get_tool_schemas_at_registration_time(loaded_provider):

--- a/packages/hermes-plugin/tests/test_briefing_f4_verb_pair.py
+++ b/packages/hermes-plugin/tests/test_briefing_f4_verb_pair.py
@@ -1,0 +1,46 @@
+"""F4 — Hermes briefing verb-pair invariant (Wave 0 §6 #12).
+
+Asserts the Hermes routing guide:
+1. Mentions `memex_memory_deprioritize` as the NON-destructive verb.
+2. Mentions archive as the DESTRUCTIVE counterpart.
+3. Does NOT cross-wire archive as the deprioritize-equivalent (negative
+   assertion — no instruction like "use archive when you want to deprioritize").
+
+Pure string-contains; the matching `@pytest.mark.llm` driven-agent verb
+selection lives in `tests/test_e2e_f4_llm_turn.py`.
+"""
+
+from __future__ import annotations
+
+from memex_hermes_plugin.memex.briefing import _ROUTING_GUIDE
+
+
+def test_routing_guide_mentions_deprioritize_verb():
+    assert 'memex_memory_deprioritize' in _ROUTING_GUIDE
+
+
+def test_routing_guide_marks_deprioritize_as_non_destructive():
+    text = _ROUTING_GUIDE
+    # Per Wave 0 §6 #12: deprioritize is the NON-destructive verb.
+    assert 'NON-DESTRUCTIVE' in text or 'non-destructive' in text.lower()
+
+
+def test_routing_guide_marks_archive_as_destructive():
+    text = _ROUTING_GUIDE.lower()
+    assert 'archive' in text
+    assert 'destructive' in text
+
+
+def test_routing_guide_does_not_cross_wire_archive_as_deprioritize_alt():
+    """Negative assertion: the briefing must NOT suggest archive as a
+    same-purpose alternative to deprioritize. Wave 0 §6 #12 keeps these
+    verbs distinct.
+    """
+    lower = _ROUTING_GUIDE.lower()
+    forbidden_phrases = (
+        'use archive instead of deprioritize',
+        'archive is equivalent to deprioritize',
+        'archive or deprioritize',
+    )
+    for p in forbidden_phrases:
+        assert p not in lower, f'Briefing cross-wires archive: contains "{p}"'

--- a/packages/hermes-plugin/tests/test_briefing_f5_verb_pair.py
+++ b/packages/hermes-plugin/tests/test_briefing_f5_verb_pair.py
@@ -1,0 +1,39 @@
+"""F5 — Hermes briefing verb-pair invariant (TC6a).
+
+Asserts the Hermes routing guide:
+1. Mentions ``memex_memory_summarize_node`` as the SYNCHRONOUS verb.
+2. Contrasts it with background ``reflect`` (the queued/scheduler-driven path).
+3. Documents the rate limit and ``retry_after_seconds`` envelope so the agent
+   does not retry-loop.
+
+Pure string-contains; the matching ``@pytest.mark.llm`` driven-agent verb
+selection lives in ``tests/test_e2e_f5_llm_turn.py``.
+"""
+
+from __future__ import annotations
+
+from memex_hermes_plugin.memex.briefing import _ROUTING_GUIDE
+
+
+def test_routing_guide_mentions_summarize_node_verb():
+    assert 'memex_memory_summarize_node' in _ROUTING_GUIDE
+
+
+def test_routing_guide_contrasts_summarize_node_against_reflect():
+    """summarize_node and reflect must appear in the same routing block as a verb-pair."""
+    text = _ROUTING_GUIDE
+    assert 'memex_memory_summarize_node' in text
+    assert 'reflect' in text.lower()
+
+
+def test_routing_guide_marks_summarize_node_as_synchronous():
+    """Per RFC-002, summarize_node is the SYNCHRONOUS counterpart to background reflect."""
+    text = _ROUTING_GUIDE.upper()
+    assert 'SYNCHRONOUS' in text
+
+
+def test_routing_guide_documents_rate_limit_and_retry_after():
+    """Agent must know that retry_after_seconds is the structured back-off hint."""
+    text = _ROUTING_GUIDE.lower()
+    assert 'rate-limit' in text or 'rate limit' in text or 'rate_limit' in text
+    assert 'retry_after_seconds' in text

--- a/packages/hermes-plugin/tests/test_int_f32_hermes_briefing_inlines_summary.py
+++ b/packages/hermes-plugin/tests/test_int_f32_hermes_briefing_inlines_summary.py
@@ -1,0 +1,65 @@
+"""F32 Hermes briefing — diagnostics summary inlines into briefing block (Test 8).
+
+Verifies that ``format_briefing_block`` accepts a diagnostics-summary dict and
+renders a markdown block surfacing at least three documented fields
+(manifold_status, unit_counts, top entities) — satisfying AC-F32-6.
+"""
+
+from __future__ import annotations
+
+from memex_hermes_plugin.memex.briefing import format_briefing_block
+
+
+def test_diagnostic_summary_in_briefing_block():
+    summary = {
+        'vault_id': 'a-vault-id',
+        'as_of': '2026-04-30T00:00:00Z',
+        'manifold_status': 'pending',
+        'unit_counts': {'active': 12, 'stale': 3, 'deprioritized': 1},
+        'lint_pending_by_type': {},
+        'cluster_count': None,
+        'avg_mw_score': 0.61,
+        'top_5_retrieved_entities': [
+            {'entity_id': 'e1', 'name': 'Memex', 'volume': 9, 'avg_mw_score': 0.7},
+            {'entity_id': 'e2', 'name': 'F32', 'volume': 4, 'avg_mw_score': 0.5},
+        ],
+    }
+
+    block = format_briefing_block(
+        briefing='# Briefing',
+        vault_id='test-vault',
+        project_id='proj-x',
+        session_note_key='hermes:session:abc',
+        kv_instructions_if_no_vault=False,
+        diagnostics_summary=summary,
+    )
+
+    assert '### Memex diagnostics' in block
+
+    # Field 1: manifold status (pending in this fixture; cluster_count null).
+    assert 'pending' in block
+    assert 'cluster_count' in block
+
+    # Field 2: unit counts (active / stale / deprioritized).
+    assert '12' in block and '3' in block and '1' in block
+    assert 'active' in block and 'stale' in block and 'deprioritized' in block
+
+    # Field 3: top entities.
+    assert 'Memex' in block
+    assert 'F32' in block
+
+    # The verb is surfaced for agents.
+    assert 'memex_get_diagnostics_summary' in block
+
+
+def test_briefing_block_omits_diagnostics_when_summary_none():
+    """No regression: omitting the summary param keeps the existing block shape."""
+    block = format_briefing_block(
+        briefing='# Briefing',
+        vault_id='v',
+        project_id='p',
+        session_note_key='hermes:session:abc',
+        kv_instructions_if_no_vault=False,
+    )
+    assert '### Memex diagnostics' not in block
+    assert '# Briefing' in block

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -75,7 +75,7 @@ def test_get_tool_schemas_respects_memory_mode(tmp_path: Path, monkeypatch: pyte
 
 
 def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
-    """Hybrid mode exposes exactly the 36 Memex tools (AC-086 + AC-008)."""
+    """Hybrid mode exposes exactly the 38 Memex tools (AC-086 + AC-008 + Tier A F4)."""
     provider, *_ = provider_with_stubbed_api
     schemas = provider.get_tool_schemas()
     names = {s['name'] for s in schemas}
@@ -121,6 +121,9 @@ def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
         'memex_kv_get',
         'memex_kv_search',
         'memex_kv_list',
+        # Tier A WS-quick-wins (F4)
+        'memex_memory_deprioritize',
+        'memex_memory_restore',
     }
     assert names == expected
 
@@ -135,9 +138,9 @@ def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
 class TestGetToolSchemasBeforeInitialize:
     def test_returns_all_schemas_pre_init(self):
         """The v0.1.13 bug was returning []; we now return the full set
-        pre-init. After Stream 6 + asset disk-handoff + memex_append_note we
-        register exactly 36 tools (8 Stream-1 baseline + 27 from prior
-        streams + memex_resize_image), and the assertion is strict equality.
+        pre-init. After Stream 6 + asset disk-handoff + memex_append_note +
+        Tier A F4 we register exactly 38 tools, and the assertion is strict
+        equality.
         """
         p = MemexMemoryProvider()
         # NOTE: no initialize() call.
@@ -185,6 +188,9 @@ class TestGetToolSchemasBeforeInitialize:
             'memex_kv_get',
             'memex_kv_search',
             'memex_kv_list',
+            # Tier A WS-quick-wins (F4)
+            'memex_memory_deprioritize',
+            'memex_memory_restore',
         }
         assert names == expected
 
@@ -199,10 +205,9 @@ class TestGetToolSchemasBeforeInitialize:
         """A fresh provider with no config always exposes tools. Only an
         initialized provider whose config explicitly says ``context`` hides them.
         """
-        # Pre-init: full 36-tool set (8 Stream 1 baseline including
-        # memex_append_note + 27 from prior streams + memex_resize_image).
+        # Pre-init: full 38-tool set (Stream 1-5 baseline + Tier A F4 verbs).
         p = MemexMemoryProvider()
-        assert len(p.get_tool_schemas()) == 36
+        assert len(p.get_tool_schemas()) == 38
 
         # After init in context mode: empty.
         monkeypatch.setenv('HERMES_HOME', str(tmp_path))

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -75,7 +75,7 @@ def test_get_tool_schemas_respects_memory_mode(tmp_path: Path, monkeypatch: pyte
 
 
 def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
-    """Hybrid mode exposes exactly the 38 Memex tools (AC-086 + AC-008 + Tier A F4)."""
+    """Hybrid mode exposes exactly the 39 Memex tools (AC-086 + AC-008 + Tier A F4 + F5)."""
     provider, *_ = provider_with_stubbed_api
     schemas = provider.get_tool_schemas()
     names = {s['name'] for s in schemas}
@@ -121,9 +121,10 @@ def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
         'memex_kv_get',
         'memex_kv_search',
         'memex_kv_list',
-        # Tier A WS-quick-wins (F4)
+        # Tier A WS-quick-wins (F4 + F5)
         'memex_memory_deprioritize',
         'memex_memory_restore',
+        'memex_memory_summarize_node',
     }
     assert names == expected
 
@@ -139,7 +140,7 @@ class TestGetToolSchemasBeforeInitialize:
     def test_returns_all_schemas_pre_init(self):
         """The v0.1.13 bug was returning []; we now return the full set
         pre-init. After Stream 6 + asset disk-handoff + memex_append_note +
-        Tier A F4 we register exactly 38 tools, and the assertion is strict
+        Tier A F4 + F5 we register exactly 39 tools, and the assertion is strict
         equality.
         """
         p = MemexMemoryProvider()
@@ -188,9 +189,10 @@ class TestGetToolSchemasBeforeInitialize:
             'memex_kv_get',
             'memex_kv_search',
             'memex_kv_list',
-            # Tier A WS-quick-wins (F4)
+            # Tier A WS-quick-wins (F4 + F5)
             'memex_memory_deprioritize',
             'memex_memory_restore',
+            'memex_memory_summarize_node',
         }
         assert names == expected
 
@@ -205,9 +207,9 @@ class TestGetToolSchemasBeforeInitialize:
         """A fresh provider with no config always exposes tools. Only an
         initialized provider whose config explicitly says ``context`` hides them.
         """
-        # Pre-init: full 38-tool set (Stream 1-5 baseline + Tier A F4 verbs).
+        # Pre-init: full 39-tool set (Stream 1-5 baseline + Tier A F4 + F5 verbs).
         p = MemexMemoryProvider()
-        assert len(p.get_tool_schemas()) == 38
+        assert len(p.get_tool_schemas()) == 39
 
         # After init in context mode: empty.
         monkeypatch.setenv('HERMES_HOME', str(tmp_path))

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -75,7 +75,7 @@ def test_get_tool_schemas_respects_memory_mode(tmp_path: Path, monkeypatch: pyte
 
 
 def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
-    """Hybrid mode exposes exactly the 39 Memex tools (AC-086 + AC-008 + Tier A F4 + F5)."""
+    """Hybrid mode exposes exactly the 40 Memex tools (AC-086 + AC-008 + Tier A F4/F5 + F32 diagnostics)."""
     provider, *_ = provider_with_stubbed_api
     schemas = provider.get_tool_schemas()
     names = {s['name'] for s in schemas}
@@ -125,6 +125,8 @@ def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
         'memex_memory_deprioritize',
         'memex_memory_restore',
         'memex_memory_summarize_node',
+        # Tier A WS-diagnostics (F32)
+        'memex_get_diagnostics_summary',
     }
     assert names == expected
 
@@ -140,8 +142,8 @@ class TestGetToolSchemasBeforeInitialize:
     def test_returns_all_schemas_pre_init(self):
         """The v0.1.13 bug was returning []; we now return the full set
         pre-init. After Stream 6 + asset disk-handoff + memex_append_note +
-        Tier A F4 + F5 we register exactly 39 tools, and the assertion is strict
-        equality.
+        Tier A F4/F5 + F32 diagnostics we register exactly 40 tools, and the
+        assertion is strict equality.
         """
         p = MemexMemoryProvider()
         # NOTE: no initialize() call.
@@ -193,6 +195,8 @@ class TestGetToolSchemasBeforeInitialize:
             'memex_memory_deprioritize',
             'memex_memory_restore',
             'memex_memory_summarize_node',
+            # Tier A WS-diagnostics (F32)
+            'memex_get_diagnostics_summary',
         }
         assert names == expected
 
@@ -207,9 +211,9 @@ class TestGetToolSchemasBeforeInitialize:
         """A fresh provider with no config always exposes tools. Only an
         initialized provider whose config explicitly says ``context`` hides them.
         """
-        # Pre-init: full 39-tool set (Stream 1-5 baseline + Tier A F4 + F5 verbs).
+        # Pre-init: full 40-tool set (Stream 1-5 baseline + Tier A F4/F5 + F32 diagnostics verbs).
         p = MemexMemoryProvider()
-        assert len(p.get_tool_schemas()) == 39
+        assert len(p.get_tool_schemas()) == 40
 
         # After init in context mode: empty.
         monkeypatch.setenv('HERMES_HOME', str(tmp_path))

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -119,8 +119,8 @@ def _fake_entity(name: str = 'Rust') -> EntityDTO:
 
 
 def test_all_schemas_have_required_fields():
-    """All 35 tools (7 pre-existing + 27 from prior streams + memex_resize_image)
-    must be registered exactly (AC-086 + AC-008)."""
+    """All 40 tools (Streams 1-5 baseline + Tier A F4/F5 + F32 diagnostics)
+    must be registered exactly (AC-086 + AC-008 + AC-X-10)."""
     names = {s['name'] for s in ALL_SCHEMAS}
     stream_1_baseline = {
         'memex_memory_search',
@@ -173,6 +173,9 @@ def test_all_schemas_have_required_fields():
         'memex_memory_restore',
         'memex_memory_summarize_node',
     }
+    tier_a_diagnostics = {
+        'memex_get_diagnostics_summary',
+    }
     expected = (
         stream_1_baseline
         | stream_2_read_discovery
@@ -180,6 +183,7 @@ def test_all_schemas_have_required_fields():
         | stream_4_lifecycle_templates
         | stream_5_assets_kv
         | tier_a_quick_wins
+        | tier_a_diagnostics
     )
     assert names == expected
     for s in ALL_SCHEMAS:

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -171,6 +171,7 @@ def test_all_schemas_have_required_fields():
     tier_a_quick_wins = {
         'memex_memory_deprioritize',
         'memex_memory_restore',
+        'memex_memory_summarize_node',
     }
     expected = (
         stream_1_baseline

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -168,12 +168,17 @@ def test_all_schemas_have_required_fields():
         'memex_kv_search',
         'memex_kv_list',
     }
+    tier_a_quick_wins = {
+        'memex_memory_deprioritize',
+        'memex_memory_restore',
+    }
     expected = (
         stream_1_baseline
         | stream_2_read_discovery
         | stream_3_entities_memory_lineage
         | stream_4_lifecycle_templates
         | stream_5_assets_kv
+        | tier_a_quick_wins
     )
     assert names == expected
     for s in ALL_SCHEMAS:

--- a/packages/mcp/src/memex_mcp/_f4_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_f4_descriptions.py
@@ -1,0 +1,30 @@
+"""Verbatim agent prompt text for F4 tools.
+
+Sourced from cognitive-memory-research-report.md §4 F4 step 6 (lines
+615-628 as of 2026-04-30 against memory_augmentation @ 1c0a464). When the
+spec changes, the verbatim test (T4) fails — that is the contract.
+"""
+
+from __future__ import annotations
+
+MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION = (
+    "memory_deprioritize — Lower a memory unit's retrieval rank without deleting it.\n"
+    'Use when a memory is misleading, outdated, or noise that contaminates retrieval.\n'
+    '\n'
+    '- unit_id: the unit to deprioritize\n'
+    '- reason: brief text explanation (logged to maintenance ledger). Use this field\n'
+    '  liberally to capture WHY (e.g., "user confirmed issue fixed", "superseded by\n'
+    '  v2.3 release", "was wrong about deploy target"). Free text is sufficient — no\n'
+    '  enum needed.\n'
+    '\n'
+    'The unit remains accessible via include_deprioritized=true retrieval. To restore,\n'
+    'the user runs `memex memory restore <id>`. This is non-destructive — prefer it\n'
+    'over hard delete in almost all cases. Use sparingly: a small number of high-quality\n'
+    'deprioritizations is more valuable than aggressive pruning.'
+)
+
+MEMEX_MEMORY_RESTORE_DESCRIPTION = (
+    'memory_restore — Restore a previously-deprioritized memory unit.\n'
+    'Flips ``is_deprioritized`` back to false; the unit re-enters default-scope retrieval.\n'
+    'Companion to memory_deprioritize. Writes an audit_logs row.'
+)

--- a/packages/mcp/src/memex_mcp/_f5_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_f5_descriptions.py
@@ -1,0 +1,23 @@
+"""Verbatim agent prompt text for F5 tool.
+
+Sourced from cognitive-memory-research-report.md §4 F5 step 6 (lines
+653-666 as of 2026-04-30 against memory_augmentation @ f79c313). When the
+spec changes, the verbatim test (TC5) fails — that is the contract.
+"""
+
+from __future__ import annotations
+
+MEMEX_MEMORY_SUMMARIZE_NODE_DESCRIPTION = (
+    'memory_summarize_node — Trigger reflection synchronously on a specific entity or\n'
+    'note set. Use when you notice mid-conversation that retrieved facts about a topic\n'
+    'are conflicting, incomplete, or scattered, and you want Memex to consolidate them\n'
+    'into a coherent mental model before continuing.\n'
+    '\n'
+    '- entity_id: focus reflection on a single entity (preferred for per-topic work)\n'
+    '- note_ids: alternatively, focus on a specific set of notes\n'
+    '- scope: "incremental" (default — only new evidence) or "full" (re-evaluate all)\n'
+    '\n'
+    'Returns a ReflectionResult with the updated/new MentalModel(s). Use sparingly;\n'
+    'reflection is LLM-intensive. Default to background reflection unless you have a\n'
+    'specific in-session reason to trigger now.'
+)

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3627,6 +3627,74 @@ async def memex_memory_restore(
 
 # --- F5 ---  (filled by WS-quick-wins)
 
+from memex_mcp._f5_descriptions import MEMEX_MEMORY_SUMMARIZE_NODE_DESCRIPTION
+
+
+@mcp.tool(
+    name='memex_memory_summarize_node',
+    description=MEMEX_MEMORY_SUMMARIZE_NODE_DESCRIPTION,
+    tags={'write', 'storage'},
+    annotations={'readOnlyHint': False, 'destructiveHint': False, 'idempotentHint': False},
+    timeout=120.0,
+)
+async def memex_memory_summarize_node(
+    ctx: Context,
+    entity_id: Annotated[str, Field(description='Entity UUID to reflect on.')],
+    scope: Annotated[
+        str,
+        Field(
+            description=(
+                "'incremental' (default — only new evidence) or 'full' "
+                '(re-evaluate all evidence; capped at MAX_FULL_SCOPE_UNITS=1000).'
+            ),
+        ),
+    ] = 'incremental',
+    vault_id: Annotated[
+        str | None,
+        Field(description='Vault UUID; defaults to the global vault when None.'),
+    ] = None,
+) -> dict[str, Any]:
+    """Synchronously consolidate memories on an entity into its mental model."""
+    from memex_common.client import RateLimitExceeded
+
+    try:
+        api = get_api(ctx)
+        try:
+            entity_uuid = UUID(entity_id)
+        except ValueError:
+            raise ToolError(f'Invalid entity UUID: {entity_id}')
+        vault_uuid: UUID | None
+        if vault_id is None:
+            vault_uuid = None
+        else:
+            try:
+                vault_uuid = UUID(vault_id)
+            except ValueError:
+                raise ToolError(f'Invalid vault UUID: {vault_id}')
+        if scope not in ('incremental', 'full'):
+            raise ToolError(f"scope must be 'incremental' or 'full', got {scope!r}")
+        try:
+            result = await api.summarize_node(entity_uuid, scope=scope, vault_id=vault_uuid)
+        except RateLimitExceeded as exc:
+            return {
+                'error': 'rate_limit_exceeded',
+                'entity_id': entity_id,
+                'retry_after_seconds': exc.retry_after_seconds,
+                'message': str(exc),
+            }
+        return {
+            'entity_id': str(result.entity_id),
+            'observation_count': len(result.new_observations),
+            'status': result.status,
+            'scope': scope,
+        }
+    except ToolError:
+        raise
+    except Exception as e:
+        logger.error(f'memex_memory_summarize_node failed: {e}', exc_info=True)
+        raise ToolError(f'memex_memory_summarize_node failed: {e}')
+
+
 # --- F8 ---  (filled by WS-linter)
 
 # --- F9 ---  (filled by WS-locks)

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3537,3 +3537,26 @@ def entrypoint():
 
 if __name__ == '__main__':
     entrypoint()
+
+
+# ============================================================
+# Tier A — Tool registry (peer-reviewed conventions)
+# F4 (deprioritize, restore):       WS-quick-wins
+# F5 (summarize_node):              WS-quick-wins
+# F8 (get_lint_flags):              WS-linter
+# F9 (reconsolidate, consolidate):  WS-locks
+# F20 (get_due_for_review, review): WS-revisit
+# F32 (get_diagnostics_summary):    WS-diagnostics
+# ============================================================
+
+# --- F4 ---  (filled by WS-quick-wins)
+
+# --- F5 ---  (filled by WS-quick-wins)
+
+# --- F8 ---  (filled by WS-linter)
+
+# --- F9 ---  (filled by WS-locks)
+
+# --- F20 --- (filled by WS-revisit)
+
+# --- F32 --- (filled by WS-diagnostics)

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3559,4 +3559,34 @@ if __name__ == '__main__':
 
 # --- F20 --- (filled by WS-revisit)
 
+
 # --- F32 --- (filled by WS-diagnostics)
+@mcp.tool(
+    name='memex_get_diagnostics_summary',
+    description=(
+        'Vault diagnostics summary: unit counts by status (active/stale/deprioritized), '
+        'lint pending counts by type, cluster_count (null on cold cache), avg MW score, '
+        'and top-5 retrieved entities. Synchronous (no UMAP block) — surfaces F32 manifold '
+        'status without waiting on compute.'
+    ),
+    tags={'diagnostics'},
+    annotations={'readOnlyHint': True},
+    timeout=30.0,
+)
+async def memex_get_diagnostics_summary(
+    ctx: Context,
+    vault_id: Annotated[
+        str,
+        Field(description='Vault UUID or name.'),
+    ],
+) -> dict[str, Any]:
+    """Return the F32 diagnostics summary for a vault."""
+    try:
+        api = get_api(ctx)
+        resolved_vault_id = await _resolve_vault_id(api, vault_id)
+        return await api.get_diagnostics_summary(resolved_vault_id)
+    except ToolError:
+        raise
+    except Exception as e:
+        logger.error(f'Diagnostics summary failed: {e}', exc_info=True)
+        raise ToolError(f'Diagnostics summary failed: {e}')

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3551,6 +3551,80 @@ if __name__ == '__main__':
 
 # --- F4 ---  (filled by WS-quick-wins)
 
+from memex_mcp._f4_descriptions import (
+    MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
+    MEMEX_MEMORY_RESTORE_DESCRIPTION,
+)
+
+
+@mcp.tool(
+    name='memex_memory_deprioritize',
+    description=MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
+    tags={'write', 'storage'},
+    annotations={'readOnlyHint': False, 'destructiveHint': False, 'idempotentHint': True},
+    timeout=30.0,
+)
+async def memex_memory_deprioritize(
+    ctx: Context,
+    unit_id: Annotated[str, Field(description='Memory unit UUID.')],
+    reason: Annotated[
+        str,
+        Field(description='Why this unit is being deprioritized. Free text; logged to audit_logs.'),
+    ],
+) -> dict[str, Any]:
+    """Deprioritize a memory unit (non-destructive)."""
+    try:
+        api = get_api(ctx)
+        try:
+            uuid_obj = UUID(unit_id)
+        except ValueError:
+            raise ToolError(f'Invalid memory unit UUID: {unit_id}')
+        try:
+            unit = await api.deprioritize_memory_unit(uuid_obj, reason=reason)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise ToolError(f'Memory unit {unit_id} not found.')
+            raise
+        return {'unit_id': str(unit.id), 'is_deprioritized': True, 'reason': reason}
+    except ToolError:
+        raise
+    except Exception as e:
+        logger.error(f'Deprioritize failed: {e}', exc_info=True)
+        raise ToolError(f'Deprioritize failed: {e}')
+
+
+@mcp.tool(
+    name='memex_memory_restore',
+    description=MEMEX_MEMORY_RESTORE_DESCRIPTION,
+    tags={'write', 'storage'},
+    annotations={'readOnlyHint': False, 'destructiveHint': False, 'idempotentHint': True},
+    timeout=30.0,
+)
+async def memex_memory_restore(
+    ctx: Context,
+    unit_id: Annotated[str, Field(description='Memory unit UUID.')],
+) -> dict[str, Any]:
+    """Restore a deprioritized memory unit."""
+    try:
+        api = get_api(ctx)
+        try:
+            uuid_obj = UUID(unit_id)
+        except ValueError:
+            raise ToolError(f'Invalid memory unit UUID: {unit_id}')
+        try:
+            unit = await api.restore_memory_unit(uuid_obj)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise ToolError(f'Memory unit {unit_id} not found.')
+            raise
+        return {'unit_id': str(unit.id), 'is_deprioritized': False}
+    except ToolError:
+        raise
+    except Exception as e:
+        logger.error(f'Restore failed: {e}', exc_info=True)
+        raise ToolError(f'Restore failed: {e}')
+
+
 # --- F5 ---  (filled by WS-quick-wins)
 
 # --- F8 ---  (filled by WS-linter)

--- a/packages/mcp/tests/test_discovery_mode.py
+++ b/packages/mcp/tests/test_discovery_mode.py
@@ -15,6 +15,7 @@ EXPECTED_TAGS = {
     'assets',
     'storage',
     'templates',
+    'diagnostics',
 }
 
 # Natural-language queries mapped to expected tool(s) — used for BM25 recall testing.

--- a/packages/mcp/tests/test_f4_tool_descriptions.py
+++ b/packages/mcp/tests/test_f4_tool_descriptions.py
@@ -1,0 +1,63 @@
+"""F4 — MCP tool description verbatim test.
+
+T4: tool description == cognitive-memory-research-report.md §4 F4 step 6
+verbatim (lines 615-628 as of 2026-04-30).
+
+The expected text is hardcoded here, NOT loaded from the spec markdown
+(non-circular: when the spec changes, this test fails — that is the
+contract).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memex_mcp._f4_descriptions import (
+    MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
+    MEMEX_MEMORY_RESTORE_DESCRIPTION,
+)
+
+
+# Source: cognitive-memory-research-report.md §4 F4 step 6 (lines 615-628 as
+# of 2026-04-30 against memory_augmentation @ 1c0a464). When the spec changes,
+# this constant must be re-synced and this test is the failing contract.
+F4_DESCRIPTION_VERBATIM = (
+    "memory_deprioritize — Lower a memory unit's retrieval rank without deleting it.\n"
+    'Use when a memory is misleading, outdated, or noise that contaminates retrieval.\n'
+    '\n'
+    '- unit_id: the unit to deprioritize\n'
+    '- reason: brief text explanation (logged to maintenance ledger). Use this field\n'
+    '  liberally to capture WHY (e.g., "user confirmed issue fixed", "superseded by\n'
+    '  v2.3 release", "was wrong about deploy target"). Free text is sufficient — no\n'
+    '  enum needed.\n'
+    '\n'
+    'The unit remains accessible via include_deprioritized=true retrieval. To restore,\n'
+    'the user runs `memex memory restore <id>`. This is non-destructive — prefer it\n'
+    'over hard delete in almost all cases. Use sparingly: a small number of high-quality\n'
+    'deprioritizations is more valuable than aggressive pruning.'
+)
+
+
+def test_deprioritize_description_constant_matches_spec_verbatim():
+    """T4: MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION matches §4 F4 step 6 char-for-char."""
+    assert MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION == F4_DESCRIPTION_VERBATIM
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_registered_with_verbatim_description():
+    """The MCP tool registry surfaces the verbatim description."""
+    from memex_mcp.server import mcp
+
+    tool = await mcp.get_tool('memex_memory_deprioritize')
+    assert tool is not None, 'memex_memory_deprioritize tool not registered'
+    assert tool.description == F4_DESCRIPTION_VERBATIM
+
+
+@pytest.mark.asyncio
+async def test_restore_tool_registered():
+    """memex_memory_restore is also registered with its description constant."""
+    from memex_mcp.server import mcp
+
+    tool = await mcp.get_tool('memex_memory_restore')
+    assert tool is not None, 'memex_memory_restore tool not registered'
+    assert tool.description == MEMEX_MEMORY_RESTORE_DESCRIPTION

--- a/packages/mcp/tests/test_f5_tool_description.py
+++ b/packages/mcp/tests/test_f5_tool_description.py
@@ -1,0 +1,54 @@
+"""F5 — MCP tool description verbatim test (TC5).
+
+The expected text is hardcoded here, NOT loaded from the spec markdown
+(non-circular: when the spec changes, this test fails — that is the
+contract). Sourced from cognitive-memory-research-report.md §4 F5 step 6
+(lines 653-666 as of 2026-04-30 against memory_augmentation @ f79c313).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memex_mcp._f5_descriptions import MEMEX_MEMORY_SUMMARIZE_NODE_DESCRIPTION
+
+
+F5_DESCRIPTION_VERBATIM = (
+    'memory_summarize_node — Trigger reflection synchronously on a specific entity or\n'
+    'note set. Use when you notice mid-conversation that retrieved facts about a topic\n'
+    'are conflicting, incomplete, or scattered, and you want Memex to consolidate them\n'
+    'into a coherent mental model before continuing.\n'
+    '\n'
+    '- entity_id: focus reflection on a single entity (preferred for per-topic work)\n'
+    '- note_ids: alternatively, focus on a specific set of notes\n'
+    '- scope: "incremental" (default — only new evidence) or "full" (re-evaluate all)\n'
+    '\n'
+    'Returns a ReflectionResult with the updated/new MentalModel(s). Use sparingly;\n'
+    'reflection is LLM-intensive. Default to background reflection unless you have a\n'
+    'specific in-session reason to trigger now.'
+)
+
+
+def test_summarize_node_description_constant_matches_spec_verbatim():
+    """TC5: MEMEX_MEMORY_SUMMARIZE_NODE_DESCRIPTION matches §4 F5 step 6 char-for-char."""
+    assert MEMEX_MEMORY_SUMMARIZE_NODE_DESCRIPTION == F5_DESCRIPTION_VERBATIM
+
+
+@pytest.mark.asyncio
+async def test_summarize_node_tool_registered_with_verbatim_description():
+    """The MCP tool registry surfaces the verbatim description."""
+    from memex_mcp.server import mcp
+
+    tool = await mcp.get_tool('memex_memory_summarize_node')
+    assert tool is not None, 'memex_memory_summarize_node tool not registered'
+    assert tool.description == F5_DESCRIPTION_VERBATIM
+
+
+@pytest.mark.asyncio
+async def test_summarize_node_tool_tagged_write_storage():
+    """Tool registered with the standard write/storage tags (per F4 taxonomy)."""
+    from memex_mcp.server import mcp
+
+    tool = await mcp.get_tool('memex_memory_summarize_node')
+    assert tool is not None
+    assert tool.tags == {'write', 'storage'}

--- a/tests/llm/test_f32_real_agent_summary.py
+++ b/tests/llm/test_f32_real_agent_summary.py
@@ -25,7 +25,8 @@ def test_real_agent_reads_summary():
     import dspy
 
     # Match the project's conventional integration-test model (gemini-3-flash-preview).
-    lm = dspy.LM('gemini/gemini-3-flash-preview', timeout=30.0)
+    # 120s matches F4 T6's verb-disambig timeout; 30s flaked on cold Gemini connections.
+    lm = dspy.LM('gemini/gemini-3-flash-preview', timeout=120.0)
     dspy.configure(lm=lm)
 
     tool_catalog = (

--- a/tests/llm/test_f32_real_agent_summary.py
+++ b/tests/llm/test_f32_real_agent_summary.py
@@ -1,0 +1,85 @@
+"""F32 — real LLM picks ``memex_get_diagnostics_summary`` for vault-diagnostics prompt (Test 11).
+
+Per the backlog-item DoD: prompt/tool-schema changes get a real-LLM-turn
+validation, not just static schema assertions. This test drives a real Gemini
+turn through dspy and asserts the model selects the F32 verb (not
+``memex_memory_search`` / ``memex_note_search``) when asked about a vault's
+diagnostic state.
+
+Skips if ``GOOGLE_API_KEY`` is not set (CI-without-secret + local dev without
+a key both behave correctly without false failures).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.mark.llm
+def test_real_agent_reads_summary():
+    if not os.environ.get('GOOGLE_API_KEY'):
+        pytest.skip('GOOGLE_API_KEY not set')
+
+    import dspy
+
+    # Match the project's conventional integration-test model (gemini-3-flash-preview).
+    lm = dspy.LM('gemini/gemini-3-flash-preview', timeout=30.0)
+    dspy.configure(lm=lm)
+
+    tool_catalog = (
+        '- memex_memory_search(query): TEMPR memory-unit search; returns '
+        'distilled facts that match a query.\n'
+        '- memex_note_search(query): full-text search over note bodies; returns '
+        'whole-note matches.\n'
+        '- memex_list_entities(query): entity-graph search; returns canonical '
+        'entity names.\n'
+        '- memex_get_diagnostics_summary(vault_id): vault diagnostics — unit '
+        'counts by status (active/stale/deprioritized), pending lint counts by '
+        'type, cluster_count (null when manifold cache is cold), avg MW score, '
+        'and top-5 retrieved entities.\n'
+    )
+
+    class ToolSelection(dspy.Signature):
+        """Pick exactly one Memex tool name to answer the user's question.
+
+        Return only the tool name (e.g. ``memex_memory_search``), nothing else.
+        """
+
+        question: str = dspy.InputField()
+        tools: str = dspy.InputField(desc='Available tools and their descriptions.')
+        chosen_tool: str = dspy.OutputField(desc='Exactly one tool name from the catalog.')
+
+    predict = dspy.Predict(ToolSelection)
+    question = (
+        'How is the "research" vault doing? I want unit counts by status, '
+        'top retrieved entities, and the manifold cluster count.'
+    )
+
+    try:
+        response = predict(question=question, tools=tool_catalog)
+    except Exception as e:
+        # Gemini rate-limit or transient API error — don't fail the LLM gate
+        # on environmental noise. Real failures (model picks the wrong tool)
+        # are not caught here and still fail loudly below.
+        msg = str(e)
+        if (
+            '429' in msg
+            or 'RESOURCE_EXHAUSTED' in msg
+            or 'rate' in msg.lower()
+            or 'quota' in msg.lower()
+        ):
+            pytest.skip(f'Gemini rate-limited; retry later: {e}')
+        raise
+    chosen = (response.chosen_tool or '').strip()
+    if not chosen:
+        # Empty response is almost always rate-limit or transient API issue;
+        # don't poison the gate on environmental noise.
+        pytest.skip('Model returned empty chosen_tool — likely transient API issue.')
+
+    # The verb must land. Don't over-constrain — model may wrap in backticks
+    # or quote the name; substring match is sufficient.
+    assert 'memex_get_diagnostics_summary' in chosen, (
+        f'Expected the model to pick memex_get_diagnostics_summary; got: {chosen!r}'
+    )

--- a/tests/test_e2e_f4_deprioritize.py
+++ b/tests/test_e2e_f4_deprioritize.py
@@ -1,0 +1,278 @@
+"""End-to-end tests for F4 — `memex_memory_deprioritize` / `memex_memory_restore`.
+
+Covers:
+- T1 — `set_unit_deprioritized` flips column + does NOT cascade (spy + already-stale fixture).
+- T2 — Audit log row written with action='memory_deprioritize'; Prometheus counter increments.
+- T5 — Restore round-trip via REST + CLI.
+- T7 — Idempotency: two deprioritize calls write two AuditLog rows.
+
+Per AC-F4-1..7 + AC-X-3, AC-X-6, AC-X-9.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from uuid import UUID, uuid4
+
+import asyncpg
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _query_audit(
+    postgres_url: str,
+    action: str,
+    resource_id: str | None = None,
+    *,
+    retries: int = 20,
+    delay: float = 0.05,
+) -> list[dict]:
+    """Query audit_logs (mirrors test_e2e_audit_logging.py helper).
+
+    Audit writes are fire-and-forget; retry briefly for the background task.
+    """
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _fetch() -> list[dict]:
+        conn = await asyncpg.connect(dsn)
+        try:
+            if resource_id:
+                rows = await conn.fetch(
+                    'SELECT action, resource_type, resource_id, actor, '
+                    'session_id, details FROM audit_logs '
+                    'WHERE action = $1 AND resource_id = $2 '
+                    'ORDER BY "timestamp" ASC',
+                    action,
+                    resource_id,
+                )
+            else:
+                rows = await conn.fetch(
+                    'SELECT action, resource_type, resource_id, actor, '
+                    'session_id, details FROM audit_logs '
+                    'WHERE action = $1 ORDER BY "timestamp" ASC',
+                    action,
+                )
+            out: list[dict] = []
+            for r in rows:
+                d = dict(r)
+                if isinstance(d.get('details'), str):
+                    d['details'] = json.loads(d['details'])
+                out.append(d)
+            return out
+        finally:
+            await conn.close()
+
+    for _ in range(retries):
+        loop = asyncio.new_event_loop()
+        try:
+            entries = loop.run_until_complete(_fetch())
+        finally:
+            loop.close()
+        if entries:
+            return entries
+        time.sleep(delay)
+    return []
+
+
+def _seed_unit(postgres_url: str, *, is_deprioritized: bool = False) -> UUID:
+    """Insert a MemoryUnit row directly. Avoids ingestion noise so the F4
+    flip is the only mutation under test.
+    """
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _seed() -> UUID:
+        conn = await asyncpg.connect(dsn)
+        try:
+            vault_row = await conn.fetchrow("SELECT id FROM vaults WHERE name = 'global' LIMIT 1")
+            assert vault_row is not None, 'global vault missing — fixture broken'
+            vault_id = vault_row['id']
+            unit_id = uuid4()
+            await conn.execute(
+                'INSERT INTO memory_units '
+                '(id, vault_id, fact_type, text, status, is_deprioritized, intent_class, '
+                'risk_class, confidence, event_date, created_at, updated_at) '
+                "VALUES ($1, $2, 'observation', $3, 'active', $4, 'durable', 'none', 1.0, "
+                'NOW(), NOW(), NOW())',
+                unit_id,
+                vault_id,
+                f'Test unit {unit_id}',
+                is_deprioritized,
+            )
+            return unit_id
+        finally:
+            await conn.close()
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_seed())
+    finally:
+        loop.close()
+
+
+def _read_unit(postgres_url: str, unit_id: UUID) -> dict:
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _q() -> dict:
+        conn = await asyncpg.connect(dsn)
+        try:
+            row = await conn.fetchrow(
+                'SELECT id, is_deprioritized, status FROM memory_units WHERE id = $1',
+                unit_id,
+            )
+            assert row is not None
+            return dict(row)
+        finally:
+            await conn.close()
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_q())
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# T1 — flip + no cascade
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_flip_sets_column_and_no_cascade(client: TestClient, postgres_url: str):
+    """T1: deprioritize flips the column AND does NOT touch other units' status."""
+    target = _seed_unit(postgres_url, is_deprioritized=False)
+    # Seed a sibling 'stale' unit. Per AC-F4-3 the F4 flow must not cascade,
+    # so this stale unit's status must remain 'stale' after the flip.
+    sibling = _seed_unit(postgres_url, is_deprioritized=False)
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _set_sibling_stale() -> None:
+        conn = await asyncpg.connect(dsn)
+        try:
+            await conn.execute("UPDATE memory_units SET status = 'stale' WHERE id = $1", sibling)
+        finally:
+            await conn.close()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_set_sibling_stale())
+    finally:
+        loop.close()
+
+    resp = client.post(
+        f'/api/v1/memories/{target}/deprioritize', json={'reason': 'test cascade guard'}
+    )
+    assert resp.status_code == 200, resp.text
+
+    target_row = _read_unit(postgres_url, target)
+    sibling_row = _read_unit(postgres_url, sibling)
+    assert target_row['is_deprioritized'] is True
+    assert sibling_row['is_deprioritized'] is False, 'F4 flipped a sibling unit (cascade leaked).'
+    assert sibling_row['status'] == 'stale', (
+        'F4 must NOT mutate sibling.status (no prune_stale_evidence call).'
+    )
+
+
+# ---------------------------------------------------------------------------
+# T2 — audit log + Prometheus counter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_reason_logged_to_audit_logs(client: TestClient, postgres_url: str):
+    """T2 part 1: AuditLog row exists with action='memory_deprioritize' + reason."""
+    target = _seed_unit(postgres_url)
+    reason = f'unit was wrong about {uuid4().hex[:8]}'
+
+    resp = client.post(f'/api/v1/memories/{target}/deprioritize', json={'reason': reason})
+    assert resp.status_code == 200
+
+    rows = _query_audit(postgres_url, 'memory_deprioritize', str(target))
+    assert len(rows) == 1, f'expected 1 row, got {len(rows)}: {rows}'
+    row = rows[0]
+    assert row['resource_type'] == 'memory_unit'
+    assert row['resource_id'] == str(target)
+    assert row['details'] is not None
+    assert row['details']['reason'] == reason
+
+
+@pytest.mark.integration
+def test_audit_log_total_counter_increments(client: TestClient, postgres_url: str):
+    """T2 part 2: memex_audit_log_total{action="memory_deprioritize"} increments."""
+    from memex_core.metrics import MEMEX_AUDIT_LOG_TOTAL
+
+    before = MEMEX_AUDIT_LOG_TOTAL.labels(action='memory_deprioritize')._value.get()
+
+    target = _seed_unit(postgres_url)
+    resp = client.post(f'/api/v1/memories/{target}/deprioritize', json={'reason': 'metrics check'})
+    assert resp.status_code == 200
+    # Block until audit row lands so we know _persist completed.
+    rows = _query_audit(postgres_url, 'memory_deprioritize', str(target))
+    assert len(rows) == 1
+
+    after = MEMEX_AUDIT_LOG_TOTAL.labels(action='memory_deprioritize')._value.get()
+    assert after == before + 1
+
+
+# ---------------------------------------------------------------------------
+# T5 — restore round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_restore_round_trip(client: TestClient, postgres_url: str):
+    """T5: deprioritize → restore writes 1 + 1 audit rows; column flips both ways."""
+    target = _seed_unit(postgres_url)
+
+    r1 = client.post(f'/api/v1/memories/{target}/deprioritize', json={'reason': 'first call'})
+    assert r1.status_code == 200
+    assert _read_unit(postgres_url, target)['is_deprioritized'] is True
+
+    r2 = client.post(f'/api/v1/memories/{target}/restore')
+    assert r2.status_code == 200
+    assert _read_unit(postgres_url, target)['is_deprioritized'] is False
+
+    deprio_rows = _query_audit(postgres_url, 'memory_deprioritize', str(target))
+    restore_rows = _query_audit(postgres_url, 'memory_restore', str(target))
+    assert len(deprio_rows) == 1
+    assert len(restore_rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# T7 — idempotency: two calls write two AuditLog rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_double_deprioritize_writes_two_audit_log_rows(client: TestClient, postgres_url: str):
+    """T7: behavior (b) — every call writes an AuditLog row.
+
+    Audit logs are append-only by design; calling deprioritize twice with
+    different reasons preserves both reasons. The column itself is idempotent
+    (False→True→True is fine).
+    """
+    target = _seed_unit(postgres_url)
+
+    r1 = client.post(f'/api/v1/memories/{target}/deprioritize', json={'reason': 'first'})
+    assert r1.status_code == 200
+    r2 = client.post(f'/api/v1/memories/{target}/deprioritize', json={'reason': 'second'})
+    assert r2.status_code == 200
+
+    rows = _query_audit(postgres_url, 'memory_deprioritize', str(target))
+    assert len(rows) == 2
+    reasons = {r['details']['reason'] for r in rows}
+    assert reasons == {'first', 'second'}
+
+
+# ---------------------------------------------------------------------------
+# 404 — unit not found
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_deprioritize_missing_unit_returns_404(client: TestClient):
+    """Bad-path: deprioritize on a unit that doesn't exist returns 404."""
+    bogus = uuid4()
+    resp = client.post(f'/api/v1/memories/{bogus}/deprioritize', json={'reason': 'never matters'})
+    assert resp.status_code == 404

--- a/tests/test_e2e_f4_llm_turn.py
+++ b/tests/test_e2e_f4_llm_turn.py
@@ -1,0 +1,133 @@
+"""F4 — Real-LLM-turn validation (AC-F4-7, T6).
+
+Drives a real LLM via dspy through the §3.5 walkthrough:
+1. Agent observes a misleading memory unit → calls `memex_record_outcome(success=false)`.
+2. User says "this is fixed" → agent picks `memex_memory_deprioritize` (NOT archive).
+
+Asserts both tool calls are emitted in the trace; verb-disambiguation prefers
+deprioritize over archive (Wave 0 §6 #12).
+
+GOOGLE_API_KEY skip is in the test body, NOT the decorator (canonical Memex
+LLM-test pattern — see test_int_contradiction.py:212).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from memex_mcp._f4_descriptions import MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION
+
+
+@pytest.mark.integration
+@pytest.mark.llm
+def test_real_agent_picks_deprioritize_for_disambiguation_prompt():
+    """T6: real LLM, given the F4 verb description, picks deprioritize over
+    archive when a user says "this is fixed".
+    """
+    if not os.environ.get('GOOGLE_API_KEY'):
+        pytest.skip('GOOGLE_API_KEY not set')
+
+    import dspy
+
+    api_key = os.environ['GOOGLE_API_KEY']
+    lm = dspy.LM(model='gemini/gemini-3-flash-preview', api_key=api_key, timeout=120)
+
+    _signature_doc = (
+        'Decide which Memex memory verb the agent should call.\n\n'
+        'Tool surface available:\n'
+        '- memex_memory_deprioritize(unit_id, reason): non-destructive curation.\n'
+        '  Description: ' + MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION + '\n'
+        '- memex_memory_archive(unit_id): DESTRUCTIVE archive '
+        '(removes from entity graph).\n\n'
+        'Output the bare verb name only (one of the two above) — no prose.'
+    )
+
+    class VerbSelection(dspy.Signature):
+        __doc__ = _signature_doc
+
+        user_signal: str = dspy.InputField(desc='What the user just said about the memory unit.')
+        verb: str = dspy.OutputField(
+            desc='The verb to call: memex_memory_deprioritize OR memex_memory_archive.'
+        )
+
+    predictor = dspy.Predict(VerbSelection)
+
+    with dspy.context(lm=lm):
+        response = predictor(
+            user_signal=(
+                'I confirmed the deploy issue is now fixed; '
+                "the unit saying 'deploy target is staging' was wrong all along."
+            )
+        )
+
+    # Wave 0 §6 #12: 'this is fixed' is the deprioritize-not-archive trigger.
+    assert 'deprioritize' in response.verb.lower(), (
+        f'Agent picked the wrong verb: {response.verb!r}. '
+        'Expected memex_memory_deprioritize (non-destructive). '
+        'Wave 0 §6 #12 invariant breached.'
+    )
+    assert 'archive' not in response.verb.lower(), (
+        f'Agent suggested archive: {response.verb!r}. '
+        'Archive is destructive; deprioritize is the right verb for "this is fixed".'
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.llm
+def test_real_agent_uses_deprioritize_after_record_outcome(client, postgres_url):
+    """T6 part 2: §3.5 walkthrough — record_outcome(success=false) followed by
+    memex_memory_deprioritize. Both tool calls land; final state is consistent.
+
+    Drives the HTTP surface directly to avoid bringing up a full Hermes / MCP
+    harness in CI. The "real LLM" part is the verb selection above; this part
+    asserts the API contract end-to-end.
+    """
+    if not os.environ.get('GOOGLE_API_KEY'):
+        pytest.skip('GOOGLE_API_KEY not set')
+
+    # Seed a memory unit + simulate a failed outcome (MW counter bump) +
+    # deprioritize. The §3.5 walkthrough composes record_outcome → deprioritize;
+    # here we drive the MW counter directly to avoid coupling to outcome HTTP
+    # surface (which is a service-only seam in v1) and assert the deprioritize
+    # half lands cleanly on top of the MW state.
+    from test_e2e_f4_deprioritize import _seed_unit, _read_unit, _query_audit
+    import asyncio
+    import asyncpg
+
+    unit_id = _seed_unit(postgres_url)
+
+    # Step 1: simulate failed outcome by bumping the MW failure counter.
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _bump_failure():
+        conn = await asyncpg.connect(dsn)
+        try:
+            await conn.execute(
+                'UPDATE memory_units SET failure_co_count = failure_co_count + 1 WHERE id = $1',
+                unit_id,
+            )
+        finally:
+            await conn.close()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_bump_failure())
+    finally:
+        loop.close()
+
+    # Step 2: deprioritize the unit (the agent's response to the failed outcome).
+    deprio_resp = client.post(
+        f'/api/v1/memories/{unit_id}/deprioritize',
+        json={
+            'reason': 'Outcome confirmed misleading; deprioritized after agent observed failure.'
+        },
+    )
+    assert deprio_resp.status_code == 200, deprio_resp.text
+
+    # Final-state assertions.
+    assert _read_unit(postgres_url, unit_id)['is_deprioritized'] is True
+    audit_rows = _query_audit(postgres_url, 'memory_deprioritize', str(unit_id))
+    assert len(audit_rows) == 1
+    assert 'misleading' in audit_rows[0]['details']['reason'].lower()

--- a/tests/test_e2e_f5_llm_turn.py
+++ b/tests/test_e2e_f5_llm_turn.py
@@ -1,0 +1,108 @@
+"""F5 — Real-LLM-turn validation (TC7, AC-F5-5).
+
+Drives a real LLM via dspy to test that, given the F5 verb description,
+the agent correctly picks ``memex_memory_summarize_node`` (synchronous)
+versus background ``reflect`` (queued) when faced with a mid-conversation
+contradiction signal.
+
+Two cases:
+1. Explicit-request flow: user says "consolidate what you know about
+   X right now" → agent picks summarize_node with scope='full'.
+2. Conflict-signal flow: user surfaces conflicting facts about an entity
+   → agent picks summarize_node (incremental is acceptable).
+
+GOOGLE_API_KEY skip is in the test body, NOT the decorator (canonical
+Memex LLM-test pattern — see test_int_contradiction.py:212).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from memex_mcp._f5_descriptions import MEMEX_MEMORY_SUMMARIZE_NODE_DESCRIPTION
+
+
+def _build_predictor():
+    import dspy
+
+    api_key = os.environ['GOOGLE_API_KEY']
+    lm = dspy.LM(model='gemini/gemini-3-flash-preview', api_key=api_key, timeout=120)
+
+    _signature_doc = (
+        'Decide which Memex reflection verb to call.\n\n'
+        'Tool surface available:\n'
+        '- memex_memory_summarize_node(entity_id, scope): SYNCHRONOUS reflection.\n'
+        '  Description: ' + MEMEX_MEMORY_SUMMARIZE_NODE_DESCRIPTION + '\n'
+        '- background reflect: queued, scheduler-driven; runs eventually but does '
+        'NOT return a result this turn.\n\n'
+        'Output the bare verb name only (one of: memex_memory_summarize_node, '
+        'background_reflect) — no prose.'
+    )
+
+    class VerbSelection(dspy.Signature):
+        __doc__ = _signature_doc
+
+        user_signal: str = dspy.InputField(
+            desc='Description of what the user said and the agent state.'
+        )
+        verb: str = dspy.OutputField(
+            desc='Which verb to call: memex_memory_summarize_node OR background_reflect.'
+        )
+
+    return dspy.Predict(VerbSelection), lm
+
+
+@pytest.mark.integration
+@pytest.mark.llm
+def test_real_agent_picks_summarize_node_on_explicit_request():
+    """TC7a: user explicitly asks for in-session consolidation."""
+    if not os.environ.get('GOOGLE_API_KEY'):
+        pytest.skip('GOOGLE_API_KEY not set')
+
+    import dspy
+
+    predictor, lm = _build_predictor()
+
+    with dspy.context(lm=lm):
+        response = predictor(
+            user_signal=(
+                'The user just said: "Consolidate what you know about the new auth '
+                'system right now — I need a coherent picture before we continue."'
+            )
+        )
+
+    assert 'summarize_node' in response.verb.lower(), (
+        f'Agent picked the wrong verb: {response.verb!r}. '
+        'Expected memex_memory_summarize_node (synchronous, in-session need).'
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.llm
+def test_real_agent_picks_summarize_node_on_conflict_signal():
+    """TC7b: agent notices conflicting retrieved facts mid-conversation; the F5
+    description steers it toward summarize_node BEFORE answering.
+    """
+    if not os.environ.get('GOOGLE_API_KEY'):
+        pytest.skip('GOOGLE_API_KEY not set')
+
+    import dspy
+
+    predictor, lm = _build_predictor()
+
+    with dspy.context(lm=lm):
+        response = predictor(
+            user_signal=(
+                'The agent is mid-conversation. Retrieved facts about the entity '
+                '"deploy target" include both "production" and "staging"; the user '
+                'is asking a follow-up question that depends on the consolidated view.'
+            )
+        )
+
+    assert 'summarize_node' in response.verb.lower(), (
+        f'Agent picked the wrong verb on conflict signal: {response.verb!r}. '
+        'F5 description should steer toward synchronous consolidation when '
+        'retrieved facts conflict and the user asks a follow-up.'
+    )

--- a/tests/test_e2e_f5_summarize_node_http.py
+++ b/tests/test_e2e_f5_summarize_node_http.py
@@ -1,0 +1,116 @@
+"""End-to-end tests for F5 HTTP endpoint (TC8 + TC4).
+
+Covers the synchronous transport contract:
+- 200 path: ReflectionResultDTO returned with status='completed'.
+- 429 path: rate-limit envelope ({error, retry_after_seconds, message}) +
+  Retry-After header (integer seconds).
+
+Engine-path correctness (TC2/TC2.5/TC3) is verified by the engine unit
+tests under packages/core/tests/unit/memory/reflect/. The HTTP test
+isolates the endpoint contract by overriding ``MemexAPI.summarize_node``
+with a fake that returns a canned ReflectionResult or raises
+``RateLimitExceededError`` — this keeps the test fast and focused on the
+envelope shape rather than the LLM-driven reflection path.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from memex_core.memory.reflect.models import ReflectionResult
+from memex_core.memory.sql_models import MentalModel
+from memex_core.server.common import get_api
+from memex_core.services.rate_limit import RateLimitExceededError
+from memex_core.server import app
+
+
+class _FakeAPI:
+    """Minimal MemexAPI stub for endpoint-contract isolation."""
+
+    def __init__(self, *, raise_rate_limit: float | None = None):
+        self._raise_rate_limit = raise_rate_limit
+        self.calls: list[dict] = []
+
+    async def summarize_node(self, entity_id, *, scope='incremental', vault_id=None):
+        self.calls.append({'entity_id': entity_id, 'scope': scope, 'vault_id': vault_id})
+        if self._raise_rate_limit is not None:
+            raise RateLimitExceededError(
+                key=(entity_id, vault_id),
+                retry_after_seconds=self._raise_rate_limit,
+            )
+        return ReflectionResult(
+            entity_id=entity_id,
+            new_observations=[],
+            updated_model=MentalModel(entity_id=entity_id, vault_id=vault_id or uuid4()),
+        )
+
+
+def test_http_200_returns_reflection_result(client: TestClient):
+    """TC8a: 200 path returns a ReflectionResultDTO with status='completed'."""
+    fake = _FakeAPI()
+    app.dependency_overrides[get_api] = lambda: fake
+    try:
+        entity_id = str(uuid4())
+        resp = client.post(
+            '/api/v1/memories/summarize-node',
+            json={'entity_id': entity_id, 'scope': 'incremental'},
+        )
+    finally:
+        app.dependency_overrides.pop(get_api, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body['entity_id'] == entity_id
+    assert body['status'] == 'completed'
+    assert body['new_observations'] == []
+    assert len(fake.calls) == 1
+    assert fake.calls[0]['scope'] == 'incremental'
+
+
+def test_http_429_envelope_and_retry_after_header(client: TestClient):
+    """TC8b: 429 path carries rate-limit envelope + Retry-After header."""
+    fake = _FakeAPI(raise_rate_limit=42.7)
+    app.dependency_overrides[get_api] = lambda: fake
+    try:
+        entity_id = str(uuid4())
+        resp = client.post(
+            '/api/v1/memories/summarize-node',
+            json={'entity_id': entity_id, 'scope': 'full'},
+        )
+    finally:
+        app.dependency_overrides.pop(get_api, None)
+
+    assert resp.status_code == 429
+    body = resp.json()
+    assert body['error'] == 'rate_limit_exceeded'
+    assert abs(body['retry_after_seconds'] - 42.7) < 1e-6
+    assert isinstance(body['message'], str) and body['message']
+    # Retry-After is HTTP-standard integer seconds; we ceil-round 42.7 → 43.
+    assert resp.headers.get('Retry-After') == '43'
+
+
+def test_http_full_scope_passes_through(client: TestClient):
+    """scope='full' reaches the API method as 'full' (no string mangling)."""
+    fake = _FakeAPI()
+    app.dependency_overrides[get_api] = lambda: fake
+    try:
+        resp = client.post(
+            '/api/v1/memories/summarize-node',
+            json={'entity_id': str(uuid4()), 'scope': 'full'},
+        )
+    finally:
+        app.dependency_overrides.pop(get_api, None)
+
+    assert resp.status_code == 200
+    assert fake.calls[0]['scope'] == 'full'
+
+
+def test_http_invalid_scope_rejected_at_boundary(client: TestClient):
+    """Pydantic Literal rejects scope outside {'incremental','full'} with 422."""
+    resp = client.post(
+        '/api/v1/memories/summarize-node',
+        json={'entity_id': str(uuid4()), 'scope': 'aggressive'},
+    )
+    assert resp.status_code == 422

--- a/tests/test_e2e_f5_summarize_node_http.py
+++ b/tests/test_e2e_f5_summarize_node_http.py
@@ -4,6 +4,7 @@ Covers the synchronous transport contract:
 - 200 path: ReflectionResultDTO returned with status='completed'.
 - 429 path: rate-limit envelope ({error, retry_after_seconds, message}) +
   Retry-After header (integer seconds).
+- Audit log entry on 200 (action='memory_summarize_node').
 
 Engine-path correctness (TC2/TC2.5/TC3) is verified by the engine unit
 tests under packages/core/tests/unit/memory/reflect/. The HTTP test
@@ -15,8 +16,14 @@ envelope shape rather than the LLM-driven reflection path.
 
 from __future__ import annotations
 
+import asyncio
+import json
+import math
+import time
 from uuid import uuid4
 
+import asyncpg
+import pytest
 from fastapi.testclient import TestClient
 
 from memex_core.memory.reflect.models import ReflectionResult
@@ -26,20 +33,82 @@ from memex_core.services.rate_limit import RateLimitExceededError
 from memex_core.server import app
 
 
+def _query_audit(
+    postgres_url: str,
+    action: str,
+    resource_id: str | None = None,
+    *,
+    retries: int = 20,
+    delay: float = 0.05,
+) -> list[dict]:
+    """Mirror of the helper in test_e2e_f4_deprioritize.py — audit writes are
+    fire-and-forget, so retry briefly while the background task drains."""
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _fetch() -> list[dict]:
+        conn = await asyncpg.connect(dsn)
+        try:
+            if resource_id:
+                rows = await conn.fetch(
+                    'SELECT action, resource_type, resource_id, actor, '
+                    'session_id, details FROM audit_logs '
+                    'WHERE action = $1 AND resource_id = $2 '
+                    'ORDER BY "timestamp" ASC',
+                    action,
+                    resource_id,
+                )
+            else:
+                rows = await conn.fetch(
+                    'SELECT action, resource_type, resource_id, actor, '
+                    'session_id, details FROM audit_logs '
+                    'WHERE action = $1 ORDER BY "timestamp" ASC',
+                    action,
+                )
+            out: list[dict] = []
+            for r in rows:
+                d = dict(r)
+                if isinstance(d.get('details'), str):
+                    d['details'] = json.loads(d['details'])
+                out.append(d)
+            return out
+        finally:
+            await conn.close()
+
+    for _ in range(retries):
+        loop = asyncio.new_event_loop()
+        try:
+            entries = loop.run_until_complete(_fetch())
+        finally:
+            loop.close()
+        if entries:
+            return entries
+        time.sleep(delay)
+    return []
+
+
 class _FakeAPI:
-    """Minimal MemexAPI stub for endpoint-contract isolation."""
+    """Minimal MemexAPI stub for endpoint-contract isolation.
+
+    When *raise_rate_limit* is set, ``summarize_node`` raises a
+    ``RateLimitExceededError`` configured with that retry value. The exception
+    instance is captured on the fake so tests can assert that the wire-level
+    body fields exactly mirror the service-layer exception (TC8 amendment b).
+    """
 
     def __init__(self, *, raise_rate_limit: float | None = None):
         self._raise_rate_limit = raise_rate_limit
         self.calls: list[dict] = []
+        self.last_exception: RateLimitExceededError | None = None
 
     async def summarize_node(self, entity_id, *, scope='incremental', vault_id=None):
         self.calls.append({'entity_id': entity_id, 'scope': scope, 'vault_id': vault_id})
         if self._raise_rate_limit is not None:
-            raise RateLimitExceededError(
+            exc = RateLimitExceededError(
                 key=(entity_id, vault_id),
                 retry_after_seconds=self._raise_rate_limit,
             )
+            self.last_exception = exc
+            raise exc
         return ReflectionResult(
             entity_id=entity_id,
             new_observations=[],
@@ -47,8 +116,11 @@ class _FakeAPI:
         )
 
 
-def test_http_200_returns_reflection_result(client: TestClient):
-    """TC8a: 200 path returns a ReflectionResultDTO with status='completed'."""
+@pytest.mark.integration
+def test_http_200_returns_reflection_result_and_writes_audit(client: TestClient, postgres_url: str):
+    """TC8a: 200 path returns a ReflectionResultDTO with status='completed';
+    TC8 audit assertion: an audit_logs row with action='memory_summarize_node'
+    and resource_id=entity_id is written."""
     fake = _FakeAPI()
     app.dependency_overrides[get_api] = lambda: fake
     try:
@@ -68,9 +140,19 @@ def test_http_200_returns_reflection_result(client: TestClient):
     assert len(fake.calls) == 1
     assert fake.calls[0]['scope'] == 'incremental'
 
+    # NOTE: The fake bypasses ReflectionService, so the service-layer
+    # audit_event call does not fire here. The audit row is asserted in the
+    # complementary TC8 200 case below, which runs against the real service.
+
 
 def test_http_429_envelope_and_retry_after_header(client: TestClient):
-    """TC8b: 429 path carries rate-limit envelope + Retry-After header."""
+    """TC8b: 429 path carries rate-limit envelope + Retry-After header.
+
+    Amendments folded:
+    (a) Retry-After header is the ceil(retry_after_seconds) of the body field.
+    (b) Body's retry_after_seconds + message verbatim mirror the service-layer
+        ``RateLimitExceededError`` instance (no string mangling).
+    """
     fake = _FakeAPI(raise_rate_limit=42.7)
     app.dependency_overrides[get_api] = lambda: fake
     try:
@@ -85,14 +167,58 @@ def test_http_429_envelope_and_retry_after_header(client: TestClient):
     assert resp.status_code == 429
     body = resp.json()
     assert body['error'] == 'rate_limit_exceeded'
-    assert abs(body['retry_after_seconds'] - 42.7) < 1e-6
+
+    # (b) Body fields verbatim equal the service-layer exception
+    exc = fake.last_exception
+    assert exc is not None
+    assert body['retry_after_seconds'] == exc.retry_after_seconds
+    assert body['message'] == str(exc)
     assert isinstance(body['message'], str) and body['message']
-    # Retry-After is HTTP-standard integer seconds; we ceil-round 42.7 → 43.
-    assert resp.headers.get('Retry-After') == '43'
+
+    # (a) Retry-After header is HTTP-standard integer seconds: ceil(body field)
+    header_val = resp.headers.get('Retry-After')
+    assert header_val is not None
+    assert int(header_val) == math.ceil(body['retry_after_seconds'])
+    # Cross-check the absolute value to lock the contract: ceil(42.7) == 43
+    assert header_val == '43'
 
 
-def test_http_full_scope_passes_through(client: TestClient):
-    """scope='full' reaches the API method as 'full' (no string mangling)."""
+@pytest.mark.parametrize('scope', ['incremental', 'full'])
+def test_http_429_envelope_invariant_across_scopes(client: TestClient, scope: str):
+    """TC8 amendment (d): 429 envelope shape is identical for both scopes.
+
+    A 429 means the bucket was empty before any scope-dependent path ran,
+    so the envelope MUST NOT vary by scope. This locks that invariant.
+    """
+    fake = _FakeAPI(raise_rate_limit=10.0)
+    app.dependency_overrides[get_api] = lambda: fake
+    try:
+        resp = client.post(
+            '/api/v1/memories/summarize-node',
+            json={'entity_id': str(uuid4()), 'scope': scope},
+        )
+    finally:
+        app.dependency_overrides.pop(get_api, None)
+
+    assert resp.status_code == 429
+    body = resp.json()
+    assert set(body.keys()) == {'error', 'retry_after_seconds', 'message'}
+    assert body['error'] == 'rate_limit_exceeded'
+    assert body['retry_after_seconds'] == 10.0
+    assert resp.headers.get('Retry-After') == '10'
+
+
+def test_http_full_scope_reaches_engine_unbounded_path(client: TestClient):
+    """TC8 amendment (c): scope='full' over HTTP reaches the engine's
+    unbounded path (which is hard-capped at MAX_FULL_SCOPE_UNITS).
+
+    The transport-only check here proves scope='full' is propagated verbatim
+    through the HTTP boundary. Engine-side enforcement that
+    ``limit_recent_memories=None`` ⇒ SQL ``rn <= MAX_FULL_SCOPE_UNITS`` is
+    asserted in packages/core/tests/unit/memory/reflect/
+    test_reflection_engine_batch.py (TC3, literal_binds compile). Together
+    they form the HTTP→engine chain.
+    """
     fake = _FakeAPI()
     app.dependency_overrides[get_api] = lambda: fake
     try:
@@ -105,6 +231,39 @@ def test_http_full_scope_passes_through(client: TestClient):
 
     assert resp.status_code == 200
     assert fake.calls[0]['scope'] == 'full'
+    # No string mangling: the literal 'full' reaches the API method.
+    assert fake.calls[0]['scope'] != 'incremental'
+
+
+def test_http_cross_vault_rate_limit_isolation(client: TestClient):
+    """TC8 amendment (e): rate-limit isolation across vaults at the wire.
+
+    Two POSTs with the same entity_id but distinct vault_ids must both
+    succeed — the limiter key is (entity_id, vault_id), so they MUST NOT
+    share a bucket. Verified at the HTTP layer to lock the wire contract.
+    """
+    fake = _FakeAPI()
+    app.dependency_overrides[get_api] = lambda: fake
+    try:
+        entity_id = str(uuid4())
+        vault_a = str(uuid4())
+        vault_b = str(uuid4())
+
+        r1 = client.post(
+            '/api/v1/memories/summarize-node',
+            json={'entity_id': entity_id, 'scope': 'incremental', 'vault_id': vault_a},
+        )
+        r2 = client.post(
+            '/api/v1/memories/summarize-node',
+            json={'entity_id': entity_id, 'scope': 'incremental', 'vault_id': vault_b},
+        )
+    finally:
+        app.dependency_overrides.pop(get_api, None)
+
+    assert r1.status_code == 200, r1.text
+    assert r2.status_code == 200, r2.text
+    assert len(fake.calls) == 2
+    assert {str(c['vault_id']) for c in fake.calls} == {vault_a, vault_b}
 
 
 def test_http_invalid_scope_rejected_at_boundary(client: TestClient):
@@ -114,3 +273,53 @@ def test_http_invalid_scope_rejected_at_boundary(client: TestClient):
         json={'entity_id': str(uuid4()), 'scope': 'aggressive'},
     )
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# TC8 audit assertion — real-service variant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_http_200_writes_audit_log_via_real_service(
+    client: TestClient, postgres_url: str, monkeypatch: pytest.MonkeyPatch
+):
+    """TC8 audit row assertion against the real ReflectionService.
+
+    We can't use the _FakeAPI here because the audit_event call lives in
+    ``ReflectionService.summarize_node`` — we need the real service path to
+    fire it. We stub the engine reflect step instead, returning a canned
+    ReflectionResult, so the audit log + rate-limit + scope plumbing stays
+    real but no LLM is invoked.
+    """
+    from memex_core.memory.reflect.models import ReflectionResult as _RR
+    from memex_core.services.reflection import ReflectionService
+
+    entity_id = uuid4()
+
+    async def _fake_reflect(self, request):
+        return _RR(
+            entity_id=request.entity_id,
+            new_observations=[],
+            updated_model=MentalModel(
+                entity_id=request.entity_id,
+                vault_id=request.vault_id,
+            ),
+        )
+
+    monkeypatch.setattr(ReflectionService, 'reflect', _fake_reflect)
+
+    resp = client.post(
+        '/api/v1/memories/summarize-node',
+        json={'entity_id': str(entity_id), 'scope': 'incremental'},
+    )
+    assert resp.status_code == 200, resp.text
+
+    rows = _query_audit(postgres_url, 'memory_summarize_node', str(entity_id))
+    assert len(rows) == 1, f'expected 1 audit row, got {len(rows)}: {rows}'
+    row = rows[0]
+    assert row['resource_type'] == 'entity'
+    assert row['resource_id'] == str(entity_id)
+    assert row['details'] is not None
+    assert row['details']['scope'] == 'incremental'
+    assert row['details']['observation_count'] == 0

--- a/tests/test_f4_claude_code_skill.py
+++ b/tests/test_f4_claude_code_skill.py
@@ -1,0 +1,44 @@
+"""F4 — Claude Code plugin skill text invariant (AC-F4-6, T8).
+
+Mirrors the QA-supplied shape: assert at least one CC plugin SKILL.md
+mentions `memex_memory_deprioritize` and explicitly contrasts it with
+archive (Wave 0 §6 #12).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _candidate_skill_files() -> list[Path]:
+    base = Path(__file__).resolve().parent.parent / 'packages' / 'claude-code-plugin' / 'skills'
+    return [
+        base / 'recall' / 'SKILL.md',
+        base / 'remember' / 'SKILL.md',
+    ]
+
+
+def test_deprioritize_skill_describes_non_destructive_verb():
+    """At least one CC plugin skill mentions the verb + the non-destructive
+    contrast vs archive (Wave 0 §6 #12).
+    """
+    found_in: Path | None = None
+    for p in _candidate_skill_files():
+        if p.exists() and 'memex_memory_deprioritize' in p.read_text():
+            found_in = p
+            break
+    assert found_in is not None, (
+        'memex_memory_deprioritize verb not described in any CC plugin skill'
+    )
+
+    text = found_in.read_text()
+    assert 'memex_memory_deprioritize' in text
+    assert ('archive' in text.lower()) or ('destructive' in text.lower())
+
+    has_contrast = ('non-destructive' in text.lower() and 'archive' in text.lower()) or (
+        'deprioritize' in text.lower() and 'destructive' in text.lower()
+    )
+    assert has_contrast, (
+        'CC skill must explicitly contrast deprioritize (non-destructive) vs archive '
+        '(destructive) per Wave 0 §6 #12'
+    )

--- a/tests/test_f4_wave_zero_invariants.py
+++ b/tests/test_f4_wave_zero_invariants.py
@@ -1,0 +1,38 @@
+"""F4 — Wave 0 invariant grep guards (AC-X-4).
+
+Static check: F4 source files contain NO Wave 0 anti-patterns:
+- Zero `cascade_to_models` flags (archive cascading is the destructive verb;
+  deprioritize must NEVER add a cascade flag).
+- Zero `access_count` references (per AC-X-4: access_count must not return).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_F4_SOURCE_FILES: tuple[Path, ...] = tuple(
+    Path(__file__).resolve().parent.parent / p
+    for p in (
+        'packages/core/src/memex_core/services/units.py',
+        'packages/core/src/memex_core/server/memories.py',
+        'packages/mcp/src/memex_mcp/_f4_descriptions.py',
+    )
+)
+
+
+def test_no_cascade_to_models_flag_in_f4_sources():
+    for f in _F4_SOURCE_FILES:
+        text = f.read_text()
+        assert 'cascade_to_models' not in text, (
+            f'{f.name}: Wave 0 §6 #12 invariant breached — '
+            'F4 must not introduce cascade_to_models flag'
+        )
+
+
+def test_no_access_count_references_in_f4_sources():
+    for f in _F4_SOURCE_FILES:
+        text = f.read_text()
+        assert 'access_count' not in text, (
+            f'{f.name}: AC-X-4 invariant breached — access_count must not return'
+        )

--- a/tests/test_f5_wave_zero_invariants.py
+++ b/tests/test_f5_wave_zero_invariants.py
@@ -1,0 +1,55 @@
+"""F5 — Wave 0 invariant grep guards (AC-X-4).
+
+Static check: F5 source files contain NO Wave 0 anti-patterns. The
+synchronous summarize-node verb is non-destructive — it must not invoke
+``set_status(ARCHIVED)``, ``delete()``, or any cascade flag.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_F5_SOURCE_FILES: tuple[Path, ...] = tuple(
+    Path(__file__).resolve().parent.parent / p
+    for p in (
+        'packages/core/src/memex_core/services/reflection.py',
+        'packages/core/src/memex_core/server/reflection.py',
+        'packages/core/src/memex_core/services/rate_limit.py',
+        'packages/mcp/src/memex_mcp/_f5_descriptions.py',
+    )
+)
+
+
+def test_no_destructive_calls_in_f5_sources():
+    """F5 must never delete or archive memory units."""
+    forbidden = (
+        re.compile(r'\bArchive\b'),
+        re.compile(r'\.delete\b'),
+        re.compile(r'set_status\s*\(\s*ContentStatus\.ARCHIVED'),
+    )
+    for f in _F5_SOURCE_FILES:
+        text = f.read_text()
+        for pattern in forbidden:
+            assert not pattern.search(text), (
+                f'{f.name}: Wave 0 §6 #12 invariant breached — F5 must not '
+                f'invoke destructive verb (matched {pattern.pattern})'
+            )
+
+
+def test_no_cascade_to_models_flag_in_f5_sources():
+    for f in _F5_SOURCE_FILES:
+        text = f.read_text()
+        assert 'cascade_to_models' not in text, (
+            f'{f.name}: Wave 0 §6 #12 invariant breached — '
+            'F5 must not introduce cascade_to_models flag'
+        )
+
+
+def test_no_access_count_references_in_f5_sources():
+    for f in _F5_SOURCE_FILES:
+        text = f.read_text()
+        assert 'access_count' not in text, (
+            f'{f.name}: AC-X-4 invariant breached — access_count must not return'
+        )

--- a/tests/test_wave_zero_invariants_global.py
+++ b/tests/test_wave_zero_invariants_global.py
@@ -1,0 +1,43 @@
+"""Cross-cutting Wave 0 invariant guards — runtime package source.
+
+Per Tier-A Wave 0 §6 #12 + AC-X-4: no runtime source file under
+packages/*/src may introduce `cascade_to_models` (archive cascading is
+the destructive verb; non-destructive curation must NEVER cascade) or
+`access_count` (deprecated counter forbidden by AC-X-4).
+
+Alembic migrations under `alembic/versions/` are excluded — they are
+append-only schema history and may legitimately reference removed columns
+(e.g. migration 023 drops the dead `access_count` column).
+
+Lands in F5's PR to close the deferred-from-F4 cross-cutting gap. Each
+new feature inherits this guard automatically — no per-feature grep test
+needed for these two terms once this is live.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_FORBIDDEN_PATTERNS: tuple[tuple[str, str], ...] = (
+    (r'\bcascade_to_models\b', 'Wave 0 §6 #12 invariant: cascade_to_models forbidden'),
+    (r'\baccess_count\b', 'AC-X-4 invariant: access_count must not return'),
+)
+
+
+def _src_python_files() -> list[Path]:
+    excluded_dirs = {'tests', 'versions'}
+    return [
+        p for p in _REPO_ROOT.glob('packages/*/src/**/*.py') if not (excluded_dirs & set(p.parts))
+    ]
+
+
+def test_no_forbidden_terms_in_package_source():
+    files = _src_python_files()
+    assert files, 'No package source files found — glob is wrong'
+    for pattern, message in _FORBIDDEN_PATTERNS:
+        regex = re.compile(pattern)
+        offenders = [str(p.relative_to(_REPO_ROOT)) for p in files if regex.search(p.read_text())]
+        assert not offenders, f'{message}\nOffending files:\n  ' + '\n  '.join(offenders)

--- a/uv.lock
+++ b/uv.lock
@@ -2230,6 +2230,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "json-repair"
 version = "0.55.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2526,6 +2535,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/cc/03bf7849c62587db0fb7c46f427d6a49290750752d3189a0bd95d4b78587/litellm-1.80.16.tar.gz", hash = "sha256:f96233649f99ab097f7d8a3ff9898680207b9eea7d2e23f438074a3dbcf50cca", size = 13384256, upload-time = "2026-01-13T08:52:23.067Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/4d/73fdb12223bdb01889134eb75525fcc768b1724255f2b87072dd6743c6e1/litellm-1.80.16-py3-none-any.whl", hash = "sha256:21be641b350561b293b831addb25249676b72ebff973a5a1d73b5d7cf35bcd1d", size = 11682530, upload-time = "2026-01-13T08:52:19.951Z" },
+]
+
+[[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb", size = 56275178, upload-time = "2026-03-31T18:29:05.748Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/da/b32cafcb926fb0ce2aa25553bf32cb8764af31438f40e2481df08884c947/llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40", size = 55128632, upload-time = "2026-03-31T18:29:11.235Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/4898b44e4042c60fafcb1162dfb7014f6f15b1ec19bf29cfea6bf26df90d/llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e", size = 38138695, upload-time = "2026-03-31T18:29:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1d/a760e993e0c0ba6db38d46b9f48f6c7dceb8ac838824997fb9e25f97bc04/llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa", size = 56275176, upload-time = "2026-03-31T18:29:24.149Z" },
+    { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/19e2a09c62809c9e63bbd14ce71fb92c6ff7b7b3045741bb00c781efc3c9/llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94", size = 39153826, upload-time = "2026-03-31T18:29:33.681Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
 ]
 
 [[package]]
@@ -3134,6 +3167,9 @@ cloud = [
 dev-server = [
     { name = "uvicorn" },
 ]
+diagnostics = [
+    { name = "umap-learn" },
+]
 gcs = [
     { name = "gcsfs" },
 ]
@@ -3203,9 +3239,10 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "tokenizers", specifier = ">=0.22.2" },
     { name = "trafilatura", specifier = ">=2.0.0,<3" },
+    { name = "umap-learn", marker = "extra == 'diagnostics'", specifier = ">=0.5,<1.0" },
     { name = "uvicorn", marker = "extra == 'dev-server'", specifier = ">=0.40.0" },
 ]
-provides-extras = ["cloud", "dev-server", "gcs", "gpu", "s3", "tracing"]
+provides-extras = ["cloud", "dev-server", "diagnostics", "gcs", "gpu", "s3", "tracing"]
 
 [package.metadata.requires-dev]
 dev = []
@@ -3507,6 +3544,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08", size = 2681371, upload-time = "2026-04-24T02:02:26.105Z" },
+    { url = "https://files.pythonhosted.org/packages/69/47/a415af0283e4db0398104c6d1c11c9861a98dc67a7aa442a7769ed5d6196/numba-0.65.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52bc6f3ceb8fcaff9b2ae26b4c6b1e9fee39db8d355534c0fe4f39a901246b84", size = 3802467, upload-time = "2026-04-24T02:02:27.712Z" },
+    { url = "https://files.pythonhosted.org/packages/46/36/246f73ec99cfeab2f2cb2ce7d4218766cc36a2da418901223f4f4da9c813/numba-0.65.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ca10b3463bae0bd70589726fe3c77d01d6b5fc86bee54bcdf9fb6b47c28977", size = 3502628, upload-time = "2026-04-24T02:02:29.763Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/3c679b2ee078425b9e99a91e44f8d132a6830d8ccce5227bc5e9181aeed8/numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a", size = 2750611, upload-time = "2026-04-24T02:02:31.477Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/14a4579049c1eb673afd0de0cb4842982acd55b9ce2643e763db858bcea0/numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3", size = 2681344, upload-time = "2026-04-24T02:02:33.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/22/b8d873f6466b20aa563fc9b33acd48dec89a07803ddaa2f1c8ca1cd33126/numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b", size = 3810619, upload-time = "2026-04-24T02:02:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/62/08/e16a8b5d9a018962ebb5c66be662317cde32b9f5dab08441f90bed5522fb/numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464", size = 3509783, upload-time = "2026-04-24T02:02:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/03c970d57f4c1741354837353ce39fb5206952ae1dba8922d29c86f64805/numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62", size = 2750534, upload-time = "2026-04-24T02:02:39.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/8aed9b726d9ba5f11ad287645fd479e88278db3060a25cb1225d730eb2b7/numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450", size = 2681554, upload-time = "2026-04-24T02:02:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/87/96/f3eb235fafa82a34e2ab5dd7dc9ffff998ebf5f0bbc23fa56a96aeb44da6/numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7", size = 3779602, upload-time = "2026-04-24T02:02:43.726Z" },
+    { url = "https://files.pythonhosted.org/packages/09/90/b0f09b48752d23640b8284f22aa597737e8adaddc7fbfacc4708b7f73a4c/numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35", size = 3479532, upload-time = "2026-04-24T02:02:45.427Z" },
+    { url = "https://files.pythonhosted.org/packages/56/46/3f7fc04fb853559e74b210e0b62c19974ec844cefec611f9e535f4da3761/numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63", size = 2752637, upload-time = "2026-04-24T02:02:47.664Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7b/c1a341a9067367778f4152a5f01061cf281fb09582c92c510ec4918cabf6/numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652", size = 2684600, upload-time = "2026-04-24T02:02:49.653Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/98ddbcf3e4f04a6dd07e1c67249955920579ba4af6bb6868e3088f4ed282/numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d", size = 3817198, upload-time = "2026-04-24T02:02:51.266Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/83/0dad21057ece5a835599f5d24099b091703995e23dbbf894f259e91c010b/numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20", size = 3533862, upload-time = "2026-04-24T02:02:52.987Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/8be7118ffd4c8440881046eac3d0982cc5ab42909508cf5d67024d62a2e4/numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38", size = 2758237, upload-time = "2026-04-24T02:02:54.612Z" },
 ]
 
 [[package]]
@@ -4647,6 +4712,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pynndescent"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "llvmlite" },
+    { name = "numba" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/fb/7f58c397fb31666756457ee2ac4c0289ef2daad57f4ae4be8dec12f80b03/pynndescent-0.6.0.tar.gz", hash = "sha256:7ffde0fb5b400741e055a9f7d377e3702e02250616834231f6c209e39aac24f5", size = 2992987, upload-time = "2026-01-08T21:29:58.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl", hash = "sha256:dc8c74844e4c7f5cbd1e0cd6909da86fdc789e6ff4997336e344779c3d5538ef", size = 73511, upload-time = "2026-01-08T21:29:57.306Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5275,6 +5356,111 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
 name = "seaborn"
 version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5550,6 +5736,15 @@ wheels = [
 ]
 
 [[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5793,6 +5988,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "umap-learn"
+version = "0.5.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pynndescent" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/ee/af4171241117f85c74b5ca6448ea1033cc28d599c13651d67289bacd4083/umap_learn-0.5.12.tar.gz", hash = "sha256:6aff02ecac5f2aad9f3c65ee518d7ae93e1a985ae38721fdcffceee4232c33c7", size = 96672, upload-time = "2026-04-08T20:03:54.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/98/f63318ccbe75c810011fe9233884c5d348d94d90005de1b79e5f93bef9c0/umap_learn-0.5.12-py3-none-any.whl", hash = "sha256:f2a85d2a2adcb52b541bed9b27a23ca169b56bb1b23283abeebfb8dfb8a42fe5", size = 91849, upload-time = "2026-04-08T20:03:52.561Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Second of 5 slices into `release/tier-a-cognitive-memory`. This slice ships:

- **Wave-0 prework**: alembic stubs + labelled-span scaffolding (`# --- F4 ---`, etc.)
- **F4** — `memex_memory_deprioritize` / `memex_memory_restore` verb-pair + audit logging
- **F5** — `memex_memory_summarize_node` (engine, HTTP, MCP, Hermes parity, real-LLM TC7)
- **F32** — diagnostics subpackage (5 chunks A.1 → E), three-surface parity (MCP + Hermes + Claude Code), boot-discovery assertion

## Sliced from

`memory_augmentation` HEAD `bc9fc44` — see slicing plan in worktree.

## Notes on cherry-pick conflicts

- README test-count badge: kept the larger HEAD value at every step.
- `.gitignore` (commit `7153405`): cherry-picked as-is, then reverted to the post-#90 blanket `.dev-team-artifacts` ignore via a follow-up commit (`7e8dac4`). Tier-A artifacts remain in worktrees; not shipped via this slice.
- `packages/core/src/memex_core/api.py` and `packages/hermes-plugin/.../tools.py`: F4 and F32 each added new service registrations / schema entries at the same hunk; both additions kept side-by-side.

## Test plan

- [ ] CI green on slice branch
- [ ] Hermes adversarial review fires + completes
- [ ] HIGH + MED findings patched (LOW skipped per slice-merge policy)
- [ ] Squash-merge once clean