### PR TITLE
Slice 3 — F14 procedural memory + F6 lint subsystem + F38 consolidation + F29 outcomes parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,362%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,369%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,401%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,402%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,493%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,505%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,375%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,384%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,356%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,362%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,395%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,398%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,461%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,470%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,478%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,479%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,401%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,448%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,384%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,390%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,489%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,493%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,474%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,478%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,470%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,474%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,390%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,395%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,331%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,337%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,369%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,375%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,448%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,447%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,398%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,401%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,337%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,356%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,447%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,461%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,402%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,401%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,479%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,489%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,505%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,506%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/claude-code-plugin/skills/recall/SKILL.md
+++ b/packages/claude-code-plugin/skills/recall/SKILL.md
@@ -25,6 +25,24 @@ You have been invoked via the `/recall` slash command.
    - Include source Note IDs so the user can drill deeper with `memex_read_note`.
    - If no results are found, tell the user and suggest alternative queries.
 
+4. **Recall a learned procedure** (F14) — when the user asks "how do I
+   X?", "what's our procedure for Y?", or you are about to perform a
+   recurring task (writing a PR, running the test matrix), check the
+   `procedure:` KV namespace BEFORE other surfaces:
+   - First scan `memex_kv_list(namespaces=["procedure"])` for matching
+     `procedure:<verb>:<context-tag>` keys.
+   - Read with `memex_kv_get(key)` for the active value, or
+     `memex_kv_get(key, include_history=true)` to also see the capped
+     5-version history (useful when the active value looks stale).
+   - After ACTUALLY using a procedure to perform the action, close the
+     loop with
+     `memex_record_outcome(target_type="kv_key", kv_key=..., success=...)`
+     so the procedure's Memory Worth counters stay calibrated.
+
+   Procedure recall is shape-different from note recall: it returns an
+   instruction to execute, not a fact to remember. Reach for it whenever
+   the user query is "how-to" rather than "what".
+
 <!--
 Tier A — /recall verb extensions
 F8:  WS-linter      (get_lint_flags surfacing)
@@ -36,7 +54,7 @@ F32: WS-diagnostics (get_diagnostics_summary surfacing)
 # --- F20 --- (filled by WS-revisit)
 
 # --- F32 --- (filled by WS-diagnostics)
-4. **Vault diagnostics** (when the user asks "how is this vault doing?",
+5. **Vault diagnostics** (when the user asks "how is this vault doing?",
    "what's in vault X?", "check vault health", or wants visualisation):
    call `memex_get_diagnostics_summary(vault_id=...)` to surface unit
    counts by status (active / stale / deprioritized), pending lint counts
@@ -44,4 +62,8 @@ F32: WS-diagnostics (get_diagnostics_summary surfacing)
    avg MW score, and top retrieved entities. For full JSON or visual
    plots, point the user to the CLI: `memex diagnostics manifold |
    retrieval | summary --vault X`.
+-->
+
+<!--
+F14: WS-quick-wins  (procedure: KV recall — see step 4 above)
 -->

--- a/packages/claude-code-plugin/skills/remember/SKILL.md
+++ b/packages/claude-code-plugin/skills/remember/SKILL.md
@@ -52,6 +52,39 @@ that contaminates retrieval, prefer the **NON-DESTRUCTIVE** verb:
   it removes the unit from the entity graph and is irreversible. Prefer
   deprioritize unless the unit MUST leave the graph entirely.
 
+## Capturing a learned procedure (procedure: KV namespace, F14)
+
+Some kinds of "remembering" are NOT a note — they are a compact, learned
+how-to: "how I write commit messages for this project", "how I run the
+test matrix on this monorepo". For those, write to the `procedure:` KV
+namespace instead of `memex_add_note`. Each procedure key is
+
+```
+procedure:<verb>:<context-tag>
+```
+
+— for example `procedure:write_pr:commit-style` or
+`procedure:run_tests:python-monorepo`. The agent owns the verb (the
+action you are taking); Memex stores observations about how to ADAPT the
+verb to a specific context (the context-tag).
+
+Use `memex_kv_write(value=..., key="procedure:<verb>:<context-tag>")` to
+save. The server keeps the active value plus a capped 5-version history,
+so an updated procedure overwrites the active value but does not lose
+prior versions — read them with
+`memex_kv_get(key, include_history=true)`.
+
+After actually USING a procedure key in a turn (you read it via
+`memex_kv_get` and then performed the action), close the loop with
+`memex_record_outcome(target_type="kv_key", kv_key=..., success=...)` so
+Memex's per-(vault, key) Memory Worth counters reflect what worked. The
+counters drive the F14 briefing surface — silence provides no learning
+signal.
+
+Use a procedure: key when the content is a how-to that you (or a future
+agent) will ACTUALLY EXECUTE; use `memex_add_note` when the content is a
+fact, decision, or piece of context to recall.
+
 ## Synchronously consolidating mid-conversation (summarize_node vs reflect)
 
 When you notice mid-conversation that retrieved facts about a topic are
@@ -86,7 +119,7 @@ F20: WS-revisit     (memory_review disclosure)
 
 # --- F9 ---  (filled by WS-locks)
 
-# --- F14 --- (filled by WS-quick-wins)
+# --- F14 --- (filled by WS-quick-wins — see "Capturing a learned procedure" section above)
 
 # --- F20 --- (filled by WS-revisit)
 -->

--- a/packages/cli/src/memex_cli/consolidate.py
+++ b/packages/cli/src/memex_cli/consolidate.py
@@ -90,7 +90,7 @@ async def tick_cmd(
             str(row.get('units_processed', 0)),
             str(row.get('entities_reflected', 0)),
             str(row.get('contradictions_run', 0)),
-            str(row.get('stale_pruned', row.get('stale_pruned_candidates', 0))),
+            str(row.get('stale_pruned', 0)),
             row.get('error') or '',
         )
     console.print(table)

--- a/packages/cli/src/memex_cli/consolidate.py
+++ b/packages/cli/src/memex_cli/consolidate.py
@@ -1,0 +1,148 @@
+"""F38 — `memex consolidate` CLI subgroup.
+
+Operator-facing surface for the consolidation orchestrator. Per AC-F38-5
+there is intentionally NO MCP / Hermes / Claude Code tool — this CLI is the
+only first-class human surface.
+
+Subcommands:
+- ``memex consolidate tick [--vault X] [--dry-run] [--budget N]``
+- ``memex consolidate status [--vault X]``
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from memex_cli.utils import async_command, get_api_context, handle_api_error
+from memex_common.config import MemexConfig
+
+console = Console()
+
+app = typer.Typer(
+    name='consolidate',
+    help='F38 — Per-vault consolidation tick (contradiction → reflection → prune-stale-only).',
+    no_args_is_help=True,
+)
+
+
+@app.command('tick')
+@async_command
+async def tick_cmd(
+    ctx: typer.Context,
+    vault: Annotated[
+        str | None,
+        typer.Option('--vault', help='Vault name or ID. Omit to tick every vault.'),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option('--dry-run', help='Skip writes; report per-step counts only.'),
+    ] = False,
+    budget: Annotated[
+        int | None,
+        typer.Option(
+            '--budget',
+            help='Override per-tick units budget. Omit to use config default (500).',
+            min=1,
+            max=10_000,
+        ),
+    ] = None,
+    json_output: Annotated[
+        bool, typer.Option('--json', help='Emit JSON instead of a table.')
+    ] = False,
+):
+    """Run consolidation tick(s) immediately."""
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            vault_id = await api.resolve_vault_identifier(vault) if vault else None
+            payload = await api.consolidation_tick(
+                vault_id=vault_id, dry_run=dry_run, budget=budget
+            )
+        except Exception as e:
+            handle_api_error(e)
+            return
+
+    if json_output:
+        console.print_json(json.dumps(payload, default=str))
+        return
+
+    ticks = payload.get('ticks', [])
+    if not ticks:
+        console.print('[dim]No vaults to consolidate.[/dim]')
+        return
+
+    title = 'Consolidation tick (dry-run)' if dry_run else 'Consolidation tick'
+    table = Table(title=title)
+    table.add_column('vault_id', style='cyan')
+    table.add_column('units', justify='right')
+    table.add_column('entities', justify='right')
+    table.add_column('contradictions', justify='right')
+    table.add_column('stale_pruned', justify='right')
+    table.add_column('error', style='red')
+    for row in ticks:
+        table.add_row(
+            row.get('vault_id', '?'),
+            str(row.get('units_processed', 0)),
+            str(row.get('entities_reflected', 0)),
+            str(row.get('contradictions_run', 0)),
+            str(row.get('stale_pruned', row.get('stale_pruned_candidates', 0))),
+            row.get('error') or '',
+        )
+    console.print(table)
+
+
+@app.command('status')
+@async_command
+async def status_cmd(
+    ctx: typer.Context,
+    vault: Annotated[
+        str | None,
+        typer.Option('--vault', help='Vault name or ID. Omit to list every vault.'),
+    ] = None,
+    json_output: Annotated[
+        bool, typer.Option('--json', help='Emit JSON instead of a table.')
+    ] = False,
+):
+    """Show the most recent consolidation tick per vault."""
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            vault_id = await api.resolve_vault_identifier(vault) if vault else None
+            payload = await api.consolidation_status(vault_id=vault_id)
+        except Exception as e:
+            handle_api_error(e)
+            return
+
+    if json_output:
+        console.print_json(json.dumps(payload, default=str))
+        return
+
+    rows = payload.get('ticks', [])
+    if not rows:
+        console.print('[dim]No consolidation ticks recorded.[/dim]')
+        return
+
+    table = Table(title='Last consolidation tick per vault')
+    table.add_column('vault_id', style='cyan')
+    table.add_column('completed_at')
+    table.add_column('units', justify='right')
+    table.add_column('entities', justify='right')
+    table.add_column('contradictions', justify='right')
+    table.add_column('stale_pruned', justify='right')
+    table.add_column('error', style='red')
+    for r in rows:
+        table.add_row(
+            r.get('vault_id', '?'),
+            r.get('completed_at') or 'in-progress',
+            str(r.get('units_processed', 0)),
+            str(r.get('entities_reflected', 0)),
+            str(r.get('contradictions_run', 0)),
+            str(r.get('stale_pruned', 0)),
+            r.get('error') or '',
+        )
+    console.print(table)

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -1,0 +1,192 @@
+"""F6 maintenance ledger / linter CLI.
+
+Subcommands:
+
+* ``memex lint status [--vault X | --global | --all]`` — pending counts.
+* ``memex lint findings [--type ...]`` — list findings.
+* ``memex lint dismiss <finding_id>`` — flip to dismissed.
+* ``memex lint resolve <finding_id>`` — flip to resolved.
+
+The maintenance ledger is read-only from the agent surface (F8 ships the
+MCP tool); this CLI is for human inspection and reconciliation.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from memex_common.config import MemexConfig
+from memex_cli.utils import async_command, get_api_context, handle_api_error, parse_uuid
+
+console = Console()
+
+app = typer.Typer(
+    name='lint',
+    help=(
+        'F6 maintenance ledger: rule-based finding scan over the vault. '
+        'Findings are advisory; nothing is auto-applied.'
+    ),
+    no_args_is_help=True,
+)
+
+
+def _resolve_vault_arg(
+    vault: str | None,
+    is_global: bool,
+    is_all: bool,
+) -> tuple[str, str | None]:
+    """Reduce the three flag-shaped vault scoping args to (scope, vault_id)."""
+    chosen = sum(1 for x in (vault, is_global, is_all) if x)
+    if chosen > 1:
+        console.print('[red]Pass at most one of --vault / --global / --all.[/red]')
+        raise typer.Exit(2)
+    if is_all:
+        return 'all', None
+    if is_global:
+        return 'global', None
+    if vault is not None:
+        # Validate UUID format eagerly for fast feedback.
+        parse_uuid(vault, 'vault')
+        return 'vault', vault
+    return 'all', None  # Default — show every pending finding.
+
+
+@app.command('status')
+@async_command
+async def lint_status(
+    ctx: typer.Context,
+    vault: Annotated[
+        str | None,
+        typer.Option('--vault', help='Vault UUID to scope to.'),
+    ] = None,
+    is_global: Annotated[
+        bool,
+        typer.Option('--global/--no-global', help='Show only global (vault_id NULL) findings.'),
+    ] = False,
+    is_all: Annotated[
+        bool,
+        typer.Option('--all/--no-all', help='Show total pending across every vault and global.'),
+    ] = False,
+):
+    """Pending finding counts. Default behaviour is ``--all``."""
+    scope, vault_id = _resolve_vault_arg(vault, is_global, is_all)
+
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            payload = await api.lint_status(scope=scope, vault_id=vault_id)
+        except Exception as e:
+            handle_api_error(e)
+
+    pending = payload.get('pending', 0)
+    if scope == 'vault':
+        console.print(f'[bold]vault {payload["vault_id"]}:[/bold] {pending} pending findings')
+    elif scope == 'global':
+        console.print(f'[bold]global:[/bold] {pending} pending findings')
+    else:
+        console.print(f'[bold]all scopes:[/bold] {pending} pending findings')
+
+
+@app.command('findings')
+@async_command
+async def lint_findings(
+    ctx: typer.Context,
+    vault: Annotated[
+        str | None,
+        typer.Option('--vault', help='Filter to one vault.'),
+    ] = None,
+    lint_type: Annotated[
+        str | None,
+        typer.Option(
+            '--type',
+            help='Filter by lint_type: structural, quality, governance, schema.',
+        ),
+    ] = None,
+    status: Annotated[
+        str,
+        typer.Option(
+            '--status',
+            help='Lifecycle filter: pending, resolved, dismissed.',
+        ),
+    ] = 'pending',
+    limit: Annotated[int, typer.Option('--limit', min=1, max=500)] = 50,
+):
+    """List maintenance findings."""
+    if vault is not None:
+        parse_uuid(vault, 'vault')
+    if lint_type is not None and lint_type not in {'structural', 'quality', 'governance', 'schema'}:
+        console.print(f'[red]Unknown --type: {lint_type!r}[/red]')
+        raise typer.Exit(2)
+
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            payload = await api.lint_findings(
+                vault_id=vault,
+                lint_type=lint_type,
+                status=status,
+                limit=limit,
+            )
+        except Exception as e:
+            handle_api_error(e)
+
+    findings = payload.get('findings', [])
+    if not findings:
+        console.print(f'[dim]No {status} findings.[/dim]')
+        return
+
+    table = Table(title=f'{status} findings ({len(findings)})')
+    table.add_column('id', style='cyan', no_wrap=False)
+    table.add_column('lint_type')
+    table.add_column('rule_name')
+    table.add_column('target_type')
+    table.add_column('target_id', max_width=36)
+    table.add_column('vault_id', max_width=36)
+    for f in findings:
+        table.add_row(
+            f['id'][:8] + '…',
+            f['lint_type'],
+            f['rule_name'],
+            f['target_type'],
+            f['target_id'],
+            f['vault_id'] or '(global)',
+        )
+    console.print(table)
+
+
+@app.command('dismiss')
+@async_command
+async def lint_dismiss_cmd(
+    ctx: typer.Context,
+    finding_id: Annotated[str, typer.Argument(help='Finding UUID to dismiss.')],
+):
+    """Flip a pending finding to ``dismissed``."""
+    parse_uuid(finding_id, 'finding_id')
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            payload = await api.lint_dismiss(finding_id)
+        except Exception as e:
+            handle_api_error(e)
+    console.print(f'[green]dismissed:[/green] {payload["finding_id"]}')
+
+
+@app.command('resolve')
+@async_command
+async def lint_resolve_cmd(
+    ctx: typer.Context,
+    finding_id: Annotated[str, typer.Argument(help='Finding UUID to mark resolved.')],
+):
+    """Flip a pending finding to ``resolved``."""
+    parse_uuid(finding_id, 'finding_id')
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            payload = await api.lint_resolve(finding_id)
+        except Exception as e:
+            handle_api_error(e)
+    console.print(f'[green]resolved:[/green] {payload["finding_id"]}')

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -34,25 +34,28 @@ app = typer.Typer(
 )
 
 
-def _resolve_vault_arg(
+def _resolve_scope(
     vault: str | None,
     is_global: bool,
     is_all: bool,
-) -> tuple[str, str | None]:
-    """Reduce the three flag-shaped vault scoping args to (scope, vault_id)."""
+) -> str:
+    """Reduce the three flag-shaped vault scoping args to a scope string.
+
+    Vault identifier resolution happens in the command body via
+    ``api.resolve_vault_identifier`` (parity with ``memex consolidate``)
+    so vault names — not just UUIDs — are accepted.
+    """
     chosen = sum(1 for x in (vault, is_global, is_all) if x)
     if chosen > 1:
         console.print('[red]Pass at most one of --vault / --global / --all.[/red]')
         raise typer.Exit(2)
     if is_all:
-        return 'all', None
+        return 'all'
     if is_global:
-        return 'global', None
+        return 'global'
     if vault is not None:
-        # Validate UUID format eagerly for fast feedback.
-        parse_uuid(vault, 'vault')
-        return 'vault', vault
-    return 'all', None  # Default — show every pending finding.
+        return 'vault'
+    return 'all'  # Default — show every pending finding.
 
 
 @app.command('status')
@@ -73,11 +76,16 @@ async def lint_status(
     ] = False,
 ):
     """Pending finding counts. Default behaviour is ``--all``."""
-    scope, vault_id = _resolve_vault_arg(vault, is_global, is_all)
+    scope = _resolve_scope(vault, is_global, is_all)
 
     config: MemexConfig = ctx.obj
     async with get_api_context(config) as api:
         try:
+            vault_id = (
+                str(await api.resolve_vault_identifier(vault))
+                if scope == 'vault' and vault is not None
+                else None
+            )
             payload = await api.lint_status(scope=scope, vault_id=vault_id)
         except Exception as e:
             handle_api_error(e)
@@ -117,8 +125,6 @@ async def lint_findings(
     limit: Annotated[int, typer.Option('--limit', min=1, max=500)] = 50,
 ):
     """List maintenance findings."""
-    if vault is not None:
-        parse_uuid(vault, 'vault')
     if lint_type is not None and lint_type not in {'structural', 'quality', 'governance', 'schema'}:
         console.print(f'[red]Unknown --type: {lint_type!r}[/red]')
         raise typer.Exit(2)
@@ -126,8 +132,9 @@ async def lint_findings(
     config: MemexConfig = ctx.obj
     async with get_api_context(config) as api:
         try:
+            vault_id = str(await api.resolve_vault_identifier(vault)) if vault is not None else None
             payload = await api.lint_findings(
-                vault_id=vault,
+                vault_id=vault_id,
                 lint_type=lint_type,
                 status=status,
                 limit=limit,

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -81,6 +81,7 @@ async def lint_status(
             payload = await api.lint_status(scope=scope, vault_id=vault_id)
         except Exception as e:
             handle_api_error(e)
+            return
 
     pending = payload.get('pending', 0)
     if scope == 'vault':
@@ -133,6 +134,7 @@ async def lint_findings(
             )
         except Exception as e:
             handle_api_error(e)
+            return
 
     findings = payload.get('findings', [])
     if not findings:
@@ -172,6 +174,7 @@ async def lint_dismiss_cmd(
             payload = await api.lint_dismiss(finding_id)
         except Exception as e:
             handle_api_error(e)
+            return
     console.print(f'[green]dismissed:[/green] {payload["finding_id"]}')
 
 
@@ -189,4 +192,5 @@ async def lint_resolve_cmd(
             payload = await api.lint_resolve(finding_id)
         except Exception as e:
             handle_api_error(e)
+            return
     console.print(f'[green]resolved:[/green] {payload["finding_id"]}')

--- a/packages/cli/src/memex_cli/procedure.py
+++ b/packages/cli/src/memex_cli/procedure.py
@@ -75,11 +75,13 @@ async def procedure_list(
     config: MemexConfig = ctx.obj
     async with get_api_context(config) as api:
         try:
+            vault_id = await api.resolve_vault_identifier(vault)
             rows = await api.list_top_procedure_outcomes(
-                vault_id=vault, context=context, limit=limit
+                vault_id=vault_id, context=context, limit=limit
             )
         except Exception as e:
             handle_api_error(e)
+            return
 
     if json_output:
         console.print_json(data=[r.model_dump(mode='json') for r in rows])
@@ -137,6 +139,7 @@ async def procedure_show(
             entry = await api.kv_get(key=key, include_history=history)
         except Exception as e:
             handle_api_error(e)
+            return
 
     if entry is None:
         console.print(f'[yellow]Key not found: {key}[/yellow]')
@@ -185,6 +188,7 @@ async def procedure_add(
             entry = await api.kv_put(value=value, key=key)
         except Exception as e:
             handle_api_error(e)
+            return
 
     console.print(f'[green]Wrote:[/green] {entry.key}')
     # Server stores the JSON envelope; show only the active value for legibility.

--- a/packages/cli/src/memex_cli/procedure.py
+++ b/packages/cli/src/memex_cli/procedure.py
@@ -1,0 +1,199 @@
+"""Procedure KV namespace commands (F14).
+
+Thin CLI wrapper over the procedure-key surface:
+
+* ``memex procedure list`` — top procedure outcomes for a vault, ranked
+  by Memory Worth.
+* ``memex procedure show`` — read a single procedure key (active value
+  by default, or the full envelope with ``--history``).
+* ``memex procedure add`` — write a new procedure value (creates v=1 or
+  bumps the version with capped history per RFC-007 §63-112).
+
+Refer to the agent-facing tools (`memex_kv_*`, `memex_record_outcome`)
+for in-session use; this CLI is for human inspection and seeding.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from memex_common.config import MemexConfig
+from memex_cli.utils import async_command, get_api_context, handle_api_error
+
+console = Console()
+
+app = typer.Typer(
+    name='procedure',
+    help=(
+        'Procedure KV namespace (F14): compact, learned how-tos owned by '
+        'the agent. Each key is procedure:<verb>:<context-tag> with a '
+        'versioned envelope and capped history (5 prior versions). '
+        'Per-(vault, key) Memory Worth counters track success/failure.'
+    ),
+    no_args_is_help=True,
+)
+
+
+@app.command('list')
+@async_command
+async def procedure_list(
+    ctx: typer.Context,
+    vault: Annotated[
+        str,
+        typer.Option(
+            '--vault',
+            help='Vault UUID to scope observations to.',
+        ),
+    ],
+    context: Annotated[
+        str | None,
+        typer.Option(
+            '--context',
+            help='Optional substring filter on the procedure key context-tag.',
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option(
+            '--limit',
+            help='Max observations to return (1-20, default 5).',
+            min=1,
+            max=20,
+        ),
+    ] = 5,
+    json_output: Annotated[
+        bool,
+        typer.Option('--json', help='Emit JSON instead of a table.'),
+    ] = False,
+):
+    """List top procedure outcomes for a vault, ranked by Memory Worth."""
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            rows = await api.list_top_procedure_outcomes(
+                vault_id=vault, context=context, limit=limit
+            )
+        except Exception as e:
+            handle_api_error(e)
+
+    if json_output:
+        console.print_json(data=[r.model_dump(mode='json') for r in rows])
+        return
+
+    if not rows:
+        console.print('[dim]No procedure outcomes recorded for this vault.[/dim]')
+        return
+
+    table = Table(title='Top procedure outcomes (Memory Worth ↓)')
+    table.add_column('kv_key', style='cyan')
+    table.add_column('success', justify='right')
+    table.add_column('failure', justify='right')
+    table.add_column('mw_score', justify='right')
+    table.add_column('last_outcome_at')
+    for r in rows:
+        last = r.last_outcome_at.isoformat() if r.last_outcome_at else '—'
+        table.add_row(
+            r.kv_key,
+            str(r.success_co_count),
+            str(r.failure_co_count),
+            f'{r.mw_score:.3f}',
+            last,
+        )
+    console.print(table)
+
+
+@app.command('show')
+@async_command
+async def procedure_show(
+    ctx: typer.Context,
+    key: Annotated[str, typer.Argument(help='Procedure key (procedure:<verb>:<context-tag>).')],
+    history: Annotated[
+        bool,
+        typer.Option(
+            '--history',
+            help='Include the full envelope (active value, version, capped 5-version history).',
+        ),
+    ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option('--json', help='Emit JSON instead of formatted output.'),
+    ] = False,
+):
+    """Read a procedure key. Default returns active value; ``--history`` exposes the envelope."""
+    if not key.startswith('procedure:'):
+        console.print(
+            f'[red]Not a procedure key: {key!r}. Expected procedure:<verb>:<context-tag>.[/red]'
+        )
+        raise typer.Exit(2)
+
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            entry = await api.kv_get(key=key, include_history=history)
+        except Exception as e:
+            handle_api_error(e)
+
+    if entry is None:
+        console.print(f'[yellow]Key not found: {key}[/yellow]')
+        raise typer.Exit(1)
+
+    if json_output:
+        console.print_json(data=entry.model_dump(mode='json'))
+        return
+
+    if history and isinstance(entry.value, dict):
+        console.print(f'[bold cyan]{entry.key}[/bold cyan]')
+        console.print(f'[bold]version:[/bold] {entry.value["version"]}')
+        console.print(f'[bold]active value:[/bold] {entry.value["value"]}')
+        prior = entry.value.get('history') or []
+        if prior:
+            console.print(f'[bold]history ({len(prior)}):[/bold]')
+            for h in prior:
+                console.print(f'  v{h["v"]} ({h.get("superseded_at", "?")}): {h["value"]}')
+        else:
+            console.print('[dim]history: empty[/dim]')
+    else:
+        console.print(f'[bold cyan]{entry.key}[/bold cyan]')
+        console.print(entry.value)
+
+
+@app.command('add')
+@async_command
+async def procedure_add(
+    ctx: typer.Context,
+    key: Annotated[str, typer.Argument(help='Procedure key (procedure:<verb>:<context-tag>).')],
+    value: Annotated[
+        str,
+        typer.Argument(help='Procedure body — the learned how-to text.'),
+    ],
+):
+    """Write or update a procedure value (versioned + capped history per RFC-007)."""
+    if not key.startswith('procedure:'):
+        console.print(
+            f'[red]Not a procedure key: {key!r}. Expected procedure:<verb>:<context-tag>.[/red]'
+        )
+        raise typer.Exit(2)
+
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            entry = await api.kv_put(value=value, key=key)
+        except Exception as e:
+            handle_api_error(e)
+
+    console.print(f'[green]Wrote:[/green] {entry.key}')
+    # Server stores the JSON envelope; show only the active value for legibility.
+    try:
+        payload = json.loads(entry.value) if isinstance(entry.value, str) else entry.value
+        if isinstance(payload, dict) and 'value' in payload:
+            console.print(f'[bold]version:[/bold] {payload.get("v", "?")}')
+            console.print(f'[bold]active value:[/bold] {payload["value"]}')
+            return
+    except (ValueError, TypeError):
+        pass
+    console.print(entry.value)

--- a/packages/cli/src/memex_cli/utils.py
+++ b/packages/cli/src/memex_cli/utils.py
@@ -43,6 +43,7 @@ LAZY_SUBCOMMANDS: dict[str, str] = {
     'setup': 'memex_cli.setup_claude_code:app',
     'report-bug': 'memex_cli.report_bug:app',
     'diagnostics': 'memex_cli.diagnose:app',
+    'consolidate': 'memex_cli.consolidate:app',
 }
 
 

--- a/packages/cli/src/memex_cli/utils.py
+++ b/packages/cli/src/memex_cli/utils.py
@@ -33,6 +33,7 @@ LAZY_SUBCOMMANDS: dict[str, str] = {
     'note': 'memex_cli.notes:app',
     'kv': 'memex_cli.kv:app',
     'procedure': 'memex_cli.procedure:app',
+    'lint': 'memex_cli.lint:app',
     'system': 'memex_cli.stats:app',
     'config': 'memex_cli.config:app',
     'server': 'memex_cli.server:app',

--- a/packages/cli/src/memex_cli/utils.py
+++ b/packages/cli/src/memex_cli/utils.py
@@ -32,6 +32,7 @@ LAZY_SUBCOMMANDS: dict[str, str] = {
     'entity': 'memex_cli.entities:app',
     'note': 'memex_cli.notes:app',
     'kv': 'memex_cli.kv:app',
+    'procedure': 'memex_cli.procedure:app',
     'system': 'memex_cli.stats:app',
     'config': 'memex_cli.config:app',
     'server': 'memex_cli.server:app',

--- a/packages/cli/tests/test_consolidate_cli.py
+++ b/packages/cli/tests/test_consolidate_cli.py
@@ -1,0 +1,53 @@
+"""Help-text fences for the F38 ``memex consolidate`` CLI (TC-F38-CLI).
+
+Locks that the operator-facing surface advertised by RFC-010 actually
+exists and exposes the documented flags:
+
+* Top-level help mentions the orchestration ordering (contradiction →
+  reflection → prune-stale-only) so an operator self-discovers the
+  contract.
+* Each subcommand (``tick`` / ``status``) is reachable via help and
+  surfaces the right flag(s) — ``--vault`` / ``--dry-run`` / ``--budget``
+  on tick, ``--vault`` on status.
+"""
+
+from __future__ import annotations
+
+import re
+
+from memex_cli.consolidate import app
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r'\s+', ' ', text).strip()
+
+
+def test_consolidate_top_help_documents_step_ordering(runner, strip_ansi):
+    result = runner.invoke(app, ['--help'])
+    assert result.exit_code == 0
+    text = _normalize(strip_ansi(result.stdout))
+    assert 'contradiction' in text and 'reflection' in text and 'prune' in text
+
+
+def test_consolidate_tick_help_exposes_dry_run_and_budget(runner, strip_ansi):
+    result = runner.invoke(app, ['tick', '--help'])
+    assert result.exit_code == 0
+    text = _normalize(strip_ansi(result.stdout))
+    assert '--vault' in text
+    assert '--dry-run' in text
+    assert '--budget' in text
+
+
+def test_consolidate_status_help_exposes_vault_filter(runner, strip_ansi):
+    result = runner.invoke(app, ['status', '--help'])
+    assert result.exit_code == 0
+    text = _normalize(strip_ansi(result.stdout))
+    assert '--vault' in text
+
+
+def test_consolidate_subcommands_listed(runner, strip_ansi):
+    result = runner.invoke(app, ['--help'])
+    assert result.exit_code == 0
+    text = strip_ansi(result.stdout)
+    assert 'tick' in text
+    assert 'status' in text

--- a/packages/cli/tests/test_lint_cli.py
+++ b/packages/cli/tests/test_lint_cli.py
@@ -1,0 +1,130 @@
+"""F6 — ``memex lint`` CLI tests (TC-20-5).
+
+Five cases covering the four subcommands plus mutual-exclusion of the
+scope flags. The CLI delegates to ``RemoteMemexAPI``, so these tests mock
+the api context and assert (a) the right client method is called with
+the right kwargs, (b) help-text fences hold.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import AsyncMock, patch
+
+from memex_cli.lint import app
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r'\s+', ' ', text).strip()
+
+
+# ---------------------------------------------------------------------------
+# Help-text fence
+# ---------------------------------------------------------------------------
+
+
+def test_lint_top_help_documents_subcommands(runner, strip_ansi):
+    """``memex lint --help`` lists every subcommand and the ledger purpose."""
+    result = runner.invoke(app, ['--help'])
+    assert result.exit_code == 0
+    text = _normalize(strip_ansi(result.stdout))
+    assert 'status' in text
+    assert 'findings' in text
+    assert 'dismiss' in text
+    assert 'resolve' in text
+    assert 'maintenance ledger' in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+def test_lint_status_default_is_all_scope(runner, mock_config, mock_api, strip_ansi):
+    """``memex lint status`` (no flags) calls scope=all and prints the count."""
+    mock_api.lint_status = AsyncMock(return_value={'scope': 'all', 'pending': 7})
+
+    with patch('memex_cli.lint.get_api_context') as gac:
+        gac.return_value.__aenter__.return_value = mock_api
+        gac.return_value.__aexit__.return_value = None
+        result = runner.invoke(app, ['status'], obj=mock_config)
+
+    assert result.exit_code == 0, strip_ansi(result.stdout) + strip_ansi(result.stderr or '')
+    mock_api.lint_status.assert_awaited_once_with(scope='all', vault_id=None)
+    text = strip_ansi(result.stdout)
+    assert '7 pending findings' in text
+
+
+def test_lint_status_rejects_multiple_scope_flags(runner, mock_config, strip_ansi):
+    """Passing both --vault and --global exits with code 2."""
+    result = runner.invoke(
+        app,
+        ['status', '--vault', '00000000-0000-0000-0000-000000000001', '--global'],
+        obj=mock_config,
+    )
+    assert result.exit_code == 2
+    text = strip_ansi(result.stdout) + strip_ansi(result.stderr or '')
+    assert 'at most one' in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# findings
+# ---------------------------------------------------------------------------
+
+
+def test_lint_findings_passes_type_filter(runner, mock_config, mock_api, strip_ansi):
+    """``memex lint findings --type governance`` forwards the filter."""
+    mock_api.lint_findings = AsyncMock(
+        return_value={
+            'count': 1,
+            'findings': [
+                {
+                    'id': '11111111-1111-1111-1111-111111111111',
+                    'lint_type': 'governance',
+                    'rule_name': 'sensitive_unreviewed_unit',
+                    'target_type': 'memory_unit',
+                    'target_id': 'unit-id',
+                    'vault_id': '22222222-2222-2222-2222-222222222222',
+                }
+            ],
+        }
+    )
+
+    with patch('memex_cli.lint.get_api_context') as gac:
+        gac.return_value.__aenter__.return_value = mock_api
+        gac.return_value.__aexit__.return_value = None
+        result = runner.invoke(app, ['findings', '--type', 'governance'], obj=mock_config)
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    mock_api.lint_findings.assert_awaited_once_with(
+        vault_id=None,
+        lint_type='governance',
+        status='pending',
+        limit=50,
+    )
+    text = strip_ansi(result.stdout)
+    # Rich may truncate the rule_name column; assert lint_type instead
+    # (shorter, always rendered in full).
+    assert 'governance' in text
+    assert 'memory_unit' in text
+
+
+# ---------------------------------------------------------------------------
+# dismiss + resolve
+# ---------------------------------------------------------------------------
+
+
+def test_lint_dismiss_calls_client_and_prints_id(runner, mock_config, mock_api, strip_ansi):
+    """``memex lint dismiss <id>`` calls ``lint_dismiss`` and prints the id."""
+    fid = '33333333-3333-3333-3333-333333333333'
+    mock_api.lint_dismiss = AsyncMock(return_value={'finding_id': fid, 'status': 'dismissed'})
+
+    with patch('memex_cli.lint.get_api_context') as gac:
+        gac.return_value.__aenter__.return_value = mock_api
+        gac.return_value.__aexit__.return_value = None
+        result = runner.invoke(app, ['dismiss', fid], obj=mock_config)
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    mock_api.lint_dismiss.assert_awaited_once_with(fid)
+    assert 'dismissed' in strip_ansi(result.stdout).lower()
+    assert fid in strip_ansi(result.stdout)

--- a/packages/cli/tests/test_procedure_cli_help.py
+++ b/packages/cli/tests/test_procedure_cli_help.py
@@ -1,0 +1,75 @@
+"""Help-text fences for the F14 ``memex procedure`` CLI (TC-F14-5).
+
+Locks that:
+
+* ``memex procedure --help`` mentions the ``procedure:<verb>:<context-tag>``
+  shape and Memory Worth (so an operator can self-discover the contract).
+* Each subcommand (``list`` / ``show`` / ``add``) is reachable via help and
+  surfaces the right flag(s).
+* ``--history`` flag is documented for ``show`` (back-compat: default
+  remains active value).
+"""
+
+from __future__ import annotations
+
+import re
+
+from memex_cli.procedure import app
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r'\s+', ' ', text).strip()
+
+
+def test_procedure_top_help_documents_namespace_and_mw_score(runner, strip_ansi):
+    """Top-level help describes the procedure: namespace + Memory Worth."""
+    result = runner.invoke(app, ['--help'])
+    assert result.exit_code == 0
+    text = _normalize(strip_ansi(result.stdout))
+    assert 'procedure:<verb>:<context-tag>' in text
+    assert 'Memory Worth' in text
+
+
+def test_procedure_list_help_documents_vault_and_limit(runner, strip_ansi):
+    """``memex procedure list --help`` exposes ``--vault`` and ``--limit``."""
+    result = runner.invoke(app, ['list', '--help'])
+    assert result.exit_code == 0
+    text = _normalize(strip_ansi(result.stdout))
+    assert '--vault' in text
+    assert '--limit' in text
+    assert 'Memory Worth' in text
+
+
+def test_procedure_show_help_documents_history_flag(runner, strip_ansi):
+    """``memex procedure show --help`` exposes the ``--history`` flag."""
+    result = runner.invoke(app, ['show', '--help'])
+    assert result.exit_code == 0
+    text = _normalize(strip_ansi(result.stdout))
+    assert '--history' in text
+    # Either 'envelope' or 'capped' is documented in the flag description.
+    assert 'envelope' in text or 'capped' in text
+
+
+def test_procedure_add_help_describes_versioned_write(runner, strip_ansi):
+    """``memex procedure add --help`` describes versioned write semantics."""
+    result = runner.invoke(app, ['add', '--help'])
+    assert result.exit_code == 0
+    text = _normalize(strip_ansi(result.stdout))
+    assert 'versioned' in text
+    assert 'history' in text
+
+
+def test_procedure_show_rejects_non_procedure_keys(runner, strip_ansi):
+    """``memex procedure show global:foo`` exits with code 2 (Typer-style misuse)."""
+    result = runner.invoke(app, ['show', 'global:not-a-procedure'])
+    assert result.exit_code == 2
+    text = strip_ansi(result.stdout)
+    assert 'Not a procedure key' in text
+
+
+def test_procedure_add_rejects_non_procedure_keys(runner, strip_ansi):
+    """``memex procedure add global:foo body`` rejects misuse before any API call."""
+    result = runner.invoke(app, ['add', 'user:not-a-procedure', 'body'])
+    assert result.exit_code == 2
+    text = strip_ansi(result.stdout)
+    assert 'Not a procedure key' in text

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -554,6 +554,27 @@ class RemoteMemexAPI:
             response.raise_for_status()
         return response.status_code, response.json()
 
+    # --- Consolidation (F38) ---
+    async def consolidation_tick(
+        self,
+        vault_id: UUID | str | None = None,
+        *,
+        dry_run: bool = False,
+        budget: int | None = None,
+    ) -> dict[str, Any]:
+        """Run a consolidation tick. ``vault_id=None`` ticks every vault."""
+        body: dict[str, Any] = {'dry_run': dry_run}
+        if vault_id is not None:
+            body['vault_id'] = str(vault_id)
+        if budget is not None:
+            body['budget'] = budget
+        return await self._post('consolidation/tick', body)
+
+    async def consolidation_status(self, vault_id: UUID | str | None = None) -> dict[str, Any]:
+        """Return the most recent consolidation tick row per vault (or for one vault)."""
+        params = {'vault_id': str(vault_id)} if vault_id is not None else None
+        return await self._get('consolidation/status', params=params)
+
     # --- Stats & Overview ---
     async def get_stats_counts(
         self,

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -575,6 +575,41 @@ class RemoteMemexAPI:
         params = {'vault_id': str(vault_id)} if vault_id is not None else None
         return await self._get('consolidation/status', params=params)
 
+    # --- Outcomes (F29) ---
+    async def record_outcome(
+        self,
+        unit_ids: list[str] | None,
+        success: bool,
+        vault_id: str | None = None,
+        outcome_confidence: float = 1.0,
+        reason: str | None = None,
+        *,
+        target_type: str = 'memory_unit',
+        kv_key: str | None = None,
+    ) -> dict[str, Any]:
+        """Record an outcome (F14 ADD-2 over HTTP).
+
+        Mirrors :meth:`memex_core.api.MemexAPI.record_outcome` exactly so
+        in-process and remote callers share one call shape. ``unit_ids``
+        and ``success`` are positional; ``target_type`` and ``kv_key`` are
+        keyword-only — preserving the F14 ADD-2 invariant that a kwargless
+        call cannot silently record FAILURE.
+        """
+        body: dict[str, Any] = {
+            'success': success,
+            'outcome_confidence': outcome_confidence,
+            'target_type': target_type,
+        }
+        if unit_ids is not None:
+            body['unit_ids'] = unit_ids
+        if vault_id is not None:
+            body['vault_id'] = vault_id
+        if reason is not None:
+            body['reason'] = reason
+        if kv_key is not None:
+            body['kv_key'] = kv_key
+        return await self._post('outcomes/record', body)
+
     # --- Stats & Overview ---
     async def get_stats_counts(
         self,

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -35,8 +35,10 @@ from memex_common.schemas import (
     IngestResponse,
     EntityDTO,
     KVEntryDTO,
+    KVProcedureEntryDTO,
     KVPutRequest,
     KVSearchRequest,
+    ProcedureOutcomeDTO,
     LineageResponse,
     LineageDirection,
     SystemStatsCountsDTO,
@@ -980,16 +982,47 @@ class RemoteMemexAPI:
     async def kv_get(
         self,
         key: str,
-    ) -> KVEntryDTO | None:
-        """Get a KV entry by exact key. Returns None if not found."""
-        params: dict[str, Any] = {'key': key}
+        *,
+        include_history: bool = False,
+    ) -> KVEntryDTO | KVProcedureEntryDTO | None:
+        """Get a KV entry by exact key. Returns None if not found.
+
+        For ``procedure:`` keys, ``include_history=True`` returns a
+        :class:`KVProcedureEntryDTO` whose ``value`` field is the
+        structured envelope ({value, version, history}).
+        """
+        params: dict[str, Any] = {'key': key, 'include_history': include_history}
         try:
             result = await self._get('kv/get', params=params)
+            if (
+                include_history
+                and key.startswith('procedure:')
+                and isinstance(result.get('value'), dict)
+            ):
+                return KVProcedureEntryDTO(**result)
             return KVEntryDTO(**result)
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 return None
             raise
+
+    async def list_top_procedure_outcomes(
+        self,
+        vault_id: str,
+        *,
+        context: str | None = None,
+        limit: int = 5,
+    ) -> list[ProcedureOutcomeDTO]:
+        """F14 — fetch top procedure outcomes for ``vault_id`` (RFC-007 §155-185).
+
+        Rows ranked by Memory Worth score
+        ``(s+1)/(s+f+2)`` descending; tie-broken by ``last_outcome_at``.
+        """
+        params: dict[str, Any] = {'vault_id': vault_id, 'limit': limit}
+        if context is not None:
+            params['context'] = context
+        result = await self._get('kv/procedure-observations', params=params)
+        return [ProcedureOutcomeDTO(**r) for r in result]
 
     async def kv_search(
         self,

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -1066,3 +1066,44 @@ class RemoteMemexAPI:
             params['pattern'] = pattern
         result = await self._get('kv', params=params or None)
         return [KVEntryDTO(**r) for r in result]
+
+    # ------------------------------------------------------------------
+    # F6 — maintenance ledger (lint)
+    # ------------------------------------------------------------------
+
+    async def lint_status(
+        self,
+        *,
+        scope: str = 'vault',
+        vault_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Pending finding counts. ``scope`` ∈ {'vault', 'global', 'all'}."""
+        params: dict[str, Any] = {'scope': scope}
+        if vault_id is not None:
+            params['vault_id'] = vault_id
+        return await self._get('lint/status', params=params)
+
+    async def lint_findings(
+        self,
+        *,
+        vault_id: str | None = None,
+        lint_type: str | None = None,
+        status: str = 'pending',
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List maintenance findings with optional filters."""
+        params: dict[str, Any] = {'status': status, 'limit': limit, 'offset': offset}
+        if vault_id is not None:
+            params['vault_id'] = vault_id
+        if lint_type is not None:
+            params['lint_type'] = lint_type
+        return await self._get('lint/findings', params=params)
+
+    async def lint_dismiss(self, finding_id: str) -> dict[str, Any]:
+        """Flip a pending finding to ``dismissed``."""
+        return await self._post(f'lint/findings/{finding_id}/dismiss', {})
+
+    async def lint_resolve(self, finding_id: str) -> dict[str, Any]:
+        """Flip a pending finding to ``resolved``."""
+        return await self._post(f'lint/findings/{finding_id}/resolve', {})

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1075,6 +1075,20 @@ class TracingConfig(BaseModel):
     )
 
 
+class LintConfig(BaseModel):
+    """Configuration for the F6 maintenance ledger / rule-based linter."""
+
+    enabled: bool = Field(
+        default=True,
+        description='Enable periodic lint runs via the scheduler.',
+    )
+    interval_seconds: int = Field(
+        default=6 * 3600,
+        ge=60,
+        description='Interval in seconds between lint runs. Default: 6 hours.',
+    )
+
+
 class MemoryConfig(BaseModel):
     """Configuration for memory subsystems."""
 
@@ -1100,6 +1114,11 @@ class MemoryConfig(BaseModel):
     circuit_breaker: CircuitBreakerConfig = Field(
         default_factory=CircuitBreakerConfig,
         description='Configuration for the LLM call circuit breaker.',
+    )
+
+    lint: LintConfig = Field(
+        default_factory=LintConfig,
+        description='Configuration for the F6 maintenance ledger / rule-based linter.',
     )
 
 

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -842,10 +842,12 @@ class ConsolidationConfig(BaseModel):
     )
     cadence_seconds: int = Field(
         default=86400,
+        ge=60,
         description='Wall-clock interval between consolidation ticks (default: 24h).',
     )
     units_per_tick: int = Field(
         default=500,
+        ge=1,
         description='Per-tick budget (oldest-first). Saturation signalled by units_processed=cap.',
     )
 

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -833,6 +833,23 @@ class ContradictionConfig(BaseModel):
     )
 
 
+class ConsolidationConfig(BaseModel):
+    """F38 consolidation orchestrator configuration."""
+
+    enabled: bool = Field(
+        default=True,
+        description='Run the per-vault consolidation tick on the scheduler.',
+    )
+    cadence_seconds: int = Field(
+        default=86400,
+        description='Wall-clock interval between consolidation ticks (default: 24h).',
+    )
+    units_per_tick: int = Field(
+        default=500,
+        description='Per-tick budget (oldest-first). Saturation signalled by units_processed=cap.',
+    )
+
+
 class Permission(str, Enum):
     """Granular permissions for API key access control."""
 
@@ -1109,6 +1126,11 @@ class MemoryConfig(BaseModel):
     contradiction: ContradictionConfig = Field(
         default_factory=ContradictionConfig,
         description='Configuration for contradiction detection.',
+    )
+
+    consolidation: ConsolidationConfig = Field(
+        default_factory=ConsolidationConfig,
+        description='F38 consolidation orchestrator configuration.',
     )
 
     circuit_breaker: CircuitBreakerConfig = Field(

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -1146,6 +1146,31 @@ class KVEntryDTO(BaseModel):
     updated_at: dt.datetime
 
 
+class KVProcedureValueDTO(BaseModel):
+    """Procedure-key value envelope returned when ``include_history=True``."""
+
+    value: str
+    version: int
+    history: list[dict[str, Any]]
+
+
+class KVProcedureEntryDTO(BaseModel):
+    """DTO for a ``procedure:`` KV entry with full envelope visible.
+
+    Returned by the kv_get endpoint when ``include_history=true``. The
+    ``value`` field is the structured envelope (active value + version +
+    capped history). For non-procedure keys callers should use
+    :class:`KVEntryDTO` (default endpoint shape).
+    """
+
+    id: UUID
+    key: str
+    value: KVProcedureValueDTO
+    expires_at: dt.datetime | None = None
+    created_at: dt.datetime
+    updated_at: dt.datetime
+
+
 class KVPutRequest(BaseModel):
     """Request to create or update a key-value entry."""
 

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -1171,6 +1171,24 @@ class KVProcedureEntryDTO(BaseModel):
     updated_at: dt.datetime
 
 
+class ProcedureOutcomeDTO(BaseModel):
+    """One row of the F14 procedure-observations briefing surface.
+
+    Returned by ``MemexAPI.list_top_procedure_outcomes`` and the
+    ``GET /api/v1/kv/procedure-observations`` endpoint. Each row exposes
+    the procedure KV key, success/failure MW counters, the
+    Beta-Bernoulli posterior-mean Memory Worth score
+    (``memex_core.services.outcomes.compute_mw_score``), and the
+    ``last_outcome_at`` timestamp.
+    """
+
+    kv_key: str
+    success_co_count: int
+    failure_co_count: int
+    mw_score: float
+    last_outcome_at: dt.datetime | None = None
+
+
 class KVPutRequest(BaseModel):
     """Request to create or update a key-value entry."""
 

--- a/packages/common/tests/test_client_record_outcome.py
+++ b/packages/common/tests/test_client_record_outcome.py
@@ -1,0 +1,125 @@
+"""Tests for RemoteMemexAPI.record_outcome() — F29 HTTP wrapper.
+
+Verifies the wrapper preserves the F14 ADD-2 contract (positional
+``unit_ids`` + ``success``, keyword-only ``target_type`` / ``kv_key``)
+and forwards body params to /api/v1/outcomes/record correctly.
+"""
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from memex_common.client import RemoteMemexAPI
+
+
+@pytest.fixture
+def mock_client():
+    """httpx.AsyncClient stub that captures the POST body."""
+    client = AsyncMock(spec=httpx.AsyncClient)
+    return client
+
+
+def _capture_post(captured: dict):
+    async def _post(path, json=None, **kwargs):
+        captured['path'] = path
+        captured['json'] = json
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = 200
+        response.headers = {'content-type': 'application/json'}
+        response.json.return_value = {
+            'units_updated': 1,
+            'entities_updated': 0,
+            'models_updated': 0,
+        }
+        response.raise_for_status = MagicMock()
+        return response
+
+    return _post
+
+
+@pytest.mark.asyncio
+async def test_memory_unit_passthrough(mock_client):
+    """Default memory_unit mode: unit_ids + success forwarded; target_type defaults."""
+    api = RemoteMemexAPI(mock_client)
+    captured: dict = {}
+    mock_client.post = _capture_post(captured)
+
+    await api.record_outcome(['unit-1', 'unit-2'], True, vault_id='vault-uuid')
+
+    assert captured['path'] == 'outcomes/record'
+    assert captured['json']['unit_ids'] == ['unit-1', 'unit-2']
+    assert captured['json']['success'] is True
+    assert captured['json']['vault_id'] == 'vault-uuid'
+    assert captured['json']['target_type'] == 'memory_unit'
+    assert captured['json']['outcome_confidence'] == 1.0
+    assert 'kv_key' not in captured['json']
+    assert 'reason' not in captured['json']
+
+
+@pytest.mark.asyncio
+async def test_kv_key_mode(mock_client):
+    """kv_key mode: keyword-only target_type='kv_key' + kv_key forwarded; unit_ids omitted."""
+    api = RemoteMemexAPI(mock_client)
+    captured: dict = {}
+    mock_client.post = _capture_post(captured)
+
+    await api.record_outcome(
+        None,
+        False,
+        vault_id='vault-uuid',
+        target_type='kv_key',
+        kv_key='procedure:run-tests:default',
+    )
+
+    assert captured['json']['success'] is False
+    assert captured['json']['target_type'] == 'kv_key'
+    assert captured['json']['kv_key'] == 'procedure:run-tests:default'
+    assert 'unit_ids' not in captured['json']
+
+
+@pytest.mark.asyncio
+async def test_optional_fields_only_sent_when_set(mock_client):
+    """outcome_confidence and reason flow through when supplied."""
+    api = RemoteMemexAPI(mock_client)
+    captured: dict = {}
+    mock_client.post = _capture_post(captured)
+
+    await api.record_outcome(
+        ['u1'],
+        True,
+        vault_id='v',
+        outcome_confidence=0.5,
+        reason='partial — only one unit was actually used',
+    )
+
+    assert captured['json']['outcome_confidence'] == 0.5
+    assert captured['json']['reason'] == 'partial — only one unit was actually used'
+
+
+# ---------------------------------------------------------------------------
+# F14 ADD-2 contract preservation
+# ---------------------------------------------------------------------------
+
+
+def test_signature_matches_in_process_api():
+    """ADD-2 invariant: RemoteMemexAPI.record_outcome must mirror MemexAPI.record_outcome.
+
+    Specifically: unit_ids + success are positional-or-keyword, target_type
+    and kv_key are keyword-only. A drift here means a Hermes call that works
+    in-process could fail (or worse, silently misbehave) over the wire.
+    """
+    sig = inspect.signature(RemoteMemexAPI.record_outcome)
+    params = sig.parameters
+
+    # Positional-or-keyword (ADD-2: success has no default — required).
+    assert params['unit_ids'].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert params['success'].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert params['success'].default is inspect.Parameter.empty, (
+        'success must have no default — kwargless calls cannot silently record FAILURE'
+    )
+
+    # Keyword-only — drift here would let a positional 7th-arg call collide.
+    assert params['target_type'].kind == inspect.Parameter.KEYWORD_ONLY
+    assert params['kv_key'].kind == inspect.Parameter.KEYWORD_ONLY

--- a/packages/core/src/memex_core/alembic/versions/025_maintenance_proposals.py
+++ b/packages/core/src/memex_core/alembic/versions/025_maintenance_proposals.py
@@ -1,14 +1,25 @@
-"""F6 maintenance_proposals — STUB; filled by WS-linter.
+"""F6 maintenance_proposals — finding ledger for the rule-based linter.
 
-Tier A seed stub — body intentionally raises so any feature workstream that
-forgets to replace it before shipping fails CI loud. `alembic check` validates
-the chain without invoking upgrade()/downgrade(), so this stub passes chain
-integrity checks while remaining unrunnable.
+Creates the `maintenance_proposals` table that stores findings emitted by the
+F6 LintService. Schema follows RFC-003 §"`MaintenanceProposal` schema":
+
+- `vault_id` is nullable (NULL = global findings; reserved for Tier B; v1
+  emits no global findings — see RFC-003 §"Cross-vault scope").
+- The 4 enum-style columns (`lint_type`, `target_type`, `status`, `source`)
+  are TEXT with CHECK constraints; matches the F25 (024) precedent.
+- A partial unique index on `(rule_name, target_type, target_id, vault_id)
+  WHERE status = 'pending'` enforces idempotent re-runs (the rule engine
+  uses `INSERT ... ON CONFLICT DO NOTHING`).
 
 Revision ID: 025_maintenance_proposals
 Revises: 024_intent_risk_classifier
 Create Date: 2026-04-30
 """
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import Uuid as SA_UUID
 
 revision: str = '025_maintenance_proposals'
 down_revision: str | None = '024_intent_risk_classifier'
@@ -16,9 +27,126 @@ branch_labels: str | list[str] | None = None
 depends_on: str | list[str] | None = None
 
 
+def _table_exists(conn, table: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            'SELECT EXISTS ('
+            '  SELECT 1 FROM information_schema.tables'
+            '  WHERE table_schema = current_schema() AND table_name = :table'
+            ')'
+        ),
+        {'table': table},
+    )
+    return bool(result.scalar())
+
+
+def _index_exists(conn, index: str) -> bool:
+    result = conn.execute(
+        sa.text('SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = :index)'),
+        {'index': index},
+    )
+    return bool(result.scalar())
+
+
 def upgrade() -> None:
-    raise NotImplementedError('F6: filled in WS-linter PR')
+    conn = op.get_bind()
+
+    if not _table_exists(conn, 'maintenance_proposals'):
+        op.create_table(
+            'maintenance_proposals',
+            sa.Column(
+                'id',
+                SA_UUID(),
+                primary_key=True,
+                server_default=sa.text('gen_random_uuid()'),
+            ),
+            sa.Column(
+                'vault_id',
+                SA_UUID(),
+                sa.ForeignKey('vaults.id', ondelete='CASCADE'),
+                nullable=True,
+            ),
+            sa.Column('lint_type', sa.Text(), nullable=False),
+            sa.Column('target_type', sa.Text(), nullable=False),
+            sa.Column('target_id', sa.Text(), nullable=False),
+            sa.Column('rule_name', sa.Text(), nullable=False),
+            sa.Column(
+                'evidence',
+                JSONB,
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column('suggested_action', sa.Text(), nullable=False),
+            sa.Column(
+                'status',
+                sa.Text(),
+                nullable=False,
+                server_default=sa.text("'pending'"),
+            ),
+            sa.Column(
+                'source',
+                sa.Text(),
+                nullable=False,
+                server_default=sa.text("'rule'"),
+            ),
+            sa.Column(
+                'created_at',
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                'resolved_at',
+                sa.TIMESTAMP(timezone=True),
+                nullable=True,
+            ),
+            sa.CheckConstraint(
+                "lint_type IN ('structural', 'quality', 'governance', 'schema')",
+                name='ck_maintenance_proposals_lint_type',
+            ),
+            sa.CheckConstraint(
+                "status IN ('pending', 'resolved', 'dismissed')",
+                name='ck_maintenance_proposals_status',
+            ),
+            sa.CheckConstraint(
+                "source IN ('rule', 'llm')",
+                name='ck_maintenance_proposals_source',
+            ),
+        )
+
+    if not _index_exists(conn, 'uq_maintenance_proposals_pending'):
+        op.execute(
+            sa.text(
+                'CREATE UNIQUE INDEX uq_maintenance_proposals_pending '
+                'ON maintenance_proposals (rule_name, target_type, target_id, vault_id) '
+                "WHERE status = 'pending'"
+            )
+        )
+
+    if not _index_exists(conn, 'idx_maintenance_proposals_vault_status'):
+        op.create_index(
+            'idx_maintenance_proposals_vault_status',
+            'maintenance_proposals',
+            ['vault_id', 'status'],
+        )
+
+    if not _index_exists(conn, 'idx_maintenance_proposals_lint_type'):
+        op.create_index(
+            'idx_maintenance_proposals_lint_type',
+            'maintenance_proposals',
+            ['lint_type'],
+        )
 
 
 def downgrade() -> None:
-    raise NotImplementedError('F6: filled in WS-linter PR')
+    conn = op.get_bind()
+
+    if _index_exists(conn, 'idx_maintenance_proposals_lint_type'):
+        op.drop_index('idx_maintenance_proposals_lint_type', table_name='maintenance_proposals')
+    if _index_exists(conn, 'idx_maintenance_proposals_vault_status'):
+        op.drop_index('idx_maintenance_proposals_vault_status', table_name='maintenance_proposals')
+    if _index_exists(conn, 'uq_maintenance_proposals_pending'):
+        op.execute(sa.text('DROP INDEX IF EXISTS uq_maintenance_proposals_pending'))
+
+    if _table_exists(conn, 'maintenance_proposals'):
+        op.drop_table('maintenance_proposals')

--- a/packages/core/src/memex_core/alembic/versions/027_consolidation_ticks.py
+++ b/packages/core/src/memex_core/alembic/versions/027_consolidation_ticks.py
@@ -1,14 +1,29 @@
-"""F38 consolidation_ticks — STUB; filled by WS-quick-wins.
+"""F38 consolidation_ticks — vault-scoped tick-summary rows for consolidation orchestrator.
 
-Tier A seed stub — body intentionally raises so any feature workstream that
-forgets to replace it before shipping fails CI loud. `alembic check` validates
-the chain without invoking upgrade()/downgrade(), so this stub passes chain
-integrity checks while remaining unrunnable.
+One row per `consolidation_tick(vault_id)` invocation. F38's `services/consolidation.py`
+is a thin orchestrator over reflection + contradiction + prune-stale-only; its sole
+DB write is the row inserted into this table at the end of each tick (AC-F38-4).
+
+Schema per RFC-010 §"Tick-summary row schema":
+- started_at + completed_at (NOT just last_tick_at — the gap captures wall-clock duration
+  + signals "in progress" via NULL completed_at)
+- units_processed: count of units returned by select_diff_units (capped at 500)
+- entities_reflected, contradictions_run, stale_pruned: per-step counts
+- error: optional free-text on failure (warning-level, not raise)
+
+Two indexes:
+- (vault_id, started_at) for ad-hoc per-vault history queries
+- (vault_id, completed_at DESC NULLS LAST) covers `get_last_tick_timestamp` lookups
+  via MAX(completed_at) — peer-review tweak from staff-eng-2.
 
 Revision ID: 027_consolidation_ticks
 Revises: 026_revisit_columns
 Create Date: 2026-04-30
 """
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
 
 revision: str = '027_consolidation_ticks'
 down_revision: str | None = '026_revisit_columns'
@@ -16,9 +31,107 @@ branch_labels: str | list[str] | None = None
 depends_on: str | list[str] | None = None
 
 
+def _table_exists(conn, table: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            'SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = :table)'
+        ),
+        {'table': table},
+    )
+    return bool(result.scalar())
+
+
+def _index_exists(conn, index: str) -> bool:
+    result = conn.execute(
+        sa.text('SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = :index)'),
+        {'index': index},
+    )
+    return bool(result.scalar())
+
+
 def upgrade() -> None:
-    raise NotImplementedError('F38: filled in WS-quick-wins PR')
+    conn = op.get_bind()
+
+    if not _table_exists(conn, 'consolidation_ticks'):
+        op.create_table(
+            'consolidation_ticks',
+            sa.Column(
+                'id',
+                UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text('gen_random_uuid()'),
+            ),
+            sa.Column('vault_id', UUID(as_uuid=True), nullable=False),
+            sa.Column('started_at', sa.TIMESTAMP(timezone=True), nullable=False),
+            sa.Column('completed_at', sa.TIMESTAMP(timezone=True), nullable=True),
+            sa.Column(
+                'units_processed',
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text('0'),
+            ),
+            sa.Column(
+                'entities_reflected',
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text('0'),
+            ),
+            sa.Column(
+                'contradictions_run',
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text('0'),
+            ),
+            sa.Column(
+                'stale_pruned',
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text('0'),
+            ),
+            sa.Column('error', sa.Text(), nullable=True),
+            sa.Column(
+                'created_at',
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.ForeignKeyConstraint(
+                ['vault_id'],
+                ['vaults.id'],
+                ondelete='CASCADE',
+                name='fk_consolidation_ticks_vault_id',
+            ),
+        )
+
+    if not _index_exists(conn, 'idx_consolidation_ticks_vault_started'):
+        op.create_index(
+            'idx_consolidation_ticks_vault_started',
+            'consolidation_ticks',
+            ['vault_id', 'started_at'],
+        )
+
+    if not _index_exists(conn, 'idx_consolidation_ticks_vault_completed'):
+        op.create_index(
+            'idx_consolidation_ticks_vault_completed',
+            'consolidation_ticks',
+            ['vault_id', sa.text('completed_at DESC NULLS LAST')],
+        )
 
 
 def downgrade() -> None:
-    raise NotImplementedError('F38: filled in WS-quick-wins PR')
+    conn = op.get_bind()
+
+    if _index_exists(conn, 'idx_consolidation_ticks_vault_completed'):
+        op.drop_index(
+            'idx_consolidation_ticks_vault_completed',
+            table_name='consolidation_ticks',
+        )
+
+    if _index_exists(conn, 'idx_consolidation_ticks_vault_started'):
+        op.drop_index(
+            'idx_consolidation_ticks_vault_started',
+            table_name='consolidation_ticks',
+        )
+
+    if _table_exists(conn, 'consolidation_ticks'):
+        op.drop_table('consolidation_ticks')

--- a/packages/core/src/memex_core/alembic/versions/027_consolidation_ticks.py
+++ b/packages/core/src/memex_core/alembic/versions/027_consolidation_ticks.py
@@ -34,7 +34,10 @@ depends_on: str | list[str] | None = None
 def _table_exists(conn, table: str) -> bool:
     result = conn.execute(
         sa.text(
-            'SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = :table)'
+            'SELECT EXISTS ('
+            '  SELECT 1 FROM information_schema.tables'
+            '  WHERE table_schema = current_schema() AND table_name = :table'
+            ')'
         ),
         {'table': table},
     )

--- a/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
+++ b/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
@@ -86,6 +86,12 @@ def upgrade() -> None:
             ),
             sa.UniqueConstraint('vault_id', 'kv_key', name='uq_procedure_outcomes_vault_key'),
             sa.ForeignKeyConstraint(
+                ['vault_id'],
+                ['vaults.id'],
+                ondelete='CASCADE',
+                name='fk_procedure_outcomes_vault_id',
+            ),
+            sa.ForeignKeyConstraint(
                 ['kv_key'],
                 ['kv_entries.key'],
                 ondelete='CASCADE',

--- a/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
+++ b/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
@@ -1,14 +1,21 @@
-"""F14 procedure_outcomes — STUB; filled by WS-quick-wins.
+"""F14 procedure_outcomes — vault-scoped MW counters for procedural KV keys.
 
-Tier A seed stub — body intentionally raises so any feature workstream that
-forgets to replace it before shipping fails CI loud. `alembic check` validates
-the chain without invoking upgrade()/downgrade(), so this stub passes chain
-integrity checks while remaining unrunnable.
+Scoped to counters ONLY — active value/version/history live in KVEntry.value
+JSON envelope (no schema change to kv_entries). One row per (vault_id, kv_key);
+counters increment via OutcomeService.record_outcome(target_type='kv_key', ...).
+
+FK to kv_entries.key ON DELETE CASCADE — deleting a procedure key cleans up its
+counter rows. UniqueConstraint(vault_id, kv_key) enforces vault-scoped isolation
+(Wave 0 invariant).
 
 Revision ID: 028_procedure_outcomes
 Revises: 027_consolidation_ticks
 Create Date: 2026-04-30
 """
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
 
 revision: str = '028_procedure_outcomes'
 down_revision: str | None = '027_consolidation_ticks'
@@ -16,9 +23,89 @@ branch_labels: str | list[str] | None = None
 depends_on: str | list[str] | None = None
 
 
+def _table_exists(conn, table: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            'SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = :table)'
+        ),
+        {'table': table},
+    )
+    return bool(result.scalar())
+
+
+def _index_exists(conn, index: str) -> bool:
+    result = conn.execute(
+        sa.text('SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = :index)'),
+        {'index': index},
+    )
+    return bool(result.scalar())
+
+
 def upgrade() -> None:
-    raise NotImplementedError('F14: filled in WS-quick-wins PR')
+    conn = op.get_bind()
+
+    if not _table_exists(conn, 'procedure_outcomes'):
+        op.create_table(
+            'procedure_outcomes',
+            sa.Column(
+                'id',
+                UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text('gen_random_uuid()'),
+            ),
+            sa.Column('vault_id', UUID(as_uuid=True), nullable=False),
+            sa.Column('kv_key', sa.Text(), nullable=False),
+            sa.Column(
+                'success_co_count',
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text('0'),
+            ),
+            sa.Column(
+                'failure_co_count',
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text('0'),
+            ),
+            sa.Column(
+                'last_outcome_at',
+                sa.TIMESTAMP(timezone=True),
+                nullable=True,
+            ),
+            sa.Column(
+                'created_at',
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                'updated_at',
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.UniqueConstraint('vault_id', 'kv_key', name='uq_procedure_outcomes_vault_key'),
+            sa.ForeignKeyConstraint(
+                ['kv_key'],
+                ['kv_entries.key'],
+                ondelete='CASCADE',
+                name='fk_procedure_outcomes_kv_key',
+            ),
+        )
+
+    if not _index_exists(conn, 'idx_procedure_outcomes_vault_key'):
+        op.create_index(
+            'idx_procedure_outcomes_vault_key',
+            'procedure_outcomes',
+            ['vault_id', 'kv_key'],
+        )
 
 
 def downgrade() -> None:
-    raise NotImplementedError('F14: filled in WS-quick-wins PR')
+    conn = op.get_bind()
+
+    if _index_exists(conn, 'idx_procedure_outcomes_vault_key'):
+        op.drop_index('idx_procedure_outcomes_vault_key', table_name='procedure_outcomes')
+
+    if _table_exists(conn, 'procedure_outcomes'):
+        op.drop_table('procedure_outcomes')

--- a/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
+++ b/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
@@ -26,7 +26,10 @@ depends_on: str | list[str] | None = None
 def _table_exists(conn, table: str) -> bool:
     result = conn.execute(
         sa.text(
-            'SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = :table)'
+            'SELECT EXISTS ('
+            '  SELECT 1 FROM information_schema.tables'
+            '  WHERE table_schema = current_schema() AND table_name = :table'
+            ')'
         ),
         {'table': table},
     )

--- a/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
+++ b/packages/core/src/memex_core/alembic/versions/028_procedure_outcomes.py
@@ -36,14 +36,6 @@ def _table_exists(conn, table: str) -> bool:
     return bool(result.scalar())
 
 
-def _index_exists(conn, index: str) -> bool:
-    result = conn.execute(
-        sa.text('SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = :index)'),
-        {'index': index},
-    )
-    return bool(result.scalar())
-
-
 def upgrade() -> None:
     conn = op.get_bind()
 
@@ -102,19 +94,12 @@ def upgrade() -> None:
             ),
         )
 
-    if not _index_exists(conn, 'idx_procedure_outcomes_vault_key'):
-        op.create_index(
-            'idx_procedure_outcomes_vault_key',
-            'procedure_outcomes',
-            ['vault_id', 'kv_key'],
-        )
+    # Note: ``UniqueConstraint('vault_id', 'kv_key')`` already creates a
+    # btree index on those columns; no separate ``CREATE INDEX`` is needed.
 
 
 def downgrade() -> None:
     conn = op.get_bind()
-
-    if _index_exists(conn, 'idx_procedure_outcomes_vault_key'):
-        op.drop_index('idx_procedure_outcomes_vault_key', table_name='procedure_outcomes')
 
     if _table_exists(conn, 'procedure_outcomes'):
         op.drop_table('procedure_outcomes')

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1169,13 +1169,22 @@ class MemexAPI:
 
     async def record_outcome(
         self,
-        unit_ids: list[str],
-        success: bool,
-        vault_id: str,
+        unit_ids: list[str] | None = None,
+        success: bool = False,
+        vault_id: str | None = None,
         outcome_confidence: float = 1.0,
         reason: str | None = None,
+        *,
+        target_type: str = 'memory_unit',
+        kv_key: str | None = None,
     ) -> dict[str, Any]:
-        """Record an outcome for memory units. Delegates to OutcomeService."""
+        """Record an outcome. Delegates to OutcomeService.
+
+        For ``target_type='kv_key'`` (F14), increments the vault-scoped
+        success/failure counters on ``procedure_outcomes`` for ``kv_key``
+        instead of memory units. See
+        :meth:`OutcomeService.record_outcome` for the full contract.
+        """
         async with self.metastore.session() as session:
             return await self._outcomes.record_outcome(
                 session=session,
@@ -1184,6 +1193,8 @@ class MemexAPI:
                 vault_id=vault_id,
                 outcome_confidence=outcome_confidence,
                 reason=reason,
+                target_type=target_type,
+                kv_key=kv_key,
             )
 
     async def create_vault(self, name: str, description: str | None = None) -> Any:

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -59,6 +59,7 @@ from memex_core.memory.entity_resolver import EntityResolver
 from memex_core.memory.extraction.core import ExtractSemanticFacts
 from memex_core.processing.files import FileContentProcessor
 from memex_core.processing.batch import JobManager
+from memex_core.services.consolidation import ConsolidationService
 from memex_core.services.diagnostics import DiagnosticsService
 from memex_core.services.entities import EntityService
 from memex_core.services.ingestion import IngestionService
@@ -515,6 +516,12 @@ class MemexAPI:
             filestore=self.filestore,
             config=self.config,
         )
+        self._consolidation = ConsolidationService(
+            metastore=self.metastore,
+            config=self.config,
+            reflection=self._reflection,
+            contradiction=self._contradiction,
+        )
 
         from memex_core.services.session_briefing import SessionBriefingService
 
@@ -567,6 +574,10 @@ class MemexAPI:
     @property
     def lint(self) -> LintService:
         return self._lint
+
+    @property
+    def consolidation(self) -> ConsolidationService:
+        return self._consolidation
 
     @property
     def embedder(self) -> EmbeddingsModel:

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1512,6 +1512,18 @@ class MemexAPI:
             query_embedding=query_embedding, namespaces=namespaces, limit=limit
         )
 
+    async def list_top_procedure_outcomes(
+        self,
+        vault_id: str | UUID,
+        *,
+        context: str | None = None,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        """F14 — Top procedure outcomes for a vault, ranked by MW score."""
+        return await self._kv.list_top_procedure_outcomes(
+            vault_id=vault_id, context=context, limit=limit
+        )
+
     async def kv_delete(self, key: str) -> bool:
         """Delete a KV entry. Delegates to KVService."""
         return await self._kv.delete(key=key)

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1481,9 +1481,14 @@ class MemexAPI:
             key=key, value=value, embedding=embedding, ttl_seconds=ttl_seconds
         )
 
-    async def kv_get(self, key: str) -> Any | None:
-        """Get a KV entry by key. Delegates to KVService."""
-        return await self._kv.get(key=key)
+    async def kv_get(self, key: str, *, include_history: bool = False) -> Any | None:
+        """Get a KV entry by key. Delegates to KVService.
+
+        For ``procedure:`` keys (RFC-007), ``include_history=True`` swaps the
+        returned entry's ``value`` field from the unwrapped active string to
+        a dict ``{value, version, history}``. Default behavior is unchanged.
+        """
+        return await self._kv.get(key=key, include_history=include_history)
 
     async def kv_search(
         self,

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -64,6 +64,7 @@ from memex_core.services.entities import EntityService
 from memex_core.services.ingestion import IngestionService
 from memex_core.services.kv import KVService
 from memex_core.services.lineage import LineageService
+from memex_core.services.lint import LintService
 from memex_core.services.notes import NoteService
 from memex_core.services.outcomes import OutcomeService
 from memex_core.services.reflection import ReflectionService
@@ -509,6 +510,11 @@ class MemexAPI:
             filestore=self.filestore,
             config=self.config,
         )
+        self._lint = LintService(
+            metastore=self.metastore,
+            filestore=self.filestore,
+            config=self.config,
+        )
 
         from memex_core.services.session_briefing import SessionBriefingService
 
@@ -557,6 +563,10 @@ class MemexAPI:
     @property
     def diagnostics(self) -> DiagnosticsService:
         return self._diagnostics
+
+    @property
+    def lint(self) -> LintService:
+        return self._lint
 
     @property
     def embedder(self) -> EmbeddingsModel:

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1169,8 +1169,8 @@ class MemexAPI:
 
     async def record_outcome(
         self,
-        unit_ids: list[str] | None = None,
-        success: bool = False,
+        unit_ids: list[str] | None,
+        success: bool,
         vault_id: str | None = None,
         outcome_confidence: float = 1.0,
         reason: str | None = None,

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -1565,7 +1565,12 @@ class ProcedureOutcome(SQLModel, table=True):  # type: ignore
     )
 
     vault_id: UUID = Field(
-        sa_column=Column(SA_UUID(), nullable=False, index=True),
+        sa_column=Column(
+            SA_UUID(),
+            ForeignKey('vaults.id', ondelete='CASCADE'),
+            nullable=False,
+            index=True,
+        ),
         description='Vault that owns this counter row (Wave 0 invariant: NOT NULL).',
     )
 

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -1621,3 +1621,119 @@ class ProcedureOutcome(SQLModel, table=True):  # type: ignore
         ),
         Index('idx_procedure_outcomes_vault_key', 'vault_id', 'kv_key'),
     )
+
+
+# ---------------------------------------------------------------------------
+# F6 — Maintenance ledger (rule-based linter)
+# ---------------------------------------------------------------------------
+
+
+class LintType(str, Enum):
+    STRUCTURAL = 'structural'
+    QUALITY = 'quality'
+    GOVERNANCE = 'governance'
+    SCHEMA = 'schema'
+
+
+class LintStatus(str, Enum):
+    PENDING = 'pending'
+    RESOLVED = 'resolved'
+    DISMISSED = 'dismissed'
+
+
+class LintSource(str, Enum):
+    RULE = 'rule'
+    LLM = 'llm'
+
+
+class MaintenanceProposal(SQLModel, table=True):  # type: ignore
+    """Finding ledger row emitted by the F6 LintService.
+
+    Read-only from the agent surface (F8). The unique partial index on
+    ``(rule_name, target_type, target_id, vault_id) WHERE status = 'pending'``
+    makes ``LintService.run_rules`` idempotent on reruns. ``vault_id`` is
+    nullable per AC-F6-1 (NULL = global findings; reserved for Tier B).
+    """
+
+    __tablename__ = 'maintenance_proposals'
+
+    id: UUID = Field(
+        sa_column=Column(SA_UUID(), primary_key=True, server_default=sql_text('gen_random_uuid()')),
+        description='Unique identifier for the maintenance proposal.',
+    )
+    vault_id: UUID | None = Field(
+        default=None,
+        sa_column=Column(
+            SA_UUID(),
+            ForeignKey('vaults.id', ondelete='CASCADE'),
+            nullable=True,
+        ),
+        description='Vault this finding belongs to. NULL = global; reserved for Tier B.',
+    )
+    lint_type: LintType = Field(
+        sa_column=Column(Text, nullable=False),
+        description='Category of the finding.',
+    )
+    target_type: str = Field(
+        sa_column=Column(Text, nullable=False),
+        description="Type of the targeted entity (e.g. 'memory_unit', 'mental_model').",
+    )
+    target_id: str = Field(
+        sa_column=Column(Text, nullable=False),
+        description='Opaque identifier of the targeted entity.',
+    )
+    rule_name: str = Field(
+        sa_column=Column(Text, nullable=False),
+        description='Name of the rule that emitted this finding.',
+    )
+    evidence: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSONB, nullable=False, server_default=sql_text("'{}'::jsonb")),
+        description='Rule-specific payload describing why the finding fired.',
+    )
+    suggested_action: str = Field(
+        sa_column=Column(Text, nullable=False),
+        description='Free-text suggestion for the agent or operator.',
+    )
+    status: LintStatus = Field(
+        default=LintStatus.PENDING,
+        sa_column=Column(Text, nullable=False, server_default='pending'),
+        description='Lifecycle state of the finding.',
+    )
+    source: LintSource = Field(
+        default=LintSource.RULE,
+        sa_column=Column(Text, nullable=False, server_default='rule'),
+        description='Whether the finding came from a SQL rule or an LLM check (F10).',
+    )
+    created_at: datetime = created_at_field()
+    resolved_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(TIMESTAMP(timezone=True), nullable=True),
+        description='Set when status flips to resolved or dismissed.',
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "lint_type IN ('structural', 'quality', 'governance', 'schema')",
+            name='ck_maintenance_proposals_lint_type',
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'resolved', 'dismissed')",
+            name='ck_maintenance_proposals_status',
+        ),
+        CheckConstraint(
+            "source IN ('rule', 'llm')",
+            name='ck_maintenance_proposals_source',
+        ),
+        Index('idx_maintenance_proposals_vault_status', 'vault_id', 'status'),
+        Index('idx_maintenance_proposals_lint_type', 'lint_type'),
+        Index(
+            'uq_maintenance_proposals_pending',
+            'rule_name',
+            'target_type',
+            'target_id',
+            'vault_id',
+            unique=True,
+            postgresql_where=sql_text("status = 'pending'"),
+        ),
+    )

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -1737,3 +1737,90 @@ class MaintenanceProposal(SQLModel, table=True):  # type: ignore
             postgresql_where=sql_text("status = 'pending'"),
         ),
     )
+
+
+class ConsolidationTick(SQLModel, table=True):  # type: ignore
+    """One row per F38 ``consolidation_tick(vault_id)`` invocation.
+
+    F38's ``services/consolidation.py`` is a thin orchestrator over
+    reflection + contradiction + prune-stale-only; this row is its sole
+    DB write at the end of each tick (AC-F38-4). ``completed_at IS NULL``
+    signals an in-progress tick; the gap between ``started_at`` and
+    ``completed_at`` is wall-clock duration.
+    """
+
+    __tablename__ = 'consolidation_ticks'
+
+    id: UUID = Field(
+        sa_column=Column(SA_UUID(), primary_key=True, server_default=sql_text('gen_random_uuid()')),
+        description='Unique identifier for the tick row.',
+    )
+
+    vault_id: UUID = Field(
+        sa_column=Column(
+            SA_UUID(),
+            nullable=False,
+        ),
+        description='Vault this tick consolidated (Wave 0 invariant: NOT NULL).',
+    )
+
+    started_at: datetime = Field(
+        sa_column=Column(TIMESTAMP(timezone=True), nullable=False),
+        description='Wall-clock timestamp when the tick began.',
+    )
+
+    completed_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(TIMESTAMP(timezone=True), nullable=True),
+        description='Wall-clock timestamp when the tick finished; NULL means in-progress.',
+    )
+
+    units_processed: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default=sql_text('0')),
+        description='Memory units returned by select_diff_units (capped at 500/tick).',
+    )
+
+    entities_reflected: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default=sql_text('0')),
+        description='Distinct entities passed to ReflectionService during this tick.',
+    )
+
+    contradictions_run: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default=sql_text('0')),
+        description='Contradiction-detection invocations made during this tick.',
+    )
+
+    stale_pruned: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default=sql_text('0')),
+        description='Units pruned by prune_stale_evidence (status=STALE only).',
+    )
+
+    error: str | None = Field(
+        default=None,
+        sa_column=Column(Text, nullable=True),
+        description='Free-text error message on failure; None on success.',
+    )
+
+    created_at: datetime = Field(
+        sa_column=Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now()),
+        description='Timestamp when the row was inserted.',
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ['vault_id'],
+            ['vaults.id'],
+            ondelete='CASCADE',
+            name='fk_consolidation_ticks_vault_id',
+        ),
+        Index('idx_consolidation_ticks_vault_started', 'vault_id', 'started_at'),
+        Index(
+            'idx_consolidation_ticks_vault_completed',
+            'vault_id',
+            sql_text('completed_at DESC NULLS LAST'),
+        ),
+    )

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -1045,7 +1045,7 @@ class BatchJob(SQLModel, table=True):  # type: ignore
 
     status: BatchJobStatus = Field(
         default=BatchJobStatus.PENDING,
-        sa_column=Column(Text, nullable=False, server_default='pending'),
+        sa_column=Column(Text, nullable=False, server_default=sql_text("'pending'")),
         description='Current status of the batch job.',
     )
 
@@ -1161,7 +1161,7 @@ class ReflectionQueue(SQLModel, table=True):  # type: ignore
 
     status: ReflectionStatus = Field(
         default=ReflectionStatus.PENDING,
-        sa_column=Column(Text, nullable=False, server_default='pending'),
+        sa_column=Column(Text, nullable=False, server_default=sql_text("'pending'")),
         description='Current status of the reflection task.',
     )
 
@@ -1612,6 +1612,8 @@ class ProcedureOutcome(SQLModel, table=True):  # type: ignore
     )
 
     __table_args__ = (
+        # The unique constraint below auto-creates a btree index on
+        # (vault_id, kv_key); no separate Index(...) is needed.
         UniqueConstraint('vault_id', 'kv_key', name='uq_procedure_outcomes_vault_key'),
         ForeignKeyConstraint(
             ['kv_key'],
@@ -1619,7 +1621,6 @@ class ProcedureOutcome(SQLModel, table=True):  # type: ignore
             ondelete='CASCADE',
             name='fk_procedure_outcomes_kv_key',
         ),
-        Index('idx_procedure_outcomes_vault_key', 'vault_id', 'kv_key'),
     )
 
 
@@ -1697,12 +1698,12 @@ class MaintenanceProposal(SQLModel, table=True):  # type: ignore
     )
     status: LintStatus = Field(
         default=LintStatus.PENDING,
-        sa_column=Column(Text, nullable=False, server_default='pending'),
+        sa_column=Column(Text, nullable=False, server_default=sql_text("'pending'")),
         description='Lifecycle state of the finding.',
     )
     source: LintSource = Field(
         default=LintSource.RULE,
-        sa_column=Column(Text, nullable=False, server_default='rule'),
+        sa_column=Column(Text, nullable=False, server_default=sql_text("'rule'")),
         description='Whether the finding came from a SQL rule or an LLM check (F10).',
     )
     created_at: datetime = created_at_field()

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -1362,7 +1362,7 @@ class KVEntry(SQLModel, table=True):  # type: ignore
     Function: Provides simple, named storage for configuration, preferences,
     and structured data that doesn't fit the note/memory model.
     Key Features:
-        - Keys must start with a namespace prefix: global:, user:, project:, or app:.
+        - Keys must start with a namespace prefix: global:, user:, project:, app:, or procedure:.
         - Unique constraint on key.
         - btree index with text_pattern_ops for efficient prefix queries.
         - Optional embedding for semantic search over values.
@@ -1544,4 +1544,75 @@ class NoteAppend(SQLModel, table=True):  # type: ignore
             ondelete='CASCADE',
         ),
         Index('idx_note_appends_note_id_applied_at', 'note_id', 'applied_at'),
+    )
+
+
+class ProcedureOutcome(SQLModel, table=True):  # type: ignore
+    """Per-(vault, procedure_kv_key) MW success/failure counter row.
+
+    Counters increment via :class:`memex_core.services.outcome.OutcomeService`
+    (target_type='kv_key'). The active value/version/history live in the
+    JSON envelope at ``kv_entries.value`` for the corresponding ``procedure:``
+    key — this table holds counters only. FK ON DELETE CASCADE removes
+    counter rows when the parent KVEntry is deleted.
+    """
+
+    __tablename__ = 'procedure_outcomes'
+
+    id: UUID = Field(
+        sa_column=Column(SA_UUID(), primary_key=True, server_default=sql_text('gen_random_uuid()')),
+        description='Unique identifier for the counter row.',
+    )
+
+    vault_id: UUID = Field(
+        sa_column=Column(SA_UUID(), nullable=False, index=True),
+        description='Vault that owns this counter row (Wave 0 invariant: NOT NULL).',
+    )
+
+    kv_key: str = Field(
+        sa_column=Column(Text, nullable=False),
+        description='The procedure KV key these counters belong to.',
+    )
+
+    success_co_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default=sql_text('0')),
+        description='Cumulative success outcomes recorded against this key.',
+    )
+
+    failure_co_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default=sql_text('0')),
+        description='Cumulative failure outcomes recorded against this key.',
+    )
+
+    last_outcome_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(TIMESTAMP(timezone=True), nullable=True),
+        description='Timestamp of the most recent recorded outcome.',
+    )
+
+    created_at: datetime = Field(
+        sa_column=Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now()),
+        description='Timestamp when the counter row was created.',
+    )
+    updated_at: datetime = Field(
+        sa_column=Column(
+            TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=func.now(),
+            onupdate=func.now(),
+        ),
+        description='Timestamp when the counter row was last updated.',
+    )
+
+    __table_args__ = (
+        UniqueConstraint('vault_id', 'kv_key', name='uq_procedure_outcomes_vault_key'),
+        ForeignKeyConstraint(
+            ['kv_key'],
+            ['kv_entries.key'],
+            ondelete='CASCADE',
+            name='fk_procedure_outcomes_kv_key',
+        ),
+        Index('idx_procedure_outcomes_vault_key', 'vault_id', 'kv_key'),
     )

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -196,3 +196,20 @@ DIAGNOSTICS_CACHE_MISSES_TOTAL = Counter(
     'Manifold cache misses (no cache or cache_key drift) by vault.',
     ['vault_id'],
 )
+
+# ---------------------------------------------------------------------------
+# Lint metrics (F6)
+# ---------------------------------------------------------------------------
+
+LINT_FINDINGS_TOTAL = Counter(
+    'memex_lint_findings_total',
+    'Maintenance proposals emitted by F6 lint rules.',
+    ['rule_name', 'lint_type', 'vault_id'],
+)
+
+LINT_RUN_DURATION_SECONDS = Histogram(
+    'memex_lint_run_duration_seconds',
+    'Wall-clock duration of a single F6 lint rule execution (seconds).',
+    ['rule_name'],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0),
+)

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -127,6 +127,28 @@ async def periodic_lint_task(api: 'MemexAPI'):
             logger.error(f'Scheduler: F6 lint task failed: {e}', exc_info=True)
 
 
+async def periodic_consolidation_task(api: 'MemexAPI', units_per_tick: int):
+    """F38: per-vault consolidation tick under the single leader lock.
+
+    Sequential per-vault iteration — per-vault parallelism is intentionally
+    out of scope (Wave 0: only F9 introduces additional advisory locks).
+    Per-vault failures are warning-logged and never raise — one bad vault
+    must not stop other vaults from being consolidated this tick.
+    """
+    async with background_session('bg-sched-consolidation'):
+        try:
+            vaults = await api.list_vaults()
+            for vault in vaults:
+                try:
+                    await api.consolidation.tick(vault.id, budget=units_per_tick)
+                except Exception as e:
+                    logger.warning(
+                        f'Scheduler: Consolidation tick failed for vault {vault.name}: {e}'
+                    )
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.error(f'Scheduler: Consolidation failed: {e}', exc_info=True)
+
+
 async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI'):
     """
     Leader election loop using Postgres Advisory Locks.
@@ -190,6 +212,19 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
         await periodic_diagnostics_refresh_task(api)
 
     # --- F38 consolidation --- (filled by WS-quick-wins)
+    consolidation_cfg = config.server.memory.consolidation
+    if consolidation_cfg.enabled:
+        logger.info(
+            f'Scheduler: F38 consolidation enabled. '
+            f'Cadence: {consolidation_cfg.cadence_seconds}s. '
+            f'Budget: {consolidation_cfg.units_per_tick} units/tick.'
+        )
+
+        @clock.task(trigger=Every(seconds=consolidation_cfg.cadence_seconds))
+        async def run_consolidation_job():
+            await periodic_consolidation_task(api, consolidation_cfg.units_per_tick)
+    else:
+        logger.info('Scheduler: F38 consolidation DISABLED via config.')
 
     # asyncpg requires a plain postgresql:// DSN (no +asyncpg driver suffix)
     sa_url = make_url(config.server.meta_store.instance.connection_string)

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -107,6 +107,26 @@ async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
             logger.error(f'Scheduler: Diagnostics refresh failed: {e}', exc_info=True)
 
 
+async def periodic_lint_task(api: 'MemexAPI'):
+    """F6: per-vault lint run under existing MEMEX_LEADER_LOCK_ID."""
+    async with background_session('bg-sched-lint'):
+        try:
+            vaults = await api.list_vaults()
+            for vault in vaults:
+                try:
+                    summary = await api.lint.run_rules(vault.id)
+                    if summary.total_findings:
+                        logger.info(
+                            'Scheduler: F6 lint emitted %d findings in vault %s',
+                            summary.total_findings,
+                            vault.name,
+                        )
+                except Exception as e:
+                    logger.warning(f'Scheduler: Lint run failed for vault {vault.name}: {e}')
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.error(f'Scheduler: F6 lint task failed: {e}', exc_info=True)
+
+
 async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI'):
     """
     Leader election loop using Postgres Advisory Locks.
@@ -155,6 +175,12 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
     # ============================================================
 
     # --- F6 lint ---       (filled by WS-linter)
+    if config.server.memory.lint.enabled:
+        lint_interval = config.server.memory.lint.interval_seconds
+
+        @clock.task(trigger=Every(seconds=lint_interval))
+        async def run_lint_job():
+            await periodic_lint_task(api)
 
     # --- F20 revisit ---   (filled by WS-revisit)
 

--- a/packages/core/src/memex_core/server/__init__.py
+++ b/packages/core/src/memex_core/server/__init__.py
@@ -37,6 +37,7 @@ from memex_core.server.notes import router as notes_router
 from memex_core.server.entities import router as entities_router
 from memex_core.server.ingestion import router as ingestion_router
 from memex_core.server.memories import router as memories_router
+from memex_core.server.outcomes import router as outcomes_router
 from memex_core.server.reflection import router as reflection_router
 from memex_core.server.resources import router as resources_router
 from memex_core.server.retrieval import router as retrieval_router
@@ -330,6 +331,7 @@ app.include_router(notes_router)
 app.include_router(stats_router)
 app.include_router(entities_router)
 app.include_router(memories_router)
+app.include_router(outcomes_router)
 app.include_router(resources_router)
 app.include_router(health_router)
 app.include_router(summary_router)

--- a/packages/core/src/memex_core/server/__init__.py
+++ b/packages/core/src/memex_core/server/__init__.py
@@ -28,6 +28,7 @@ from memex_core.logging_config import configure_logging
 from memex_core.server.audit import router as audit_router
 from memex_core.server.auth import auth_middleware, setup_auth
 from memex_core.server.diagnostics import router as diagnostics_router
+from memex_core.server.lint import router as lint_router
 from memex_core.server.rate_limit import setup_rate_limiting
 from memex_core.services.audit import AuditService
 from memex_core.server.kv import router as kv_router
@@ -337,3 +338,4 @@ app.include_router(survey_router)
 app.include_router(vault_summary_router)
 app.include_router(session_briefing_router)
 app.include_router(diagnostics_router)
+app.include_router(lint_router)

--- a/packages/core/src/memex_core/server/__init__.py
+++ b/packages/core/src/memex_core/server/__init__.py
@@ -27,6 +27,7 @@ except ImportError:
 from memex_core.logging_config import configure_logging
 from memex_core.server.audit import router as audit_router
 from memex_core.server.auth import auth_middleware, setup_auth
+from memex_core.server.consolidation import router as consolidation_router
 from memex_core.server.diagnostics import router as diagnostics_router
 from memex_core.server.lint import router as lint_router
 from memex_core.server.rate_limit import setup_rate_limiting
@@ -339,3 +340,4 @@ app.include_router(vault_summary_router)
 app.include_router(session_briefing_router)
 app.include_router(diagnostics_router)
 app.include_router(lint_router)
+app.include_router(consolidation_router)

--- a/packages/core/src/memex_core/server/consolidation.py
+++ b/packages/core/src/memex_core/server/consolidation.py
@@ -1,0 +1,86 @@
+"""F38 — Consolidation orchestrator endpoints.
+
+Operator-facing routes for the `memex consolidate` CLI. Per AC-F38-5 there
+is intentionally NO MCP / Hermes / Claude Code tool surface — these are
+HTTP-only and the CLI is the only first-class client.
+
+Routes:
+- POST /api/v1/consolidation/tick      — run a tick for one (or all) vaults
+- GET  /api/v1/consolidation/status    — last-run timestamps per vault
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+
+from memex_core.api import MemexAPI
+from memex_core.server.auth import require_read, require_write
+from memex_core.server.common import _handle_error, get_api
+
+logger = logging.getLogger('memex.core.server.consolidation')
+
+router = APIRouter(prefix='/api/v1/consolidation')
+
+
+class ConsolidationTickRequest(BaseModel):
+    vault_id: UUID | None = Field(
+        default=None,
+        description='Single vault to tick. None = tick every vault sequentially.',
+    )
+    dry_run: bool = Field(
+        default=False,
+        description='Skip writes; return per-step counts only.',
+    )
+    budget: int | None = Field(
+        default=None,
+        ge=1,
+        le=10_000,
+        description='Override units-per-tick budget. None = config default.',
+    )
+
+
+@router.post('/tick', dependencies=[Depends(require_write)])
+async def post_tick(
+    body: ConsolidationTickRequest,
+    api: Annotated[MemexAPI, Depends(get_api)],
+) -> dict[str, Any]:
+    """Run consolidation tick(s) immediately. Returns per-vault summaries."""
+    try:
+        budget = body.budget or api.config.server.memory.consolidation.units_per_tick
+        if body.vault_id is not None:
+            result = await api.consolidation.tick(
+                body.vault_id, dry_run=body.dry_run, budget=budget
+            )
+            return {'ticks': [result]}
+
+        vaults = await api.list_vaults()
+        results: list[dict[str, Any]] = []
+        for vault in vaults:
+            try:
+                results.append(
+                    await api.consolidation.tick(vault.id, dry_run=body.dry_run, budget=budget)
+                )
+            except Exception as exc:
+                logger.warning('Consolidation tick failed for vault %s: %s', vault.id, exc)
+                results.append({'vault_id': str(vault.id), 'error': str(exc)})
+        return {'ticks': results}
+    except Exception as exc:
+        raise _handle_error(exc, 'Failed to run consolidation tick')
+
+
+@router.get('/status', dependencies=[Depends(require_read)])
+async def get_status(
+    api: Annotated[MemexAPI, Depends(get_api)],
+    vault_id: UUID | None = Query(default=None),
+) -> dict[str, Any]:
+    """Return the most recent tick row per vault (or for one vault)."""
+    try:
+        rows = await api.consolidation.status(vault_id)
+        return {'ticks': rows}
+    except Exception as exc:
+        raise _handle_error(exc, 'Failed to query consolidation status')

--- a/packages/core/src/memex_core/server/kv.py
+++ b/packages/core/src/memex_core/server/kv.py
@@ -13,6 +13,7 @@ from memex_common.schemas import (
     KVProcedureValueDTO,
     KVPutRequest,
     KVSearchRequest,
+    ProcedureOutcomeDTO,
 )
 
 from memex_core.api import MemexAPI
@@ -179,3 +180,52 @@ async def kv_list(
         return [KVEntryDTO.model_validate(e, from_attributes=True) for e in entries]
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, 'Failed to list KV entries')
+
+
+@router.get(
+    '/kv/procedure-observations',
+    response_model=list[ProcedureOutcomeDTO],
+    dependencies=[Depends(require_read)],
+)
+async def kv_procedure_observations(
+    api: Annotated[MemexAPI, Depends(get_api)],
+    vault_id: Annotated[str, Query(description='Vault UUID to scope observations to.')],
+    context: Annotated[
+        str | None,
+        Query(
+            description=(
+                'Optional substring filter on the procedure key '
+                "context-tag (the third segment after 'procedure:<verb>:'). "
+                'Case-insensitive.'
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=20,
+            description='Max observations to return (1-20, default 5).',
+        ),
+    ] = 5,
+):
+    """F14 — Top procedure outcomes ranked by Memory Worth (RFC-007 §155-185).
+
+    Drives the F14 procedural-observations briefing block. Rows are ordered
+    by ``mw_score = (success + 1) / (success + failure + 2)`` descending,
+    tie-broken by ``last_outcome_at`` descending.
+    """
+    from uuid import UUID
+
+    try:
+        UUID(vault_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f'Invalid vault_id: {vault_id}')
+
+    try:
+        rows = await api.list_top_procedure_outcomes(
+            vault_id=vault_id, context=context, limit=limit
+        )
+        return [ProcedureOutcomeDTO.model_validate(r) for r in rows]
+    except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
+        raise _handle_error(e, 'Failed to list procedure observations')

--- a/packages/core/src/memex_core/server/kv.py
+++ b/packages/core/src/memex_core/server/kv.py
@@ -7,7 +7,13 @@ from pydantic import BaseModel
 
 from memex_common.exceptions import MemexError
 from memex_core.server.auth import require_delete, require_read, require_write
-from memex_common.schemas import KVEntryDTO, KVPutRequest, KVSearchRequest
+from memex_common.schemas import (
+    KVEntryDTO,
+    KVProcedureEntryDTO,
+    KVProcedureValueDTO,
+    KVPutRequest,
+    KVSearchRequest,
+)
 
 from memex_core.api import MemexAPI
 from memex_core.server.common import _handle_error, get_api
@@ -58,16 +64,42 @@ async def kv_put(
         raise _handle_error(e, 'Failed to put KV entry')
 
 
-@router.get('/kv/get', response_model=KVEntryDTO, dependencies=[Depends(require_read)])
+@router.get(
+    '/kv/get',
+    response_model=KVEntryDTO | KVProcedureEntryDTO,
+    dependencies=[Depends(require_read)],
+)
 async def kv_get(
     api: Annotated[MemexAPI, Depends(get_api)],
     key: str = Query(description='Key to look up'),
+    include_history: bool = Query(
+        False,
+        description=(
+            'For procedure: keys, return the full envelope (value, version, history) '
+            'instead of just the active value. Ignored for non-procedure keys.'
+        ),
+    ),
 ):
-    """Get a key-value entry by key."""
+    """Get a key-value entry by key.
+
+    For ``procedure:`` keys (RFC-007), the default response contains only
+    the active value (back-compat — same shape as any other KV entry). Pass
+    ``include_history=true`` to expose the structured envelope as
+    :class:`KVProcedureEntryDTO`.
+    """
     try:
-        entry = await api.kv_get(key=key)
+        entry = await api.kv_get(key=key, include_history=include_history)
         if entry is None:
             raise HTTPException(status_code=404, detail=f'KV entry not found: {key}')
+        if include_history and key.startswith('procedure:') and isinstance(entry.value, dict):
+            return KVProcedureEntryDTO(
+                id=entry.id,
+                key=entry.key,
+                value=KVProcedureValueDTO.model_validate(entry.value),
+                expires_at=entry.expires_at,
+                created_at=entry.created_at,
+                updated_at=entry.updated_at,
+            )
         return KVEntryDTO.model_validate(entry, from_attributes=True)
     except HTTPException:
         raise

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -32,7 +32,7 @@ router = APIRouter(prefix='/api/v1/lint')
 async def lint_status(
     api: Annotated[MemexAPI, Depends(get_api)],
     vault_id: UUID | None = Query(None, description='Scope to one vault.'),
-    scope: str = Query('vault', regex='^(vault|global|all)$'),
+    scope: str = Query('vault', pattern='^(vault|global|all)$'),
 ) -> dict[str, Any]:
     """Pending finding counts.
 
@@ -67,8 +67,8 @@ async def lint_status(
 async def lint_findings(
     api: Annotated[MemexAPI, Depends(get_api)],
     vault_id: UUID | None = Query(None, description='Scope to one vault.'),
-    lint_type: str | None = Query(None, regex='^(structural|quality|governance|schema)$'),
-    status: str = Query('pending', regex='^(pending|resolved|dismissed)$'),
+    lint_type: str | None = Query(None, pattern='^(structural|quality|governance|schema)$'),
+    status: str = Query('pending', pattern='^(pending|resolved|dismissed)$'),
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ) -> dict[str, Any]:

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -1,0 +1,135 @@
+"""F6 — Lint endpoints (maintenance ledger).
+
+Routes:
+- GET    /api/v1/lint/status                          — pending counts (global + per-vault)
+- GET    /api/v1/lint/findings                        — list findings with optional filters
+- POST   /api/v1/lint/findings/{finding_id}/dismiss   — flip status to 'dismissed'
+- POST   /api/v1/lint/findings/{finding_id}/resolve   — flip status to 'resolved'
+
+The maintenance ledger is read-only from the agent surface (F8 ships the
+MCP tool); these endpoints back the human-facing CLI (``memex lint ...``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import text
+
+from memex_core.api import MemexAPI
+from memex_core.server.auth import require_read, require_write
+from memex_core.server.common import _handle_error, get_api
+
+logger = logging.getLogger('memex.core.server.lint')
+
+router = APIRouter(prefix='/api/v1/lint')
+
+
+@router.get('/status', dependencies=[Depends(require_read)])
+async def lint_status(
+    api: Annotated[MemexAPI, Depends(get_api)],
+    vault_id: UUID | None = Query(None, description='Scope to one vault.'),
+    scope: str = Query('vault', regex='^(vault|global|all)$'),
+) -> dict[str, Any]:
+    """Pending finding counts.
+
+    - ``scope=vault`` (default): count for ``vault_id`` (or active vault).
+    - ``scope=global``: count for findings with vault_id NULL.
+    - ``scope=all``: total across every vault and global.
+    """
+    try:
+        if scope == 'global':
+            count = await api.lint.count_pending(None)
+            return {'scope': 'global', 'pending': count}
+        if scope == 'all':
+            async with api.metastore.session() as session:
+                row = await session.execute(
+                    text("SELECT count(*) FROM maintenance_proposals WHERE status = 'pending'")
+                )
+                return {'scope': 'all', 'pending': int(row.scalar() or 0)}
+        if vault_id is None:
+            raise HTTPException(
+                status_code=400,
+                detail='vault_id is required when scope=vault',
+            )
+        count = await api.lint.count_pending(vault_id)
+        return {'scope': 'vault', 'vault_id': str(vault_id), 'pending': count}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise _handle_error(e, 'Failed to read lint status')
+
+
+@router.get('/findings', dependencies=[Depends(require_read)])
+async def lint_findings(
+    api: Annotated[MemexAPI, Depends(get_api)],
+    vault_id: UUID | None = Query(None, description='Scope to one vault.'),
+    lint_type: str | None = Query(None, regex='^(structural|quality|governance|schema)$'),
+    status: str = Query('pending', regex='^(pending|resolved|dismissed)$'),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> dict[str, Any]:
+    """List maintenance findings with optional filters."""
+    try:
+        clauses = ['status = :status']
+        params: dict[str, Any] = {'status': status}
+        if vault_id is not None:
+            clauses.append('vault_id = :vault_id')
+            params['vault_id'] = str(vault_id)
+        if lint_type is not None:
+            clauses.append('lint_type = :lint_type')
+            params['lint_type'] = lint_type
+
+        where = ' AND '.join(clauses)
+        params['limit'] = limit
+        params['offset'] = offset
+
+        async with api.metastore.session() as session:
+            result = await session.execute(
+                text(
+                    'SELECT id::text, vault_id::text, lint_type, target_type, target_id, '
+                    'rule_name, evidence, suggested_action, status, source, '
+                    'created_at, resolved_at '
+                    f'FROM maintenance_proposals WHERE {where} '
+                    'ORDER BY created_at DESC '
+                    'LIMIT :limit OFFSET :offset'
+                ),
+                params,
+            )
+            rows = [dict(row) for row in result.mappings().all()]
+        return {'count': len(rows), 'findings': rows}
+    except Exception as e:
+        raise _handle_error(e, 'Failed to list lint findings')
+
+
+@router.post('/findings/{finding_id}/dismiss', dependencies=[Depends(require_write)])
+async def lint_dismiss(
+    finding_id: UUID,
+    api: Annotated[MemexAPI, Depends(get_api)],
+) -> dict[str, Any]:
+    """Flip a pending finding to ``dismissed``. Idempotent."""
+    try:
+        ok = await api.lint.set_status(finding_id, 'dismissed')
+    except Exception as e:
+        raise _handle_error(e, 'Failed to dismiss finding')
+    if not ok:
+        raise HTTPException(status_code=404, detail='Finding not found or not pending')
+    return {'finding_id': str(finding_id), 'status': 'dismissed'}
+
+
+@router.post('/findings/{finding_id}/resolve', dependencies=[Depends(require_write)])
+async def lint_resolve(
+    finding_id: UUID,
+    api: Annotated[MemexAPI, Depends(get_api)],
+) -> dict[str, Any]:
+    """Flip a pending finding to ``resolved``. Idempotent."""
+    try:
+        ok = await api.lint.set_status(finding_id, 'resolved')
+    except Exception as e:
+        raise _handle_error(e, 'Failed to resolve finding')
+    if not ok:
+        raise HTTPException(status_code=404, detail='Finding not found or not pending')
+    return {'finding_id': str(finding_id), 'status': 'resolved'}

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -32,13 +32,13 @@ router = APIRouter(prefix='/api/v1/lint')
 async def lint_status(
     api: Annotated[MemexAPI, Depends(get_api)],
     vault_id: UUID | None = Query(None, description='Scope to one vault.'),
-    scope: str = Query('vault', pattern='^(vault|global|all)$'),
+    scope: str = Query('all', pattern='^(vault|global|all)$'),
 ) -> dict[str, Any]:
     """Pending finding counts.
 
-    - ``scope=vault`` (default): count for ``vault_id`` (or active vault).
+    - ``scope=all`` (default): total across every vault and global.
+    - ``scope=vault``: count for ``vault_id``; required when scope=vault.
     - ``scope=global``: count for findings with vault_id NULL.
-    - ``scope=all``: total across every vault and global.
     """
     try:
         if scope == 'global':
@@ -74,6 +74,10 @@ async def lint_findings(
 ) -> dict[str, Any]:
     """List maintenance findings with optional filters."""
     try:
+        # `clauses` only contains hard-coded predicate fragments (no user input);
+        # the column/operator strings are trusted constants and all values are
+        # bound via :named parameters. SQLAlchemy Core constructs would be more
+        # idiomatic but offer no additional safety here.
         clauses = ['status = :status']
         params: dict[str, Any] = {'status': status}
         if vault_id is not None:
@@ -93,7 +97,7 @@ async def lint_findings(
                     'SELECT id::text, vault_id::text, lint_type, target_type, target_id, '
                     'rule_name, evidence, suggested_action, status, source, '
                     'created_at, resolved_at '
-                    f'FROM maintenance_proposals WHERE {where} '
+                    f'FROM maintenance_proposals WHERE {where} '  # noqa: S608
                     'ORDER BY created_at DESC '
                     'LIMIT :limit OFFSET :offset'
                 ),

--- a/packages/core/src/memex_core/server/outcomes.py
+++ b/packages/core/src/memex_core/server/outcomes.py
@@ -1,0 +1,109 @@
+"""F29 — Outcome recording endpoint.
+
+HTTP wire surface for ``MemexAPI.record_outcome`` (F14 ADD-2). Required so
+remote clients (the Hermes plugin via ``RemoteMemexAPI``) can train MW
+scoring on memory units or procedure KV keys. The MCP tool calls
+``api.record_outcome`` in-process; this route gives non-in-process clients
+the same surface.
+
+Routes:
+- POST /api/v1/outcomes/record  — record an outcome (memory_unit or kv_key mode)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from memex_common.exceptions import MemexError
+from memex_core.api import MemexAPI
+from memex_core.server.auth import require_write
+from memex_core.server.common import _handle_error, get_api
+
+logger = logging.getLogger('memex.core.server.outcomes')
+
+router = APIRouter(prefix='/api/v1/outcomes')
+
+
+class RecordOutcomeRequest(BaseModel):
+    success: bool = Field(
+        ...,
+        description='True if the task succeeded using these memories or this procedure.',
+    )
+    unit_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            'memory_unit mode only. UUIDs of memory units that were load-bearing '
+            "in the agent's reasoning. Required when target_type='memory_unit'."
+        ),
+    )
+    vault_id: str | None = Field(
+        default=None,
+        description='Vault UUID or name. Resolved server-side via VaultService.',
+    )
+    outcome_confidence: float = Field(
+        default=1.0,
+        ge=0.0,
+        le=1.0,
+        description='Weight for this outcome signal (0.0-1.0). Default 1.0.',
+    )
+    reason: str | None = Field(
+        default=None,
+        description='Optional free-text reason (logged, not stored on units).',
+    )
+    target_type: str = Field(
+        default='memory_unit',
+        description=(
+            "What the outcome scores. 'memory_unit' increments MW counters on "
+            "the memory units in unit_ids. 'kv_key' (F14) increments counters "
+            'on the procedure_outcomes row for kv_key.'
+        ),
+    )
+    kv_key: str | None = Field(
+        default=None,
+        description=(
+            'kv_key mode only. Procedure KV key (procedure:<verb>:<context-tag>). '
+            "Required when target_type='kv_key'."
+        ),
+    )
+
+
+@router.post('/record', dependencies=[Depends(require_write)])
+async def post_record_outcome(
+    body: RecordOutcomeRequest,
+    api: Annotated[MemexAPI, Depends(get_api)],
+) -> dict[str, Any]:
+    """Record an outcome for memory units or a procedure key.
+
+    Mirrors :meth:`MemexAPI.record_outcome`; preserves the F14 ADD-2 contract
+    (positional ``unit_ids``, ``success`` at the in-process call site).
+    Vault is resolved server-side so callers may pass UUID or name.
+    """
+    resolved_vault: str | None = None
+    if body.vault_id is not None:
+        try:
+            resolved_vault = str(await api.resolve_vault_identifier(body.vault_id))
+        except (MemexError, ValueError, KeyError) as exc:
+            raise HTTPException(
+                status_code=400, detail=f'Unknown vault: {body.vault_id!r}'
+            ) from exc
+
+    try:
+        return await api.record_outcome(
+            body.unit_ids,
+            body.success,
+            resolved_vault,
+            body.outcome_confidence,
+            body.reason,
+            target_type=body.target_type,
+            kv_key=body.kv_key,
+        )
+    except ValueError as exc:
+        # OutcomeService raises ValueError for missing unit_ids / kv_key /
+        # vault_id and for invalid target_type. These are caller errors.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (MemexError, KeyError, RuntimeError, OSError) as exc:
+        raise _handle_error(exc, 'Failed to record outcome')

--- a/packages/core/src/memex_core/services/consolidation.py
+++ b/packages/core/src/memex_core/services/consolidation.py
@@ -1,0 +1,373 @@
+"""F38 ConsolidationService — thin orchestrator over reflection + contradiction + prune.
+
+Per RFC-010, this is intentionally a thin module. Its **only** direct DB write
+is the ``consolidation_ticks`` summary row inserted at the end of each tick
+(AC-F38-4 module-write audit). All other writes are delegated.
+
+Step ordering (B1 adjudication, AC-F38-1):
+    1. ``select_diff_units`` — read AuditLog rows with ``action='outcome.record'``
+       since the previous tick's ``completed_at``.
+    2. ``ContradictionEngine.detect_contradictions`` — runs first so reflection
+       observes the post-contradiction confidence state.
+    3. ``ReflectionService.reflect_batch`` — synthesizes mental models for the
+       entities touched by the diff units.
+    4. ``prune_stale_evidence`` — invoked **only** on units already at
+       ``ContentStatus.STALE``. F38 does NOT decide staleness — that lives in
+       F25 / contradiction-driven confidence drops / archive cascade.
+    5. ``write_tick_summary`` — single ``ConsolidationTick`` row per tick.
+
+The 500-units-per-tick budget (oldest-first by ``mentioned_at`` /
+``event_date``) is enforced at the ``select_diff_units`` boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func as sa_func
+from sqlmodel import select
+
+from memex_core.config import MemexConfig
+from memex_core.memory.contradiction.engine import ContradictionEngine
+from memex_core.memory.reflect.models import ReflectionRequest
+from memex_core.memory.sql_models import (
+    AuditLog,
+    ConsolidationTick,
+    ContentStatus,
+    MemoryUnit,
+    UnitEntity,
+)
+from memex_core.services.mental_model_cleanup import prune_stale_evidence
+from memex_core.services.reflection import ReflectionService
+from memex_core.storage.metastore import AsyncBaseMetaStoreEngine
+
+logger = logging.getLogger('memex.core.services.consolidation')
+
+DEFAULT_TICK_BUDGET = 500
+
+
+class ConsolidationService:
+    """Per-vault consolidation orchestrator.
+
+    Owns no domain state of its own. Holds references to the metastore (for
+    audit-log queries + tick-summary write), the reflection service, the
+    contradiction engine, and per-step timeouts pulled from
+    ``config.server.memory.consolidation``.
+    """
+
+    def __init__(
+        self,
+        metastore: AsyncBaseMetaStoreEngine,
+        config: MemexConfig,
+        reflection: ReflectionService,
+        contradiction: ContradictionEngine | None,
+    ) -> None:
+        self.metastore = metastore
+        self.config = config
+        self.reflection = reflection
+        self.contradiction = contradiction
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def tick(
+        self,
+        vault_id: UUID,
+        *,
+        dry_run: bool = False,
+        budget: int = DEFAULT_TICK_BUDGET,
+    ) -> dict[str, Any]:
+        """Run a single consolidation tick for one vault.
+
+        Returns a dict with the per-step counts and the tick row id (or
+        ``None`` for dry runs). On dry-run, no writes happen — neither the
+        reflection/contradiction/prune calls nor the tick-summary row.
+        """
+        started_at = datetime.now(timezone.utc)
+        last_tick = await self.get_last_tick_timestamp(vault_id)
+
+        async with self.metastore.session() as session:
+            unit_ids = await self.select_diff_units(session, vault_id, last_tick, budget=budget)
+            entity_ids = (
+                await self.resolve_unit_ids_to_entity_ids(session, unit_ids, vault_id)
+                if unit_ids
+                else set()
+            )
+            already_stale_ids = (
+                await self._select_already_stale_ids(session, unit_ids, vault_id)
+                if unit_ids
+                else []
+            )
+
+        log = logger.getChild(str(vault_id))
+        log.info(
+            'consolidation.tick.start',
+            extra={
+                'vault_id': str(vault_id),
+                'units': len(unit_ids),
+                'entities': len(entity_ids),
+                'already_stale': len(already_stale_ids),
+                'dry_run': dry_run,
+            },
+        )
+
+        if dry_run:
+            return {
+                'vault_id': str(vault_id),
+                'dry_run': True,
+                'units_processed': len(unit_ids),
+                'entities_reflected': len(entity_ids),
+                'contradictions_run': len(unit_ids),
+                'stale_pruned_candidates': len(already_stale_ids),
+                'tick_id': None,
+            }
+
+        contradictions_run = 0
+        entities_reflected = 0
+        stale_pruned = 0
+        error: str | None = None
+
+        if unit_ids:
+            try:
+                # Step 2: contradiction BEFORE reflection (B1 adjudication).
+                if self.contradiction is not None:
+                    await self.contradiction.detect_contradictions(
+                        session_factory=self.metastore.session_maker(),
+                        document_id=None,
+                        unit_ids=unit_ids,
+                        vault_id=vault_id,
+                    )
+                    contradictions_run = len(unit_ids)
+                else:
+                    log.warning('consolidation.tick.contradiction_disabled')
+
+                # Step 3: reflection AFTER contradiction.
+                if entity_ids:
+                    requests = [
+                        ReflectionRequest(entity_id=eid, vault_id=vault_id) for eid in entity_ids
+                    ]
+                    await self.reflection.reflect_batch(requests)
+                    entities_reflected = len(entity_ids)
+
+                # Step 4: prune ONLY units already STALE (F38 does NOT stale).
+                if already_stale_ids and entity_ids:
+                    async with self.metastore.session() as session:
+                        await prune_stale_evidence(
+                            session,
+                            entity_ids=entity_ids,
+                            deleted_unit_ids=already_stale_ids,
+                            vault_id=vault_id,
+                        )
+                        await session.commit()
+                    stale_pruned = len(already_stale_ids)
+            except Exception as exc:
+                error = f'{type(exc).__name__}: {exc}'
+                log.warning('consolidation.tick.error', extra={'error': error}, exc_info=True)
+
+        tick_id = await self._write_tick_summary(
+            vault_id=vault_id,
+            started_at=started_at,
+            completed_at=datetime.now(timezone.utc),
+            units_processed=len(unit_ids),
+            entities_reflected=entities_reflected,
+            contradictions_run=contradictions_run,
+            stale_pruned=stale_pruned,
+            error=error,
+        )
+
+        log.info(
+            'consolidation.tick.complete',
+            extra={
+                'vault_id': str(vault_id),
+                'tick_id': str(tick_id),
+                'error': error,
+            },
+        )
+
+        return {
+            'vault_id': str(vault_id),
+            'tick_id': str(tick_id),
+            'units_processed': len(unit_ids),
+            'entities_reflected': entities_reflected,
+            'contradictions_run': contradictions_run,
+            'stale_pruned': stale_pruned,
+            'error': error,
+        }
+
+    async def status(self, vault_id: UUID | None = None) -> list[dict[str, Any]]:
+        """Return the most recent tick row per vault.
+
+        Pass ``vault_id=None`` to get one row per vault (latest each); pass a
+        specific vault_id to get only that vault's latest row.
+        """
+        async with self.metastore.session() as session:
+            stmt = (
+                select(ConsolidationTick)
+                .order_by(ConsolidationTick.completed_at.desc().nullslast())  # type: ignore[union-attr]
+                .limit(1 if vault_id is not None else 1000)
+            )
+            if vault_id is not None:
+                stmt = stmt.where(ConsolidationTick.vault_id == vault_id)
+            result = await session.exec(stmt)
+            rows = result.all()
+
+        seen: set[UUID] = set()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            if row.vault_id in seen:
+                continue
+            seen.add(row.vault_id)
+            out.append(
+                {
+                    'vault_id': str(row.vault_id),
+                    'started_at': row.started_at.isoformat() if row.started_at else None,
+                    'completed_at': row.completed_at.isoformat() if row.completed_at else None,
+                    'units_processed': row.units_processed,
+                    'entities_reflected': row.entities_reflected,
+                    'contradictions_run': row.contradictions_run,
+                    'stale_pruned': row.stale_pruned,
+                    'error': row.error,
+                }
+            )
+        return out
+
+    # ------------------------------------------------------------------
+    # Diff selection
+    # ------------------------------------------------------------------
+
+    async def get_last_tick_timestamp(self, vault_id: UUID) -> datetime | None:
+        """Return ``MAX(completed_at)`` for the vault, or ``None`` if never run.
+
+        Served by ``idx_consolidation_ticks_vault_completed`` (peer-review tweak).
+        """
+        async with self.metastore.session() as session:
+            stmt = select(sa_func.max(ConsolidationTick.completed_at)).where(
+                ConsolidationTick.vault_id == vault_id
+            )
+            result = await session.exec(stmt)  # type: ignore[call-overload]
+            return result.one_or_none()
+
+    async def select_diff_units(
+        self,
+        session: Any,
+        vault_id: UUID,
+        last_tick_timestamp: datetime | None,
+        *,
+        budget: int = DEFAULT_TICK_BUDGET,
+    ) -> list[UUID]:
+        """Return at most ``budget`` unit IDs with new outcome signal.
+
+        Reads ``AuditLog`` rows where ``action='outcome.record'``,
+        ``resource_type='memory_unit'``, ``details->>'vault_id' = vault_id``,
+        and ``timestamp > last_tick_timestamp`` (or all rows if no prior tick).
+        Distinct on ``resource_id``; oldest-first by AuditLog.timestamp; then
+        sliced to ``budget``.
+
+        Returns parsed UUIDs; rows whose ``resource_id`` is unparseable are
+        dropped (defensive — should not happen since record_outcome writes
+        ``str(uuid)``).
+        """
+        stmt = (
+            select(AuditLog.resource_id, sa_func.min(AuditLog.timestamp).label('first_seen'))
+            .where(
+                AuditLog.action == 'outcome.record',
+                AuditLog.resource_type == 'memory_unit',
+                AuditLog.details['vault_id'].astext == str(vault_id),
+            )
+            .group_by(AuditLog.resource_id)
+            .order_by(sa_func.min(AuditLog.timestamp))
+        )
+        if last_tick_timestamp is not None:
+            stmt = stmt.where(AuditLog.timestamp > last_tick_timestamp)
+
+        result = await session.exec(stmt)  # type: ignore[call-overload]
+        out: list[UUID] = []
+        for row in result.all():
+            resource_id = row[0] if isinstance(row, tuple) else row.resource_id
+            if not resource_id:
+                continue
+            try:
+                out.append(UUID(resource_id))
+            except (ValueError, TypeError):
+                continue
+            if len(out) >= budget:
+                break
+        return out
+
+    async def resolve_unit_ids_to_entity_ids(
+        self,
+        session: Any,
+        unit_ids: list[UUID],
+        vault_id: UUID,
+    ) -> set[UUID]:
+        """Return the set of entity IDs co-occurring with any unit in ``unit_ids``.
+
+        Vault-scoped — never crosses vault boundaries.
+        """
+        if not unit_ids:
+            return set()
+        stmt = (
+            select(UnitEntity.entity_id)
+            .where(UnitEntity.unit_id.in_(unit_ids), UnitEntity.vault_id == vault_id)  # type: ignore[attr-defined]
+            .distinct()
+        )
+        result = await session.exec(stmt)
+        return {row for row in result.all() if row is not None}
+
+    async def _select_already_stale_ids(
+        self,
+        session: Any,
+        unit_ids: list[UUID],
+        vault_id: UUID,
+    ) -> list[UUID]:
+        """Return the subset of ``unit_ids`` whose ``status == STALE``.
+
+        This is the AC-F38-2 invariant: F38 invokes ``prune_stale_evidence``
+        ONLY on units already marked stale by some other service. F38 does
+        NOT mutate ``status`` from active to stale.
+        """
+        if not unit_ids:
+            return []
+        stmt = select(MemoryUnit.id).where(
+            MemoryUnit.id.in_(unit_ids),  # type: ignore[attr-defined]
+            MemoryUnit.status == ContentStatus.STALE,
+            MemoryUnit.vault_id == vault_id,
+        )
+        result = await session.exec(stmt)
+        return [row for row in result.all() if row is not None]
+
+    # ------------------------------------------------------------------
+    # Tick-summary write (the single direct write — AC-F38-4)
+    # ------------------------------------------------------------------
+
+    async def _write_tick_summary(
+        self,
+        *,
+        vault_id: UUID,
+        started_at: datetime,
+        completed_at: datetime,
+        units_processed: int,
+        entities_reflected: int,
+        contradictions_run: int,
+        stale_pruned: int,
+        error: str | None,
+    ) -> UUID:
+        row = ConsolidationTick(
+            vault_id=vault_id,
+            started_at=started_at,
+            completed_at=completed_at,
+            units_processed=units_processed,
+            entities_reflected=entities_reflected,
+            contradictions_run=contradictions_run,
+            stale_pruned=stale_pruned,
+            error=error,
+        )
+        async with self.metastore.session() as session:
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+        return row.id

--- a/packages/core/src/memex_core/services/consolidation.py
+++ b/packages/core/src/memex_core/services/consolidation.py
@@ -29,6 +29,7 @@ from uuid import UUID
 
 from sqlalchemy import func as sa_func
 from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from memex_core.config import MemexConfig
 from memex_core.memory.contradiction.engine import ContradictionEngine
@@ -122,7 +123,7 @@ class ConsolidationService:
                 'units_processed': len(unit_ids),
                 'entities_reflected': len(entity_ids),
                 'contradictions_run': len(unit_ids),
-                'stale_pruned_candidates': len(already_stale_ids),
+                'stale_pruned': len(already_stale_ids),
                 'tick_id': None,
             }
 
@@ -203,24 +204,32 @@ class ConsolidationService:
 
         Pass ``vault_id=None`` to get one row per vault (latest each); pass a
         specific vault_id to get only that vault's latest row.
+
+        Uses Postgres ``DISTINCT ON (vault_id)`` so every vault's latest tick
+        is returned regardless of total tick volume — no implicit row cap.
         """
         async with self.metastore.session() as session:
-            stmt = (
-                select(ConsolidationTick)
-                .order_by(ConsolidationTick.completed_at.desc().nullslast())  # type: ignore[union-attr]
-                .limit(1 if vault_id is not None else 1000)
-            )
             if vault_id is not None:
-                stmt = stmt.where(ConsolidationTick.vault_id == vault_id)
+                stmt = (
+                    select(ConsolidationTick)
+                    .where(ConsolidationTick.vault_id == vault_id)
+                    .order_by(ConsolidationTick.completed_at.desc().nullslast())  # type: ignore[union-attr]
+                    .limit(1)
+                )
+            else:
+                stmt = (
+                    select(ConsolidationTick)
+                    .distinct(ConsolidationTick.vault_id)
+                    .order_by(
+                        ConsolidationTick.vault_id,
+                        ConsolidationTick.completed_at.desc().nullslast(),  # type: ignore[union-attr]
+                    )
+                )
             result = await session.exec(stmt)
             rows = result.all()
 
-        seen: set[UUID] = set()
         out: list[dict[str, Any]] = []
         for row in rows:
-            if row.vault_id in seen:
-                continue
-            seen.add(row.vault_id)
             out.append(
                 {
                     'vault_id': str(row.vault_id),
@@ -253,7 +262,7 @@ class ConsolidationService:
 
     async def select_diff_units(
         self,
-        session: Any,
+        session: AsyncSession,
         vault_id: UUID,
         last_tick_timestamp: datetime | None,
         *,
@@ -301,7 +310,7 @@ class ConsolidationService:
 
     async def resolve_unit_ids_to_entity_ids(
         self,
-        session: Any,
+        session: AsyncSession,
         unit_ids: list[UUID],
         vault_id: UUID,
     ) -> set[UUID]:
@@ -321,7 +330,7 @@ class ConsolidationService:
 
     async def _select_already_stale_ids(
         self,
-        session: Any,
+        session: AsyncSession,
         unit_ids: list[UUID],
         vault_id: UUID,
     ) -> list[UUID]:

--- a/packages/core/src/memex_core/services/consolidation.py
+++ b/packages/core/src/memex_core/services/consolidation.py
@@ -264,8 +264,8 @@ class ConsolidationService:
         Reads ``AuditLog`` rows where ``action='outcome.record'``,
         ``resource_type='memory_unit'``, ``details->>'vault_id' = vault_id``,
         and ``timestamp > last_tick_timestamp`` (or all rows if no prior tick).
-        Distinct on ``resource_id``; oldest-first by AuditLog.timestamp; then
-        sliced to ``budget``.
+        Distinct on ``resource_id``; oldest-first by AuditLog.timestamp;
+        capped to ``budget`` rows via SQL ``LIMIT``.
 
         Returns parsed UUIDs; rows whose ``resource_id`` is unparseable are
         dropped (defensive — should not happen since record_outcome writes
@@ -280,6 +280,7 @@ class ConsolidationService:
             )
             .group_by(AuditLog.resource_id)
             .order_by(sa_func.min(AuditLog.timestamp))
+            .limit(budget)
         )
         if last_tick_timestamp is not None:
             stmt = stmt.where(AuditLog.timestamp > last_tick_timestamp)

--- a/packages/core/src/memex_core/services/kv.py
+++ b/packages/core/src/memex_core/services/kv.py
@@ -30,6 +30,7 @@ import logging
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from uuid import UUID
 
 from sqlalchemy import text
 from sqlmodel import col, or_, select
@@ -335,6 +336,72 @@ class KVService(BaseService):
                     entry.value = parsed['value']
 
             return entry
+
+    async def list_top_procedure_outcomes(
+        self,
+        vault_id: str | UUID,
+        *,
+        context: str | None = None,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        """F14 — Top procedure outcomes for a vault, ranked by Memory Worth.
+
+        Returns up to ``limit`` rows from ``procedure_outcomes`` joined to
+        ``kv_entries`` for the given ``vault_id``, ordered by
+        ``compute_mw_score(success_co_count, failure_co_count) DESC`` and
+        tie-broken by ``last_outcome_at DESC NULLS LAST``. The MW score is
+        computed in-database with the SAME Beta-Bernoulli formula as
+        :func:`memex_core.services.outcomes.compute_mw_score`
+        (``(s + 1) / (s + f + 2)``).
+
+        If ``context`` is provided, narrow results to procedure keys whose
+        context-tag contains it (substring match on the third
+        ``procedure:<verb>:<context-tag>`` segment).
+        """
+        if limit <= 0:
+            return []
+        if not isinstance(vault_id, UUID):
+            try:
+                vault_uuid: UUID = UUID(str(vault_id))
+            except ValueError as exc:
+                raise ValueError(f'Invalid vault_id: {vault_id}') from exc
+        else:
+            vault_uuid = vault_id
+
+        # MW score formula MUST match compute_mw_score: (s+1)/(s+f+2).
+        sql = (
+            'SELECT '
+            '  po.kv_key, '
+            '  po.success_co_count, '
+            '  po.failure_co_count, '
+            '  ((po.success_co_count + 1)::float / '
+            '   (po.success_co_count + po.failure_co_count + 2)::float) AS mw_score, '
+            '  po.last_outcome_at '
+            'FROM procedure_outcomes po '
+            'JOIN kv_entries kv ON kv.key = po.kv_key '
+            'WHERE po.vault_id = :vid '
+        )
+        params: dict[str, Any] = {'vid': vault_uuid, 'lim': limit}
+        if context:
+            # context-tag is the segment after the last colon
+            sql += "AND split_part(po.kv_key, ':', 3) ILIKE :ctx "
+            params['ctx'] = f'%{context}%'
+        sql += 'ORDER BY mw_score DESC, po.last_outcome_at DESC NULLS LAST, po.kv_key LIMIT :lim'
+
+        async with self.metastore.session() as session:
+            result = await session.execute(text(sql), params)
+            rows = result.all()
+
+        return [
+            {
+                'kv_key': r[0],
+                'success_co_count': int(r[1]),
+                'failure_co_count': int(r[2]),
+                'mw_score': float(r[3]),
+                'last_outcome_at': r[4],
+            }
+            for r in rows
+        ]
 
     async def search(
         self,

--- a/packages/core/src/memex_core/services/kv.py
+++ b/packages/core/src/memex_core/services/kv.py
@@ -219,7 +219,7 @@ class KVService(BaseService):
                     )
                     stmt = stmt.on_conflict_do_nothing(constraint='uq_kv_key')
                     stmt = stmt.returning(KVEntry.__table__)
-                    insert_result = await session.exec(stmt)  # type: ignore[arg-type]
+                    insert_result = await session.execute(stmt)
                     row = insert_result.first()
                     await session.commit()
                     if row is not None:

--- a/packages/core/src/memex_core/services/kv.py
+++ b/packages/core/src/memex_core/services/kv.py
@@ -1,4 +1,27 @@
-"""Key-value store service — CRUD and semantic search for KV entries."""
+"""Key-value store service — CRUD and semantic search for KV entries.
+
+KV namespaces
+-------------
+
+Keys must start with one of the valid namespace prefixes:
+
+- ``global:`` — vault-default operational state
+- ``user:`` — per-user preferences
+- ``project:`` — per-project bindings
+- ``app:`` — per-application configuration
+- ``procedure:`` — procedural observations (F14)
+
+The ``procedure:<verb>:<context-tag>`` namespace is special: writes use
+last-writer-wins on the active value with a ``version`` increment, and
+superseded values are appended to a capped (5-entry) history kept inside
+the same KV row's JSON envelope (NO schema change to ``kv_entries``).
+The agent owns the procedure (the verb — ``write_pr``, ``run_tests``);
+Memex stores observations about how to ADAPT it to specific contexts
+(the context-tag — ``commit-style``, ``python-monorepo``).
+
+See :func:`validate_procedure_key` for the strict format check on
+procedure keys (RFC-007).
+"""
 
 from __future__ import annotations
 
@@ -17,7 +40,27 @@ logger = logging.getLogger('memex.core.services.kv')
 
 _PROTOCOL_RE = re.compile(r'[a-zA-Z][a-zA-Z0-9+\-.]*://')
 
-VALID_NAMESPACES = ('global', 'user', 'project', 'app')
+VALID_NAMESPACES = ('global', 'user', 'project', 'app', 'procedure')
+
+PROCEDURE_KEY_RE = re.compile(r'^procedure:[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$')
+
+
+def validate_procedure_key(key: str) -> None:
+    """Validate a ``procedure:<verb>:<context-tag>`` KV key.
+
+    Raises :class:`ValueError` if the key does not match the strict
+    namespace format. The regex only permits lowercase letters, digits,
+    hyphens, and underscores in segments, with a leading lowercase letter
+    on each of the verb and context-tag segments. Exactly two colons.
+
+    See RFC-007 §53-61 for the contract.
+    """
+    if not PROCEDURE_KEY_RE.match(key):
+        raise ValueError(
+            f'Invalid procedure key: {key!r}. '
+            'Expected procedure:<verb>:<context-tag> with each segment '
+            'matching [a-z][a-z0-9_-]*.'
+        )
 
 
 def _pattern_to_prefix(pattern: str) -> str | None:

--- a/packages/core/src/memex_core/services/kv.py
+++ b/packages/core/src/memex_core/services/kv.py
@@ -383,9 +383,13 @@ class KVService(BaseService):
         )
         params: dict[str, Any] = {'vid': vault_uuid, 'lim': limit}
         if context:
-            # context-tag is the segment after the last colon
-            sql += "AND split_part(po.kv_key, ':', 3) ILIKE :ctx "
-            params['ctx'] = f'%{context}%'
+            # context-tag is the segment after the last colon. Escape ILIKE
+            # metacharacters in the user-supplied value so '%' / '_' are
+            # treated literally; the ESCAPE clause uses '\' as the escape
+            # character (doubled in the Python string for SQL literal '\\').
+            escaped_context = context.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+            sql += "AND split_part(po.kv_key, ':', 3) ILIKE :ctx ESCAPE '\\' "
+            params['ctx'] = f'%{escaped_context}%'
         sql += 'ORDER BY mw_score DESC, po.last_outcome_at DESC NULLS LAST, po.kv_key LIMIT :lim'
 
         async with self.metastore.session() as session:

--- a/packages/core/src/memex_core/services/kv.py
+++ b/packages/core/src/memex_core/services/kv.py
@@ -25,6 +25,7 @@ procedure keys (RFC-007).
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from datetime import datetime, timedelta, timezone
@@ -43,6 +44,20 @@ _PROTOCOL_RE = re.compile(r'[a-zA-Z][a-zA-Z0-9+\-.]*://')
 VALID_NAMESPACES = ('global', 'user', 'project', 'app', 'procedure')
 
 PROCEDURE_KEY_RE = re.compile(r'^procedure:[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$')
+
+PROCEDURE_HISTORY_CAP = 5
+PROCEDURE_RETRY_BUDGET = 5
+
+
+class ProcedureKVConcurrencyError(RuntimeError):
+    """Raised when procedure-key optimistic concurrency exhausts its retry budget."""
+
+    def __init__(self, key: str, retries: int) -> None:
+        super().__init__(
+            f'Procedure KV write contention: {retries} retries exhausted on key {key!r}.'
+        )
+        self.key = key
+        self.retries = retries
 
 
 def validate_procedure_key(key: str) -> None:
@@ -106,13 +121,23 @@ class KVService(BaseService):
         embedding: list[float] | None = None,
         ttl_seconds: int | None = None,
     ) -> Any:
-        """Upsert a KV entry. Uses INSERT ... ON CONFLICT DO UPDATE."""
+        """Upsert a KV entry.
+
+        For ``procedure:`` keys (RFC-007) the write is routed through
+        :meth:`_procedure_put` which wraps ``value`` in a versioned envelope
+        with capped history; for all other namespaces uses the existing
+        INSERT ... ON CONFLICT DO UPDATE path.
+        """
         from sqlalchemy.dialects.postgresql import insert
 
         from memex_core.memory.sql_models import KVEntry
 
         key = _normalize_key(key)
         _validate_namespace(key)
+
+        if key.startswith('procedure:'):
+            validate_procedure_key(key)
+            return await self._procedure_put(key, value, embedding=embedding)
 
         expires_at_val: datetime | None = None
         if ttl_seconds is not None:
@@ -150,8 +175,133 @@ class KVService(BaseService):
             audit_event(self._audit_service, 'kv.written', 'kv', key)
             return entry
 
-    async def get(self, key: str) -> Any | None:
-        """Exact key lookup. Expired entries are deleted on read."""
+    async def _procedure_put(
+        self,
+        key: str,
+        value: str,
+        embedding: list[float] | None = None,
+    ) -> Any:
+        """Write a procedure-key value with version + capped history.
+
+        Single-row optimistic-concurrency UPDATE on the JSON envelope; on
+        rowcount=0 (concurrent writer beat us) re-reads and retries up to
+        :data:`PROCEDURE_RETRY_BUDGET` times. First write creates the
+        envelope at v=1 with empty history. Each subsequent write
+        increments the version, appends the previously-active value to
+        history, and caps history at :data:`PROCEDURE_HISTORY_CAP` entries
+        (oldest dropped).
+
+        See RFC-007 §63-112 for the contract.
+        """
+        from sqlalchemy.dialects.postgresql import insert
+
+        from memex_core.memory.sql_models import KVEntry
+
+        for _ in range(PROCEDURE_RETRY_BUDGET):
+            async with self.metastore.session() as session:
+                existing_stmt = select(KVEntry).where(col(KVEntry.key) == key)
+                result = await session.exec(existing_stmt)
+                existing = result.first()
+
+                if existing is None:
+                    # First write — create envelope at v=1, empty history.
+                    new_payload = {
+                        'v': 1,
+                        'value': value,
+                        'tags': {},
+                        'history': [],
+                    }
+                    stmt = insert(KVEntry).values(
+                        key=key,
+                        value=json.dumps(new_payload),
+                        embedding=embedding,
+                    )
+                    stmt = stmt.on_conflict_do_nothing(constraint='uq_kv_key')
+                    stmt = stmt.returning(KVEntry.__table__)
+                    insert_result = await session.exec(stmt)  # type: ignore[arg-type]
+                    row = insert_result.first()
+                    await session.commit()
+                    if row is not None:
+                        entry = await session.get(KVEntry, row.id)
+                        audit_event(
+                            self._audit_service,
+                            'kv.procedure_written',
+                            'kv',
+                            key,
+                            version=1,
+                        )
+                        return entry
+                    # Lost the race to a concurrent INSERT; retry with UPDATE path.
+                    continue
+
+                try:
+                    parsed = json.loads(existing.value)
+                except (ValueError, TypeError) as exc:
+                    raise RuntimeError(
+                        f'Procedure KV envelope at {key!r} is not valid JSON: {exc}'
+                    ) from exc
+
+                old_v = int(parsed['v'])
+                new_v = old_v + 1
+                superseded = {
+                    'v': old_v,
+                    'value': parsed['value'],
+                    'superseded_at': datetime.now(timezone.utc).isoformat(),
+                }
+                new_history = (parsed.get('history') or []) + [superseded]
+                new_history = new_history[-PROCEDURE_HISTORY_CAP:]
+                new_payload = {
+                    'v': new_v,
+                    'value': value,
+                    'tags': parsed.get('tags') or {},
+                    'history': new_history,
+                }
+
+                update_stmt = text(
+                    'UPDATE kv_entries SET value = :v, updated_at = now() '
+                    "WHERE key = :k AND (value::jsonb->>'v') = :expected"
+                )
+                update_result = await session.execute(
+                    update_stmt,
+                    {
+                        'v': json.dumps(new_payload),
+                        'k': key,
+                        'expected': str(old_v),
+                    },
+                )
+                if update_result.rowcount == 1:
+                    await session.commit()
+                    refresh_stmt = select(KVEntry).where(col(KVEntry.key) == key)
+                    refresh_result = await session.exec(refresh_stmt)
+                    entry = refresh_result.first()
+                    audit_event(
+                        self._audit_service,
+                        'kv.procedure_written',
+                        'kv',
+                        key,
+                        version=new_v,
+                    )
+                    return entry
+                # Concurrent writer beat us; retry.
+                await session.rollback()
+
+        raise ProcedureKVConcurrencyError(key, PROCEDURE_RETRY_BUDGET)
+
+    async def get(
+        self,
+        key: str,
+        *,
+        include_history: bool = False,
+    ) -> Any | None:
+        """Exact key lookup. Expired entries are deleted on read.
+
+        For ``procedure:`` keys: by default returns an entry whose ``value``
+        is the unwrapped active value (back-compat — non-procedure callers
+        and existing procedure-naive callers see a string, not the JSON
+        envelope). With ``include_history=True``, the returned entry's
+        ``value`` is replaced with a dict ``{value, version, history}`` per
+        RFC-007 §114-116.
+        """
         from memex_core.memory.sql_models import KVEntry
 
         key = _normalize_key(key)
@@ -168,6 +318,21 @@ class KVService(BaseService):
                 await session.delete(entry)
                 await session.commit()
                 return None
+
+            if key.startswith('procedure:'):
+                try:
+                    parsed = json.loads(entry.value)
+                except (ValueError, TypeError):
+                    # Fallback: not an envelope (legacy data); return as-is.
+                    return entry
+                if include_history:
+                    entry.value = {  # type: ignore[assignment]
+                        'value': parsed['value'],
+                        'version': parsed['v'],
+                        'history': parsed.get('history') or [],
+                    }
+                else:
+                    entry.value = parsed['value']
 
             return entry
 

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -1,0 +1,378 @@
+"""F6 maintenance ledger — rule-based linter.
+
+Implements ``LintService.run_rules(vault_id?)`` which iterates the v1 rule
+registry and emits ``MaintenanceProposal`` rows. Rules are read-only against
+the resources they inspect; the only writes ``run_rules`` performs are
+``INSERT INTO maintenance_proposals`` (with ``ON CONFLICT DO NOTHING`` against
+the partial unique index ``uq_maintenance_proposals_pending``).
+
+v1 rule set (one per ``LintType`` enum value, per AC-F6-6):
+
+  - ``orphan_mental_model``         (structural)
+  - ``cold_low_mw_unit``            (quality)
+  - ``sensitive_unreviewed_unit``   (governance, AC-F6-G1)
+  - ``dangling_entity_ref_in_unit`` (schema)
+
+The mw_score expression is the inline form of
+``services.outcomes.compute_mw_score`` (Beta-Bernoulli posterior mean
+α=β=1):  ``(success_co_count + 1.0) / (success_co_count + failure_co_count + 2)``
+Drift between the two forms is guarded by a unit test.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from memex_core.memory.sql_models import LintType
+from memex_core.services.base import BaseService
+
+try:
+    from opentelemetry import trace as _otel_trace
+
+    _tracer = _otel_trace.get_tracer('memex.lint')
+except Exception:  # pragma: no cover — OTel optional at import time
+    _tracer = None
+
+logger = logging.getLogger('memex.core.services.lint')
+
+
+@dataclass(frozen=True)
+class RuleSpec:
+    """Static description of a lint rule.
+
+    The ``select_sql`` is a SELECT statement that returns one row per finding
+    with the columns ``target_id`` (text) and ``evidence`` (jsonb). Rules MUST
+    include ``vault_id = :vault_id`` in their WHERE clause when their target
+    is vault-scoped — guarded by ``test_lint_rule_sql_audits.py``.
+    """
+
+    name: str
+    lint_type: LintType
+    target_type: str
+    suggested_action: str
+    select_sql: str
+
+
+# ---------------------------------------------------------------------------
+# v1 rule definitions
+# ---------------------------------------------------------------------------
+
+
+_MW_SCORE_EXPR = '((success_co_count + 1.0) / (success_co_count + failure_co_count + 2))'
+
+
+_ORPHAN_MENTAL_MODEL_SQL = """
+    SELECT
+        mm.id::text AS target_id,
+        jsonb_build_object(
+            'last_refreshed', mm.last_refreshed,
+            'observation_count', jsonb_array_length(mm.observations),
+            'linked_active_units', 0
+        ) AS evidence
+    FROM mental_models mm
+    WHERE mm.vault_id = :vault_id
+      AND mm.last_refreshed < (now() - interval '30 days')
+      AND NOT EXISTS (
+          SELECT 1
+          FROM unit_entities ue
+          JOIN memory_units mu ON mu.id = ue.unit_id
+          WHERE ue.entity_id = mm.entity_id
+            AND ue.vault_id = mm.vault_id
+            AND mu.status = 'active'
+      )
+"""
+
+
+_COLD_LOW_MW_UNIT_SQL = f"""
+    SELECT
+        mu.id::text AS target_id,
+        jsonb_build_object(
+            'mw_score', {_MW_SCORE_EXPR},
+            'success_co_count', mu.success_co_count,
+            'failure_co_count', mu.failure_co_count,
+            'last_outcome_age_days', extract(epoch FROM (now() - mu.updated_at)) / 86400
+        ) AS evidence
+    FROM memory_units mu
+    WHERE mu.vault_id = :vault_id
+      AND mu.status = 'active'
+      AND mu.is_deprioritized = false
+      AND (mu.success_co_count + mu.failure_co_count) >= 5
+      AND {_MW_SCORE_EXPR} < 0.3
+      AND mu.updated_at < (now() - interval '30 days')
+"""
+
+
+_SENSITIVE_UNREVIEWED_UNIT_SQL = """
+    SELECT
+        mu.id::text AS target_id,
+        jsonb_build_object(
+            'risk_class', mu.risk_class,
+            'created_at', mu.created_at,
+            'last_review_at', NULL
+        ) AS evidence
+    FROM memory_units mu
+    WHERE mu.vault_id = :vault_id
+      AND mu.status = 'active'
+      AND mu.risk_class = 'sensitive'
+      AND mu.is_deprioritized = false
+      AND NOT EXISTS (
+          SELECT 1
+          FROM audit_logs al
+          WHERE al.action = 'memory_review'
+            AND al.resource_type = 'memory_unit'
+            AND al.resource_id = mu.id::text
+            AND al.timestamp > (now() - interval '30 days')
+      )
+"""
+
+
+_DANGLING_ENTITY_REF_IN_UNIT_SQL = """
+    SELECT
+        ue.unit_id::text AS target_id,
+        jsonb_build_object(
+            'entity_id', ue.entity_id::text
+        ) AS evidence
+    FROM unit_entities ue
+    LEFT JOIN entities e ON e.id = ue.entity_id
+    WHERE ue.vault_id = :vault_id
+      AND e.id IS NULL
+"""
+
+
+V1_RULES: tuple[RuleSpec, ...] = (
+    RuleSpec(
+        name='orphan_mental_model',
+        lint_type=LintType.STRUCTURAL,
+        target_type='mental_model',
+        suggested_action=(
+            'Mental model has no active linked memory units for >30 days. '
+            'Archive it or restore observations.'
+        ),
+        select_sql=_ORPHAN_MENTAL_MODEL_SQL,
+    ),
+    RuleSpec(
+        name='cold_low_mw_unit',
+        lint_type=LintType.QUALITY,
+        target_type='memory_unit',
+        suggested_action=(
+            'Unit has 5+ outcomes, low MW score, and 30+ days of inactivity. '
+            "Call memex_memory_deprioritize with reason='low MW after 5+ outcomes'."
+        ),
+        select_sql=_COLD_LOW_MW_UNIT_SQL,
+    ),
+    RuleSpec(
+        name='sensitive_unreviewed_unit',
+        lint_type=LintType.GOVERNANCE,
+        target_type='memory_unit',
+        suggested_action=(
+            'Sensitive unit has not been reviewed in 30 days. '
+            'Review and either confirm or call memex_memory_deprioritize.'
+        ),
+        select_sql=_SENSITIVE_UNREVIEWED_UNIT_SQL,
+    ),
+    RuleSpec(
+        name='dangling_entity_ref_in_unit',
+        lint_type=LintType.SCHEMA,
+        target_type='unit_entity',
+        suggested_action=(
+            'UnitEntity row references an entity that no longer exists '
+            '(data integrity issue). Remove the dangling reference.'
+        ),
+        select_sql=_DANGLING_ENTITY_REF_IN_UNIT_SQL,
+    ),
+)
+
+
+_INSERT_FINDING_SQL = text("""
+    INSERT INTO maintenance_proposals (
+        vault_id, lint_type, target_type, target_id,
+        rule_name, evidence, suggested_action, status, source
+    )
+    VALUES (
+        :vault_id, :lint_type, :target_type, :target_id,
+        :rule_name, CAST(:evidence AS jsonb), :suggested_action, 'pending', 'rule'
+    )
+    ON CONFLICT (rule_name, target_type, target_id, vault_id)
+    WHERE status = 'pending'
+    DO NOTHING
+""")
+
+
+@dataclass
+class RuleRunResult:
+    rule_name: str
+    lint_type: LintType
+    findings_emitted: int
+    duration_seconds: float
+
+
+@dataclass
+class LintRunSummary:
+    vault_id: UUID
+    rules: list[RuleRunResult]
+
+    @property
+    def total_findings(self) -> int:
+        return sum(r.findings_emitted for r in self.rules)
+
+
+class LintService(BaseService):
+    """Runs the v1 rule set and writes findings to ``maintenance_proposals``."""
+
+    async def run_rules(
+        self,
+        vault_id: UUID,
+        *,
+        rules: tuple[RuleSpec, ...] = V1_RULES,
+    ) -> LintRunSummary:
+        """Execute every registered rule against ``vault_id`` and persist findings.
+
+        Returns a :class:`LintRunSummary` with per-rule counts. Idempotent on
+        reruns thanks to the partial unique index — already-pending findings
+        for the same ``(rule_name, target_type, target_id, vault_id)`` are
+        silently skipped.
+        """
+        results: list[RuleRunResult] = []
+        async with self.metastore.session() as session:
+            for spec in rules:
+                results.append(await self._run_one(session, spec, vault_id))
+            await session.commit()
+        return LintRunSummary(vault_id=vault_id, rules=results)
+
+    async def _run_one(
+        self,
+        session: AsyncSession,
+        spec: RuleSpec,
+        vault_id: UUID,
+    ) -> RuleRunResult:
+        from memex_core import metrics
+
+        start = time.perf_counter()
+        attrs = {
+            'lint.rule_name': spec.name,
+            'lint.lint_type': spec.lint_type.value,
+            'lint.vault_id': str(vault_id),
+        }
+
+        emitted = 0
+        ctx = (
+            _tracer.start_as_current_span('memex.lint.run_rule', attributes=attrs)
+            if _tracer
+            else None
+        )
+        try:
+            if ctx is not None:
+                ctx.__enter__()
+            result = await session.execute(text(spec.select_sql), {'vault_id': str(vault_id)})
+            for row in result.mappings().all():
+                ins = await session.execute(
+                    _INSERT_FINDING_SQL,
+                    {
+                        'vault_id': str(vault_id),
+                        'lint_type': spec.lint_type.value,
+                        'target_type': spec.target_type,
+                        'target_id': row['target_id'],
+                        'rule_name': spec.name,
+                        'evidence': _json_dumps(row['evidence']),
+                        'suggested_action': spec.suggested_action,
+                    },
+                )
+                if ins.rowcount:
+                    emitted += 1
+            metrics.LINT_FINDINGS_TOTAL.labels(
+                rule_name=spec.name,
+                lint_type=spec.lint_type.value,
+                vault_id=str(vault_id),
+            ).inc(emitted)
+        except Exception:
+            logger.exception('Lint rule %s failed', spec.name)
+            raise
+        finally:
+            duration = time.perf_counter() - start
+            metrics.LINT_RUN_DURATION_SECONDS.labels(rule_name=spec.name).observe(duration)
+            if ctx is not None:
+                ctx.__exit__(None, None, None)
+
+        logger.info(
+            'lint rule %s emitted %d findings in vault %s (%.3fs)',
+            spec.name,
+            emitted,
+            vault_id,
+            duration,
+        )
+        return RuleRunResult(
+            rule_name=spec.name,
+            lint_type=spec.lint_type,
+            findings_emitted=emitted,
+            duration_seconds=duration,
+        )
+
+    async def count_pending(self, vault_id: UUID | None = None) -> int:
+        stmt = text(
+            'SELECT count(*) FROM maintenance_proposals '
+            "WHERE status = 'pending' AND ("
+            '    (CAST(:v AS uuid) IS NULL AND vault_id IS NULL) '
+            ' OR vault_id = CAST(:v AS uuid)'
+            ')'
+        )
+        if vault_id is None:
+            stmt = text("SELECT count(*) FROM maintenance_proposals WHERE status = 'pending'")
+            params: dict[str, Any] = {}
+        else:
+            params = {'v': str(vault_id)}
+
+        async with self.metastore.session() as session:
+            result = await session.execute(stmt, params)
+            return int(result.scalar() or 0)
+
+    async def set_status(
+        self,
+        finding_id: UUID,
+        new_status: str,
+    ) -> bool:
+        """Flip a finding's status to ``resolved`` or ``dismissed``.
+
+        Returns True iff one row was updated; the finding must currently be
+        ``pending``. Idempotent: hitting an already-resolved/dismissed row
+        returns False without raising.
+        """
+        if new_status not in ('resolved', 'dismissed'):
+            raise ValueError(f"new_status must be 'resolved' or 'dismissed', got {new_status!r}")
+
+        async with self.metastore.session() as session:
+            result = await session.execute(
+                text(
+                    'UPDATE maintenance_proposals SET status = :new, resolved_at = now() '
+                    "WHERE id = :id AND status = 'pending'"
+                ),
+                {'new': new_status, 'id': str(finding_id)},
+            )
+            await session.commit()
+            return bool(result.rowcount)
+
+
+def _json_dumps(value: Any) -> str:
+    """Serialise rule-emitted evidence to a JSON string for the insert.
+
+    pgvector's asyncpg adapter emits JSONB rows as Python dicts; we round-trip
+    through ``json.dumps`` so the INSERT can ``CAST(... AS jsonb)`` cleanly.
+    """
+    import json
+    from datetime import date, datetime
+    from uuid import UUID as _UUID
+
+    def default(o: Any) -> Any:
+        if isinstance(o, (datetime, date)):
+            return o.isoformat()
+        if isinstance(o, _UUID):
+            return str(o)
+        raise TypeError(f'unhandled type {type(o).__name__}')
+
+    return json.dumps(value, default=default)

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -315,17 +315,25 @@ class LintService(BaseService):
         )
 
     async def count_pending(self, vault_id: UUID | None = None) -> int:
-        stmt = text(
-            'SELECT count(*) FROM maintenance_proposals '
-            "WHERE status = 'pending' AND ("
-            '    (CAST(:v AS uuid) IS NULL AND vault_id IS NULL) '
-            ' OR vault_id = CAST(:v AS uuid)'
-            ')'
-        )
+        """Count pending findings.
+
+        - ``vault_id is None`` → global scope (only ``vault_id IS NULL`` rows).
+        - ``vault_id is not None`` → that vault only.
+
+        Total-across-everything is intentionally not exposed here; the server
+        handles ``scope='all'`` with its own SQL.
+        """
         if vault_id is None:
-            stmt = text("SELECT count(*) FROM maintenance_proposals WHERE status = 'pending'")
+            stmt = text(
+                'SELECT count(*) FROM maintenance_proposals '
+                "WHERE status = 'pending' AND vault_id IS NULL"
+            )
             params: dict[str, Any] = {}
         else:
+            stmt = text(
+                'SELECT count(*) FROM maintenance_proposals '
+                "WHERE status = 'pending' AND vault_id = :v"
+            )
             params = {'v': str(vault_id)}
 
         async with self.metastore.session() as session:

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -64,17 +64,29 @@ class OutcomeService:
     async def record_outcome(
         self,
         session: AsyncSession,
-        unit_ids: list[str],
-        success: bool,
-        vault_id: str,
+        unit_ids: list[str] | None = None,
+        success: bool = False,
+        vault_id: str | None = None,
         outcome_confidence: float = 1.0,
         reason: str | None = None,
+        *,
+        target_type: str = 'memory_unit',
+        kv_key: str | None = None,
     ) -> dict[str, Any]:
-        """Record an outcome for one or more memory units.
+        """Record an outcome.
 
-        Increments success_co_count (success=True) or failure_co_count
-        (success=False) on each unit, and propagates the counter increment
-        to linked UnitEntity and MentalModel rows.
+        Two target modes (selected by keyword-only ``target_type``):
+
+        * ``target_type='memory_unit'`` (default — existing positional path):
+          increments success/failure co-counters on each MemoryUnit and
+          propagates to linked UnitEntity + MentalModel rows. Requires
+          positional ``unit_ids``.
+        * ``target_type='kv_key'`` (F14 — added 2026-04-30): increments
+          success/failure co-counters on the vault-scoped
+          ``procedure_outcomes`` row matching ``(vault_id, kv_key)``. Row
+          is upserted; ``last_outcome_at`` is set to ``now()``. Requires
+          keyword-only ``kv_key`` (must be a ``procedure:<verb>:<tag>``
+          key per RFC-007 §53-61) plus ``success`` and ``vault_id``.
 
         .. note::
 
@@ -86,17 +98,23 @@ class OutcomeService:
 
         Args:
             session: Active async DB session.
-            unit_ids: UUIDs of the memory units that were load-bearing.
-            success: True if the units contributed to a successful outcome.
+            unit_ids: UUIDs of memory units (memory_unit mode only).
+            success: True if outcome was successful.
             vault_id: Vault scope for the outcome.
             outcome_confidence: Weight for this outcome signal (0.0–1.0).
                 Currently recorded but not used in counter arithmetic (v1
                 uses integer increments; fractional weighting is F36).
                 # TODO(F36): fractional counter weighting
             reason: Optional free-text reason (logged, not stored on units).
+            target_type: 'memory_unit' (default) or 'kv_key' (F14 procedure
+                outcomes).
+            kv_key: Procedure KV key (kv_key mode only).
 
         Returns:
-            Dict with counts of updated units, entities, and models.
+            Dict with counts of updated rows. For ``memory_unit``:
+            ``{units_updated, entities_updated, models_updated}``. For
+            ``kv_key``: ``{kv_key, vault_id, success_co_count,
+            failure_co_count, last_outcome_at}``.
         """
         if outcome_confidence is not None and outcome_confidence != 1.0:
             warnings.warn(
@@ -108,6 +126,18 @@ class OutcomeService:
                 FutureWarning,
                 stacklevel=2,
             )
+        if target_type == 'kv_key':
+            return await self._record_outcome_kv_key(
+                session=session,
+                kv_key=kv_key,
+                success=success,
+                vault_id=vault_id,
+                reason=reason,
+            )
+        if target_type != 'memory_unit':
+            raise ValueError(f"target_type must be 'memory_unit' or 'kv_key', got {target_type!r}")
+        if unit_ids is None or vault_id is None:
+            raise ValueError("memory_unit mode requires 'unit_ids' and 'vault_id'.")
 
         from memex_core.memory.sql_models import MemoryUnit as MU
 
@@ -207,4 +237,96 @@ class OutcomeService:
             'units_updated': units_updated,
             'entities_updated': entity_count,
             'models_updated': model_count,
+        }
+
+    async def _record_outcome_kv_key(
+        self,
+        session: AsyncSession,
+        kv_key: str | None,
+        success: bool,
+        vault_id: str | None,
+        reason: str | None,
+    ) -> dict[str, Any]:
+        """F14: vault-scoped MW counter increment for a procedure KV key.
+
+        Upserts into ``procedure_outcomes`` keyed on ``(vault_id, kv_key)``,
+        atomically incrementing ``success_co_count`` (success=True) or
+        ``failure_co_count`` (success=False) and stamping
+        ``last_outcome_at = now()``.
+
+        Validates that ``kv_key`` matches the
+        ``procedure:<verb>:<context-tag>`` shape (RFC-007 §53-61) before
+        touching the DB.
+        """
+        from memex_core.services.kv import validate_procedure_key
+
+        if kv_key is None or vault_id is None:
+            raise ValueError("kv_key mode requires 'kv_key' and 'vault_id'.")
+        validate_procedure_key(kv_key)
+        try:
+            vault_uuid = UUID(vault_id)
+        except ValueError as exc:
+            raise ValueError(f'Invalid vault_id: {vault_id}') from exc
+
+        log = logger.bind(
+            kv_key=kv_key,
+            vault_id=str(vault_id),
+            outcome='success' if success else 'failure',
+        )
+        log.info('outcome.kv_key.record', reason=reason)
+
+        from sqlalchemy import text as sql_text
+
+        success_inc = 1 if success else 0
+        failure_inc = 0 if success else 1
+        # Upsert: INSERT ... ON CONFLICT (vault_id, kv_key) DO UPDATE.
+        # Atomic at the row level — no read-modify-write window.
+        upsert = sql_text(
+            'INSERT INTO procedure_outcomes '
+            '(vault_id, kv_key, success_co_count, failure_co_count, last_outcome_at) '
+            'VALUES (:vid, :k, :sinc, :finc, now()) '
+            'ON CONFLICT ON CONSTRAINT uq_procedure_outcomes_vault_key DO UPDATE SET '
+            '  success_co_count = procedure_outcomes.success_co_count + EXCLUDED.success_co_count, '
+            '  failure_co_count = procedure_outcomes.failure_co_count + EXCLUDED.failure_co_count, '
+            '  last_outcome_at = EXCLUDED.last_outcome_at, '
+            '  updated_at = now() '
+            'RETURNING success_co_count, failure_co_count, last_outcome_at'
+        )
+        result = await session.execute(
+            upsert,
+            {
+                'vid': vault_uuid,
+                'k': kv_key,
+                'sinc': success_inc,
+                'finc': failure_inc,
+            },
+        )
+        row = result.first()
+        await session.commit()
+
+        OUTCOME_RECORDED_TOTAL.labels(
+            vault_id=str(vault_id), outcome='success' if success else 'failure'
+        ).inc(1)
+
+        if row is None:
+            log.warning('outcome.kv_key.no_row_returned')
+            return {
+                'kv_key': kv_key,
+                'vault_id': str(vault_uuid),
+                'success_co_count': 0,
+                'failure_co_count': 0,
+                'last_outcome_at': None,
+            }
+        last_outcome_at = row[2]
+        log.info(
+            'outcome.kv_key.recorded',
+            success_co_count=row[0],
+            failure_co_count=row[1],
+        )
+        return {
+            'kv_key': kv_key,
+            'vault_id': str(vault_uuid),
+            'success_co_count': row[0],
+            'failure_co_count': row[1],
+            'last_outcome_at': last_outcome_at.isoformat() if last_outcome_at else None,
         }

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -64,8 +64,8 @@ class OutcomeService:
     async def record_outcome(
         self,
         session: AsyncSession,
-        unit_ids: list[str] | None = None,
-        success: bool = False,
+        unit_ids: list[str] | None,
+        success: bool,
         vault_id: str | None = None,
         outcome_confidence: float = 1.0,
         reason: str | None = None,
@@ -87,6 +87,13 @@ class OutcomeService:
           is upserted; ``last_outcome_at`` is set to ``now()``. Requires
           keyword-only ``kv_key`` (must be a ``procedure:<verb>:<tag>``
           key per RFC-007 §53-61) plus ``success`` and ``vault_id``.
+          ``unit_ids`` MUST be ``None`` or empty for kv_key mode —
+          mixing modes is an error (silent counter divergence otherwise).
+
+        Both ``unit_ids`` and ``success`` are required (no defaults) so a
+        caller cannot accidentally invoke ``record_outcome(session)`` and
+        silently record a FAILURE outcome — the exact MW-signal-quality
+        pathology F1 is built to detect.
 
         .. note::
 
@@ -98,8 +105,9 @@ class OutcomeService:
 
         Args:
             session: Active async DB session.
-            unit_ids: UUIDs of memory units (memory_unit mode only).
-            success: True if outcome was successful.
+            unit_ids: UUIDs of memory units (memory_unit mode only). Pass
+                ``None`` or ``[]`` for kv_key mode.
+            success: True if outcome was successful. Required — no default.
             vault_id: Vault scope for the outcome.
             outcome_confidence: Weight for this outcome signal (0.0–1.0).
                 Currently recorded but not used in counter arithmetic (v1
@@ -127,6 +135,11 @@ class OutcomeService:
                 stacklevel=2,
             )
         if target_type == 'kv_key':
+            if unit_ids:
+                raise ValueError(
+                    'kv_key mode does not accept unit_ids; pass unit_ids only '
+                    'with target_type="memory_unit"'
+                )
             return await self._record_outcome_kv_key(
                 session=session,
                 kv_key=kv_key,

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -19,6 +19,7 @@ from typing import Any
 from uuid import UUID
 
 import structlog
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -305,22 +306,13 @@ class OutcomeService:
 
         from sqlalchemy import text as sql_text
 
-        # Pre-check that the referenced kv_key exists. Without this, the
-        # downstream INSERT into ``procedure_outcomes`` (which has a FK to
-        # ``kv_entries.key``) would raise a raw asyncpg
-        # ``ForeignKeyViolationError`` — surface a clean ``ValueError``
-        # instead so callers can distinguish bad input from infra errors.
-        existence_check = await session.execute(
-            sql_text('SELECT 1 FROM kv_entries WHERE key = :k'),
-            {'k': kv_key},
-        )
-        if existence_check.scalar_one_or_none() is None:
-            raise ValueError(f'Cannot record outcome for unknown kv_key: {kv_key!r}')
-
         success_inc = 1 if success else 0
         failure_inc = 0 if success else 1
         # Upsert: INSERT ... ON CONFLICT (vault_id, kv_key) DO UPDATE.
         # Atomic at the row level — no read-modify-write window.
+        # Rely on the FK constraint to ``kv_entries.key`` to validate that
+        # the referenced procedure exists; catching the raw IntegrityError
+        # here avoids the TOCTOU race a SELECT 1 pre-check would introduce.
         upsert = sql_text(
             'INSERT INTO procedure_outcomes '
             '(vault_id, kv_key, success_co_count, failure_co_count, last_outcome_at) '
@@ -332,17 +324,24 @@ class OutcomeService:
             '  updated_at = now() '
             'RETURNING success_co_count, failure_co_count, last_outcome_at'
         )
-        result = await session.execute(
-            upsert,
-            {
-                'vid': vault_uuid,
-                'k': kv_key,
-                'sinc': success_inc,
-                'finc': failure_inc,
-            },
-        )
-        row = result.first()
-        await session.commit()
+        try:
+            result = await session.execute(
+                upsert,
+                {
+                    'vid': vault_uuid,
+                    'k': kv_key,
+                    'sinc': success_inc,
+                    'finc': failure_inc,
+                },
+            )
+            row = result.first()
+            await session.commit()
+        except IntegrityError as exc:
+            await session.rollback()
+            err_text = str(exc).lower()
+            if 'foreign key' in err_text or 'fk_' in err_text:
+                raise ValueError(f'Cannot record outcome for unknown kv_key: {kv_key!r}') from exc
+            raise
 
         OUTCOME_RECORDED_TOTAL.labels(
             vault_id=str(vault_id), outcome='success' if success else 'failure'

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -223,6 +223,21 @@ class OutcomeService:
         model_result = await session.exec(model_stmt)
         model_count = model_result.rowcount  # type: ignore[union-attr]
 
+        # F38 diff hook: emit one audit row per unit so consolidation_tick can
+        # find units with new outcome signal via AuditLog.action='outcome.record'.
+        from memex_core.memory.sql_models import AuditLog
+
+        outcome_label = 'success' if success else 'failure'
+        for uid in parsed_ids:
+            session.add(
+                AuditLog(
+                    action='outcome.record',
+                    resource_type='memory_unit',
+                    resource_id=str(uid),
+                    details={'vault_id': str(vault_uuid), 'outcome': outcome_label},
+                )
+            )
+
         # Single commit for all three counter updates — preserves co-occurrence
         # invariant across MemoryUnit, UnitEntity, and MentalModel tables.
         await session.commit()

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -305,6 +305,18 @@ class OutcomeService:
 
         from sqlalchemy import text as sql_text
 
+        # Pre-check that the referenced kv_key exists. Without this, the
+        # downstream INSERT into ``procedure_outcomes`` (which has a FK to
+        # ``kv_entries.key``) would raise a raw asyncpg
+        # ``ForeignKeyViolationError`` — surface a clean ``ValueError``
+        # instead so callers can distinguish bad input from infra errors.
+        existence_check = await session.execute(
+            sql_text('SELECT 1 FROM kv_entries WHERE key = :k'),
+            {'k': kv_key},
+        )
+        if existence_check.scalar_one_or_none() is None:
+            raise ValueError(f'Cannot record outcome for unknown kv_key: {kv_key!r}')
+
         success_inc = 1 if success else 0
         failure_inc = 0 if success else 1
         # Upsert: INSERT ... ON CONFLICT (vault_id, kv_key) DO UPDATE.

--- a/packages/core/tests/integration/_alembic_test_helpers.py
+++ b/packages/core/tests/integration/_alembic_test_helpers.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import asyncio
 import pathlib as plb
 import secrets
-from typing import AsyncGenerator
+from contextlib import contextmanager
+from typing import AsyncGenerator, Iterator
 from urllib.parse import urlparse, urlunparse
 
 from alembic import command
@@ -102,3 +103,42 @@ async def make_fresh_db(
             )
             await conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
         await admin_engine.dispose()
+
+
+@contextmanager
+def neutralized_stub_revisions(revision_ids: list[str]) -> Iterator[None]:
+    """Replace ``upgrade``/``downgrade`` with no-ops on the named stub revisions.
+
+    Used by Tier A migration tests whose new revision sits *downstream* of
+    other workstreams' raising stubs. Alembic loads each revision file via
+    ``importlib.util.spec_from_file_location`` + a fresh ``exec_module``
+    (see ``alembic/util/pyfiles.py:load_module_py``), producing a brand-new
+    module object each time — distinct from any module registered in
+    ``sys.modules``. So we patch alembic's loader directly: after each
+    revision module is loaded, we replace its ``upgrade``/``downgrade``
+    with no-ops if the revision id matches one of ``revision_ids``.
+
+    Example::
+
+        with neutralized_stub_revisions(['025_maintenance_proposals',
+                                         '026_revisit_columns',
+                                         '027_consolidation_ticks']):
+            await alembic_upgrade(db_url, target='028_procedure_outcomes')
+    """
+    from alembic.util import pyfiles  # type: ignore[import-not-found]
+
+    target_module_ids = {f'{rev_id}_py' for rev_id in revision_ids}
+    original_load = pyfiles.load_module_py
+
+    def _patched_load_module_py(module_id: str, path):  # type: ignore[no-untyped-def]
+        module = original_load(module_id, path)
+        if module_id in target_module_ids:
+            module.upgrade = lambda: None  # type: ignore[assignment]
+            module.downgrade = lambda: None  # type: ignore[assignment]
+        return module
+
+    pyfiles.load_module_py = _patched_load_module_py
+    try:
+        yield
+    finally:
+        pyfiles.load_module_py = original_load

--- a/packages/core/tests/integration/services/test_int_lint.py
+++ b/packages/core/tests/integration/services/test_int_lint.py
@@ -276,3 +276,41 @@ async def test_run_rules_is_read_only_on_inspected_tables(
     assert not write_violations, (
         'LintService.run_rules wrote to a non-ledger table:\n  ' + '\n  '.join(write_violations)
     )
+
+
+@pytest.mark.asyncio
+async def test_count_pending_global_excludes_vault_scoped_rows(session: AsyncSession, api) -> None:
+    """``count_pending(None)`` returns ONLY ``vault_id IS NULL`` pending rows.
+
+    Regression: previously, the ``vault_id is None`` branch counted EVERY
+    pending row (global + per-vault), which broke ``scope='global'`` on
+    ``GET /api/v1/lint/status``.
+    """
+    vault_id, _ = await _seed_all_rules_fire(session)
+
+    # Run the rules so we have some vault-scoped pending rows.
+    summary = await api.lint.run_rules(vault_id)
+    assert summary.total_findings == 4
+
+    # Insert one global (vault_id IS NULL) pending finding directly.
+    await session.execute(
+        text(
+            'INSERT INTO maintenance_proposals '
+            '(vault_id, lint_type, target_type, target_id, rule_name, '
+            ' evidence, suggested_action, status, source) '
+            "VALUES (NULL, 'structural', 'memory_unit', :tid, 'global_test_rule', "
+            "       CAST('{}' AS jsonb), 'noop', 'pending', 'rule')"
+        ),
+        {'tid': str(uuid4())},
+    )
+    await session.commit()
+
+    # Global count should be exactly 1 (only the NULL-vault row).
+    global_count = await api.lint.count_pending(None)
+    assert global_count == 1, (
+        f'count_pending(None) returned {global_count}; global scope must exclude vault-scoped rows'
+    )
+
+    # Vault count should be exactly 4 (the seeded rules; the global row excluded).
+    vault_count = await api.lint.count_pending(vault_id)
+    assert vault_count == 4

--- a/packages/core/tests/integration/services/test_int_lint.py
+++ b/packages/core/tests/integration/services/test_int_lint.py
@@ -1,0 +1,278 @@
+"""F6 — LintService integration tests (TC-20-3).
+
+Three cases:
+
+  * ``test_run_rules_emits_findings_and_summary`` — happy path: seed all four
+    rules with crafted-fires fixtures, run, assert (a) per-rule
+    ``findings_emitted`` matches the seeded rows, (b) summary.total_findings
+    is the sum, (c) every finding lands in ``maintenance_proposals`` with
+    ``status='pending'`` and ``source='rule'``.
+  * ``test_run_rules_is_idempotent_on_rerun`` — running twice produces no
+    duplicates (partial unique index ``uq_maintenance_proposals_pending``
+    catches re-inserts; second run reports 0 findings emitted).
+  * ``test_run_rules_is_read_only_on_inspected_tables`` — captures every SQL
+    statement issued during ``run_rules`` via SQLAlchemy
+    ``before_cursor_execute``; asserts no INSERT/UPDATE/DELETE against any
+    table except ``maintenance_proposals``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import event, text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core.memory.sql_models import (
+    Entity,
+    MemoryUnit,
+    MentalModel,
+    Note,
+    UnitEntity,
+    Vault,
+)
+
+
+pytestmark = [pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Multi-rule fixture: seeds one fires-case for every v1 rule in one vault
+# ---------------------------------------------------------------------------
+
+
+async def _seed_all_rules_fire(session: AsyncSession) -> tuple[UUID, dict[str, str]]:
+    """Seed each of the 4 v1 rules with exactly one fires-case in one vault.
+
+    Returns: (vault_id, expected_targets) where expected_targets maps
+    rule_name → target_id of the seeded row that should fire.
+    """
+    vault = Vault(name=f'F6-int-{uuid4().hex[:8]}')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+
+    note = Note(
+        id=uuid4(),
+        vault_id=vault.id,
+        content_hash=f'hash-{uuid4().hex[:8]}',
+        original_text='seed',
+    )
+    session.add(note)
+    await session.commit()
+
+    # 1) orphan_mental_model — old MM with no active linked unit
+    orphan_ent = Entity(canonical_name=f'Orphaned-{uuid4().hex[:6]}')
+    session.add(orphan_ent)
+    await session.commit()
+    await session.refresh(orphan_ent)
+    orphan_mm = MentalModel(
+        id=uuid4(),
+        vault_id=vault.id,
+        entity_id=orphan_ent.id,
+        name=orphan_ent.canonical_name,
+        observations=[],
+    )
+    session.add(orphan_mm)
+    await session.commit()
+    await session.execute(
+        text('UPDATE mental_models SET last_refreshed = :ts WHERE id = :id'),
+        {
+            'ts': datetime.now(timezone.utc) - timedelta(days=45),
+            'id': str(orphan_mm.id),
+        },
+    )
+    await session.commit()
+
+    # 2) cold_low_mw_unit — 6 outcomes, MW=0.25, idle 45d
+    cold_unit = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault.id,
+        note_id=note.id,
+        text='cold unit',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        is_deprioritized=False,
+        risk_class='none',
+        success_co_count=1,
+        failure_co_count=5,
+        event_date=datetime.now(timezone.utc),
+        embedding=[0.1] * 384,
+    )
+    session.add(cold_unit)
+    await session.commit()
+    await session.execute(
+        text('UPDATE memory_units SET updated_at = :ts WHERE id = :id'),
+        {
+            'ts': datetime.now(timezone.utc) - timedelta(days=45),
+            'id': str(cold_unit.id),
+        },
+    )
+    await session.commit()
+
+    # 3) sensitive_unreviewed_unit — sensitive, never reviewed
+    sensitive_unit = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault.id,
+        note_id=note.id,
+        text='sensitive unit',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        is_deprioritized=False,
+        risk_class='sensitive',
+        event_date=datetime.now(timezone.utc),
+        embedding=[0.1] * 384,
+    )
+    session.add(sensitive_unit)
+    await session.commit()
+
+    # 4) dangling_entity_ref_in_unit — drop FK, delete entity, restore FK NOT VALID
+    dangling_unit = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault.id,
+        note_id=note.id,
+        text='dangling unit',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        is_deprioritized=False,
+        risk_class='none',
+        event_date=datetime.now(timezone.utc),
+        embedding=[0.1] * 384,
+    )
+    session.add(dangling_unit)
+    await session.commit()
+    dangling_ent = Entity(canonical_name=f'Dangling-{uuid4().hex[:6]}')
+    session.add(dangling_ent)
+    await session.commit()
+    await session.refresh(dangling_ent)
+    ue = UnitEntity(
+        unit_id=dangling_unit.id,
+        entity_id=dangling_ent.id,
+        vault_id=vault.id,
+    )
+    session.add(ue)
+    await session.commit()
+    await session.execute(
+        text('ALTER TABLE unit_entities DROP CONSTRAINT unit_entities_entity_id_fkey')
+    )
+    await session.execute(text('DELETE FROM entities WHERE id = :id'), {'id': str(dangling_ent.id)})
+    await session.commit()
+    await session.execute(
+        text(
+            'ALTER TABLE unit_entities ADD CONSTRAINT unit_entities_entity_id_fkey '
+            'FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE '
+            'NOT VALID'
+        )
+    )
+    await session.commit()
+
+    targets = {
+        'orphan_mental_model': str(orphan_mm.id),
+        'cold_low_mw_unit': str(cold_unit.id),
+        'sensitive_unreviewed_unit': str(sensitive_unit.id),
+        'dangling_entity_ref_in_unit': str(dangling_unit.id),
+    }
+    return vault.id, targets
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_rules_emits_findings_and_summary(session: AsyncSession, api) -> None:
+    """All 4 v1 rules each emit exactly one finding; summary totals match."""
+    vault_id, expected_targets = await _seed_all_rules_fire(session)
+
+    summary = await api.lint.run_rules(vault_id)
+
+    assert summary.vault_id == vault_id
+    assert summary.total_findings == 4
+
+    by_rule = {r.rule_name: r for r in summary.rules}
+    assert set(by_rule.keys()) == {
+        'orphan_mental_model',
+        'cold_low_mw_unit',
+        'sensitive_unreviewed_unit',
+        'dangling_entity_ref_in_unit',
+    }
+    for rule_name, expected_target in expected_targets.items():
+        assert by_rule[rule_name].findings_emitted == 1, f'rule {rule_name} did not emit'
+
+    # Verify ledger contents.
+    rows = await session.execute(
+        text(
+            'SELECT rule_name, target_id, status, source, lint_type '
+            'FROM maintenance_proposals WHERE vault_id = :v'
+        ),
+        {'v': str(vault_id)},
+    )
+    by_rule_row = {row['rule_name']: dict(row) for row in rows.mappings().all()}
+    assert len(by_rule_row) == 4
+    for rule_name, expected_target in expected_targets.items():
+        row = by_rule_row[rule_name]
+        assert row['target_id'] == expected_target
+        assert row['status'] == 'pending'
+        assert row['source'] == 'rule'
+
+
+@pytest.mark.asyncio
+async def test_run_rules_is_idempotent_on_rerun(session: AsyncSession, api) -> None:
+    """Re-running against the same fixture produces no new rows."""
+    vault_id, _ = await _seed_all_rules_fire(session)
+
+    first = await api.lint.run_rules(vault_id)
+    assert first.total_findings == 4
+
+    second = await api.lint.run_rules(vault_id)
+    assert second.total_findings == 0, 'Second run should hit ON CONFLICT DO NOTHING for every row'
+
+    # Ledger still has exactly 4 rows.
+    count = (
+        await session.execute(
+            text('SELECT count(*) FROM maintenance_proposals WHERE vault_id = :v'),
+            {'v': str(vault_id)},
+        )
+    ).scalar()
+    assert count == 4
+
+
+@pytest.mark.asyncio
+async def test_run_rules_is_read_only_on_inspected_tables(
+    session: AsyncSession, api, metastore
+) -> None:
+    """Capture every SQL statement issued during ``run_rules`` and assert no
+    INSERT/UPDATE/DELETE against tables other than ``maintenance_proposals``.
+
+    Rationale (RFC-003): rules are read-only against the resources they
+    inspect; the only writes are to the ledger itself.
+    """
+    vault_id, _ = await _seed_all_rules_fire(session)
+
+    captured: list[str] = []
+
+    def _before_cursor(conn, cursor, statement, parameters, context, executemany):
+        captured.append(statement)
+
+    sync_engine = metastore.engine.sync_engine
+    event.listen(sync_engine, 'before_cursor_execute', _before_cursor)
+    try:
+        await api.lint.run_rules(vault_id)
+    finally:
+        event.remove(sync_engine, 'before_cursor_execute', _before_cursor)
+
+    write_violations: list[str] = []
+    for stmt in captured:
+        normalised = ' '.join(stmt.strip().split())
+        head = normalised.upper()
+        if head.startswith(('INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'COPY')):
+            if 'maintenance_proposals' not in normalised.lower():
+                write_violations.append(normalised)
+
+    assert not write_violations, (
+        'LintService.run_rules wrote to a non-ledger table:\n  ' + '\n  '.join(write_violations)
+    )

--- a/packages/core/tests/integration/services/test_int_lint_metrics.py
+++ b/packages/core/tests/integration/services/test_int_lint_metrics.py
@@ -1,0 +1,110 @@
+"""F6 — Prometheus scrape after a lint run (TC-20-5 +1, AC-F6-5).
+
+After ``LintService.run_rules`` emits findings, the registered Prometheus
+metrics must reflect that:
+
+  * ``memex_lint_findings_total{rule_name, lint_type, vault_id}`` counter is
+    ``>= 1`` for the rule that fired.
+  * ``memex_lint_run_duration_seconds{rule_name}`` histogram has at least one
+    sample for every rule executed (`_count > 0`).
+
+We read counters/histogram samples from the metric objects directly (the
+Prometheus default registry is process-wide), which mirrors what the
+``/metrics`` endpoint scrapes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core import metrics as metrics_mod
+from memex_core.memory.sql_models import MemoryUnit, Note, Vault
+
+
+pytestmark = [pytest.mark.integration]
+
+
+def _counter_value(counter, **labels) -> float:
+    """Read a single Counter sample by label values."""
+    return counter.labels(**labels)._value.get()
+
+
+def _histogram_count(hist, **labels) -> int:
+    """Read the ``_count`` of a Histogram sample by label values.
+
+    prometheus_client exposes the count via ``_metrics[<labelvalues>]._count``
+    on the parent or via ``collect()`` walking samples; we use the
+    ``_sum/_count`` attributes on the per-label child after labels(...).
+    """
+    child = hist.labels(**labels)
+    # Histogram child stores count + sum directly.
+    sample_count = getattr(child, '_count', None)
+    if sample_count is not None:
+        return int(sample_count.get())
+    # Fallback: walk the metric family for a `_count` sample.
+    for sample in hist.collect()[0].samples:
+        if sample.name.endswith('_count') and all(
+            sample.labels.get(k) == v for k, v in labels.items()
+        ):
+            return int(sample.value)
+    return 0
+
+
+@pytest.mark.asyncio
+async def test_prometheus_scrape_reflects_lint_run(session: AsyncSession, api) -> None:
+    """Run lint with one fires-case, then verify the scrape."""
+    vault = Vault(name=f'F6-metrics-{uuid4().hex[:8]}')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+
+    note = Note(
+        id=uuid4(),
+        vault_id=vault.id,
+        content_hash=f'hash-{uuid4().hex[:8]}',
+        original_text='seed',
+    )
+    session.add(note)
+    await session.commit()
+
+    unit = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault.id,
+        note_id=note.id,
+        text='sensitive metrics-test unit',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        is_deprioritized=False,
+        risk_class='sensitive',
+        event_date=datetime.now(timezone.utc),
+        embedding=[0.1] * 384,
+    )
+    session.add(unit)
+    await session.commit()
+
+    summary = await api.lint.run_rules(vault.id)
+    assert summary.total_findings == 1
+    fired = next(r for r in summary.rules if r.findings_emitted)
+
+    # Counter labelled with the firing rule must show >= 1.
+    counter_value = _counter_value(
+        metrics_mod.LINT_FINDINGS_TOTAL,
+        rule_name=fired.rule_name,
+        lint_type=fired.lint_type.value,
+        vault_id=str(vault.id),
+    )
+    assert counter_value >= 1, (
+        f'Expected LINT_FINDINGS_TOTAL >= 1 for {fired.rule_name}; got {counter_value}'
+    )
+
+    # Every rule that ran (fired or not) records at least one duration sample.
+    for r in summary.rules:
+        hist_count = _histogram_count(metrics_mod.LINT_RUN_DURATION_SECONDS, rule_name=r.rule_name)
+        assert hist_count >= 1, (
+            f'Expected LINT_RUN_DURATION_SECONDS samples for {r.rule_name}; got {hist_count}'
+        )

--- a/packages/core/tests/integration/services/test_int_lint_scheduler.py
+++ b/packages/core/tests/integration/services/test_int_lint_scheduler.py
@@ -1,0 +1,146 @@
+"""F6 — scheduler integration tests (TC-20-4).
+
+Two cases:
+
+  * ``test_scheduler_uses_only_existing_leader_lock_id`` — static AST-style audit
+    of ``packages/core/src/memex_core/scheduler.py``: exactly one
+    ``MEMEX_LEADER_LOCK_ID`` literal is defined, and every advisory-lock SQL
+    call references that constant. AC-F6-3 (no new lock).
+  * ``test_periodic_lint_task_emits_findings_under_leader_lock`` — drives the
+    scheduler-callable ``periodic_lint_task(api)`` against the integration
+    ``api`` fixture. Seeds one fires-case for one rule, calls
+    ``periodic_lint_task`` directly (mimicking what the AioClock job runs
+    once the Postgres advisory lock is held), asserts the finding lands in
+    ``maintenance_proposals``.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core import scheduler as scheduler_mod
+from memex_core.memory.sql_models import MemoryUnit, Note, Vault
+
+
+pytestmark = [pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# AC-F6-3 — no new advisory lock
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_uses_only_existing_leader_lock_id() -> None:
+    """Static audit: scheduler.py defines exactly ONE lock-ID constant
+    (``MEMEX_LEADER_LOCK_ID``) and every advisory-lock call references it.
+
+    Failure modes this catches:
+      * a future commit hardcoding a magic number on a new lock
+      * a feature workstream introducing its own lock constant
+      * a typo'd reference to a different lock
+    """
+    src_path = Path(scheduler_mod.__file__)
+    src = src_path.read_text()
+
+    # Exactly one lock-ID definition.
+    lock_defs = re.findall(r'^([A-Z_]+_LOCK_ID)\s*=\s*\d+', src, flags=re.MULTILINE)
+    assert lock_defs == ['MEMEX_LEADER_LOCK_ID'], (
+        f'Expected exactly one *_LOCK_ID definition (MEMEX_LEADER_LOCK_ID); got {lock_defs}'
+    )
+
+    # Match every line containing pg_*advisory_* and capture the constant
+    # name following it; assert it's only ever MEMEX_LEADER_LOCK_ID.
+    advisory_refs = re.findall(
+        r'pg_(?:try_)?advisory_(?:lock|unlock).*?([A-Z_][A-Z0-9_]+_LOCK_ID)',
+        src,
+    )
+    assert advisory_refs, 'Expected at least one advisory-lock SQL call'
+    assert set(advisory_refs) == {'MEMEX_LEADER_LOCK_ID'}, (
+        f'Advisory-lock calls reference unexpected constants: {set(advisory_refs)}'
+    )
+
+    # Hardcoded magic numbers in advisory-lock SQL would be caught here.
+    bad = re.findall(r'pg_(?:try_)?advisory_(?:lock|unlock)\([\'"]?\d+', src)
+    assert not bad, f'Hardcoded lock IDs found: {bad}'
+
+
+# ---------------------------------------------------------------------------
+# AC-F6-3 — periodic_lint_task fires under leader-lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_periodic_lint_task_emits_findings_under_leader_lock(
+    session: AsyncSession, api
+) -> None:
+    """Drive ``periodic_lint_task(api)`` end-to-end.
+
+    The function is what AioClock invokes once the Postgres advisory lock is
+    held; calling it directly proves the scheduler hook produces findings
+    against the live DB. Tests AC-F6-3 (the lint task is reachable from the
+    scheduler) and AC-F6-2 (run_rules writes via the scheduler path).
+    """
+    vault = Vault(name=f'F6-sched-{uuid4().hex[:8]}')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+
+    note = Note(
+        id=uuid4(),
+        vault_id=vault.id,
+        content_hash=f'hash-{uuid4().hex[:8]}',
+        original_text='seed',
+    )
+    session.add(note)
+    await session.commit()
+
+    # Sensitive-unreviewed-unit fires immediately (no time-travel needed).
+    unit = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault.id,
+        note_id=note.id,
+        text='sensitive scheduler-trigger unit',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        is_deprioritized=False,
+        risk_class='sensitive',
+        event_date=datetime.now(timezone.utc),
+        embedding=[0.1] * 384,
+    )
+    session.add(unit)
+    await session.commit()
+
+    # Drive the scheduler-callable directly. This mimics what AioClock invokes
+    # under the held MEMEX_LEADER_LOCK_ID; the lock is the leader-election
+    # gate, not a per-call wrapper, so no per-test lock dance is needed.
+    await scheduler_mod.periodic_lint_task(api)
+
+    rows = (
+        (
+            await session.execute(
+                text(
+                    'SELECT target_id, status, source FROM maintenance_proposals '
+                    "WHERE rule_name = 'sensitive_unreviewed_unit' AND vault_id = :v"
+                ),
+                {'v': str(vault.id)},
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    assert len(rows) == 1, (
+        f'periodic_lint_task should have emitted 1 sensitive-unit finding; got {len(rows)}'
+    )
+    row = dict(rows[0])
+    assert row['target_id'] == str(unit.id)
+    assert row['status'] == 'pending'
+    assert row['source'] == 'rule'

--- a/packages/core/tests/integration/test_int_alembic_025.py
+++ b/packages/core/tests/integration/test_int_alembic_025.py
@@ -1,0 +1,220 @@
+"""F6 — alembic 025_maintenance_proposals migration tests (TC-20-1).
+
+Verifies the `maintenance_proposals` table and its three indexes are created,
+that the partial unique index actually enforces idempotency only on `pending`
+rows, and that the upgrade/downgrade pair is reversible.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import NullPool, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import create_async_engine
+from testcontainers.postgres import PostgresContainer
+
+from _alembic_test_helpers import (  # noqa: F401
+    alembic_downgrade as _alembic_downgrade,
+    alembic_upgrade as _alembic_upgrade,
+    make_fresh_db,
+)
+
+pytestmark = [pytest.mark.integration]
+
+
+_TARGET = '025_maintenance_proposals'
+_DOWN = '024_intent_risk_classifier'
+
+
+@pytest_asyncio.fixture
+async def fresh_db_url(postgres_container: PostgresContainer) -> AsyncGenerator[str, None]:
+    async for url in make_fresh_db(postgres_container, db_prefix='mig025'):
+        yield url
+
+
+@pytest.mark.asyncio
+async def test_alembic_upgrade_creates_table_and_indexes(fresh_db_url: str) -> None:
+    """TC-20-1a: upgrade creates `maintenance_proposals` with the 3 expected indexes."""
+    await _alembic_upgrade(fresh_db_url, target=_TARGET)
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            cols = (
+                await conn.execute(
+                    text(
+                        'SELECT column_name, data_type, is_nullable '
+                        'FROM information_schema.columns '
+                        "WHERE table_name = 'maintenance_proposals' "
+                        'ORDER BY ordinal_position'
+                    )
+                )
+            ).all()
+            col_map = {row[0]: (row[1], row[2]) for row in cols}
+
+            assert 'id' in col_map and col_map['id'][0] == 'uuid'
+            assert 'vault_id' in col_map and col_map['vault_id'][1] == 'YES', (
+                'vault_id MUST be nullable per AC-F6-1 (NULL = global findings)'
+            )
+            assert 'lint_type' in col_map and col_map['lint_type'][1] == 'NO'
+            assert 'target_type' in col_map and col_map['target_type'][1] == 'NO'
+            assert 'target_id' in col_map and col_map['target_id'][1] == 'NO'
+            assert 'rule_name' in col_map and col_map['rule_name'][1] == 'NO'
+            assert 'evidence' in col_map and col_map['evidence'][0] == 'jsonb'
+            assert 'suggested_action' in col_map and col_map['suggested_action'][1] == 'NO'
+            assert 'status' in col_map and col_map['status'][1] == 'NO'
+            assert 'source' in col_map and col_map['source'][1] == 'NO'
+            # created_at + resolved_at: introspection reports YES across the
+            # codebase for TIMESTAMP columns with server_default=now() (see
+            # note_appends.applied_at for the same pattern). Defaults populate
+            # the value at insert time even with nullable=YES.
+            assert 'created_at' in col_map and col_map['created_at'][0].startswith('timestamp')
+            assert 'resolved_at' in col_map and col_map['resolved_at'][0].startswith('timestamp')
+
+            indexes = {
+                row[0]
+                for row in (
+                    await conn.execute(
+                        text(
+                            "SELECT indexname FROM pg_indexes WHERE tablename = 'maintenance_proposals'"
+                        )
+                    )
+                ).all()
+            }
+            assert 'uq_maintenance_proposals_pending' in indexes
+            assert 'idx_maintenance_proposals_vault_status' in indexes
+            assert 'idx_maintenance_proposals_lint_type' in indexes
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_alembic_downgrade_drops_table(fresh_db_url: str) -> None:
+    """TC-20-1b: downgrade past 025 leaves the table and all 3 indexes gone."""
+    await _alembic_upgrade(fresh_db_url, target=_TARGET)
+    await _alembic_downgrade(fresh_db_url, _DOWN)
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            tbl = (
+                await conn.execute(
+                    text(
+                        'SELECT 1 FROM information_schema.tables '
+                        "WHERE table_name = 'maintenance_proposals'"
+                    )
+                )
+            ).scalar()
+            assert tbl is None
+
+            for ix in (
+                'uq_maintenance_proposals_pending',
+                'idx_maintenance_proposals_vault_status',
+                'idx_maintenance_proposals_lint_type',
+            ):
+                exists = (
+                    await conn.execute(
+                        text('SELECT 1 FROM pg_indexes WHERE indexname = :ix'),
+                        {'ix': ix},
+                    )
+                ).scalar()
+                assert exists is None, f'index {ix} should be gone after downgrade'
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_partial_unique_index_blocks_pending_dup(fresh_db_url: str) -> None:
+    """TC-20-1c: partial unique index allows duplicates only when at least one is non-pending."""
+    await _alembic_upgrade(fresh_db_url, target=_TARGET)
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text('CREATE EXTENSION IF NOT EXISTS vector'))
+            await conn.commit()
+
+        async with engine.connect() as conn:
+            vault_id = uuid4()
+            await conn.execute(
+                text(
+                    'INSERT INTO vaults (id, name, description) '
+                    "VALUES (:id, :name, 'F6 partial-unique-index test')"
+                ),
+                {'id': vault_id, 'name': f'mig025_{uuid4().hex[:8]}'},
+            )
+
+            target_id = str(uuid4())
+            params = {
+                'vault_id': vault_id,
+                'target_id': target_id,
+            }
+
+            await conn.execute(
+                text(
+                    'INSERT INTO maintenance_proposals '
+                    '(vault_id, lint_type, target_type, target_id, rule_name, '
+                    ' evidence, suggested_action) '
+                    "VALUES (:vault_id, 'quality', 'memory_unit', :target_id, "
+                    " 'cold_low_mw_unit', '{}'::jsonb, 'fix it')"
+                ),
+                params,
+            )
+            await conn.commit()
+
+            # Second pending insert with identical (rule_name, target_type, target_id, vault_id)
+            # must fail.
+            with pytest.raises(IntegrityError):
+                await conn.execute(
+                    text(
+                        'INSERT INTO maintenance_proposals '
+                        '(vault_id, lint_type, target_type, target_id, rule_name, '
+                        ' evidence, suggested_action) '
+                        "VALUES (:vault_id, 'quality', 'memory_unit', :target_id, "
+                        " 'cold_low_mw_unit', '{}'::jsonb, 'fix it again')"
+                    ),
+                    params,
+                )
+            await conn.rollback()
+
+            # Flip the existing row to resolved; second pending insert should now succeed
+            # (partial index ignores resolved rows).
+            await conn.execute(
+                text(
+                    "UPDATE maintenance_proposals SET status = 'resolved', resolved_at = now() "
+                    "WHERE rule_name = 'cold_low_mw_unit' "
+                    '  AND target_id = :target_id AND vault_id = :vault_id'
+                ),
+                params,
+            )
+            await conn.execute(
+                text(
+                    'INSERT INTO maintenance_proposals '
+                    '(vault_id, lint_type, target_type, target_id, rule_name, '
+                    ' evidence, suggested_action) '
+                    "VALUES (:vault_id, 'quality', 'memory_unit', :target_id, "
+                    " 'cold_low_mw_unit', '{}'::jsonb, 'pending again')"
+                ),
+                params,
+            )
+            await conn.commit()
+
+            count = (
+                await conn.execute(
+                    text(
+                        'SELECT count(*) FROM maintenance_proposals '
+                        "WHERE rule_name = 'cold_low_mw_unit' "
+                        '  AND target_id = :target_id AND vault_id = :vault_id'
+                    ),
+                    params,
+                )
+            ).scalar()
+            assert count == 2, (
+                'Expected 2 rows after resolved+pending sequence; partial index should not block.'
+            )
+    finally:
+        await engine.dispose()

--- a/packages/core/tests/integration/test_int_alembic_027.py
+++ b/packages/core/tests/integration/test_int_alembic_027.py
@@ -1,0 +1,221 @@
+"""Integration tests for migration 027_consolidation_ticks (F38).
+
+Verifies the vault-scoped ``consolidation_ticks`` summary table created by
+the migration: column shape, FK to ``vaults.id`` with ON DELETE CASCADE,
+both indexes (started_at history + completed_at MAX-lookup), and
+upgrade/downgrade reversibility. Mirrors the structure of
+``test_int_alembic_028.py``.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import NullPool, text
+from sqlalchemy.ext.asyncio import create_async_engine
+from testcontainers.postgres import PostgresContainer
+
+from _alembic_test_helpers import (  # noqa: F401
+    alembic_downgrade as _alembic_downgrade,
+    alembic_upgrade as _alembic_upgrade,
+    make_fresh_db,
+    neutralized_stub_revisions,
+)
+
+pytestmark = [pytest.mark.integration]
+
+_STUBS_BETWEEN = [
+    '025_maintenance_proposals',
+    '026_revisit_columns',
+]
+
+
+@pytest_asyncio.fixture
+async def fresh_db_url(postgres_container: PostgresContainer) -> AsyncGenerator[str, None]:
+    async for url in make_fresh_db(postgres_container, db_prefix='mig027'):
+        yield url
+
+
+@pytest.mark.asyncio
+async def test_creates_consolidation_ticks(fresh_db_url: str) -> None:
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='027_consolidation_ticks')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            cols = (
+                await conn.execute(
+                    text(
+                        'SELECT column_name, data_type, is_nullable '
+                        'FROM information_schema.columns '
+                        "WHERE table_name = 'consolidation_ticks' "
+                        'ORDER BY ordinal_position'
+                    )
+                )
+            ).all()
+        assert cols, 'consolidation_ticks table missing after upgrade.'
+        col_map = {row[0]: (row[1], row[2]) for row in cols}
+
+        # Wave 0 invariant: vault_id NOT NULL.
+        assert col_map['vault_id'][1] == 'NO'
+        assert col_map['vault_id'][0] == 'uuid'
+
+        # started_at NOT NULL; completed_at NULLABLE (NULL = in-progress).
+        assert col_map['started_at'][1] == 'NO'
+        assert col_map['completed_at'][1] == 'YES'
+
+        # Counters NOT NULL with default 0.
+        for c in ('units_processed', 'entities_reflected', 'contradictions_run', 'stale_pruned'):
+            assert col_map[c][1] == 'NO', f'{c} must be NOT NULL'
+            assert col_map[c][0] in ('integer', 'bigint')
+
+        assert col_map['error'][1] == 'YES'
+        assert col_map['created_at'][1] == 'NO'
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_completed_at_index_supports_max_lookup(fresh_db_url: str) -> None:
+    """``idx_consolidation_ticks_vault_completed`` is the covering index for
+    ``MAX(completed_at) WHERE vault_id = ?`` used by ``get_last_tick_timestamp``.
+    """
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='027_consolidation_ticks')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    text(
+                        'SELECT indexdef FROM pg_indexes '
+                        "WHERE indexname = 'idx_consolidation_ticks_vault_completed' "
+                        "AND tablename = 'consolidation_ticks'"
+                    )
+                )
+            ).first()
+        assert row is not None, (
+            'Expected idx_consolidation_ticks_vault_completed for MAX(completed_at) lookup.'
+        )
+        defn = row[0].lower()
+        assert 'vault_id' in defn
+        assert 'completed_at desc nulls last' in defn, (
+            f'Expected DESC NULLS LAST ordering on completed_at; got {row[0]!r}'
+        )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_fk_cascades_on_vault_delete(fresh_db_url: str) -> None:
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='027_consolidation_ticks')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    text(
+                        """
+                        SELECT confdeltype
+                        FROM pg_constraint
+                        WHERE conrelid = 'consolidation_ticks'::regclass
+                          AND contype = 'f'
+                          AND confrelid = 'vaults'::regclass
+                          AND conname = 'fk_consolidation_ticks_vault_id'
+                        """
+                    )
+                )
+            ).first()
+        assert row is not None
+        confdeltype = row[0]
+        if isinstance(confdeltype, bytes):
+            confdeltype = confdeltype.decode()
+        assert confdeltype == 'c', f'Expected ON DELETE CASCADE; got {confdeltype!r}'
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_027_round_trip_clean(fresh_db_url: str) -> None:
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='027_consolidation_ticks')
+        await _alembic_downgrade(fresh_db_url, '026_revisit_columns')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            tbl = (
+                await conn.execute(
+                    text(
+                        'SELECT 1 FROM information_schema.tables '
+                        "WHERE table_name = 'consolidation_ticks'"
+                    )
+                )
+            ).scalar()
+            assert tbl is None
+            for idx_name in (
+                'idx_consolidation_ticks_vault_started',
+                'idx_consolidation_ticks_vault_completed',
+            ):
+                idx = (
+                    await conn.execute(
+                        text('SELECT 1 FROM pg_indexes WHERE indexname = :n'),
+                        {'n': idx_name},
+                    )
+                ).scalar()
+                assert idx is None, f'{idx_name} should be gone after downgrade.'
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_cascade_clears_tick_rows(fresh_db_url: str) -> None:
+    """Deleting a vault removes its consolidation_ticks rows."""
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='027_consolidation_ticks')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        vault_id = uuid4()
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("INSERT INTO vaults (id, name, description) VALUES (:id, :n, '')"),
+                {'id': vault_id, 'n': f'v-{vault_id.hex[:8]}'},
+            )
+            await conn.execute(
+                text(
+                    'INSERT INTO consolidation_ticks (vault_id, started_at, completed_at) '
+                    'VALUES (:vid, now(), now())'
+                ),
+                {'vid': vault_id},
+            )
+
+        async with engine.connect() as conn:
+            count = (
+                await conn.execute(
+                    text('SELECT COUNT(*) FROM consolidation_ticks WHERE vault_id = :v'),
+                    {'v': vault_id},
+                )
+            ).scalar()
+            assert count == 1
+
+        async with engine.begin() as conn:
+            await conn.execute(text('DELETE FROM vaults WHERE id = :v'), {'v': vault_id})
+
+        async with engine.connect() as conn:
+            count = (
+                await conn.execute(
+                    text('SELECT COUNT(*) FROM consolidation_ticks WHERE vault_id = :v'),
+                    {'v': vault_id},
+                )
+            ).scalar()
+            assert count == 0
+    finally:
+        await engine.dispose()

--- a/packages/core/tests/integration/test_int_alembic_028.py
+++ b/packages/core/tests/integration/test_int_alembic_028.py
@@ -243,6 +243,10 @@ async def test_fk_cascade_on_kv_entry_delete_clears_counter_row(fresh_db_url: st
         vault_id = uuid4()
         async with engine.begin() as conn:
             await conn.execute(
+                text("INSERT INTO vaults (id, name, description) VALUES (:id, :name, '')"),
+                {'id': vault_id, 'name': f'v-{vault_id.hex[:8]}'},
+            )
+            await conn.execute(
                 text('INSERT INTO kv_entries (key, value) VALUES (:k, :v)'),
                 {'k': kv_key, 'v': '{}'},
             )

--- a/packages/core/tests/integration/test_int_alembic_028.py
+++ b/packages/core/tests/integration/test_int_alembic_028.py
@@ -1,0 +1,285 @@
+"""Integration tests for migration 028_procedure_outcomes (F14).
+
+Verifies the vault-scoped ``procedure_outcomes`` MW counter table created by
+the migration: column shape, unique constraint on ``(vault_id, kv_key)``, FK
+to ``kv_entries.key`` with ``ON DELETE CASCADE``, secondary index, and
+upgrade/downgrade reversibility.
+
+Reuses the helpers from ``_alembic_test_helpers.py``. Because 028 sits
+downstream of three still-stub revisions (025/F6, 026/F20, 027/F38), the
+tests neutralize those stubs in-process via ``neutralized_stub_revisions``
+so this test only exercises the F14 DDL.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import NullPool, text
+from sqlalchemy.ext.asyncio import create_async_engine
+from testcontainers.postgres import PostgresContainer
+
+from _alembic_test_helpers import (  # noqa: F401
+    alembic_downgrade as _alembic_downgrade,
+    alembic_upgrade as _alembic_upgrade,
+    make_fresh_db,
+    neutralized_stub_revisions,
+)
+
+pytestmark = [pytest.mark.integration]
+
+_STUBS_BETWEEN = [
+    '025_maintenance_proposals',
+    '026_revisit_columns',
+    '027_consolidation_ticks',
+]
+
+
+@pytest_asyncio.fixture
+async def fresh_db_url(postgres_container: PostgresContainer) -> AsyncGenerator[str, None]:
+    """Create an empty DB in the session container, yield its URL, then drop it."""
+    async for url in make_fresh_db(postgres_container, db_prefix='mig028'):
+        yield url
+
+
+@pytest.mark.asyncio
+async def test_procedure_outcomes_table_present_with_expected_shape(fresh_db_url: str) -> None:
+    """After upgrade to 028, procedure_outcomes has the columns + types declared by the migration."""
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='028_procedure_outcomes')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            cols = (
+                await conn.execute(
+                    text(
+                        'SELECT column_name, data_type, is_nullable '
+                        'FROM information_schema.columns '
+                        "WHERE table_name = 'procedure_outcomes' "
+                        'ORDER BY ordinal_position'
+                    )
+                )
+            ).all()
+        assert cols, 'procedure_outcomes table missing after upgrade.'
+        col_map = {row[0]: (row[1], row[2]) for row in cols}
+
+        # vault-scoped (Wave 0 invariant): vault_id NOT NULL
+        assert 'vault_id' in col_map
+        assert col_map['vault_id'][0] == 'uuid'
+        assert col_map['vault_id'][1] == 'NO', (
+            'vault_id MUST be NOT NULL — Wave 0 vault-scoping invariant for '
+            'all per-vault counter tables.'
+        )
+
+        assert 'kv_key' in col_map
+        assert col_map['kv_key'][0] in ('text', 'character varying')
+        assert col_map['kv_key'][1] == 'NO'
+
+        assert 'success_co_count' in col_map
+        assert col_map['success_co_count'][0] in ('integer', 'bigint')
+        assert col_map['success_co_count'][1] == 'NO'
+
+        assert 'failure_co_count' in col_map
+        assert col_map['failure_co_count'][0] in ('integer', 'bigint')
+        assert col_map['failure_co_count'][1] == 'NO'
+
+        assert 'last_outcome_at' in col_map
+        assert col_map['last_outcome_at'][0].startswith('timestamp')
+        assert col_map['last_outcome_at'][1] == 'YES'
+
+        assert 'created_at' in col_map
+        assert col_map['created_at'][0].startswith('timestamp')
+        assert col_map['created_at'][1] == 'NO'
+
+        assert 'updated_at' in col_map
+        assert col_map['updated_at'][0].startswith('timestamp')
+        assert col_map['updated_at'][1] == 'NO'
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_procedure_outcomes_unique_constraint_on_vault_kv_key(fresh_db_url: str) -> None:
+    """``UniqueConstraint(vault_id, kv_key)`` enforces vault-scoped isolation."""
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='028_procedure_outcomes')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    text(
+                        """
+                        SELECT a.attname
+                        FROM pg_constraint c
+                        JOIN pg_attribute a
+                          ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+                        WHERE c.conrelid = 'procedure_outcomes'::regclass
+                          AND c.conname = 'uq_procedure_outcomes_vault_key'
+                        ORDER BY array_position(c.conkey, a.attnum)
+                        """
+                    )
+                )
+            ).all()
+        cols = [r[0] for r in row]
+        assert cols == ['vault_id', 'kv_key'], (
+            f'Expected uq_procedure_outcomes_vault_key on (vault_id, kv_key); got {cols}'
+        )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_procedure_outcomes_fk_cascades_on_kv_entry_delete(fresh_db_url: str) -> None:
+    """FK ``kv_key → kv_entries.key`` is ON DELETE CASCADE."""
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='028_procedure_outcomes')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    text(
+                        """
+                        SELECT confdeltype
+                        FROM pg_constraint
+                        WHERE conrelid = 'procedure_outcomes'::regclass
+                          AND contype = 'f'
+                          AND confrelid = 'kv_entries'::regclass
+                          AND conname = 'fk_procedure_outcomes_kv_key'
+                        """
+                    )
+                )
+            ).first()
+        assert row is not None, (
+            'Expected a foreign key from procedure_outcomes.kv_key → kv_entries.key.'
+        )
+        confdeltype = row[0]
+        if isinstance(confdeltype, bytes):
+            confdeltype = confdeltype.decode()
+        assert confdeltype == 'c', (
+            f'Expected ON DELETE CASCADE (confdeltype="c"), got {confdeltype!r}. '
+            'Without cascade, deleting a procedure key would leave orphan counter rows.'
+        )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_procedure_outcomes_secondary_index(fresh_db_url: str) -> None:
+    """Secondary btree index ``idx_procedure_outcomes_vault_key`` covers (vault_id, kv_key)."""
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='028_procedure_outcomes')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    text(
+                        'SELECT indexdef FROM pg_indexes '
+                        "WHERE indexname = 'idx_procedure_outcomes_vault_key' "
+                        "AND tablename = 'procedure_outcomes'"
+                    )
+                )
+            ).first()
+        assert row is not None, (
+            'Expected idx_procedure_outcomes_vault_key for cheap per-vault counter lookups.'
+        )
+        defn = row[0].lower()
+        assert 'vault_id' in defn and 'kv_key' in defn
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_028_round_trip_clean(fresh_db_url: str) -> None:
+    """upgrade → downgrade past 028 leaves procedure_outcomes gone."""
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='028_procedure_outcomes')
+        await _alembic_downgrade(fresh_db_url, '027_consolidation_ticks')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            tbl = (
+                await conn.execute(
+                    text(
+                        'SELECT 1 FROM information_schema.tables '
+                        "WHERE table_name = 'procedure_outcomes'"
+                    )
+                )
+            ).scalar()
+            assert tbl is None, 'procedure_outcomes should be gone after downgrade.'
+
+            idx = (
+                await conn.execute(
+                    text(
+                        'SELECT 1 FROM pg_indexes '
+                        "WHERE indexname = 'idx_procedure_outcomes_vault_key'"
+                    )
+                )
+            ).scalar()
+            assert idx is None, 'index should be gone after downgrade.'
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_fk_cascade_on_kv_entry_delete_clears_counter_row(fresh_db_url: str) -> None:
+    """End-to-end FK cascade: deleting a kv_entries row removes its counter row."""
+    with neutralized_stub_revisions(_STUBS_BETWEEN):
+        await _alembic_upgrade(fresh_db_url, target='028_procedure_outcomes')
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        kv_key = 'procedure:write_pr:commit-style'
+        vault_id = uuid4()
+        async with engine.begin() as conn:
+            await conn.execute(
+                text('INSERT INTO kv_entries (key, value) VALUES (:k, :v)'),
+                {'k': kv_key, 'v': '{}'},
+            )
+            await conn.execute(
+                text(
+                    'INSERT INTO procedure_outcomes (vault_id, kv_key, '
+                    'success_co_count, failure_co_count) '
+                    'VALUES (:vid, :k, 1, 0)'
+                ),
+                {'vid': vault_id, 'k': kv_key},
+            )
+
+        async with engine.connect() as conn:
+            count = (
+                await conn.execute(
+                    text('SELECT COUNT(*) FROM procedure_outcomes WHERE kv_key = :k'),
+                    {'k': kv_key},
+                )
+            ).scalar()
+            assert count == 1
+
+        async with engine.begin() as conn:
+            await conn.execute(
+                text('DELETE FROM kv_entries WHERE key = :k'),
+                {'k': kv_key},
+            )
+
+        async with engine.connect() as conn:
+            count = (
+                await conn.execute(
+                    text('SELECT COUNT(*) FROM procedure_outcomes WHERE kv_key = :k'),
+                    {'k': kv_key},
+                )
+            ).scalar()
+            assert count == 0, (
+                'FK ON DELETE CASCADE should have removed the counter row '
+                'when the parent kv_entries row was deleted.'
+            )
+    finally:
+        await engine.dispose()

--- a/packages/core/tests/integration/test_int_alembic_028.py
+++ b/packages/core/tests/integration/test_int_alembic_028.py
@@ -173,7 +173,8 @@ async def test_procedure_outcomes_fk_cascades_on_kv_entry_delete(fresh_db_url: s
 
 @pytest.mark.asyncio
 async def test_procedure_outcomes_secondary_index(fresh_db_url: str) -> None:
-    """Secondary btree index ``idx_procedure_outcomes_vault_key`` covers (vault_id, kv_key)."""
+    """The unique constraint ``uq_procedure_outcomes_vault_key`` auto-creates a
+    btree index covering (vault_id, kv_key); no separate ``idx_*`` is needed."""
     with neutralized_stub_revisions(_STUBS_BETWEEN):
         await _alembic_upgrade(fresh_db_url, target='028_procedure_outcomes')
 
@@ -184,13 +185,14 @@ async def test_procedure_outcomes_secondary_index(fresh_db_url: str) -> None:
                 await conn.execute(
                     text(
                         'SELECT indexdef FROM pg_indexes '
-                        "WHERE indexname = 'idx_procedure_outcomes_vault_key' "
+                        "WHERE indexname = 'uq_procedure_outcomes_vault_key' "
                         "AND tablename = 'procedure_outcomes'"
                     )
                 )
             ).first()
         assert row is not None, (
-            'Expected idx_procedure_outcomes_vault_key for cheap per-vault counter lookups.'
+            'Expected uq_procedure_outcomes_vault_key index '
+            '(auto-created by the unique constraint) for per-vault counter lookups.'
         )
         defn = row[0].lower()
         assert 'vault_id' in defn and 'kv_key' in defn
@@ -222,11 +224,11 @@ async def test_028_round_trip_clean(fresh_db_url: str) -> None:
                 await conn.execute(
                     text(
                         'SELECT 1 FROM pg_indexes '
-                        "WHERE indexname = 'idx_procedure_outcomes_vault_key'"
+                        "WHERE indexname = 'uq_procedure_outcomes_vault_key'"
                     )
                 )
             ).scalar()
-            assert idx is None, 'index should be gone after downgrade.'
+            assert idx is None, 'unique-constraint index should be gone after downgrade.'
     finally:
         await engine.dispose()
 

--- a/packages/core/tests/integration/test_int_f14_procedure_kv.py
+++ b/packages/core/tests/integration/test_int_f14_procedure_kv.py
@@ -1,0 +1,177 @@
+"""Integration tests for F14 procedure-key envelope semantics (TC-F14-2).
+
+Covers RFC-007 §63-116 over a real Postgres backend:
+
+* Envelope shape on first write (v=1, empty history)
+* Version monotonic increment + capped history (5 entries, FIFO drop)
+* Concurrent writers under optimistic concurrency (final v=N+2 with both
+  intermediate values landing in history)
+* ``include_history=True`` exposure of ``{value, version, history}``
+* Default ``get`` shape unchanged for procedure keys (back-compat) — value
+  is the unwrapped active string, not the JSON envelope
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from memex_core.memory.sql_models import KVEntry
+from memex_core.services.kv import (
+    PROCEDURE_HISTORY_CAP,
+    KVService,
+)
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest_asyncio.fixture
+async def kv(metastore, filestore, memex_config):
+    """KVService wired to the real test database."""
+    return KVService(metastore=metastore, filestore=filestore, config=memex_config)
+
+
+def _unique_proc_key() -> str:
+    """A unique procedure key per test run (verb + uuid-derived context-tag)."""
+    return f'procedure:write_pr:tag-{uuid4().hex[:8]}'
+
+
+@pytest.mark.asyncio
+async def test_first_write_creates_envelope_at_v1_empty_history(kv: KVService) -> None:
+    """First write wraps value in {v=1, value, tags={}, history=[]}."""
+    key = _unique_proc_key()
+    await kv.put(key=key, value='draft-then-self-review')
+
+    async with kv.metastore.session() as session:
+        from sqlmodel import select as sm_select
+
+        result = await session.exec(sm_select(KVEntry).where(KVEntry.key == key))
+        entry = result.first()
+    assert entry is not None
+    payload = json.loads(entry.value)
+    assert payload['v'] == 1
+    assert payload['value'] == 'draft-then-self-review'
+    assert payload['history'] == []
+    assert payload.get('tags') == {}
+
+
+@pytest.mark.asyncio
+async def test_seven_writes_v7_history_capped_at_5(kv: KVService) -> None:
+    """Seven sequential writes: final version=7, history holds 5 most-recent superseded values."""
+    key = _unique_proc_key()
+    values = [f'step-{i}' for i in range(1, 8)]
+    for v in values:
+        await kv.put(key=key, value=v)
+
+    async with kv.metastore.session() as session:
+        from sqlmodel import select as sm_select
+
+        result = await session.exec(sm_select(KVEntry).where(KVEntry.key == key))
+        entry = result.first()
+    assert entry is not None
+    payload = json.loads(entry.value)
+
+    assert payload['v'] == 7
+    assert payload['value'] == 'step-7'
+    history = payload['history']
+    assert len(history) == PROCEDURE_HISTORY_CAP, (
+        f'history must be capped at {PROCEDURE_HISTORY_CAP}; got {len(history)}'
+    )
+    # FIFO drop: history retains v2..v6 (after v7 wrote, v6 was the prior active).
+    history_versions = [h['v'] for h in history]
+    assert history_versions == [2, 3, 4, 5, 6], (
+        f'expected oldest-dropped FIFO retention v2..v6; got {history_versions}'
+    )
+    history_values = [h['value'] for h in history]
+    assert history_values == ['step-2', 'step-3', 'step-4', 'step-5', 'step-6']
+
+
+@pytest.mark.asyncio
+async def test_concurrent_writes_single_row_atomic(kv: KVService) -> None:
+    """Two concurrent writers serialize via optimistic concurrency.
+
+    After two ``gather``ed ``put`` calls on the same key (starting from v=1),
+    the final version must be 3 and history must contain BOTH intermediate
+    superseded entries (the original v=1 plus whichever writer landed first
+    at v=2).
+    """
+    key = _unique_proc_key()
+    await kv.put(key=key, value='baseline')
+
+    await asyncio.gather(
+        kv.put(key=key, value='writer-A'),
+        kv.put(key=key, value='writer-B'),
+    )
+
+    async with kv.metastore.session() as session:
+        from sqlmodel import select as sm_select
+
+        result = await session.exec(sm_select(KVEntry).where(KVEntry.key == key))
+        entry = result.first()
+    assert entry is not None
+    payload = json.loads(entry.value)
+
+    assert payload['v'] == 3, (
+        f'expected final v=3 (baseline → first writer → second writer); got {payload["v"]}'
+    )
+    assert payload['value'] in {'writer-A', 'writer-B'}
+
+    history_versions = [h['v'] for h in payload['history']]
+    assert history_versions == [1, 2], (
+        f'history must hold both intermediates (v=1 baseline + v=2 first writer); '
+        f'got {history_versions}'
+    )
+    superseded_values = {h['value'] for h in payload['history']}
+    # baseline + the writer that landed at v=2.
+    assert 'baseline' in superseded_values
+    assert {'writer-A', 'writer-B'} & superseded_values, (
+        'one of the two writers must appear at v=2 in history'
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_default_returns_unwrapped_active_value(kv: KVService) -> None:
+    """Default ``get`` exposes the unwrapped string (back-compat) — not the envelope."""
+    key = _unique_proc_key()
+    await kv.put(key=key, value='active-procedure-text')
+    await kv.put(key=key, value='updated-procedure-text')
+
+    entry = await kv.get(key=key)
+    assert entry is not None
+    assert entry.value == 'updated-procedure-text', (
+        'default get() must unwrap the envelope so existing procedure-naive callers '
+        'see a string, not the JSON envelope'
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_include_history_exposes_value_version_history(kv: KVService) -> None:
+    """``include_history=True`` swaps value→ {value, version, history}."""
+    key = _unique_proc_key()
+    await kv.put(key=key, value='v1')
+    await kv.put(key=key, value='v2')
+    await kv.put(key=key, value='v3')
+
+    entry = await kv.get(key=key, include_history=True)
+    assert entry is not None
+    assert isinstance(entry.value, dict)
+    assert entry.value['value'] == 'v3'
+    assert entry.value['version'] == 3
+    history = entry.value['history']
+    assert [h['v'] for h in history] == [1, 2]
+    assert [h['value'] for h in history] == ['v1', 'v2']
+
+
+@pytest.mark.asyncio
+async def test_non_procedure_key_get_shape_unchanged(kv: KVService) -> None:
+    """Non-procedure namespaces never invoke envelope unwrapping."""
+    key = f'global:test:plain:{uuid4().hex[:8]}'
+    await kv.put(key=key, value='plain-text')
+
+    entry = await kv.get(key=key)
+    assert entry is not None
+    assert entry.value == 'plain-text'

--- a/packages/core/tests/integration/test_int_f14_record_outcome.py
+++ b/packages/core/tests/integration/test_int_f14_record_outcome.py
@@ -52,6 +52,7 @@ async def test_kv_key_mode_inserts_and_increments_counter(
     async with kv.metastore.session() as session:
         first = await outcomes.record_outcome(
             session=session,
+            unit_ids=None,
             target_type='kv_key',
             kv_key=key,
             success=True,
@@ -64,6 +65,7 @@ async def test_kv_key_mode_inserts_and_increments_counter(
     async with kv.metastore.session() as session:
         second = await outcomes.record_outcome(
             session=session,
+            unit_ids=None,
             target_type='kv_key',
             kv_key=key,
             success=True,
@@ -84,6 +86,7 @@ async def test_kv_key_mode_failure_increments_failure_only(
     async with kv.metastore.session() as session:
         a = await outcomes.record_outcome(
             session=session,
+            unit_ids=None,
             target_type='kv_key',
             kv_key=key,
             success=True,
@@ -92,6 +95,7 @@ async def test_kv_key_mode_failure_increments_failure_only(
     async with kv.metastore.session() as session:
         b = await outcomes.record_outcome(
             session=session,
+            unit_ids=None,
             target_type='kv_key',
             kv_key=key,
             success=False,
@@ -122,6 +126,7 @@ async def test_cross_vault_isolation_for_kv_key_outcomes(
     async with metastore.session() as session:
         await outcomes.record_outcome(
             session=session,
+            unit_ids=None,
             target_type='kv_key',
             kv_key=key,
             success=True,
@@ -129,6 +134,7 @@ async def test_cross_vault_isolation_for_kv_key_outcomes(
         )
         await outcomes.record_outcome(
             session=session,
+            unit_ids=None,
             target_type='kv_key',
             kv_key=key,
             success=True,
@@ -136,6 +142,7 @@ async def test_cross_vault_isolation_for_kv_key_outcomes(
         )
         await outcomes.record_outcome(
             session=session,
+            unit_ids=None,
             target_type='kv_key',
             kv_key=key,
             success=False,
@@ -168,6 +175,7 @@ async def test_kv_key_mode_rejects_non_procedure_keys(
         with pytest.raises(ValueError, match='Invalid procedure key'):
             await outcomes.record_outcome(
                 session=session,
+                unit_ids=None,
                 target_type='kv_key',
                 kv_key='global:not-a-procedure',
                 success=True,
@@ -176,13 +184,8 @@ async def test_kv_key_mode_rejects_non_procedure_keys(
 
 
 @pytest.mark.asyncio
-async def test_memory_unit_positional_path_unchanged(outcomes: OutcomeService, metastore) -> None:
-    """The default ``target_type='memory_unit'`` path still works positionally.
-
-    Regression guard: F14 added a keyword-only ``target_type``/``kv_key``;
-    existing callers passing only positional args must continue to land on
-    the memory_unit path.
-    """
+async def test_memory_unit_path_works(outcomes: OutcomeService, metastore) -> None:
+    """The default ``target_type='memory_unit'`` path increments unit counters."""
     unit_id = uuid4()
     async with metastore.session() as session:
         await session.execute(
@@ -214,15 +217,101 @@ async def test_memory_unit_positional_path_unchanged(outcomes: OutcomeService, m
 
 
 @pytest.mark.asyncio
+async def test_memory_unit_path_positional_call_signature(
+    outcomes: OutcomeService, metastore
+) -> None:
+    """Positional-shape lock: ``record_outcome(session, unit_ids, success, vault_id)``.
+
+    The contract specifies that ``unit_ids`` and ``success`` remain
+    POSITIONAL and required. This test calls with literal positional
+    arguments — if a future refactor inserts a ``*,`` kw-only barrier
+    between ``unit_ids`` and ``success``, this test will fail with
+    TypeError, defeating the silent regression that broke the F1
+    MW-signal-quality contract.
+
+    Also asserts that the new kv_key path's ``procedure_outcomes`` table
+    is EMPTY after a memory_unit-mode call — proves the new path does NOT
+    leak side-effects into the memory_unit path.
+    """
+    unit_id = uuid4()
+    async with metastore.session() as session:
+        await session.execute(
+            text(
+                'INSERT INTO memory_units (id, vault_id, text, '
+                'fact_type, status, confidence, event_date) '
+                "VALUES (:id, :vid, 'fact-content', 'world', 'active', 0.9, now())"
+            ),
+            {'id': unit_id, 'vid': GLOBAL_VAULT_ID},
+        )
+        await session.commit()
+
+    async with metastore.session() as session:
+        # Literal positional call — the load-bearing assertion.
+        result = await outcomes.record_outcome(session, [str(unit_id)], True, str(GLOBAL_VAULT_ID))
+    assert result['units_updated'] == 1
+
+    async with metastore.session() as session:
+        proc_count = (
+            await session.execute(text('SELECT COUNT(*) FROM procedure_outcomes'))
+        ).scalar()
+    assert proc_count == 0, (
+        f'memory_unit path must not write to procedure_outcomes; got {proc_count} rows'
+    )
+
+
+@pytest.mark.asyncio
 async def test_unknown_target_type_raises(outcomes: OutcomeService, metastore) -> None:
     """Unknown ``target_type`` rejects with ValueError."""
     async with metastore.session() as session:
         with pytest.raises(ValueError, match='target_type must be'):
             await outcomes.record_outcome(
                 session=session,
+                unit_ids=None,
+                success=True,
                 target_type='entity',  # not supported
                 vault_id=str(GLOBAL_VAULT_ID),
             )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'kwargs, expected_match',
+    [
+        # Path 1: kv_key mode without kv_key argument
+        ({'target_type': 'kv_key'}, "requires 'kv_key'"),
+        # Path 2: kv_key mode with non-empty unit_ids (silent mode-mixing)
+        (
+            {
+                'target_type': 'kv_key',
+                'kv_key': 'procedure:run_tests:tag-x',
+                'unit_ids': [str(uuid4())],
+            },
+            'does not accept unit_ids',
+        ),
+    ],
+)
+async def test_record_outcome_kv_path_validation(
+    outcomes: OutcomeService, metastore, kwargs: dict, expected_match: str
+) -> None:
+    """Both kv_key error paths surface as ValueError with diagnostic messages.
+
+    - kv_key mode WITHOUT kv_key → ValueError ('requires kv_key')
+    - kv_key mode WITH non-empty unit_ids → ValueError ('does not accept unit_ids')
+
+    The second is the load-bearing one: silent mode-mixing means the
+    caller assumes ``unit_ids`` got incremented while only the kv-key
+    counter actually moved — exact silent-divergence pathology QA caught
+    in the v2 contract.
+    """
+    base = {
+        'unit_ids': None,
+        'success': True,
+        'vault_id': str(GLOBAL_VAULT_ID),
+    }
+    base.update(kwargs)
+    async with metastore.session() as session:
+        with pytest.raises(ValueError, match=expected_match):
+            await outcomes.record_outcome(session=session, **base)
 
 
 @pytest.mark.asyncio
@@ -236,6 +325,7 @@ async def test_kv_key_outcome_persists_through_kv_entry(
     async with metastore.session() as session:
         await outcomes.record_outcome(
             session=session,
+            unit_ids=None,
             target_type='kv_key',
             kv_key=key,
             success=True,

--- a/packages/core/tests/integration/test_int_f14_record_outcome.py
+++ b/packages/core/tests/integration/test_int_f14_record_outcome.py
@@ -1,0 +1,259 @@
+"""Integration tests for F14 ``OutcomeService.record_outcome`` extension (TC-F14-3).
+
+Three angles:
+
+* The new ``target_type='kv_key'`` path upserts into ``procedure_outcomes``,
+  atomically incrementing the right counter and stamping ``last_outcome_at``.
+* Cross-vault isolation: same kv_key in two vaults yields two distinct
+  rows, neither leaking counts to the other.
+* The default positional ``target_type='memory_unit'`` path remains
+  unchanged — adding the new mode must NOT regress existing callers.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from memex_common.config import GLOBAL_VAULT_ID
+from memex_core.memory.sql_models import MemoryUnit
+from memex_core.services.kv import KVService
+from memex_core.services.outcomes import OutcomeService
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest_asyncio.fixture
+async def kv(metastore, filestore, memex_config):
+    return KVService(metastore=metastore, filestore=filestore, config=memex_config)
+
+
+@pytest.fixture
+def outcomes() -> OutcomeService:
+    return OutcomeService()
+
+
+def _unique_proc_key() -> str:
+    return f'procedure:run_tests:tag-{uuid4().hex[:8]}'
+
+
+@pytest.mark.asyncio
+async def test_kv_key_mode_inserts_and_increments_counter(
+    kv: KVService, outcomes: OutcomeService
+) -> None:
+    """First call inserts a row at (1,0); second success call lifts to (2,0)."""
+    key = _unique_proc_key()
+    # Procedure key must exist as a kv_entries row (FK target).
+    await kv.put(key=key, value='step-one')
+
+    async with kv.metastore.session() as session:
+        first = await outcomes.record_outcome(
+            session=session,
+            target_type='kv_key',
+            kv_key=key,
+            success=True,
+            vault_id=str(GLOBAL_VAULT_ID),
+        )
+    assert first['success_co_count'] == 1
+    assert first['failure_co_count'] == 0
+    assert first['last_outcome_at'] is not None
+
+    async with kv.metastore.session() as session:
+        second = await outcomes.record_outcome(
+            session=session,
+            target_type='kv_key',
+            kv_key=key,
+            success=True,
+            vault_id=str(GLOBAL_VAULT_ID),
+        )
+    assert second['success_co_count'] == 2
+    assert second['failure_co_count'] == 0
+
+
+@pytest.mark.asyncio
+async def test_kv_key_mode_failure_increments_failure_only(
+    kv: KVService, outcomes: OutcomeService
+) -> None:
+    """``success=False`` lifts only ``failure_co_count``."""
+    key = _unique_proc_key()
+    await kv.put(key=key, value='step-x')
+
+    async with kv.metastore.session() as session:
+        a = await outcomes.record_outcome(
+            session=session,
+            target_type='kv_key',
+            kv_key=key,
+            success=True,
+            vault_id=str(GLOBAL_VAULT_ID),
+        )
+    async with kv.metastore.session() as session:
+        b = await outcomes.record_outcome(
+            session=session,
+            target_type='kv_key',
+            kv_key=key,
+            success=False,
+            vault_id=str(GLOBAL_VAULT_ID),
+        )
+    assert a['success_co_count'] == 1
+    assert a['failure_co_count'] == 0
+    assert b['success_co_count'] == 1
+    assert b['failure_co_count'] == 1
+
+
+@pytest.mark.asyncio
+async def test_cross_vault_isolation_for_kv_key_outcomes(
+    kv: KVService, outcomes: OutcomeService, metastore
+) -> None:
+    """Same kv_key in two vaults → two distinct counter rows, no leakage."""
+    key = _unique_proc_key()
+    await kv.put(key=key, value='shared-procedure')
+
+    other_vault_id = uuid4()
+    async with metastore.session() as session:
+        await session.execute(
+            text("INSERT INTO vaults (id, name, description) VALUES (:id, :name, '')"),
+            {'id': other_vault_id, 'name': f'v-{other_vault_id.hex[:8]}'},
+        )
+        await session.commit()
+
+    async with metastore.session() as session:
+        await outcomes.record_outcome(
+            session=session,
+            target_type='kv_key',
+            kv_key=key,
+            success=True,
+            vault_id=str(GLOBAL_VAULT_ID),
+        )
+        await outcomes.record_outcome(
+            session=session,
+            target_type='kv_key',
+            kv_key=key,
+            success=True,
+            vault_id=str(GLOBAL_VAULT_ID),
+        )
+        await outcomes.record_outcome(
+            session=session,
+            target_type='kv_key',
+            kv_key=key,
+            success=False,
+            vault_id=str(other_vault_id),
+        )
+
+    async with metastore.session() as session:
+        rows = (
+            await session.execute(
+                text(
+                    'SELECT vault_id, success_co_count, failure_co_count '
+                    'FROM procedure_outcomes WHERE kv_key = :k '
+                    'ORDER BY vault_id'
+                ),
+                {'k': key},
+            )
+        ).all()
+    by_vault = {str(r[0]): (r[1], r[2]) for r in rows}
+    assert len(by_vault) == 2, f'expected two distinct vault rows; got {by_vault}'
+    assert by_vault[str(GLOBAL_VAULT_ID)] == (2, 0)
+    assert by_vault[str(other_vault_id)] == (0, 1)
+
+
+@pytest.mark.asyncio
+async def test_kv_key_mode_rejects_non_procedure_keys(
+    kv: KVService, outcomes: OutcomeService, metastore
+) -> None:
+    """``kv_key`` must match ``procedure:<verb>:<tag>`` regex; otherwise ValueError."""
+    async with metastore.session() as session:
+        with pytest.raises(ValueError, match='Invalid procedure key'):
+            await outcomes.record_outcome(
+                session=session,
+                target_type='kv_key',
+                kv_key='global:not-a-procedure',
+                success=True,
+                vault_id=str(GLOBAL_VAULT_ID),
+            )
+
+
+@pytest.mark.asyncio
+async def test_memory_unit_positional_path_unchanged(outcomes: OutcomeService, metastore) -> None:
+    """The default ``target_type='memory_unit'`` path still works positionally.
+
+    Regression guard: F14 added a keyword-only ``target_type``/``kv_key``;
+    existing callers passing only positional args must continue to land on
+    the memory_unit path.
+    """
+    unit_id = uuid4()
+    async with metastore.session() as session:
+        await session.execute(
+            text(
+                'INSERT INTO memory_units (id, vault_id, text, '
+                'fact_type, status, confidence, event_date) '
+                "VALUES (:id, :vid, 'fact-content', 'world', 'active', 0.9, now())"
+            ),
+            {'id': unit_id, 'vid': GLOBAL_VAULT_ID},
+        )
+        await session.commit()
+
+    async with metastore.session() as session:
+        result = await outcomes.record_outcome(
+            session=session,
+            unit_ids=[str(unit_id)],
+            success=True,
+            vault_id=str(GLOBAL_VAULT_ID),
+        )
+    assert result['units_updated'] == 1
+
+    async with metastore.session() as session:
+        from sqlmodel import select as sm_select
+
+        row = (await session.exec(sm_select(MemoryUnit).where(MemoryUnit.id == unit_id))).first()
+    assert row is not None
+    assert row.success_co_count == 1
+    assert row.failure_co_count == 0
+
+
+@pytest.mark.asyncio
+async def test_unknown_target_type_raises(outcomes: OutcomeService, metastore) -> None:
+    """Unknown ``target_type`` rejects with ValueError."""
+    async with metastore.session() as session:
+        with pytest.raises(ValueError, match='target_type must be'):
+            await outcomes.record_outcome(
+                session=session,
+                target_type='entity',  # not supported
+                vault_id=str(GLOBAL_VAULT_ID),
+            )
+
+
+@pytest.mark.asyncio
+async def test_kv_key_outcome_persists_through_kv_entry(
+    kv: KVService, outcomes: OutcomeService, metastore
+) -> None:
+    """End-to-end: kv.put creates the FK target, record_outcome inserts the counter."""
+    key = _unique_proc_key()
+    await kv.put(key=key, value='full-loop')
+
+    async with metastore.session() as session:
+        await outcomes.record_outcome(
+            session=session,
+            target_type='kv_key',
+            kv_key=key,
+            success=True,
+            vault_id=str(GLOBAL_VAULT_ID),
+        )
+
+    async with metastore.session() as session:
+        result = await session.execute(
+            text(
+                'SELECT po.success_co_count, kv.value '
+                'FROM procedure_outcomes po '
+                'JOIN kv_entries kv ON po.kv_key = kv.key '
+                'WHERE po.kv_key = :k'
+            ),
+            {'k': key},
+        )
+        row = result.first()
+    assert row is not None
+    assert row[0] == 1
+    # value is still the JSON envelope at the kv_entries level
+    assert '"value": "full-loop"' in row[1]

--- a/packages/core/tests/integration/test_int_f14_top_outcomes.py
+++ b/packages/core/tests/integration/test_int_f14_top_outcomes.py
@@ -1,0 +1,190 @@
+"""Integration tests for F14 ``list_top_procedure_outcomes`` ranking + limit.
+
+Locks the contract that drives the briefing surface (TC-F14-4 data path):
+
+* Rows are returned ordered by Beta-Bernoulli MW score
+  (``(s+1)/(s+f+2)``) descending — the SAME formula as
+  ``compute_mw_score`` so the briefing surface and the F1c retrieval
+  composition agree.
+* ``limit`` caps the result count (default 5).
+* Cross-vault isolation: rows for one vault don't leak into another.
+* Optional ``context`` substring filter narrows on the third
+  ``procedure:<verb>:<context-tag>`` segment.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+
+from memex_common.config import GLOBAL_VAULT_ID
+from memex_core.services.kv import KVService
+from memex_core.services.outcomes import OutcomeService, compute_mw_score
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest_asyncio.fixture
+async def kv(metastore, filestore, memex_config) -> KVService:
+    return KVService(metastore=metastore, filestore=filestore, config=memex_config)
+
+
+@pytest.fixture
+def outcomes() -> OutcomeService:
+    return OutcomeService()
+
+
+async def _seed_outcome(
+    kv: KVService,
+    outcomes: OutcomeService,
+    key: str,
+    successes: int,
+    failures: int,
+    vault_id: UUID,
+) -> None:
+    await kv.put(key=key, value=f'body-of-{key}')
+    async with kv.metastore.session() as session:
+        for _ in range(successes):
+            await outcomes.record_outcome(
+                session=session,
+                target_type='kv_key',
+                kv_key=key,
+                success=True,
+                vault_id=str(vault_id),
+            )
+        for _ in range(failures):
+            await outcomes.record_outcome(
+                session=session,
+                target_type='kv_key',
+                kv_key=key,
+                success=False,
+                vault_id=str(vault_id),
+            )
+
+
+@pytest.mark.asyncio
+async def test_top_outcomes_ranked_by_mw_score_desc(
+    kv: KVService, outcomes: OutcomeService
+) -> None:
+    """Three keys with different success/failure mixes return in MW-score order."""
+    high = f'procedure:run_tests:high-{uuid4().hex[:6]}'
+    mid = f'procedure:run_tests:mid-{uuid4().hex[:6]}'
+    low = f'procedure:run_tests:low-{uuid4().hex[:6]}'
+
+    # high: 8/0 → mw = 9/10 = 0.9
+    # mid:  4/2 → mw = 5/8  = 0.625
+    # low:  1/4 → mw = 2/7  ≈ 0.286
+    await _seed_outcome(kv, outcomes, high, 8, 0, GLOBAL_VAULT_ID)
+    await _seed_outcome(kv, outcomes, mid, 4, 2, GLOBAL_VAULT_ID)
+    await _seed_outcome(kv, outcomes, low, 1, 4, GLOBAL_VAULT_ID)
+
+    rows = await kv.list_top_procedure_outcomes(vault_id=GLOBAL_VAULT_ID, limit=10)
+    assert len(rows) >= 3
+    # Drop any seeds from prior tests that happen to share GLOBAL_VAULT_ID.
+    by_key = {r['kv_key']: r for r in rows}
+    assert high in by_key and mid in by_key and low in by_key
+
+    # Locate them in the global ordering — they MUST appear in the high>mid>low
+    # relative order.
+    keys_in_order = [r['kv_key'] for r in rows]
+    pos_high = keys_in_order.index(high)
+    pos_mid = keys_in_order.index(mid)
+    pos_low = keys_in_order.index(low)
+    assert pos_high < pos_mid < pos_low, (
+        f'expected high<mid<low MW-score positions; got high={pos_high} '
+        f'mid={pos_mid} low={pos_low} in {keys_in_order}'
+    )
+
+    # MW score values must match compute_mw_score exactly (same Beta-Bernoulli
+    # formula in SQL as in Python — RFC v6.9 §3.4 / RFC-007 §155-185).
+    assert by_key[high]['mw_score'] == pytest.approx(compute_mw_score(8, 0))
+    assert by_key[mid]['mw_score'] == pytest.approx(compute_mw_score(4, 2))
+    assert by_key[low]['mw_score'] == pytest.approx(compute_mw_score(1, 4))
+
+
+@pytest.mark.asyncio
+async def test_top_outcomes_respects_limit_cap(kv: KVService, outcomes: OutcomeService) -> None:
+    """``limit`` parameter caps the result count."""
+    suffix = uuid4().hex[:6]
+    keys = [f'procedure:edit_yaml:limit{suffix}-{i}' for i in range(7)]
+    for i, k in enumerate(keys):
+        await _seed_outcome(kv, outcomes, k, i + 1, 0, GLOBAL_VAULT_ID)
+
+    rows = await kv.list_top_procedure_outcomes(vault_id=GLOBAL_VAULT_ID, limit=3)
+    matching = [r for r in rows if r['kv_key'].startswith(f'procedure:edit_yaml:limit{suffix}')]
+    # Even though we seeded 7, the limit=3 cap MUST take effect on the
+    # global ordering, so at most 3 of the 7 surface — and they must be the
+    # top 3 (i=4, 5, 6 successes).
+    assert len(rows) == 3
+    # The 3 returned must be the highest-MW from this batch (or higher-MW
+    # rows from older test seeds).
+    if matching:
+        # Among the matching ones, the top should be those with most successes.
+        ours = sorted((r for r in matching), key=lambda r: r['success_co_count'], reverse=True)
+        assert ours[0]['success_co_count'] >= ours[-1]['success_co_count']
+
+
+@pytest.mark.asyncio
+async def test_top_outcomes_cross_vault_isolation(
+    kv: KVService, outcomes: OutcomeService, metastore
+) -> None:
+    """Outcomes for one vault don't leak into another vault's listing."""
+    other_vault_id = uuid4()
+    from sqlalchemy import text as sql_text
+
+    async with metastore.session() as session:
+        await session.execute(
+            sql_text("INSERT INTO vaults (id, name, description) VALUES (:id, :name, '')"),
+            {'id': other_vault_id, 'name': f'v-{other_vault_id.hex[:8]}'},
+        )
+        await session.commit()
+
+    only_in_other = f'procedure:write_pr:other-{uuid4().hex[:6]}'
+    await _seed_outcome(kv, outcomes, only_in_other, 5, 0, other_vault_id)
+
+    global_rows = await kv.list_top_procedure_outcomes(vault_id=GLOBAL_VAULT_ID, limit=20)
+    keys = {r['kv_key'] for r in global_rows}
+    assert only_in_other not in keys, (
+        'a procedure scoped to another vault must not appear in GLOBAL_VAULT_ID listing'
+    )
+
+    other_rows = await kv.list_top_procedure_outcomes(vault_id=other_vault_id, limit=10)
+    other_keys = {r['kv_key'] for r in other_rows}
+    assert only_in_other in other_keys
+
+
+@pytest.mark.asyncio
+async def test_top_outcomes_context_filter_narrows_by_tag(
+    kv: KVService, outcomes: OutcomeService
+) -> None:
+    """``context`` substring filter narrows on the procedure key context-tag."""
+    suffix = uuid4().hex[:6]
+    matching_key = f'procedure:run_tests:python-monorepo-{suffix}'
+    other_key = f'procedure:run_tests:js-frontend-{suffix}'
+    await _seed_outcome(kv, outcomes, matching_key, 3, 0, GLOBAL_VAULT_ID)
+    await _seed_outcome(kv, outcomes, other_key, 3, 0, GLOBAL_VAULT_ID)
+
+    narrowed = await kv.list_top_procedure_outcomes(
+        vault_id=GLOBAL_VAULT_ID, context=f'python-monorepo-{suffix}', limit=5
+    )
+    keys = {r['kv_key'] for r in narrowed}
+    assert matching_key in keys
+    assert other_key not in keys
+
+
+@pytest.mark.asyncio
+async def test_top_outcomes_zero_limit_returns_empty_list(
+    kv: KVService,
+) -> None:
+    """``limit=0`` short-circuits to an empty list (no DB hit)."""
+    rows = await kv.list_top_procedure_outcomes(vault_id=GLOBAL_VAULT_ID, limit=0)
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_top_outcomes_invalid_vault_id_raises(kv: KVService) -> None:
+    """Invalid ``vault_id`` raises ``ValueError`` with a clear message."""
+    with pytest.raises(ValueError, match='Invalid vault_id'):
+        await kv.list_top_procedure_outcomes(vault_id='not-a-uuid', limit=5)

--- a/packages/core/tests/integration/test_int_f14_top_outcomes.py
+++ b/packages/core/tests/integration/test_int_f14_top_outcomes.py
@@ -49,6 +49,7 @@ async def _seed_outcome(
         for _ in range(successes):
             await outcomes.record_outcome(
                 session=session,
+                unit_ids=None,
                 target_type='kv_key',
                 kv_key=key,
                 success=True,
@@ -57,6 +58,7 @@ async def _seed_outcome(
         for _ in range(failures):
             await outcomes.record_outcome(
                 session=session,
+                unit_ids=None,
                 target_type='kv_key',
                 kv_key=key,
                 success=False,

--- a/packages/core/tests/integration/test_int_f38_outcomes_audit.py
+++ b/packages/core/tests/integration/test_int_f38_outcomes_audit.py
@@ -1,0 +1,144 @@
+"""F38 outcome audit hook (TC-F38-OUTCOMES-AUDIT).
+
+Per RFC-010, ``OutcomeService.record_outcome`` (memory_unit mode) must emit
+one ``AuditLog`` row per unit with ``action='outcome.record'``,
+``resource_type='memory_unit'``, ``resource_id=str(unit_id)``, and
+``details = {'vault_id': str(vault_id), 'outcome': 'success' | 'failure'}``.
+
+This is the diff hook ConsolidationService.select_diff_units reads from.
+Without it, F38's diff selection silently misses every newly-outcomed unit.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlmodel import select
+
+from memex_common.types import FactTypes
+from memex_core.memory.sql_models import (
+    AuditLog,
+    MemoryUnit,
+    Note,
+    Vault,
+)
+from memex_core.services.outcomes import OutcomeService
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_emits_audit_row(metastore):
+    outcomes = OutcomeService()
+
+    async with metastore.session() as session:
+        vault_id = uuid4()
+        note_id = uuid4()
+        unit_id = uuid4()
+        session.add(Vault(id=vault_id, name=f'v-{vault_id.hex[:8]}', description=''))
+        await session.commit()
+        session.add(
+            Note(
+                id=note_id,
+                vault_id=vault_id,
+                content_hash=f'h-{note_id.hex[:8]}',
+                original_text='seed',
+                filestore_path=None,
+                assets=[],
+            )
+        )
+        await session.commit()
+        session.add(
+            MemoryUnit(
+                id=unit_id,
+                note_id=note_id,
+                vault_id=vault_id,
+                text='seed unit',
+                fact_type=FactTypes.WORLD,
+                embedding=[0.1] * 384,
+                event_date=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+        await outcomes.record_outcome(
+            session=session,
+            unit_ids=[str(unit_id)],
+            success=True,
+            vault_id=str(vault_id),
+        )
+
+    async with metastore.session() as session:
+        rows = (
+            await session.exec(
+                select(AuditLog).where(
+                    AuditLog.action == 'outcome.record',
+                    AuditLog.resource_id == str(unit_id),
+                )
+            )
+        ).all()
+
+    assert len(rows) == 1, (
+        f'Expected exactly one outcome.record audit row for unit {unit_id}; '
+        f'got {len(rows)}. F38 select_diff_units relies on this hook.'
+    )
+    row = rows[0]
+    assert row.resource_type == 'memory_unit'
+    assert row.details == {'vault_id': str(vault_id), 'outcome': 'success'}
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_failure_audits_failure_label(metastore):
+    outcomes = OutcomeService()
+
+    async with metastore.session() as session:
+        vault_id = uuid4()
+        note_id = uuid4()
+        unit_id = uuid4()
+        session.add(Vault(id=vault_id, name=f'v-{vault_id.hex[:8]}', description=''))
+        await session.commit()
+        session.add(
+            Note(
+                id=note_id,
+                vault_id=vault_id,
+                content_hash=f'h-{note_id.hex[:8]}',
+                original_text='seed',
+                filestore_path=None,
+                assets=[],
+            )
+        )
+        await session.commit()
+        session.add(
+            MemoryUnit(
+                id=unit_id,
+                note_id=note_id,
+                vault_id=vault_id,
+                text='seed unit',
+                fact_type=FactTypes.WORLD,
+                embedding=[0.1] * 384,
+                event_date=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+        await outcomes.record_outcome(
+            session=session,
+            unit_ids=[str(unit_id)],
+            success=False,
+            vault_id=str(vault_id),
+        )
+
+    async with metastore.session() as session:
+        rows = (
+            await session.exec(
+                select(AuditLog).where(
+                    AuditLog.action == 'outcome.record',
+                    AuditLog.resource_id == str(unit_id),
+                )
+            )
+        ).all()
+
+    assert len(rows) == 1
+    assert rows[0].details['outcome'] == 'failure'

--- a/packages/core/tests/integration/test_int_f38_tick.py
+++ b/packages/core/tests/integration/test_int_f38_tick.py
@@ -1,0 +1,312 @@
+"""F38 ConsolidationService.tick() integration tests.
+
+Covers the AC-F38 invariants from RFC-010:
+- AC-F38-1 step ordering (contradiction → reflection → prune) via call-order spy
+- AC-F38-2 already-stale-only prune (assert F38 does NOT touch active units)
+- Tick-summary row written with per-step counts
+- Per-tick budget cap (oldest-first by AuditLog timestamp)
+- No-op tick on empty diff (empty unit_ids → empty entity_ids → no calls)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core.memory.sql_models import (
+    AuditLog,
+    ConsolidationTick,
+    ContentStatus,
+    MemoryUnit,
+    UnitEntity,
+    Entity,
+    Note,
+    Vault,
+)
+from memex_core.services.consolidation import ConsolidationService
+
+pytestmark = [pytest.mark.integration]
+
+
+async def _seed_vault(session: AsyncSession) -> UUID:
+    vault_id = uuid4()
+    session.add(Vault(id=vault_id, name=f'v-{vault_id.hex[:8]}', description=''))
+    await session.commit()
+    return vault_id
+
+
+async def _seed_note(session: AsyncSession, vault_id: UUID) -> UUID:
+    note_id = uuid4()
+    session.add(
+        Note(
+            id=note_id,
+            vault_id=vault_id,
+            content_hash=f'h-{note_id.hex[:8]}',
+            original_text='seed note for F38 tests',
+            filestore_path=None,
+            assets=[],
+        )
+    )
+    await session.commit()
+    return note_id
+
+
+async def _seed_unit_with_entity(
+    session: AsyncSession,
+    *,
+    vault_id: UUID,
+    note_id: UUID,
+    status: ContentStatus = ContentStatus.ACTIVE,
+) -> tuple[UUID, UUID]:
+    unit_id = uuid4()
+    entity_id = uuid4()
+    session.add(
+        MemoryUnit(
+            id=unit_id,
+            note_id=note_id,
+            vault_id=vault_id,
+            text='seeded fact',
+            fact_type=FactTypes.WORLD,
+            embedding=[0.1] * 384,
+            status=status,
+            event_date=datetime.now(timezone.utc),
+        )
+    )
+    session.add(Entity(id=entity_id, canonical_name=f'E-{entity_id.hex[:6]}'))
+    session.add(UnitEntity(unit_id=unit_id, entity_id=entity_id, vault_id=vault_id))
+    await session.commit()
+    return unit_id, entity_id
+
+
+async def _emit_outcome_audit(
+    session: AsyncSession,
+    *,
+    unit_id: UUID,
+    vault_id: UUID,
+    when: datetime | None = None,
+) -> None:
+    row = AuditLog(
+        action='outcome.record',
+        resource_type='memory_unit',
+        resource_id=str(unit_id),
+        details={'vault_id': str(vault_id), 'outcome': 'success'},
+    )
+    if when is not None:
+        row.timestamp = when
+    session.add(row)
+    await session.commit()
+
+
+def _make_service(metastore, *, contradiction_spy, reflection_spy, config) -> ConsolidationService:
+    refl = MagicMock()
+    refl.reflect_batch = reflection_spy
+    return ConsolidationService(
+        metastore=metastore,
+        config=config,
+        reflection=refl,
+        contradiction=contradiction_spy,
+    )
+
+
+@pytest.mark.asyncio
+async def test_runs_contradiction_then_reflection_then_prune(metastore, memex_config, session):
+    """AC-F38-1: tick() invokes contradiction BEFORE reflection BEFORE prune."""
+    vault_id = await _seed_vault(session)
+    note_id = await _seed_note(session, vault_id)
+    # One stale unit so prune is reachable.
+    unit_id, _entity_id = await _seed_unit_with_entity(
+        session, vault_id=vault_id, note_id=note_id, status=ContentStatus.STALE
+    )
+    await _emit_outcome_audit(session, unit_id=unit_id, vault_id=vault_id)
+
+    call_order: list[str] = []
+
+    async def _record_contradiction(**_kwargs):
+        call_order.append('contradiction')
+
+    async def _record_reflection(_requests):
+        call_order.append('reflection')
+        return []
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock(side_effect=_record_contradiction)
+    reflection_spy = AsyncMock(side_effect=_record_reflection)
+
+    # Patch prune_stale_evidence at the module-import location used by tick().
+    from memex_core.services import consolidation as cm
+
+    async def _record_prune(*_a, **_kw):
+        call_order.append('prune')
+        return set()
+
+    original = cm.prune_stale_evidence
+    cm.prune_stale_evidence = _record_prune  # type: ignore
+    try:
+        svc = _make_service(
+            metastore,
+            contradiction_spy=contradiction_spy,
+            reflection_spy=reflection_spy,
+            config=memex_config,
+        )
+        await svc.tick(vault_id)
+    finally:
+        cm.prune_stale_evidence = original  # type: ignore
+
+    assert call_order == ['contradiction', 'reflection', 'prune'], (
+        f'AC-F38-1 step ordering violated: got {call_order}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_does_not_prune_active_units(metastore, memex_config, session):
+    """AC-F38-2: tick() must NOT call prune_stale_evidence when no units are STALE."""
+    vault_id = await _seed_vault(session)
+    note_id = await _seed_note(session, vault_id)
+    unit_id, _entity_id = await _seed_unit_with_entity(
+        session, vault_id=vault_id, note_id=note_id, status=ContentStatus.ACTIVE
+    )
+    await _emit_outcome_audit(session, unit_id=unit_id, vault_id=vault_id)
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock()
+    reflection_spy = AsyncMock(return_value=[])
+
+    from memex_core.services import consolidation as cm
+
+    prune_calls = 0
+
+    async def _track_prune(*_a, **_kw):
+        nonlocal prune_calls
+        prune_calls += 1
+        return set()
+
+    original = cm.prune_stale_evidence
+    cm.prune_stale_evidence = _track_prune  # type: ignore
+    try:
+        svc = _make_service(
+            metastore,
+            contradiction_spy=contradiction_spy,
+            reflection_spy=reflection_spy,
+            config=memex_config,
+        )
+        result = await svc.tick(vault_id)
+    finally:
+        cm.prune_stale_evidence = original  # type: ignore
+
+    assert prune_calls == 0, 'F38 must NOT prune ACTIVE units (AC-F38-2 invariant)'
+    assert result['stale_pruned'] == 0
+
+
+@pytest.mark.asyncio
+async def test_tick_summary_row_written_with_counts(metastore, memex_config, session):
+    """Tick summary row carries per-step counts and a non-null completed_at."""
+    vault_id = await _seed_vault(session)
+    note_id = await _seed_note(session, vault_id)
+    unit_id, _ = await _seed_unit_with_entity(
+        session, vault_id=vault_id, note_id=note_id, status=ContentStatus.STALE
+    )
+    await _emit_outcome_audit(session, unit_id=unit_id, vault_id=vault_id)
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock()
+    reflection_spy = AsyncMock(return_value=[])
+
+    from memex_core.services import consolidation as cm
+
+    async def _noop_prune(*_a, **_kw):
+        return set()
+
+    original = cm.prune_stale_evidence
+    cm.prune_stale_evidence = _noop_prune  # type: ignore
+    try:
+        svc = _make_service(
+            metastore,
+            contradiction_spy=contradiction_spy,
+            reflection_spy=reflection_spy,
+            config=memex_config,
+        )
+        result = await svc.tick(vault_id)
+    finally:
+        cm.prune_stale_evidence = original  # type: ignore
+
+    async with metastore.session() as s:
+        rows = (
+            await s.exec(select(ConsolidationTick).where(ConsolidationTick.vault_id == vault_id))
+        ).all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.completed_at is not None, 'completed_at NULL means in-progress; tick() must stamp it'
+    assert row.units_processed == 1
+    assert row.entities_reflected == 1
+    assert row.contradictions_run == 1
+    assert row.stale_pruned == 1
+    assert row.error is None
+    assert result['tick_id'] == str(row.id)
+
+
+@pytest.mark.asyncio
+async def test_no_op_tick_on_empty_diff(metastore, memex_config, session):
+    """An empty diff still writes a tick row (with zero counts) and skips all calls."""
+    vault_id = await _seed_vault(session)
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock()
+    reflection_spy = AsyncMock(return_value=[])
+
+    svc = _make_service(
+        metastore,
+        contradiction_spy=contradiction_spy,
+        reflection_spy=reflection_spy,
+        config=memex_config,
+    )
+    result = await svc.tick(vault_id)
+
+    contradiction_spy.detect_contradictions.assert_not_called()
+    reflection_spy.assert_not_called()
+    assert result['units_processed'] == 0
+    assert result['entities_reflected'] == 0
+    assert result['contradictions_run'] == 0
+
+
+@pytest.mark.asyncio
+async def test_500_unit_cap_oldest_first(metastore, memex_config, session):
+    """Per-tick budget caps at 500 units; oldest-first by AuditLog.timestamp."""
+    vault_id = await _seed_vault(session)
+    note_id = await _seed_note(session, vault_id)
+
+    base = datetime.now(timezone.utc) - timedelta(days=1)
+    seeded_ids: list[UUID] = []
+    for i in range(7):
+        uid, _ = await _seed_unit_with_entity(
+            session, vault_id=vault_id, note_id=note_id, status=ContentStatus.ACTIVE
+        )
+        seeded_ids.append(uid)
+        await _emit_outcome_audit(
+            session,
+            unit_id=uid,
+            vault_id=vault_id,
+            when=base + timedelta(seconds=i),
+        )
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock()
+    reflection_spy = AsyncMock(return_value=[])
+
+    svc = _make_service(
+        metastore,
+        contradiction_spy=contradiction_spy,
+        reflection_spy=reflection_spy,
+        config=memex_config,
+    )
+    # Budget = 3; expect the 3 oldest (seeded_ids[0..2]).
+    async with metastore.session() as s:
+        selected = await svc.select_diff_units(s, vault_id, last_tick_timestamp=None, budget=3)
+    assert selected == seeded_ids[:3], (
+        f'Expected oldest-3 ordering; got {selected} vs {seeded_ids[:3]}'
+    )

--- a/packages/core/tests/integration/test_int_f38_tick.py
+++ b/packages/core/tests/integration/test_int_f38_tick.py
@@ -6,6 +6,7 @@ Covers the AC-F38 invariants from RFC-010:
 - Tick-summary row written with per-step counts
 - Per-tick budget cap (oldest-first by AuditLog timestamp)
 - No-op tick on empty diff (empty unit_ids → empty entity_ids → no calls)
+- MEDIUM-1 LIMIT regression: budget enforced via SQL ``LIMIT``, not Python slice
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
 import pytest
+from sqlalchemy import event
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -309,4 +311,80 @@ async def test_500_unit_cap_oldest_first(metastore, memex_config, session):
         selected = await svc.select_diff_units(s, vault_id, last_tick_timestamp=None, budget=3)
     assert selected == seeded_ids[:3], (
         f'Expected oldest-3 ordering; got {selected} vs {seeded_ids[:3]}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_diff_units_pushes_limit_into_sql(metastore, session):
+    """MEDIUM-1 regression: budget is enforced by SQL ``LIMIT``, not Python slice.
+
+    Hooks ``before_cursor_execute`` on the underlying sync engine, runs
+    ``select_diff_units`` against a vault with more rows than the budget,
+    and asserts the issued SQL contains ``LIMIT <budget>``. Without the
+    LIMIT push-down, the query materialises every matching audit row into
+    memory before the Python-side slice — a ~50ms vs ~5s difference under
+    realistic prod traffic with a 24h gap.
+    """
+    vault_id = await _seed_vault(session)
+    note_id = await _seed_note(session, vault_id)
+
+    base = datetime.now(timezone.utc) - timedelta(hours=1)
+    seeded_ids: list[UUID] = []
+    for i in range(10):
+        uid, _ = await _seed_unit_with_entity(
+            session, vault_id=vault_id, note_id=note_id, status=ContentStatus.ACTIVE
+        )
+        seeded_ids.append(uid)
+        await _emit_outcome_audit(
+            session, unit_id=uid, vault_id=vault_id, when=base + timedelta(seconds=i)
+        )
+
+    captured_sql: list[str] = []
+
+    def _capture(_conn, _cursor, statement, _parameters, _context, _executemany):
+        captured_sql.append(statement)
+
+    contradiction_spy = MagicMock()
+    contradiction_spy.detect_contradictions = AsyncMock()
+    reflection_spy = AsyncMock(return_value=[])
+
+    from memex_common.config import MemexConfig
+
+    svc = _make_service(
+        metastore,
+        contradiction_spy=contradiction_spy,
+        reflection_spy=reflection_spy,
+        config=MemexConfig(),
+    )
+
+    budget = 5
+    async with metastore.session() as s:
+        sync_engine = s.bind.sync_engine  # type: ignore[union-attr]
+        event.listen(sync_engine, 'before_cursor_execute', _capture)
+        try:
+            selected = await svc.select_diff_units(
+                s, vault_id, last_tick_timestamp=None, budget=budget
+            )
+        finally:
+            event.remove(sync_engine, 'before_cursor_execute', _capture)
+
+    # Behavioural: result is exactly the oldest `budget` units, not all 10.
+    assert len(selected) == budget
+    assert selected == seeded_ids[:budget]
+
+    # SQL surface: a statement containing both audit_logs + LIMIT was issued
+    # with the budget value bound. asyncpg renders LIMIT as `LIMIT $N::INTEGER`,
+    # so the literal isn't in the statement string — assert the LIMIT clause
+    # is present and that no statement scanned audit_logs without one.
+    audit_select_stmts = [s for s in captured_sql if 'audit_logs' in s.lower()]
+    assert audit_select_stmts, 'Expected at least one SELECT against audit_logs'
+    select_stmts_with_limit = [s for s in audit_select_stmts if 'limit' in s.lower()]
+    assert select_stmts_with_limit, (
+        'AC: select_diff_units must push LIMIT into SQL, but no audit_logs '
+        f'SELECT contained a LIMIT clause. Captured: {audit_select_stmts}'
+    )
+    select_stmts_without_limit = [s for s in audit_select_stmts if 'limit' not in s.lower()]
+    assert not select_stmts_without_limit, (
+        'AC: a SELECT against audit_logs ran WITHOUT a LIMIT clause — would '
+        f'materialise every matching row into memory. Found: {select_stmts_without_limit}'
     )

--- a/packages/core/tests/integration/test_int_f6_rules.py
+++ b/packages/core/tests/integration/test_int_f6_rules.py
@@ -1,0 +1,508 @@
+"""F6 — LintService rule fire/silent matrix (TC-20-2).
+
+Covers each v1 rule with a positive (fires) case and a negative (silent) case.
+The governance rule (AC-F6-G1) ships a 5-case parametrized predicate-violation
+canary, each paired with a positive control in the same fixture so that a
+silent assertion proves the SQL filter is working — not the fixture being
+empty.
+
+Rules under test:
+
+  * orphan_mental_model        (structural)
+  * cold_low_mw_unit           (quality)
+  * sensitive_unreviewed_unit  (governance, AC-F6-G1)
+  * dangling_entity_ref_in_unit (schema)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core.memory.sql_models import (
+    AuditLog,
+    Entity,
+    MemoryUnit,
+    MentalModel,
+    Note,
+    UnitEntity,
+    Vault,
+)
+
+
+pytestmark = [pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_vault(session: AsyncSession, suffix: str | None = None) -> Vault:
+    suffix = suffix or uuid4().hex[:8]
+    vault = Vault(name=f'F6-{suffix}', description='F6 lint rule test')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+    return vault
+
+
+async def _make_note(session: AsyncSession, vault_id: UUID) -> Note:
+    note = Note(
+        id=uuid4(),
+        vault_id=vault_id,
+        content_hash=f'hash-{uuid4().hex[:8]}',
+        original_text='seed note',
+    )
+    session.add(note)
+    await session.commit()
+    return note
+
+
+async def _make_unit(
+    session: AsyncSession,
+    *,
+    vault_id: UUID,
+    note_id: UUID,
+    status: str = 'active',
+    is_deprioritized: bool = False,
+    risk_class: str = 'none',
+    success_co_count: int = 0,
+    failure_co_count: int = 0,
+    intent_class: str = 'durable',
+    text_value: str = 'unit text',
+) -> MemoryUnit:
+    unit = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault_id,
+        note_id=note_id,
+        text=text_value,
+        fact_type=FactTypes.WORLD,
+        status=status,
+        is_deprioritized=is_deprioritized,
+        risk_class=risk_class,
+        intent_class=intent_class,
+        success_co_count=success_co_count,
+        failure_co_count=failure_co_count,
+        event_date=datetime.now(timezone.utc),
+        embedding=[0.1] * 384,
+    )
+    session.add(unit)
+    await session.commit()
+    return unit
+
+
+async def _backdate_unit_updated_at(session: AsyncSession, unit_id: UUID, days_ago: int) -> None:
+    """Force MemoryUnit.updated_at into the past.
+
+    `updated_at` has onupdate=now(), so a raw SQL UPDATE is required to set it
+    deterministically.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    await session.execute(
+        text('UPDATE memory_units SET updated_at = :ts WHERE id = :id'),
+        {'ts': cutoff, 'id': str(unit_id)},
+    )
+    await session.commit()
+
+
+async def _make_entity(session: AsyncSession, name: str | None = None) -> Entity:
+    ent = Entity(canonical_name=name or f'Entity-{uuid4().hex[:8]}')
+    session.add(ent)
+    await session.commit()
+    await session.refresh(ent)
+    return ent
+
+
+async def _make_mental_model(
+    session: AsyncSession,
+    *,
+    vault_id: UUID,
+    entity_id: UUID,
+    name: str,
+    last_refreshed_days_ago: int = 0,
+) -> MentalModel:
+    mm = MentalModel(
+        id=uuid4(),
+        vault_id=vault_id,
+        entity_id=entity_id,
+        name=name,
+        observations=[],
+        last_refreshed=datetime.now(timezone.utc),
+    )
+    session.add(mm)
+    await session.commit()
+
+    if last_refreshed_days_ago > 0:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=last_refreshed_days_ago)
+        await session.execute(
+            text('UPDATE mental_models SET last_refreshed = :ts WHERE id = :id'),
+            {'ts': cutoff, 'id': str(mm.id)},
+        )
+        await session.commit()
+    return mm
+
+
+async def _link_unit_entity(
+    session: AsyncSession,
+    *,
+    unit_id: UUID,
+    entity_id: UUID,
+    vault_id: UUID,
+) -> None:
+    ue = UnitEntity(unit_id=unit_id, entity_id=entity_id, vault_id=vault_id)
+    session.add(ue)
+    await session.commit()
+
+
+async def _make_audit_review(session: AsyncSession, *, unit_id: UUID, days_ago: int) -> None:
+    """Insert an audit_logs row marking unit as reviewed N days ago."""
+    when = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    al = AuditLog(
+        action='memory_review',
+        resource_type='memory_unit',
+        resource_id=str(unit_id),
+        timestamp=when,
+    )
+    session.add(al)
+    await session.commit()
+    # AuditLog timestamp has server_default=now(), so re-stamp via UPDATE.
+    await session.execute(
+        text('UPDATE audit_logs SET timestamp = :ts WHERE id = :id'),
+        {'ts': when, 'id': str(al.id)},
+    )
+    await session.commit()
+
+
+async def _findings_for_rule(
+    session: AsyncSession, rule_name: str, vault_id: UUID
+) -> list[dict[str, Any]]:
+    rows = await session.execute(
+        text(
+            'SELECT id::text, target_id, evidence::text AS evidence, status '
+            'FROM maintenance_proposals '
+            'WHERE rule_name = :r AND vault_id = :v'
+        ),
+        {'r': rule_name, 'v': str(vault_id)},
+    )
+    return [dict(row) for row in rows.mappings().all()]
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — orphan_mental_model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orphan_mental_model_fires_on_old_empty_mm(session: AsyncSession, api) -> None:
+    """Mental model >30 days old with no active linked units → finding fires."""
+    vault = await _make_vault(session)
+    ent = await _make_entity(session, 'Orphaned Concept')
+    mm = await _make_mental_model(
+        session,
+        vault_id=vault.id,
+        entity_id=ent.id,
+        name=ent.canonical_name,
+        last_refreshed_days_ago=45,
+    )
+
+    summary = await api.lint.run_rules(vault.id)
+
+    rule_results = {r.rule_name: r for r in summary.rules}
+    assert rule_results['orphan_mental_model'].findings_emitted == 1
+
+    findings = await _findings_for_rule(session, 'orphan_mental_model', vault.id)
+    assert len(findings) == 1
+    assert findings[0]['target_id'] == str(mm.id)
+    assert findings[0]['status'] == 'pending'
+
+
+@pytest.mark.asyncio
+async def test_orphan_mental_model_silent_on_clean(session: AsyncSession, api) -> None:
+    """Recent MM with one active linked unit → no finding."""
+    vault = await _make_vault(session)
+    note = await _make_note(session, vault.id)
+    ent = await _make_entity(session)
+    unit = await _make_unit(session, vault_id=vault.id, note_id=note.id)
+    await _link_unit_entity(session, unit_id=unit.id, entity_id=ent.id, vault_id=vault.id)
+    await _make_mental_model(
+        session,
+        vault_id=vault.id,
+        entity_id=ent.id,
+        name=ent.canonical_name,
+        last_refreshed_days_ago=45,
+    )
+
+    await api.lint.run_rules(vault.id)
+    findings = await _findings_for_rule(session, 'orphan_mental_model', vault.id)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — cold_low_mw_unit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cold_low_mw_unit_fires_on_30d_no_outcomes_low_mw(session: AsyncSession, api) -> None:
+    """Active unit with 5+ outcomes, MW < 0.3, idle 30+d → finding fires."""
+    vault = await _make_vault(session)
+    note = await _make_note(session, vault.id)
+    # MW = (1+1)/(1+5+2) = 0.25 < 0.3, total = 6 ≥ 5
+    unit = await _make_unit(
+        session,
+        vault_id=vault.id,
+        note_id=note.id,
+        success_co_count=1,
+        failure_co_count=5,
+    )
+    await _backdate_unit_updated_at(session, unit.id, days_ago=45)
+
+    summary = await api.lint.run_rules(vault.id)
+    rule_results = {r.rule_name: r for r in summary.rules}
+    assert rule_results['cold_low_mw_unit'].findings_emitted == 1
+
+    findings = await _findings_for_rule(session, 'cold_low_mw_unit', vault.id)
+    assert len(findings) == 1
+    assert findings[0]['target_id'] == str(unit.id)
+
+
+@pytest.mark.asyncio
+async def test_cold_low_mw_unit_silent_on_clean(session: AsyncSession, api) -> None:
+    """High-MW unit, fresh unit, deprioritized unit, and stale unit are all silent."""
+    vault = await _make_vault(session)
+    note = await _make_note(session, vault.id)
+    # High MW
+    high_mw = await _make_unit(
+        session,
+        vault_id=vault.id,
+        note_id=note.id,
+        success_co_count=8,
+        failure_co_count=1,  # MW = 9/11 ≈ 0.82
+    )
+    await _backdate_unit_updated_at(session, high_mw.id, days_ago=45)
+    # Fresh (low MW, but updated_at recent)
+    await _make_unit(
+        session,
+        vault_id=vault.id,
+        note_id=note.id,
+        success_co_count=0,
+        failure_co_count=6,  # MW = 1/8 = 0.125
+    )
+    # Deprioritized — already-flagged unit, should NOT re-fire
+    depri = await _make_unit(
+        session,
+        vault_id=vault.id,
+        note_id=note.id,
+        success_co_count=1,
+        failure_co_count=5,
+        is_deprioritized=True,
+    )
+    await _backdate_unit_updated_at(session, depri.id, days_ago=45)
+    # Below threshold: only 4 outcomes total
+    few = await _make_unit(
+        session,
+        vault_id=vault.id,
+        note_id=note.id,
+        success_co_count=0,
+        failure_co_count=4,
+    )
+    await _backdate_unit_updated_at(session, few.id, days_ago=45)
+
+    await api.lint.run_rules(vault.id)
+    findings = await _findings_for_rule(session, 'cold_low_mw_unit', vault.id)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — sensitive_unreviewed_unit (governance / AC-F6-G1 canary)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sensitive_unreviewed_unit_fires_on_low_mw_sensitive_unit(
+    session: AsyncSession, api
+) -> None:
+    """Active+sensitive+not-deprioritized+no recent review → finding fires."""
+    vault = await _make_vault(session)
+    note = await _make_note(session, vault.id)
+    unit = await _make_unit(
+        session,
+        vault_id=vault.id,
+        note_id=note.id,
+        risk_class='sensitive',
+    )
+
+    summary = await api.lint.run_rules(vault.id)
+    rule_results = {r.rule_name: r for r in summary.rules}
+    assert rule_results['sensitive_unreviewed_unit'].findings_emitted == 1
+
+    findings = await _findings_for_rule(session, 'sensitive_unreviewed_unit', vault.id)
+    assert len(findings) == 1
+    assert findings[0]['target_id'] == str(unit.id)
+
+
+# AC-F6-G1 parametrized canary: 5 ways the governance rule MUST stay silent.
+# Each case seeds a positive control in the same fixture (unit_pos) — a
+# sensitive unit that DOES meet every predicate — to prove the SQL is
+# filtering, not the fixture being empty.
+_GOVERNANCE_SILENT_CASES = [
+    'risk_class_none',
+    'is_deprioritized_true',
+    'mw_score_above_threshold',  # rule has no MW gate but listed for parity
+    'recently_reviewed',
+    'status_stale',
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('predicate', _GOVERNANCE_SILENT_CASES)
+async def test_sensitive_unreviewed_unit_silent_when(
+    session: AsyncSession, api, predicate: str
+) -> None:
+    """Each of the 5 predicate-violations must NOT fire — but the positive
+    control in the same vault MUST fire, proving the SQL filter is working."""
+    vault = await _make_vault(session, suffix=f'gov-{predicate}')
+    note = await _make_note(session, vault.id)
+
+    # Positive control — meets every predicate, MUST fire
+    unit_pos = await _make_unit(
+        session,
+        vault_id=vault.id,
+        note_id=note.id,
+        risk_class='sensitive',
+    )
+
+    # Negative — violates exactly one predicate
+    if predicate == 'risk_class_none':
+        unit_neg = await _make_unit(
+            session,
+            vault_id=vault.id,
+            note_id=note.id,
+            risk_class='none',
+        )
+    elif predicate == 'is_deprioritized_true':
+        unit_neg = await _make_unit(
+            session,
+            vault_id=vault.id,
+            note_id=note.id,
+            risk_class='sensitive',
+            is_deprioritized=True,
+        )
+    elif predicate == 'mw_score_above_threshold':
+        # Rule has no MW gate; even very high MW shouldn't matter — this case
+        # documents the absence of an MW interaction. Sensitive + healthy MW
+        # → still fires (so unit_neg is itself a *fires* case).
+        unit_neg = await _make_unit(
+            session,
+            vault_id=vault.id,
+            note_id=note.id,
+            risk_class='sensitive',
+            success_co_count=20,
+            failure_co_count=0,
+        )
+    elif predicate == 'recently_reviewed':
+        unit_neg = await _make_unit(
+            session,
+            vault_id=vault.id,
+            note_id=note.id,
+            risk_class='sensitive',
+        )
+        await _make_audit_review(session, unit_id=unit_neg.id, days_ago=5)
+    elif predicate == 'status_stale':
+        unit_neg = await _make_unit(
+            session,
+            vault_id=vault.id,
+            note_id=note.id,
+            risk_class='sensitive',
+            status='stale',
+        )
+    else:
+        raise AssertionError(f'unhandled predicate: {predicate}')
+
+    await api.lint.run_rules(vault.id)
+    findings = await _findings_for_rule(session, 'sensitive_unreviewed_unit', vault.id)
+    target_ids = {f['target_id'] for f in findings}
+
+    assert str(unit_pos.id) in target_ids, (
+        f'positive control should fire for predicate={predicate} but did not — '
+        'fixture/control may be broken'
+    )
+
+    if predicate == 'mw_score_above_threshold':
+        # Documented: rule has no MW gate, so a healthy-MW sensitive unit DOES
+        # fire. Verify presence to lock in the absence of an MW interaction.
+        assert str(unit_neg.id) in target_ids
+    else:
+        assert str(unit_neg.id) not in target_ids, (
+            f'predicate={predicate} should keep the negative case silent, '
+            f'but {unit_neg.id} appeared in findings'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 — dangling_entity_ref_in_unit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dangling_entity_ref_in_unit_fires_on_orphaned_unit_entity(
+    session: AsyncSession, api
+) -> None:
+    """unit_entities row whose entity_id no longer resolves → finding fires."""
+    vault = await _make_vault(session)
+    note = await _make_note(session, vault.id)
+    unit = await _make_unit(session, vault_id=vault.id, note_id=note.id)
+
+    # Insert a unit_entity pointing at a non-existent entity. We bypass the
+    # ORM relationship to avoid the FK insert path, then drop the FK
+    # constraint check by inserting via raw SQL with a synthetic UUID.
+    # The unit_entities table has FK ondelete=CASCADE on entities.id; we
+    # cannot insert a dangling row directly. Instead we create an entity,
+    # link it, then DELETE the entity using a raw query that bypasses the
+    # cascade (we suspend the FK).
+    ent = await _make_entity(session)
+    await _link_unit_entity(session, unit_id=unit.id, entity_id=ent.id, vault_id=vault.id)
+    # Drop FK temporarily to leave the ue row dangling.
+    await session.execute(
+        text('ALTER TABLE unit_entities DROP CONSTRAINT unit_entities_entity_id_fkey')
+    )
+    await session.execute(text('DELETE FROM entities WHERE id = :id'), {'id': str(ent.id)})
+    await session.commit()
+    # Restore FK without validation so future inserts still work.
+    await session.execute(
+        text(
+            'ALTER TABLE unit_entities ADD CONSTRAINT unit_entities_entity_id_fkey '
+            'FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE '
+            'NOT VALID'
+        )
+    )
+    await session.commit()
+
+    summary = await api.lint.run_rules(vault.id)
+    rule_results = {r.rule_name: r for r in summary.rules}
+    assert rule_results['dangling_entity_ref_in_unit'].findings_emitted == 1
+
+    findings = await _findings_for_rule(session, 'dangling_entity_ref_in_unit', vault.id)
+    assert len(findings) == 1
+    assert findings[0]['target_id'] == str(unit.id)
+
+
+@pytest.mark.asyncio
+async def test_dangling_entity_ref_in_unit_silent_on_clean(session: AsyncSession, api) -> None:
+    """Healthy unit-entity link → no finding."""
+    vault = await _make_vault(session)
+    note = await _make_note(session, vault.id)
+    unit = await _make_unit(session, vault_id=vault.id, note_id=note.id)
+    ent = await _make_entity(session)
+    await _link_unit_entity(session, unit_id=unit.id, entity_id=ent.id, vault_id=vault.id)
+
+    await api.lint.run_rules(vault.id)
+    findings = await _findings_for_rule(session, 'dangling_entity_ref_in_unit', vault.id)
+    assert findings == []

--- a/packages/core/tests/unit/services/test_kv_validator.py
+++ b/packages/core/tests/unit/services/test_kv_validator.py
@@ -1,0 +1,57 @@
+"""Unit tests for F14 ``validate_procedure_key`` (TC-F14-1).
+
+Locks the strict ``procedure:<verb>:<context-tag>`` format against
+regression. Per RFC-007 §53-61: regex ``^procedure:[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$``,
+underscores ARE allowed (RFC-007 is canonical; an earlier RFC-012 sketch
+without underscore was superseded).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memex_core.services.kv import VALID_NAMESPACES, validate_procedure_key
+
+
+def test_valid_namespaces_includes_procedure():
+    """``procedure`` is part of the canonical namespace tuple."""
+    assert 'procedure' in VALID_NAMESPACES
+
+
+@pytest.mark.parametrize(
+    'valid_key',
+    [
+        'procedure:write_pr:commit-style',
+        'procedure:run_tests:python-monorepo',
+        'procedure:edit_yaml:ci-config',
+        'procedure:add-note:vault-binding',
+        'procedure:reflect_on:f5-debug',
+    ],
+)
+def test_validate_procedure_key_accepts_valid(valid_key: str) -> None:
+    """RFC-007 §53-61 valid examples (underscores + hyphens, lowercase only)."""
+    validate_procedure_key(valid_key)  # must not raise
+
+
+@pytest.mark.parametrize(
+    'malformed_key',
+    [
+        'foo:bar:baz',  # missing 'procedure:' prefix
+        'procedure:verb',  # missing context-tag
+        'procedure:verb:',  # trailing-colon empty context-tag
+        'procedure::tag',  # empty verb
+        'procedure:Verb:tag',  # uppercase verb
+        'procedure:verb:Tag',  # uppercase context-tag
+        'procedure:verb:tag with space',  # whitespace (regex char class disallows)
+        'procedure:-verb:tag',  # leading hyphen on verb (anchor [a-z])
+        'procedure:verb:-tag',  # leading hyphen on context-tag (anchor [a-z])
+        'procedure:verb:tag:extra',  # triple-segment
+        '',  # empty string
+        'procedure:',  # single-colon
+        'procedure:verb:9tag',  # leading digit on context-tag (anchor [a-z])
+    ],
+)
+def test_validate_procedure_key_rejects_malformed(malformed_key: str) -> None:
+    """RFC-007 §53-61 invalid examples — must raise ValueError."""
+    with pytest.raises(ValueError, match='Invalid procedure key'):
+        validate_procedure_key(malformed_key)

--- a/packages/core/tests/unit/test_consolidation_writes.py
+++ b/packages/core/tests/unit/test_consolidation_writes.py
@@ -1,0 +1,61 @@
+"""AC-F38-4 — `services/consolidation.py` is a thin orchestrator.
+
+Per RFC-010 §"Module-write audit", the consolidation module's only direct
+DB write is the ``ConsolidationTick`` summary row. All other side-effects
+are delegated to ReflectionService / ContradictionEngine / prune_stale_evidence.
+
+This test inspects the module source for ``session.add(...)`` and ``session.execute(insert(...))``
+references and asserts the only target is ``ConsolidationTick``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+from memex_core.services import consolidation
+
+
+_SOURCE = inspect.getsource(consolidation)
+
+
+def test_only_tick_summary_is_direct_session_add():
+    """Every ``session.add`` call must add a ``ConsolidationTick``-typed row."""
+    add_sites = re.findall(r'session\.add\(\s*(\w+)\s*\)', _SOURCE)
+    assert add_sites, 'expected at least one session.add — the tick-summary write'
+    # Each variable name passed to session.add must be assigned a
+    # ``ConsolidationTick(...)`` constructor in the same source file.
+    for varname in set(add_sites):
+        pattern = re.compile(rf'\b{re.escape(varname)}\s*=\s*ConsolidationTick\s*\(', re.MULTILINE)
+        assert pattern.search(_SOURCE), (
+            f'AC-F38-4 violation: session.add({varname}) but {varname} is not '
+            f'assigned a ConsolidationTick row in services/consolidation.py.'
+        )
+
+
+def test_no_direct_inserts_other_than_tick():
+    direct_inserts = re.findall(r'insert\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)', _SOURCE)
+    bad = [x for x in direct_inserts if x != 'ConsolidationTick']
+    assert not bad, f'AC-F38-4 violation: direct inserts to {bad}'
+
+
+def test_step_ordering_contradiction_before_reflection_in_source():
+    """Source-level guard: contradiction.detect_contradictions occurs before
+    reflection.reflect_batch in tick(). Defends against accidental reordering."""
+    contradiction_idx = _SOURCE.find('detect_contradictions(')
+    reflection_idx = _SOURCE.find('reflect_batch(')
+    prune_idx = _SOURCE.find('prune_stale_evidence(')
+    assert contradiction_idx > 0 and reflection_idx > 0 and prune_idx > 0
+    assert contradiction_idx < reflection_idx, (
+        'Step ordering violation: contradiction must run BEFORE reflection in tick().'
+    )
+    assert reflection_idx < prune_idx, (
+        'Step ordering violation: reflection must run BEFORE prune in tick().'
+    )
+
+
+def test_prune_only_on_already_stale_check_present():
+    """Source-level guard: tick() filters to ContentStatus.STALE before prune."""
+    assert 'ContentStatus.STALE' in _SOURCE, (
+        'AC-F38-2 violation: tick() must filter to ContentStatus.STALE before prune.'
+    )

--- a/packages/core/tests/unit/test_f38_no_agent_surface.py
+++ b/packages/core/tests/unit/test_f38_no_agent_surface.py
@@ -1,0 +1,137 @@
+"""TC-F38-6 — F38 ships NO agent-callable surface (AC-F38-5 invariant).
+
+RFC-010 §"No agent-facing surface (AC-F38-5)": F38 is operator-facing only
+(scheduler + CLI). It must NEVER expose:
+
+* an MCP tool (would let an agent trigger consolidation or prune)
+* a Hermes plugin schema (same risk via the Hermes provider)
+* a Claude Code SKILL.md mention (same risk via the plugin)
+
+This test locks the invariant against future drift. If a later PR
+accidentally registers a `memex_consolidate` MCP verb or adds a
+`MEMORY_CONSOLIDATE_SCHEMA` to Hermes' ALL_SCHEMAS, this test trips
+before merge.
+
+Plus AC-X-10 boot-discovery canary: the MCP tag taxonomy + tool count
+remains unchanged because F38 ships zero MCP tools.
+"""
+
+from __future__ import annotations
+
+import pathlib as plb
+
+import pytest
+
+
+_FORBIDDEN_AGENT_NAMES = {
+    'memex_consolidate',
+    'memex_consolidation_tick',
+    'memex_consolidation_status',
+    'memex_get_consolidation_status',
+    'memex_prune_stale_evidence',
+    'memex_prune',
+}
+
+
+# ---------------------------------------------------------------------------
+# AC-F38-5 invariant — three surface boundaries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f38_no_mcp_tool() -> None:
+    """No F38 MCP verb is registered (the agent surface)."""
+    from memex_mcp.server import mcp
+
+    tools = await mcp._list_tools()
+    names = {t.name for t in tools}
+    intersect = names & _FORBIDDEN_AGENT_NAMES
+    assert not intersect, (
+        f'AC-F38-5 violation: F38 must NOT expose MCP tools, but found: {sorted(intersect)}'
+    )
+
+
+def test_f38_no_hermes_schema() -> None:
+    """No F38 verb is mentioned in the Hermes plugin's tools.py module.
+
+    Source-level check: the Hermes runtime's :mod:`tools.registry` is not
+    available in the dev venv, so we can't import the module to inspect
+    ALL_SCHEMAS at runtime. Reading the source covers the same surface —
+    a schema with name='memex_consolidate' would have to land somewhere in
+    this file as a string literal, and adding it would trip this test.
+    """
+    tools_path = (
+        plb.Path(__file__).resolve().parents[3]
+        / 'hermes-plugin'
+        / 'src'
+        / 'memex_hermes_plugin'
+        / 'memex'
+        / 'tools.py'
+    )
+    source = tools_path.read_text()
+    found = sorted(name for name in _FORBIDDEN_AGENT_NAMES if name in source)
+    assert not found, f'AC-F38-5 violation: F38 verb appears in Hermes tools.py: {found}'
+
+
+def test_f38_no_claude_code_skill_mention() -> None:
+    """No F38 verb is mentioned in the Claude Code plugin's SKILL.md files."""
+    plugin_root = plb.Path(__file__).resolve().parents[3] / 'claude-code-plugin' / 'skills'
+    skill_dirs = ('remember', 'recall', 'retro')
+    found_in: dict[str, list[str]] = {}
+    for skill in skill_dirs:
+        path = plugin_root / skill / 'SKILL.md'
+        if not path.exists():
+            continue
+        text = path.read_text()
+        hits = sorted(name for name in _FORBIDDEN_AGENT_NAMES if name in text)
+        if hits:
+            found_in[skill] = hits
+    assert not found_in, f'AC-F38-5 violation: F38 verb mentioned in Claude Code skills: {found_in}'
+
+
+# ---------------------------------------------------------------------------
+# AC-X-10 boot-discovery canary — MCP tag taxonomy + tool count unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_f38_does_not_add_mcp_tag() -> None:
+    """F38 must not add a new tag to the MCP tag taxonomy.
+
+    The :mod:`memex_mcp` discovery layer treats the tag set as load-bearing
+    surface area. F38 ships no MCP tool → no new tag. If a future change
+    adds a 'consolidation' tag, the existing
+    ``test_discovery_mode.py::test_tag_taxonomy`` trips — this test makes
+    the invariant explicit at the F38 boundary instead of relying on the
+    other suite to fail first.
+    """
+    from memex_mcp.server import mcp
+
+    # Mirrors EXPECTED_TAGS in packages/mcp/tests/test_discovery_mode.py.
+    # Kept inline because mcp/tests is not an importable package.
+    expected_tags = {
+        'search',
+        'read',
+        'write',
+        'browse',
+        'entities',
+        'assets',
+        'storage',
+        'templates',
+        'diagnostics',
+    }
+
+    tools = await mcp._list_tools()
+    all_tags: set[str] = set()
+    for t in tools:
+        all_tags |= t.tags or set()
+
+    forbidden_tags = {'consolidation', 'consolidate'}
+    assert not (all_tags & forbidden_tags), (
+        f'AC-X-10 violation: F38 introduced a new MCP tag: {all_tags & forbidden_tags}'
+    )
+    assert all_tags == expected_tags, (
+        f'AC-X-10 violation: MCP tag taxonomy drifted. '
+        f'Added: {sorted(all_tags - expected_tags)} '
+        f'Removed: {sorted(expected_tags - all_tags)}'
+    )

--- a/packages/core/tests/unit/test_lint_mw_score_sql.py
+++ b/packages/core/tests/unit/test_lint_mw_score_sql.py
@@ -1,0 +1,60 @@
+"""Drift guard between the inline MW-score SQL and the Python implementation.
+
+The F6 ``cold_low_mw_unit`` rule embeds the Beta-Bernoulli posterior-mean
+formula directly in SQL (so the database can apply the predicate without
+a round-trip). That formula MUST match
+:func:`memex_core.services.outcomes.compute_mw_score`. If either changes
+without the other, this test fails.
+
+Implementation strategy: parse the inline SQL expression (which is a
+fixed shape — `(s + 1.0) / (s + f + 2)`), substitute integers for the
+column names, and compare the result against the Python function for a
+small grid of (s, f) pairs.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from memex_core.services.lint import _MW_SCORE_EXPR
+from memex_core.services.outcomes import compute_mw_score
+
+
+def _evaluate_sql_expr(expr: str, s: int, f: int) -> float:
+    """Evaluate the inline MW-score SQL expression in Python.
+
+    The expression uses the column names ``success_co_count`` and
+    ``failure_co_count``; we substitute them with literal integers and
+    eval safely (the expression is from our own source, not user input).
+    """
+    py = expr.replace('success_co_count', str(s)).replace('failure_co_count', str(f))
+    # Allow only digits, parens, +-*/, dots and spaces.
+    assert re.fullmatch(r'[\d\s\(\)\+\-\*\/\.\,]+', py), (
+        f'Unexpected characters in MW-score SQL expression after substitution: {py!r}'
+    )
+    return float(eval(py))  # noqa: S307 — expression is from our own source code
+
+
+@pytest.mark.parametrize(
+    's, f',
+    [
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 5),
+        (5, 1),
+        (3, 3),
+        (10, 0),
+        (0, 10),
+        (8, 7),
+    ],
+)
+def test_inline_mw_score_sql_matches_python(s: int, f: int) -> None:
+    """For every (s, f) pair, SQL expression == compute_mw_score(s, f)."""
+    sql_value = _evaluate_sql_expr(_MW_SCORE_EXPR, s, f)
+    py_value = compute_mw_score(s, f)
+    assert sql_value == pytest.approx(py_value, rel=1e-12, abs=1e-12), (
+        f'Drift detected at s={s}, f={f}: SQL={sql_value}, Python={py_value}'
+    )

--- a/packages/core/tests/unit/test_lint_rule_sql_audits.py
+++ b/packages/core/tests/unit/test_lint_rule_sql_audits.py
@@ -1,0 +1,65 @@
+"""Standing-item unit tests for the F6 v1 rule SQL.
+
+These are guards against contributor regressions that a future rule author
+might introduce — they assert structural properties of the SQL strings that
+must hold for **every** rule, regardless of what the rule actually checks.
+
+Currently:
+
+  * Every rule whose target is vault-scoped MUST include
+    ``vault_id = :vault_id`` in its WHERE clause (otherwise a rule-run
+    against vault A would also count vault B's rows in vault A's
+    findings).
+  * The :class:`RuleSpec` ``select_sql`` must yield a SELECT (not an
+    INSERT/UPDATE/DELETE) — guards the AC-F6-2 read-only invariant at the
+    spec level.
+  * Every rule's ``select_sql`` must project both ``target_id`` and
+    ``evidence`` columns; otherwise the insert into ``maintenance_proposals``
+    will fail at runtime.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from memex_core.services.lint import V1_RULES
+
+
+def _normalize(sql: str) -> str:
+    return re.sub(r'\s+', ' ', sql).strip().lower()
+
+
+@pytest.mark.parametrize('spec', V1_RULES, ids=lambda s: s.name)
+def test_each_rule_filters_on_vault_id(spec) -> None:
+    """Every v1 rule must include ``vault_id = :vault_id`` in its WHERE clause.
+
+    Reason: rules are vault-scoped (`run_rules(vault_id)`), so any rule that
+    forgets the predicate would fan-out across vaults.
+    """
+    norm = _normalize(spec.select_sql)
+    assert 'vault_id = :vault_id' in norm, (
+        f'Rule {spec.name} is missing `vault_id = :vault_id` in its WHERE clause'
+    )
+
+
+@pytest.mark.parametrize('spec', V1_RULES, ids=lambda s: s.name)
+def test_each_rule_select_starts_with_select(spec) -> None:
+    """Spec-level read-only guard: ``select_sql`` must start with SELECT."""
+    norm = _normalize(spec.select_sql)
+    assert norm.startswith('select '), (
+        f'Rule {spec.name} select_sql does not start with SELECT: {norm[:60]!r}'
+    )
+    forbidden = ('insert ', 'update ', 'delete ', 'truncate ', 'merge ', 'copy ')
+    assert not any(tok in norm for tok in forbidden), (
+        f'Rule {spec.name} select_sql contains a write keyword'
+    )
+
+
+@pytest.mark.parametrize('spec', V1_RULES, ids=lambda s: s.name)
+def test_each_rule_projects_target_id_and_evidence(spec) -> None:
+    """The SELECT must project both ``target_id`` and ``evidence``."""
+    norm = _normalize(spec.select_sql)
+    assert 'as target_id' in norm, f'Rule {spec.name} does not alias a column to `target_id`'
+    assert 'as evidence' in norm, f'Rule {spec.name} does not alias a column to `evidence`'

--- a/packages/core/tests/unit/test_seed_alembic_stubs.py
+++ b/packages/core/tests/unit/test_seed_alembic_stubs.py
@@ -25,10 +25,10 @@ _TIER_A_STUBS: list[tuple[str, str, str]] = [
     # (real maintenance_proposals table + LintService rule engine).
     # Integration coverage in tests/integration/test_int_f6_rules.py.
     ('026_revisit_columns', '025_maintenance_proposals', 'F20'),
-    ('027_consolidation_ticks', '026_revisit_columns', 'F38'),
+    # 027_consolidation_ticks (F38) is no longer a stub — see PR #19
+    # (real consolidation_ticks table + per-tick summary rows).
     # 028_procedure_outcomes (F14) is no longer a stub — see PR #18
     # (real procedure_outcomes table + vault-scoped MW counters).
-    # Integration coverage in tests/integration/test_int_alembic_028.py.
     ('029_lint_llm_quota', '028_procedure_outcomes', 'F10'),
 ]
 

--- a/packages/core/tests/unit/test_seed_alembic_stubs.py
+++ b/packages/core/tests/unit/test_seed_alembic_stubs.py
@@ -21,7 +21,9 @@ _ALEMBIC_INI = _PACKAGE_ROOT / 'alembic.ini'
 _VERSIONS_DIR = _PACKAGE_ROOT / 'alembic' / 'versions'
 
 _TIER_A_STUBS: list[tuple[str, str, str]] = [
-    ('025_maintenance_proposals', '024_intent_risk_classifier', 'F6'),
+    # 025_maintenance_proposals (F6) is no longer a stub — see PR #20
+    # (real maintenance_proposals table + LintService rule engine).
+    # Integration coverage in tests/integration/test_int_f6_rules.py.
     ('026_revisit_columns', '025_maintenance_proposals', 'F20'),
     ('027_consolidation_ticks', '026_revisit_columns', 'F38'),
     # 028_procedure_outcomes (F14) is no longer a stub — see PR #18

--- a/packages/core/tests/unit/test_seed_alembic_stubs.py
+++ b/packages/core/tests/unit/test_seed_alembic_stubs.py
@@ -24,7 +24,9 @@ _TIER_A_STUBS: list[tuple[str, str, str]] = [
     ('025_maintenance_proposals', '024_intent_risk_classifier', 'F6'),
     ('026_revisit_columns', '025_maintenance_proposals', 'F20'),
     ('027_consolidation_ticks', '026_revisit_columns', 'F38'),
-    ('028_procedure_outcomes', '027_consolidation_ticks', 'F14'),
+    # 028_procedure_outcomes (F14) is no longer a stub — see PR #18
+    # (real procedure_outcomes table + vault-scoped MW counters).
+    # Integration coverage in tests/integration/test_int_alembic_028.py.
     ('029_lint_llm_quota', '028_procedure_outcomes', 'F10'),
 ]
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -149,7 +149,13 @@ Match the tool to the query type:
 - **KV store** → namespaced operational state — preferences, project
   bindings, conventions — via `memex_kv_write(value, key)` /
   `memex_kv_get(key)` / `memex_kv_search(query)` / `memex_kv_list()`. Keys
-  MUST start with `global:`, `user:`, `project:<id>:`, or `app:<id>:`.
+  MUST start with `global:`, `user:`, `project:<id>:`, `app:<id>:`, or
+  `procedure:<verb>:<context-tag>` (RFC-007). The `procedure:` namespace is
+  for compact, learned how-tos owned by the agent — write it for a
+  procedure that worked, then `memex_kv_get(key, include_history=true)` to
+  see prior versions. Pair every procedure call with
+  `memex_record_outcome(target_type="kv_key", kv_key=..., success=...)` so
+  the procedure's MW counters reflect whether it actually worked.
   Deletion is CLI-only (`memex kv delete`).
 - **Capturing work**:
     - `memex_add_note` for a NEW note (or to fully overwrite an existing one).
@@ -195,13 +201,15 @@ def format_briefing_block(
     session_note_key: str,
     kv_instructions_if_no_vault: bool,
     diagnostics_summary: dict[str, Any] | None = None,
+    procedural_observations: list[dict[str, Any]] | None = None,
 ) -> str:
     """Compose the Memex system-prompt block.
 
     Includes vault/project metadata, the session note key, routing guidance
     for tool selection, the fetched briefing markdown, and (optionally) the
-    F32 diagnostics summary block. If no vault is resolved, appends guidance
-    on how to bind one via the KV store.
+    F32 diagnostics summary block and F14 procedural-observations block. If
+    no vault is resolved, appends guidance on how to bind one via the KV
+    store.
     """
     lines = ['## Memex Memory']
     if vault_id:
@@ -231,6 +239,9 @@ def format_briefing_block(
 
     lines.append('\n' + _ROUTING_GUIDE)
 
+    if procedural_observations:
+        lines.append('\n' + _render_procedural_block(procedural_observations))
+
     if diagnostics_summary:
         lines.append('\n' + _render_diagnostics_block(diagnostics_summary))
 
@@ -254,7 +265,44 @@ __all__ = ['BriefingCache', 'format_briefing_block']
 
 # --- F6 ---  (filled by WS-linter)
 
+
 # --- F14 --- (filled by WS-quick-wins)
+def _render_procedural_block(observations: list[dict[str, Any]]) -> str:
+    """Render the F14 procedural-observations block.
+
+    ``observations`` is a list of ``{kv_key, success_co_count,
+    failure_co_count, last_outcome_at}`` dicts (typically the top-N rows
+    from ``procedure_outcomes`` for the active vault, sorted by
+    ``last_outcome_at`` desc). The rendered block exposes each procedure's
+    MW counters and an actionability cue per RFC-007 §155-185 — the agent
+    is told to pair every procedure call with ``memex_record_outcome`` so
+    the counters stay calibrated.
+    """
+    lines = ['### Learned procedures (recent)']
+    if not observations:
+        lines.append(
+            '- No procedure keys recorded yet. When you discover a how-to that '
+            'works, write it to a `procedure:<verb>:<context-tag>` key (e.g. '
+            '`procedure:write_pr:commit-style`) and record the outcome.'
+        )
+        return '\n'.join(lines)
+
+    for obs in observations[:5]:
+        key = obs.get('kv_key', '?')
+        succ = int(obs.get('success_co_count', 0))
+        fail = int(obs.get('failure_co_count', 0))
+        last = obs.get('last_outcome_at')
+        last_str = f' · last: {last}' if last else ''
+        lines.append(f'- `{key}` — {succ} success / {fail} failure{last_str}')
+
+    lines.append(
+        'Read the active value with `memex_kv_get(key)`; pair every use with '
+        '`memex_record_outcome(target_type="kv_key", kv_key=..., success=...)` '
+        'so the counters reflect what actually worked. Use '
+        '`memex_kv_get(key, include_history=true)` to see prior versions.'
+    )
+    return '\n'.join(lines)
+
 
 # --- F20 --- (filled by WS-revisit)
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -151,11 +151,13 @@ Match the tool to the query type:
   `memex_kv_get(key)` / `memex_kv_search(query)` / `memex_kv_list()`. Keys
   MUST start with `global:`, `user:`, `project:<id>:`, `app:<id>:`, or
   `procedure:<verb>:<context-tag>` (RFC-007). The `procedure:` namespace is
-  for compact, learned how-tos owned by the agent — write it for a
-  procedure that worked, then `memex_kv_get(key, include_history=true)` to
-  see prior versions. Pair every procedure call with
-  `memex_record_outcome(target_type="kv_key", kv_key=..., success=...)` so
-  the procedure's MW counters reflect whether it actually worked.
+  for compact, learned how-tos owned by the agent — write a procedure that
+  worked using `memex_kv_write`, then read the active value with
+  `memex_kv_get(key)` or pass `include_history=true` to inspect the
+  envelope (active value + version + capped 5-version history). Memex
+  tracks per-procedure success/failure counters server-side
+  (procedure_outcomes table); on the MCP surface those counters are
+  updated via `memex_record_outcome(target_type="kv_key", kv_key=..., success=...)`.
   Deletion is CLI-only (`memex kv delete`).
 - **Capturing work**:
     - `memex_add_note` for a NEW note (or to fully overwrite an existing one).

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -204,6 +204,7 @@ def format_briefing_block(
     kv_instructions_if_no_vault: bool,
     diagnostics_summary: dict[str, Any] | None = None,
     procedural_observations: list[dict[str, Any]] | None = None,
+    lint_pending_count: int | None = None,
 ) -> str:
     """Compose the Memex system-prompt block.
 
@@ -244,6 +245,9 @@ def format_briefing_block(
     if procedural_observations:
         lines.append('\n' + _render_procedural_block(procedural_observations))
 
+    if lint_pending_count is not None and lint_pending_count > 0:
+        lines.append('\n' + _render_lint_block(lint_pending_count))
+
     if diagnostics_summary:
         lines.append('\n' + _render_diagnostics_block(diagnostics_summary))
 
@@ -265,7 +269,21 @@ __all__ = ['BriefingCache', 'format_briefing_block']
 # F32: diagnostic summary                 (WS-diagnostics)
 # ============================================================
 
+
 # --- F6 ---  (filled by WS-linter)
+def _render_lint_block(pending_count: int) -> str:
+    """Render the F6 maintenance-ledger pending-count block (AC-F6-7).
+
+    Surfaces the pending count from ``maintenance_proposals`` and points the
+    operator at the CLI for triage. Read-only on the agent surface — the
+    agent should NOT auto-resolve findings; deferring to a human is the
+    intended default in v1.
+    """
+    return (
+        f'### Maintenance findings\n'
+        f'- {pending_count} pending lint findings. To inspect them, '
+        f'run `memex lint findings`.'
+    )
 
 
 # --- F14 --- (filled by WS-quick-wins)

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -228,7 +228,28 @@ class MemexMemoryProvider(MemoryProvider):
             project_id=self._project_id,
             session_note_key=self._session_note_key,
             kv_instructions_if_no_vault=self._vault_name is None,
+            procedural_observations=self._fetch_top_procedure_outcomes(),
         )
+
+    def _fetch_top_procedure_outcomes(self) -> list[dict[str, Any]] | None:
+        """F14 — fetch top 5 procedure outcomes for the active vault.
+
+        Best-effort and synchronous (briefing render is on the hot path);
+        any failure logs at DEBUG and returns ``None`` so the briefing
+        still renders without the procedural section. The vault must be
+        resolved (``self._vault_id``) — without it there is no per-vault
+        listing to surface.
+        """
+        if self._api is None or self._vault_id is None:
+            return None
+        try:
+            return run_sync(
+                self._api.list_top_procedure_outcomes(vault_id=str(self._vault_id), limit=5),
+                timeout=2.0,
+            )
+        except Exception as e:
+            logger.debug('procedure_outcomes fetch failed: %s', e)
+            return None
 
     # -- Tools ---------------------------------------------------------------
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -229,6 +229,7 @@ class MemexMemoryProvider(MemoryProvider):
             session_note_key=self._session_note_key,
             kv_instructions_if_no_vault=self._vault_name is None,
             procedural_observations=self._fetch_top_procedure_outcomes(),
+            lint_pending_count=self._fetch_lint_pending_count(),
         )
 
     def _fetch_top_procedure_outcomes(self) -> list[dict[str, Any]] | None:
@@ -249,6 +250,24 @@ class MemexMemoryProvider(MemoryProvider):
             )
         except Exception as e:
             logger.debug('procedure_outcomes fetch failed: %s', e)
+            return None
+
+    def _fetch_lint_pending_count(self) -> int | None:
+        """F6 — fetch pending lint-finding count for the active vault.
+
+        Best-effort: any failure returns None and the briefing renders
+        without the maintenance section. Vault must be resolved.
+        """
+        if self._api is None or self._vault_id is None:
+            return None
+        try:
+            payload = run_sync(
+                self._api.lint_status(scope='vault', vault_id=str(self._vault_id)),
+                timeout=2.0,
+            )
+            return int(payload.get('pending', 0))
+        except Exception as e:
+            logger.debug('lint_status fetch failed: %s', e)
             return None
 
     # -- Tools ---------------------------------------------------------------

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -1210,13 +1210,28 @@ KV_WRITE_SCHEMA: dict[str, Any] = {
 
 KV_GET_SCHEMA: dict[str, Any] = {
     'name': 'memex_kv_get',
-    'description': 'Get a KV entry by exact key. Returns null if not found.',
+    'description': (
+        'Get a KV entry by exact key. Returns null if not found. For '
+        'procedure: keys (RFC-007), the default response value is the '
+        'unwrapped active procedure text. Pass include_history=true to '
+        'receive the structured envelope ({value, version, history}) so '
+        'you can review prior versions.'
+    ),
     'parameters': {
         'type': 'object',
         'properties': {
             'key': {
                 'type': 'string',
                 'description': 'Exact key to look up.',
+            },
+            'include_history': {
+                'type': 'boolean',
+                'description': (
+                    'For procedure: keys (RFC-007), return the full '
+                    'envelope (value, version, capped history of 5 prior '
+                    'versions) instead of just the active value. Ignored '
+                    'for non-procedure keys.'
+                ),
             },
         },
         'required': ['key'],

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -100,6 +100,7 @@ class MemexAPIProtocol(Protocol):
     async def deprioritize_memory_unit(self, *args: Any, **kwargs: Any) -> Any: ...
     async def restore_memory_unit(self, *args: Any, **kwargs: Any) -> Any: ...
     async def summarize_node(self, *args: Any, **kwargs: Any) -> Any: ...
+    async def record_outcome(self, *args: Any, **kwargs: Any) -> Any: ...
 
     # Vaults
     async def list_vaults(self, *args: Any, **kwargs: Any) -> Any: ...
@@ -3224,6 +3225,8 @@ __all__ = [
     # --- F4 (WS-quick-wins) ---
     'MEMORY_DEPRIORITIZE_SCHEMA',
     'MEMORY_RESTORE_SCHEMA',
+    # --- F14 / F29 record_outcome (WS-quick-wins) ---
+    'RECORD_OUTCOME_SCHEMA',
 ]
 
 
@@ -3439,6 +3442,139 @@ def handle_memory_summarize_node(
 
 HANDLERS['memex_memory_summarize_node'] = handle_memory_summarize_node
 ALL_SCHEMAS.append(MEMORY_SUMMARIZE_NODE_SCHEMA)
+
+
+# --- F14 / F29 record_outcome --- (WS-quick-wins; fills the F14 ADD-2 Hermes gap)
+
+RECORD_OUTCOME_SCHEMA: dict[str, Any] = {
+    'name': 'memex_record_outcome',
+    'description': (
+        'Record whether previously retrieved memories or a stored procedure '
+        'contributed to a successful outcome. Default mode increments MW '
+        "counters on memory units (target_type='memory_unit', "
+        "unit_ids=[...]); set target_type='kv_key' with kv_key="
+        "'procedure:<verb>:<context-tag>' to score a stored procedure. Call "
+        'after you actually used the retrieved memory or the procedure.\n\n'
+        'Call generously. Silence provides no learning signal.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'success': {
+                'type': 'boolean',
+                'description': (
+                    'True if the task succeeded using these memories, '
+                    'false if they were misleading.'
+                ),
+            },
+            'unit_ids': {
+                'type': 'array',
+                'items': {'type': 'string'},
+                'description': (
+                    'memory_unit mode only. UUIDs of memory units you actually '
+                    'used — not all retrieved units, only the ones that were '
+                    "load-bearing in your reasoning. Required when target_type='memory_unit'."
+                ),
+            },
+            'vault_id': {
+                'type': 'string',
+                'description': 'Vault UUID or name. Defaults to the session-bound vault.',
+            },
+            'outcome_confidence': {
+                'type': 'number',
+                'minimum': 0.0,
+                'maximum': 1.0,
+                'description': 'Weight for this outcome signal (0.0-1.0). Default 1.0.',
+            },
+            'reason': {
+                'type': 'string',
+                'description': 'Optional free-text reason (logged, not stored on units).',
+            },
+            'target_type': {
+                'type': 'string',
+                'enum': ['memory_unit', 'kv_key'],
+                'description': (
+                    "What the outcome scores. 'memory_unit' (default) increments "
+                    "MW counters on memory units in unit_ids. 'kv_key' (F14) "
+                    'increments counters on the procedure_outcomes row for kv_key.'
+                ),
+            },
+            'kv_key': {
+                'type': 'string',
+                'description': (
+                    'kv_key mode only. Procedure KV key '
+                    "(procedure:<verb>:<context-tag>). Required when target_type='kv_key'."
+                ),
+            },
+        },
+        'required': ['success'],
+    },
+}
+
+
+def handle_record_outcome(
+    api: MemexAPIProtocol,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+    args: dict[str, Any],
+) -> str:
+    """Dual-mode dispatcher (memory_unit / kv_key).
+
+    Preserves the F14 ADD-2 invariant by passing ``unit_ids`` and ``success``
+    positionally and ``target_type`` / ``kv_key`` keyword-only — same shape
+    as MemexAPI.record_outcome and RemoteMemexAPI.record_outcome.
+    """
+    try:
+        success = _require(args, 'success')
+    except ValueError as e:
+        return tool_error(str(e))
+    if not isinstance(success, bool):
+        return tool_error(f"'success' must be a boolean, got {type(success).__name__}")
+
+    target_type = args.get('target_type', 'memory_unit')
+    if target_type not in ('memory_unit', 'kv_key'):
+        return tool_error(f"target_type must be 'memory_unit' or 'kv_key', got {target_type!r}")
+
+    unit_ids = args.get('unit_ids')
+    if unit_ids is not None and not isinstance(unit_ids, list):
+        return tool_error("'unit_ids' must be a list of UUID strings")
+
+    kv_key = args.get('kv_key')
+    if kv_key is not None and not isinstance(kv_key, str):
+        return tool_error("'kv_key' must be a string")
+
+    raw_vault = args.get('vault_id')
+    target_vault: str | None
+    if raw_vault is None:
+        target_vault = str(vault_id) if vault_id else None
+    else:
+        target_vault = str(raw_vault)
+
+    outcome_confidence = args.get('outcome_confidence', 1.0)
+    reason = args.get('reason')
+
+    try:
+        result = run_sync(
+            api.record_outcome(
+                unit_ids,
+                success,
+                target_vault,
+                outcome_confidence,
+                reason,
+                target_type=target_type,
+                kv_key=kv_key,
+            ),
+            timeout=30.0,
+        )
+    except Exception as e:
+        logger.warning('memex_record_outcome failed: %s', e)
+        return tool_error(f'record_outcome failed: {e}')
+
+    return json.dumps(result)
+
+
+HANDLERS['memex_record_outcome'] = handle_record_outcome
+ALL_SCHEMAS.append(RECORD_OUTCOME_SCHEMA)
 
 
 # --- F8 ---  (filled by WS-linter)

--- a/packages/hermes-plugin/tests/test_briefing_f14.py
+++ b/packages/hermes-plugin/tests/test_briefing_f14.py
@@ -1,0 +1,131 @@
+"""F14 briefing tests (TC-F14-4): procedural-observations block + routing guide.
+
+The Hermes briefing surface must:
+
+* render a "Learned procedures (recent)" section when ``procedural_observations``
+  is provided, exposing each procedure's success/failure counters and an
+  actionability cue (record_outcome pairing);
+* gracefully render an empty-state hint when the list is empty;
+* document the ``procedure:`` namespace and the ``record_outcome``
+  pairing in the routing guide so an agent can act without prior context.
+"""
+
+from __future__ import annotations
+
+from memex_hermes_plugin.memex.briefing import (
+    _ROUTING_GUIDE,
+    _render_procedural_block,
+    format_briefing_block,
+)
+
+
+def test_routing_guide_documents_procedure_namespace_and_record_outcome_pairing():
+    """The routing guide must document the procedure: namespace + outcome pairing."""
+    assert 'procedure:<verb>:<context-tag>' in _ROUTING_GUIDE
+    assert 'memex_record_outcome' in _ROUTING_GUIDE
+    assert 'target_type="kv_key"' in _ROUTING_GUIDE
+    assert 'include_history=true' in _ROUTING_GUIDE
+
+
+def test_render_procedural_block_lists_top_observations_with_counters():
+    """Each observation lifts its kv_key + counters into the rendered block."""
+    rendered = _render_procedural_block(
+        [
+            {
+                'kv_key': 'procedure:write_pr:commit-style',
+                'success_co_count': 4,
+                'failure_co_count': 1,
+                'last_outcome_at': '2026-04-30T14:00:00Z',
+            },
+            {
+                'kv_key': 'procedure:run_tests:python-monorepo',
+                'success_co_count': 7,
+                'failure_co_count': 0,
+                'last_outcome_at': '2026-04-29T10:00:00Z',
+            },
+        ]
+    )
+    assert '### Learned procedures (recent)' in rendered
+    assert '`procedure:write_pr:commit-style`' in rendered
+    assert '4 success / 1 failure' in rendered
+    assert '`procedure:run_tests:python-monorepo`' in rendered
+    assert '7 success / 0 failure' in rendered
+    # Actionability cue + outcome pairing must be present (RFC-007 §155-185).
+    assert 'memex_record_outcome' in rendered
+    assert 'target_type="kv_key"' in rendered
+    assert 'include_history=true' in rendered
+
+
+def test_render_procedural_block_caps_at_five_entries():
+    """Renderer caps to 5 even if the caller passes more."""
+    obs = [
+        {
+            'kv_key': f'procedure:verb_{i}:tag-{i}',
+            'success_co_count': i,
+            'failure_co_count': 0,
+            'last_outcome_at': None,
+        }
+        for i in range(8)
+    ]
+    rendered = _render_procedural_block(obs)
+    for i in range(5):
+        assert f'verb_{i}:tag-{i}' in rendered, f'first 5 must be rendered (i={i})'
+    for i in range(5, 8):
+        assert f'verb_{i}:tag-{i}' not in rendered, f'overflow must be dropped (i={i})'
+
+
+def test_render_procedural_block_empty_state_provides_onboarding_hint():
+    """Empty list still emits a hint that procedure: keys exist + how to seed one."""
+    rendered = _render_procedural_block([])
+    assert '### Learned procedures (recent)' in rendered
+    assert 'procedure:<verb>:<context-tag>' in rendered
+    # Empty-state must NOT pretend any procedures exist
+    assert ' success ' not in rendered
+
+
+def test_format_briefing_block_includes_procedural_section_when_provided():
+    """The procedural-observations block must appear in the formatted briefing."""
+    block = format_briefing_block(
+        briefing='',
+        vault_id='my-vault',
+        project_id='my-project',
+        session_note_key='session/2026-04-30',
+        kv_instructions_if_no_vault=False,
+        procedural_observations=[
+            {
+                'kv_key': 'procedure:edit_yaml:ci-config',
+                'success_co_count': 2,
+                'failure_co_count': 0,
+                'last_outcome_at': '2026-04-30T15:00:00Z',
+            }
+        ],
+    )
+    assert '### Learned procedures (recent)' in block
+    assert '`procedure:edit_yaml:ci-config`' in block
+    assert '2 success / 0 failure' in block
+
+
+def test_format_briefing_block_omits_procedural_section_when_none():
+    """No section is emitted when procedural_observations is None or [].
+
+    Default path stays unchanged so existing F32/F4/F5 briefing tests do not
+    pick up an unexpected section.
+    """
+    block_none = format_briefing_block(
+        briefing='',
+        vault_id='my-vault',
+        project_id='my-project',
+        session_note_key='session/2026-04-30',
+        kv_instructions_if_no_vault=False,
+    )
+    assert '### Learned procedures (recent)' not in block_none
+
+    block_empty = format_briefing_block(
+        briefing='',
+        vault_id='my-vault',
+        project_id='my-project',
+        session_note_key='session/2026-04-30',
+        kv_instructions_if_no_vault=False,
+        procedural_observations=[],
+    )
+    assert '### Learned procedures (recent)' not in block_empty

--- a/packages/hermes-plugin/tests/test_briefing_f6.py
+++ b/packages/hermes-plugin/tests/test_briefing_f6.py
@@ -1,0 +1,70 @@
+"""F6 briefing tests (AC-F6-7): pending lint findings block + CLI pointer.
+
+The Hermes briefing surface must:
+
+* Render a "Maintenance findings" section when ``lint_pending_count`` is
+  passed and > 0.
+* Include the literal CLI pointer ``run `memex lint findings``` so the
+  agent (or a human reader) can self-discover the inspection path.
+* Suppress the section when the count is 0 or None — no "0 pending"
+  noise on a clean vault.
+"""
+
+from __future__ import annotations
+
+from memex_hermes_plugin.memex.briefing import (
+    _render_lint_block,
+    format_briefing_block,
+)
+
+
+def test_render_lint_block_includes_pending_count_and_cli_pointer():
+    """Renderer surfaces the integer count + literal CLI pointer."""
+    rendered = _render_lint_block(7)
+    assert '### Maintenance findings' in rendered
+    assert '7 pending lint findings' in rendered
+    # AC-F6-7: the literal CLI pointer must be present so the agent has a
+    # concrete next action.
+    assert 'run `memex lint findings`' in rendered
+
+
+def test_format_briefing_block_includes_lint_section_when_count_positive():
+    """When ``lint_pending_count > 0``, the lint section appears in the briefing."""
+    block = format_briefing_block(
+        briefing='',
+        vault_id='my-vault',
+        project_id='proj',
+        session_note_key='session/proj/2026-04-30',
+        kv_instructions_if_no_vault=False,
+        lint_pending_count=3,
+    )
+    assert '### Maintenance findings' in block
+    assert '3 pending lint findings' in block
+    assert 'run `memex lint findings`' in block
+
+
+def test_format_briefing_block_suppresses_lint_section_when_zero():
+    """A clean vault (count=0) must NOT add a "0 pending" line."""
+    block = format_briefing_block(
+        briefing='',
+        vault_id='my-vault',
+        project_id='proj',
+        session_note_key='session/proj/2026-04-30',
+        kv_instructions_if_no_vault=False,
+        lint_pending_count=0,
+    )
+    assert '### Maintenance findings' not in block
+    assert 'pending lint findings' not in block
+
+
+def test_format_briefing_block_suppresses_lint_section_when_none():
+    """When the fetch fails (None), the lint section is omitted."""
+    block = format_briefing_block(
+        briefing='',
+        vault_id='my-vault',
+        project_id='proj',
+        session_note_key='session/proj/2026-04-30',
+        kv_instructions_if_no_vault=False,
+        lint_pending_count=None,
+    )
+    assert '### Maintenance findings' not in block

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -75,7 +75,7 @@ def test_get_tool_schemas_respects_memory_mode(tmp_path: Path, monkeypatch: pyte
 
 
 def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
-    """Hybrid mode exposes exactly the 40 Memex tools (AC-086 + AC-008 + Tier A F4/F5 + F32 diagnostics)."""
+    """Hybrid mode exposes exactly the 41 Memex tools (AC-086 + AC-008 + Tier A F4/F5/F29 + F32 diagnostics)."""
     provider, *_ = provider_with_stubbed_api
     schemas = provider.get_tool_schemas()
     names = {s['name'] for s in schemas}
@@ -125,6 +125,8 @@ def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
         'memex_memory_deprioritize',
         'memex_memory_restore',
         'memex_memory_summarize_node',
+        # Tier A WS-quick-wins (F14 / F29 — record_outcome Hermes parity)
+        'memex_record_outcome',
         # Tier A WS-diagnostics (F32)
         'memex_get_diagnostics_summary',
     }
@@ -142,8 +144,8 @@ class TestGetToolSchemasBeforeInitialize:
     def test_returns_all_schemas_pre_init(self):
         """The v0.1.13 bug was returning []; we now return the full set
         pre-init. After Stream 6 + asset disk-handoff + memex_append_note +
-        Tier A F4/F5 + F32 diagnostics we register exactly 40 tools, and the
-        assertion is strict equality.
+        Tier A F4/F5 + F14/F29 + F32 diagnostics we register exactly 41
+        tools, and the assertion is strict equality.
         """
         p = MemexMemoryProvider()
         # NOTE: no initialize() call.
@@ -195,6 +197,8 @@ class TestGetToolSchemasBeforeInitialize:
             'memex_memory_deprioritize',
             'memex_memory_restore',
             'memex_memory_summarize_node',
+            # Tier A WS-quick-wins (F14 / F29 — record_outcome Hermes parity)
+            'memex_record_outcome',
             # Tier A WS-diagnostics (F32)
             'memex_get_diagnostics_summary',
         }
@@ -211,9 +215,9 @@ class TestGetToolSchemasBeforeInitialize:
         """A fresh provider with no config always exposes tools. Only an
         initialized provider whose config explicitly says ``context`` hides them.
         """
-        # Pre-init: full 40-tool set (Stream 1-5 baseline + Tier A F4/F5 + F32 diagnostics verbs).
+        # Pre-init: full 41-tool set (Stream 1-5 baseline + Tier A F4/F5 + F14/F29 + F32 diagnostics verbs).
         p = MemexMemoryProvider()
-        assert len(p.get_tool_schemas()) == 40
+        assert len(p.get_tool_schemas()) == 41
 
         # After init in context mode: empty.
         monkeypatch.setenv('HERMES_HOME', str(tmp_path))

--- a/packages/hermes-plugin/tests/test_record_outcome_f29.py
+++ b/packages/hermes-plugin/tests/test_record_outcome_f29.py
@@ -1,0 +1,247 @@
+"""Hermes-side tests for F29 — memex_record_outcome schema + handler.
+
+Pairs with packages/common/tests/test_client_record_outcome.py (HTTP wrapper)
+and tests/test_e2e_f29_outcomes_route.py (HTTP route). This file covers the
+agent-facing surface: schema registration, dispatch routing, dual-mode
+parameter handling, and the F14 ADD-2 invariant (success has no default).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from memex_hermes_plugin.memex.config import HermesMemexConfig
+from memex_hermes_plugin.memex.tools import (
+    ALL_SCHEMAS,
+    HANDLERS,
+    RECORD_OUTCOME_SCHEMA,
+    MemexAPIProtocol,
+    dispatch,
+    handle_record_outcome,
+)
+
+
+@pytest.fixture
+def config() -> HermesMemexConfig:
+    return HermesMemexConfig()
+
+
+@pytest.fixture
+def vault_id():
+    return uuid4()
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_schema_registered_in_all_schemas():
+    """memex_record_outcome must appear in ALL_SCHEMAS exactly once."""
+    matches = [s for s in ALL_SCHEMAS if s['name'] == 'memex_record_outcome']
+    assert len(matches) == 1, f'expected 1 record_outcome schema, got {len(matches)}'
+    assert matches[0] is RECORD_OUTCOME_SCHEMA
+
+
+def test_handler_dispatchable():
+    """HANDLERS routing entry exists and points at the right function."""
+    assert HANDLERS.get('memex_record_outcome') is handle_record_outcome
+
+
+def test_schema_shape():
+    """Schema covers both modes; only success is required at the schema level
+    (mode-specific requirements are validated in the handler/route since they
+    depend on target_type — the JSON-schema ``required`` array can't express
+    that conditionally without oneOf bloat)."""
+    props = RECORD_OUTCOME_SCHEMA['parameters']['properties']
+    assert {'success', 'unit_ids', 'kv_key', 'target_type', 'vault_id'} <= set(props)
+    assert RECORD_OUTCOME_SCHEMA['parameters']['required'] == ['success']
+    assert props['target_type']['enum'] == ['memory_unit', 'kv_key']
+    assert props['outcome_confidence']['minimum'] == 0.0
+    assert props['outcome_confidence']['maximum'] == 1.0
+
+
+def test_protocol_method_present():
+    """MemexAPIProtocol must declare record_outcome so static type tools and
+    structural-type asserts (Mock(spec=MemexAPIProtocol)) work."""
+    assert hasattr(MemexAPIProtocol, 'record_outcome')
+
+
+# ---------------------------------------------------------------------------
+# Dispatch — memory_unit mode
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_memory_unit_passthrough(config, vault_id):
+    """dispatch routes memex_record_outcome through handle_record_outcome,
+    which calls api.record_outcome with positional unit_ids/success and the
+    keyword-only target_type/kv_key."""
+    api = Mock()
+    api.record_outcome = AsyncMock(
+        return_value={'units_updated': 2, 'entities_updated': 0, 'models_updated': 0}
+    )
+
+    out = dispatch(
+        'memex_record_outcome',
+        {'success': True, 'unit_ids': ['u1', 'u2'], 'target_type': 'memory_unit'},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert data['units_updated'] == 2
+    api.record_outcome.assert_awaited_once()
+    call = api.record_outcome.await_args
+    assert call is not None
+    # ADD-2: unit_ids + success are positional, target_type + kv_key kwargs.
+    assert call.args == (
+        ['u1', 'u2'],  # unit_ids
+        True,  # success
+        str(vault_id),  # vault_id (defaulted from session-bound)
+        1.0,  # outcome_confidence
+        None,  # reason
+    )
+    assert call.kwargs == {'target_type': 'memory_unit', 'kv_key': None}
+
+
+def test_dispatch_kv_key_mode(config, vault_id):
+    """kv_key mode: unit_ids omitted, kv_key passed via kwargs."""
+    api = Mock()
+    api.record_outcome = AsyncMock(
+        return_value={
+            'kv_key': 'procedure:run-tests:default',
+            'vault_id': str(vault_id),
+            'success_co_count': 1,
+            'failure_co_count': 0,
+            'last_outcome_at': '2026-05-01T05:59:00Z',
+        }
+    )
+
+    out = dispatch(
+        'memex_record_outcome',
+        {
+            'success': False,
+            'kv_key': 'procedure:run-tests:default',
+            'target_type': 'kv_key',
+        },
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert data['kv_key'] == 'procedure:run-tests:default'
+    call = api.record_outcome.await_args
+    assert call is not None
+    assert call.args[0] is None  # unit_ids
+    assert call.args[1] is False  # success
+    assert call.kwargs['target_type'] == 'kv_key'
+    assert call.kwargs['kv_key'] == 'procedure:run-tests:default'
+
+
+def test_dispatch_explicit_vault_overrides_session(config, vault_id):
+    """When args carry vault_id, it overrides the session-bound vault."""
+    api = Mock()
+    api.record_outcome = AsyncMock(return_value={'units_updated': 0})
+    explicit = uuid4()
+    dispatch(
+        'memex_record_outcome',
+        {'success': True, 'unit_ids': ['u1'], 'vault_id': str(explicit)},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    call = api.record_outcome.await_args
+    assert call is not None
+    assert call.args[2] == str(explicit)
+
+
+# ---------------------------------------------------------------------------
+# Bad inputs (handler-level validation)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_success_returns_tool_error(config, vault_id):
+    """ADD-2 invariant: success is required; absent → tool_error JSON.
+
+    The handler must reject before calling api.record_outcome — a regression
+    that defaulted success=False would silently train MW counters with
+    failure signals on every kwargless agent call. The api mock is left
+    un-stubbed so any call would raise AttributeError and surface here.
+    """
+    api = Mock(spec=[])  # spec=[] means no attributes; any access raises.
+    out = dispatch(
+        'memex_record_outcome',
+        {'unit_ids': ['u1']},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    assert 'error' in json.loads(out)
+
+
+def test_invalid_target_type_returns_tool_error(config, vault_id):
+    """target_type must be 'memory_unit' or 'kv_key'."""
+    api = Mock()
+    out = dispatch(
+        'memex_record_outcome',
+        {'success': True, 'target_type': 'something-else'},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    assert 'error' in json.loads(out)
+
+
+def test_non_bool_success_returns_tool_error(config, vault_id):
+    """success must be a JSON boolean, not 0/1/'true'."""
+    api = Mock()
+    out = dispatch(
+        'memex_record_outcome',
+        {'success': 1, 'unit_ids': ['u1']},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    assert 'error' in json.loads(out)
+
+
+def test_api_error_surfaces_as_tool_error(config, vault_id):
+    """Underlying api.record_outcome RuntimeError → tool_error envelope, not crash."""
+    api = Mock()
+    api.record_outcome = AsyncMock(side_effect=RuntimeError('vault not found'))
+    out = dispatch(
+        'memex_record_outcome',
+        {'success': True, 'unit_ids': ['u1']},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    payload = json.loads(out)
+    assert 'error' in payload
+    assert 'vault not found' in payload.get('message', payload.get('error', ''))
+
+
+# ---------------------------------------------------------------------------
+# F14 ADD-2 contract — handler signature lock
+# ---------------------------------------------------------------------------
+
+
+def test_handler_passes_keyword_only_args_as_kwargs():
+    """Source-level lock: handle_record_outcome must call api.record_outcome
+    with target_type and kv_key as keyword arguments, not positional.
+
+    The api signature has those as keyword-only (per the in-process MemexAPI
+    contract); a regression that passed them positionally would only fail
+    against a real RemoteMemexAPI, not against AsyncMock — so we lock the
+    call shape here."""
+    src = inspect.getsource(handle_record_outcome)
+    # The api call must use target_type=... and kv_key=... — never the
+    # positional 6th/7th arg form. Line breaks accepted; rely on the keyword
+    # token presence.
+    assert 'target_type=target_type' in src, 'target_type must be passed as kwarg'
+    assert 'kv_key=kv_key' in src, 'kv_key must be passed as kwarg'

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -172,6 +172,7 @@ def test_all_schemas_have_required_fields():
         'memex_memory_deprioritize',
         'memex_memory_restore',
         'memex_memory_summarize_node',
+        'memex_record_outcome',
     }
     tier_a_diagnostics = {
         'memex_get_diagnostics_summary',

--- a/packages/mcp/src/memex_mcp/models.py
+++ b/packages/mcp/src/memex_mcp/models.py
@@ -354,7 +354,10 @@ class McpDeleteAssetsResult(BaseModel):
 
 class McpKVEntry(BaseModel):
     key: str
-    value: str
+    # value is normally a string; for procedure: keys read with
+    # include_history=True it is a structured dict {value, version, history}
+    # per RFC-007 §114-116.
+    value: str | dict[str, Any]
     scope: str
     updated_at: datetime
     expires_at: datetime | None = None

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3163,7 +3163,12 @@ async def memex_kv_write(
 
 @mcp.tool(
     name='memex_kv_get',
-    description='Get a KV entry by exact key.',
+    description=(
+        'Get a KV entry by exact key. For procedure: keys (RFC-007), the '
+        'default response value is the unwrapped active procedure text. Pass '
+        'include_history=true to receive the structured envelope '
+        '({value, version, history}) so you can review prior versions.'
+    ),
     tags={'storage'},
     annotations={'readOnlyHint': True},
     timeout=15.0,
@@ -3171,15 +3176,30 @@ async def memex_kv_write(
 async def memex_kv_get(
     ctx: Context,
     key: Annotated[str, Field(description='Exact key to look up.')],
+    include_history: Annotated[
+        bool,
+        BeforeValidator(_coerce_bool),
+        Field(
+            default=False,
+            description=(
+                'For procedure: keys (RFC-007), return the full envelope '
+                '(value, version, capped history of 5 prior versions) instead '
+                'of just the active value. Ignored for non-procedure keys.'
+            ),
+        ),
+    ] = False,
 ) -> McpKVEntry | None:
     """Exact key lookup in the KV store."""
     try:
         api = get_api(ctx)
-        entry = await api.kv_get(key=key)
+        entry = await api.kv_get(key=key, include_history=include_history)
 
         if entry is None:
             return None
 
+        # When include_history=True for procedure keys, entry.value is a dict;
+        # for everything else it is the unwrapped string. McpKVEntry.value is
+        # typed loosely so both shapes flow through.
         return McpKVEntry(
             key=entry.key,
             value=entry.value,
@@ -3448,9 +3468,12 @@ async def memex_get_vault_summary(
 @mcp.tool(
     name='memex_record_outcome',
     description=(
-        'Record whether previously retrieved memory units contributed '
-        'to a successful outcome. Call this after you have actually used retrieved memories '
-        'to perform a task or answer a question.\n\n'
+        'Record whether previously retrieved memories or a stored procedure '
+        'contributed to a successful outcome. Default mode increments MW '
+        'counters on memory units (target_type="memory_unit", '
+        'unit_ids=[...]); set target_type="kv_key" with kv_key='
+        '"procedure:<verb>:<context-tag>" to score a stored procedure. Call '
+        'after you actually used the retrieved memory or the procedure.\n\n'
         'Call generously. Silence provides no learning signal.'
     ),
     tags={'write'},
@@ -3458,16 +3481,6 @@ async def memex_get_vault_summary(
 )
 async def memex_record_outcome(
     ctx: Context,
-    unit_ids: Annotated[
-        list[str],
-        BeforeValidator(_coerce_list),
-        Field(
-            description=(
-                'UUIDs of memory units you actually used — not all retrieved units, '
-                'only the ones that were load-bearing in your reasoning.'
-            ),
-        ),
-    ],
     success: Annotated[
         bool,
         BeforeValidator(_coerce_bool),
@@ -3475,6 +3488,18 @@ async def memex_record_outcome(
             description='True if the task succeeded using these memories, false if they were misleading.'
         ),
     ],
+    unit_ids: Annotated[
+        list[str] | None,
+        BeforeValidator(_coerce_list),
+        Field(
+            default=None,
+            description=(
+                'memory_unit mode only. UUIDs of memory units you actually used — '
+                'not all retrieved units, only the ones that were load-bearing '
+                'in your reasoning. Required when target_type="memory_unit".'
+            ),
+        ),
+    ] = None,
     vault_id: Annotated[
         str | None,
         Field(description='Vault UUID or name. Omit to use config defaults.'),
@@ -3496,8 +3521,31 @@ async def memex_record_outcome(
             description='Optional free-text reason for the outcome (logged, not stored on units).',
         ),
     ] = None,
+    target_type: Annotated[
+        str,
+        Field(
+            default='memory_unit',
+            description=(
+                'What the outcome scores. "memory_unit" (default) increments '
+                'MW counters on memory units in unit_ids. "kv_key" (F14) '
+                'increments vault-scoped counters on the procedure_outcomes '
+                'row for kv_key.'
+            ),
+        ),
+    ] = 'memory_unit',
+    kv_key: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                'kv_key mode only. Procedure KV key (procedure:<verb>:<context-tag>, '
+                'RFC-007) whose MW counters should be incremented. '
+                'Required when target_type="kv_key".'
+            ),
+        ),
+    ] = None,
 ) -> dict:
-    """Record an outcome for memory units to train Memory Worth scoring."""
+    """Record an outcome for memory units or a procedure key to train MW scoring."""
     try:
         api = get_api(ctx)
         vault_id = vault_id or _default_write_vault(ctx)
@@ -3509,6 +3557,8 @@ async def memex_record_outcome(
             vault_id=str(resolved_vid),
             outcome_confidence=outcome_confidence,
             reason=reason,
+            target_type=target_type,
+            kv_key=kv_key,
         )
 
     except ToolError:

--- a/tests/test_e2e_f14_kv_get_http.py
+++ b/tests/test_e2e_f14_kv_get_http.py
@@ -97,3 +97,55 @@ def test_kv_get_returns_404_when_missing(client: TestClient) -> None:
         params={'key': f'procedure:run_tests:does-not-exist-{uuid4().hex[:8]}'},
     )
     assert response.status_code == 404
+
+
+def test_kv_procedure_observations_route_returns_list(
+    client: TestClient,
+) -> None:
+    """``GET /api/v1/kv/procedure-observations`` returns a JSON list.
+
+    Endpoint contract is exercised here (route + auth + response_model). The
+    rich ranking semantics (mw_score ordering, limit cap, cross-vault
+    isolation, context filter) are covered by the integration tests in
+    ``test_int_f14_top_outcomes.py`` — those exercise the SQL path, this
+    one locks the wire shape.
+    """
+    from memex_common.config import GLOBAL_VAULT_ID
+
+    response = client.get(
+        '/api/v1/kv/procedure-observations',
+        params={'vault_id': str(GLOBAL_VAULT_ID), 'limit': 5},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert isinstance(body, list)
+
+
+def test_kv_procedure_observations_rejects_invalid_limit(
+    client: TestClient,
+) -> None:
+    """``limit`` must be 1-20."""
+    from memex_common.config import GLOBAL_VAULT_ID
+
+    response = client.get(
+        '/api/v1/kv/procedure-observations',
+        params={'vault_id': str(GLOBAL_VAULT_ID), 'limit': 0},
+    )
+    assert response.status_code == 422
+
+    response = client.get(
+        '/api/v1/kv/procedure-observations',
+        params={'vault_id': str(GLOBAL_VAULT_ID), 'limit': 21},
+    )
+    assert response.status_code == 422
+
+
+def test_kv_procedure_observations_rejects_invalid_vault_id(
+    client: TestClient,
+) -> None:
+    """Non-UUID ``vault_id`` returns a 4xx (ValueError → handled error)."""
+    response = client.get(
+        '/api/v1/kv/procedure-observations',
+        params={'vault_id': 'not-a-uuid', 'limit': 5},
+    )
+    assert response.status_code in (400, 422)

--- a/tests/test_e2e_f14_kv_get_http.py
+++ b/tests/test_e2e_f14_kv_get_http.py
@@ -1,0 +1,99 @@
+"""End-to-end tests for F14 ``GET /api/v1/kv/get?include_history=...``.
+
+Two contracts to lock:
+
+1. **Default (back-compat)**: GET without ``include_history`` returns the
+   existing :class:`KVEntryDTO` shape — for procedure: keys, the ``value``
+   field is the unwrapped active string, identical to non-procedure keys.
+2. **include_history=true**: GET returns
+   :class:`KVProcedureEntryDTO` — same outer envelope, but ``value`` is now
+   ``{value, version, history}``. Non-procedure keys ignore the flag.
+
+These are HTTP-level tests so the wire shape is what we lock down — the
+service layer is exercised separately by the unit + integration tests.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _put_proc_key(client: TestClient, key: str, value: str) -> None:
+    response = client.put('/api/v1/kv', json={'key': key, 'value': value})
+    assert response.status_code == 200, response.text
+
+
+@pytest.fixture
+def proc_key() -> str:
+    return f'procedure:write_pr:tag-{uuid4().hex[:8]}'
+
+
+def test_kv_get_default_shape_unchanged_for_procedure_key(
+    client: TestClient, proc_key: str
+) -> None:
+    """Default GET on a procedure: key returns KVEntryDTO with the active value as a string."""
+    _put_proc_key(client, proc_key, 'first-value')
+    _put_proc_key(client, proc_key, 'second-value')
+
+    response = client.get('/api/v1/kv/get', params={'key': proc_key})
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body['key'] == proc_key
+    assert isinstance(body['value'], str), (
+        f'expected default kv_get to return value: str (back-compat); got '
+        f'{type(body["value"]).__name__}: {body["value"]!r}'
+    )
+    assert body['value'] == 'second-value'
+
+
+def test_kv_get_include_history_true_returns_envelope(client: TestClient, proc_key: str) -> None:
+    """``?include_history=true`` returns KVProcedureEntryDTO with structured value."""
+    for v in ('a', 'b', 'c'):
+        _put_proc_key(client, proc_key, v)
+
+    response = client.get(
+        '/api/v1/kv/get',
+        params={'key': proc_key, 'include_history': 'true'},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body['key'] == proc_key
+    value = body['value']
+    assert isinstance(value, dict), (
+        f'expected include_history=true to return value: dict; got {type(value).__name__}'
+    )
+    assert value['value'] == 'c'
+    assert value['version'] == 3
+    history = value['history']
+    assert [h['v'] for h in history] == [1, 2]
+    assert [h['value'] for h in history] == ['a', 'b']
+
+
+def test_kv_get_include_history_ignored_for_non_procedure_key(
+    client: TestClient,
+) -> None:
+    """``include_history=true`` on a non-procedure key still returns plain KVEntryDTO."""
+    plain_key = f'global:test:plain:{uuid4().hex[:8]}'
+    response = client.put('/api/v1/kv', json={'key': plain_key, 'value': 'plain-value'})
+    assert response.status_code == 200
+
+    response = client.get(
+        '/api/v1/kv/get',
+        params={'key': plain_key, 'include_history': 'true'},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert isinstance(body['value'], str)
+    assert body['value'] == 'plain-value'
+
+
+def test_kv_get_returns_404_when_missing(client: TestClient) -> None:
+    """Unknown key still 404s — F14 didn't change this."""
+    response = client.get(
+        '/api/v1/kv/get',
+        params={'key': f'procedure:run_tests:does-not-exist-{uuid4().hex[:8]}'},
+    )
+    assert response.status_code == 404

--- a/tests/test_e2e_f14_llm_turn.py
+++ b/tests/test_e2e_f14_llm_turn.py
@@ -1,0 +1,213 @@
+"""F14 — Real-LLM-turn validation (TC-F14-LLM, AC-F14-7).
+
+Drives a real LLM via dspy through the F14 procedure-key surface to test
+that, given the agent-facing description, the agent correctly chooses
+the procedure-namespace verbs over alternatives.
+
+Two cases:
+
+1. **Capture flow** — user describes a how-to that worked → agent picks
+   ``memex_kv_write`` against a ``procedure:<verb>:<context-tag>`` key
+   over ``memex_add_note`` (the F14 verb-vs-note distinction in
+   /remember SKILL.md).
+
+2. **Recall + close-loop flow** — agent is about to perform a recurring
+   task ("write a PR for this repo") → it picks
+   ``memex_kv_get(key="procedure:write_pr:...")`` over
+   ``memex_memory_search`` (procedure recall is shape-different from
+   note recall) AND, after acting, it pairs with
+   ``memex_record_outcome(target_type="kv_key", ...)`` to close the
+   MW-counter loop.
+
+GOOGLE_API_KEY skip is in the test body, NOT the decorator (canonical
+Memex LLM-test pattern — see test_int_contradiction.py:212,
+test_e2e_f5_llm_turn.py).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+_PROCEDURE_SURFACE_DESCRIPTION = """
+The Memex procedure: KV namespace (F14, RFC-007) is for compact, learned
+how-tos owned by the agent. Keys MUST be shaped procedure:<verb>:<context-tag>
+(e.g. procedure:write_pr:commit-style or procedure:run_tests:python-monorepo).
+The agent owns the verb (the action it is taking); Memex stores observations
+about how to ADAPT the verb to the specific context (the context-tag).
+
+Tool surface available:
+
+- memex_kv_write(value, key): WRITE-side. Use to capture a procedure that
+  worked. The server stores a JSON envelope with active value + version
+  + capped 5-version history.
+- memex_kv_get(key, include_history=false): READ-side. Use to recall an
+  active procedure value. Pass include_history=true to inspect the full
+  envelope (active value + version + history).
+- memex_record_outcome(target_type="kv_key", kv_key=..., success=...):
+  CLOSE-LOOP after using a procedure. Increments per-(vault, key) Memory
+  Worth counters so the procedure's MW score stays calibrated. Silence
+  provides no learning signal.
+- memex_add_note(title, markdown_content, ...): note-capture verb (not
+  for procedures — notes are FACTS to recall, procedures are how-tos to
+  EXECUTE).
+- memex_memory_search(query): note/fact search (not procedure recall).
+"""
+
+
+def _build_predictor():
+    """Build the dspy verb-selection predictor + LM. Lazy import to keep
+    pytest collection cheap when GOOGLE_API_KEY is absent.
+    """
+    import dspy
+
+    api_key = os.environ['GOOGLE_API_KEY']
+    lm = dspy.LM(model='gemini/gemini-3-flash-preview', api_key=api_key, timeout=120)
+
+    _signature_doc = (
+        'Decide which Memex tool the agent should call.\n\n'
+        + _PROCEDURE_SURFACE_DESCRIPTION
+        + '\n\nOutput the bare verb name only (one of: memex_kv_write, '
+        'memex_kv_get, memex_record_outcome, memex_add_note, '
+        'memex_memory_search) — no prose, no arguments.'
+    )
+
+    class VerbSelection(dspy.Signature):
+        __doc__ = _signature_doc
+
+        user_signal: str = dspy.InputField(
+            desc='Description of what the user said and the agent state.'
+        )
+        verb: str = dspy.OutputField(
+            desc=(
+                'Which verb to call: memex_kv_write OR memex_kv_get OR '
+                'memex_record_outcome OR memex_add_note OR memex_memory_search.'
+            )
+        )
+
+    return dspy.Predict(VerbSelection), lm
+
+
+@pytest.mark.integration
+@pytest.mark.llm
+def test_real_agent_picks_kv_write_for_procedure_capture():
+    """TC-F14-LLM-1: user describes a how-to that worked → agent picks
+    ``memex_kv_write`` (procedure-namespace) over ``memex_add_note``.
+
+    The /remember SKILL.md F14 block says: "Use a procedure: key when the
+    content is a how-to that you (or a future agent) will ACTUALLY EXECUTE;
+    use memex_add_note when the content is a fact, decision, or piece of
+    context to recall." This test asserts the LLM honors that distinction.
+    """
+    if not os.environ.get('GOOGLE_API_KEY'):
+        pytest.skip('GOOGLE_API_KEY not set')
+
+    import dspy
+
+    predictor, lm = _build_predictor()
+
+    with dspy.context(lm=lm):
+        response = predictor(
+            user_signal=(
+                'The user just walked through how to run the test matrix on '
+                'this Python monorepo: "uv run pytest -m integration tests/, '
+                'then check just docs-build, then prek for lint." It worked. '
+                'Save this how-to so future sessions can repeat it.'
+            )
+        )
+
+    verb = response.verb.lower()
+    assert 'kv_write' in verb, (
+        f'Agent picked the wrong verb: {response.verb!r}. '
+        'Expected memex_kv_write — a how-to that the agent will EXECUTE '
+        'belongs in the procedure: KV namespace, not as a note.'
+    )
+    assert 'add_note' not in verb, (
+        f'Agent suggested memex_add_note: {response.verb!r}. '
+        'Procedures are how-tos to execute; notes are facts to recall. '
+        'F14 verb-vs-note distinction breached.'
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.llm
+def test_real_agent_picks_kv_get_for_procedure_recall():
+    """TC-F14-LLM-2: agent about to perform a recurring task → picks
+    ``memex_kv_get`` against a ``procedure:`` key over ``memex_memory_search``.
+
+    The /recall SKILL.md F14 step says to check the procedure: KV namespace
+    BEFORE other surfaces when the user query is "how do I X?" or the agent
+    is about to perform a recurring task.
+    """
+    if not os.environ.get('GOOGLE_API_KEY'):
+        pytest.skip('GOOGLE_API_KEY not set')
+
+    import dspy
+
+    predictor, lm = _build_predictor()
+
+    with dspy.context(lm=lm):
+        response = predictor(
+            user_signal=(
+                'The user just said: "Open a PR for the bug fix we just '
+                'finished." The agent is about to write the PR title and '
+                'body. The agent KNOWS this team has captured a procedure '
+                'for PR commit-message style at procedure:write_pr:commit-style '
+                'previously. The agent should look up that procedure before '
+                'drafting the PR.'
+            )
+        )
+
+    verb = response.verb.lower()
+    assert 'kv_get' in verb, (
+        f'Agent picked the wrong verb: {response.verb!r}. '
+        'Expected memex_kv_get — procedure recall is shape-different from '
+        'note recall (the procedure: namespace is the right surface for '
+        '"how do I X?" queries).'
+    )
+    assert 'memory_search' not in verb, (
+        f'Agent suggested memex_memory_search: {response.verb!r}. '
+        'Notes/facts come from memory_search; procedures come from kv_get '
+        'on procedure:<verb>:<context-tag>. F14 read-side breached.'
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.llm
+def test_real_agent_closes_loop_with_record_outcome():
+    """TC-F14-LLM-3: after USING a procedure key, agent picks
+    ``memex_record_outcome(target_type="kv_key", ...)`` to close the loop.
+
+    The /remember SKILL.md F14 block + the Hermes routing guide both say
+    "After actually USING a procedure key in a turn (you read it via
+    memex_kv_get and then performed the action), close the loop with
+    memex_record_outcome(target_type='kv_key', kv_key=..., success=...)."
+    Silence provides no learning signal.
+    """
+    if not os.environ.get('GOOGLE_API_KEY'):
+        pytest.skip('GOOGLE_API_KEY not set')
+
+    import dspy
+
+    predictor, lm = _build_predictor()
+
+    with dspy.context(lm=lm):
+        response = predictor(
+            user_signal=(
+                'The agent just READ procedure:write_pr:commit-style via '
+                'memex_kv_get and used the procedure to draft a PR. The PR '
+                'was approved by the user with no edits. The agent should '
+                'now record that the procedure worked, so its Memory Worth '
+                "counters reflect what's working."
+            )
+        )
+
+    verb = response.verb.lower()
+    assert 'record_outcome' in verb, (
+        f'Agent picked the wrong verb: {response.verb!r}. '
+        'Expected memex_record_outcome — close-loop after using a procedure '
+        'is REQUIRED to keep MW counters calibrated. Silence is the F14 '
+        'failure mode F1c is built to detect.'
+    )

--- a/tests/test_e2e_f14_llm_turn.py
+++ b/tests/test_e2e_f14_llm_turn.py
@@ -31,6 +31,40 @@ import os
 import pytest
 
 
+async def _build_metastore_engine(postgres_url: str):
+    """Construct + connect a metastore engine pointing at the testcontainers DB.
+
+    Mirrors ``packages/core/tests/integration/conftest.py::metastore`` but
+    inline so this E2E test doesn't need the package fixture. The full-loop
+    test runs the OutcomeService against the same DB the FastAPI test
+    client is reading via ``client``.
+    """
+    from urllib.parse import urlparse
+
+    from memex_common.config import (
+        PostgresInstanceConfig,
+        PostgresMetaStoreConfig,
+        SecretStr,
+    )
+    from memex_core.storage.metastore import AsyncPostgresMetaStoreEngine
+
+    # postgres_url comes in either postgresql+asyncpg:// or postgresql://
+    # form; normalize so urlparse extracts user/host/port consistently.
+    parsed = urlparse(postgres_url.replace('postgresql+asyncpg://', 'postgresql://'))
+    config = PostgresMetaStoreConfig(
+        instance=PostgresInstanceConfig(
+            host=parsed.hostname or 'localhost',
+            port=parsed.port or 5432,
+            database=(parsed.path or '').lstrip('/'),
+            user=parsed.username or 'postgres',
+            password=SecretStr(parsed.password or 'postgres'),
+        )
+    )
+    engine = AsyncPostgresMetaStoreEngine(config)
+    await engine.connect()
+    return engine
+
+
 _PROCEDURE_SURFACE_DESCRIPTION = """
 The Memex procedure: KV namespace (F14, RFC-007) is for compact, learned
 how-tos owned by the agent. Keys MUST be shaped procedure:<verb>:<context-tag>
@@ -210,4 +244,200 @@ def test_real_agent_closes_loop_with_record_outcome():
         'Expected memex_record_outcome — close-loop after using a procedure '
         'is REQUIRED to keep MW counters calibrated. Silence is the F14 '
         'failure mode F1c is built to detect.'
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.llm
+def test_real_agent_full_loop_briefing_to_mw_counter_increment(client, postgres_url):
+    """TC-F14-LLM-FULL-LOOP: end-to-end agent loop that closes the F14 contract.
+
+    Drives the full briefing → kv_get → act → record_outcome → counter
+    increment → next-turn briefing reflects updated mw_score loop:
+
+    1. Seed a procedure: KV key (the how-to content).
+    2. Seed prior outcomes for that key (3s/1f → mw_score ≈ 0.667 baseline).
+    3. Render the briefing data once (HTTP /procedure-observations) — the
+       surface the next-turn agent sees. Capture pre-state mw_score.
+    4. Real LLM (turn 1): given the briefing surface, agent picks
+       ``memex_kv_get`` against the procedure key.
+    5. Drive kv_get via HTTP — confirm the procedure body returns.
+    6. Real LLM (turn 2): given post-action context (procedure used,
+       outcome successful), agent picks ``memex_record_outcome``.
+    7. Drive record_outcome via the service (no HTTP surface — service-only
+       seam in v1, mirroring F4 walkthrough).
+    8. Re-render the briefing data — assert mw_score moved upward by the
+       expected delta (4s/1f → ≈0.7143, +0.0476).
+
+    The PRE→POST mw_score delta is the load-bearing assertion — it proves
+    the full loop closes and the next-turn briefing surface actually
+    reflects the agent's prior outcome.
+    """
+    if not os.environ.get('GOOGLE_API_KEY'):
+        pytest.skip('GOOGLE_API_KEY not set')
+
+    import asyncio
+    from uuid import uuid4
+
+    import dspy
+
+    from memex_common.config import GLOBAL_VAULT_ID
+    from memex_core.services.outcomes import OutcomeService, compute_mw_score
+
+    proc_key = f'procedure:write_pr:full-loop-{uuid4().hex[:8]}'
+    proc_body = (
+        'Write the PR title in conventional-commit format (feat:/fix:/refactor:); '
+        'open with a one-line summary; bullet the test plan; cite the issue.'
+    )
+
+    # --- Step 1: seed the procedure key via the kv put route. -----------
+    put_resp = client.put('/api/v1/kv', json={'key': proc_key, 'value': proc_body})
+    assert put_resp.status_code == 200, put_resp.text
+
+    # --- Step 2: seed prior outcomes (3s / 1f → mw ≈ 0.667). ------------
+    # No HTTP surface for record_outcome (service-only seam in v1, mirroring
+    # F4 walkthrough at test_e2e_f4_llm_turn.py:92); drive the service
+    # directly. Same path used to close the loop after the agent's turn.
+    async def _seed_outcomes():
+        engine = await _build_metastore_engine(postgres_url)
+        try:
+            outcomes = OutcomeService()
+            async with engine.session() as session:
+                for _ in range(3):
+                    await outcomes.record_outcome(
+                        session=session,
+                        unit_ids=None,
+                        success=True,
+                        vault_id=str(GLOBAL_VAULT_ID),
+                        target_type='kv_key',
+                        kv_key=proc_key,
+                    )
+                await outcomes.record_outcome(
+                    session=session,
+                    unit_ids=None,
+                    success=False,
+                    vault_id=str(GLOBAL_VAULT_ID),
+                    target_type='kv_key',
+                    kv_key=proc_key,
+                )
+        finally:
+            await engine.close()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_seed_outcomes())
+    finally:
+        loop.close()
+
+    # --- Step 3: render briefing pre-state via /procedure-observations. ---
+    pre_resp = client.get(
+        '/api/v1/kv/procedure-observations',
+        params={'vault_id': str(GLOBAL_VAULT_ID), 'limit': 20},
+    )
+    assert pre_resp.status_code == 200, pre_resp.text
+    pre_rows = [r for r in pre_resp.json() if r['kv_key'] == proc_key]
+    assert len(pre_rows) == 1, (
+        f'expected procedure to surface in briefing data; got {pre_resp.json()}'
+    )
+    pre_mw = pre_rows[0]['mw_score']
+    expected_pre_mw = compute_mw_score(3, 1)  # 4/6 ≈ 0.6667
+    assert pre_mw == pytest.approx(expected_pre_mw, abs=1e-6), (
+        f'briefing pre-state mw_score={pre_mw} did not match seed (3s/1f → '
+        f'{expected_pre_mw}); the briefing surface is not reflecting the '
+        'procedure_outcomes table.'
+    )
+
+    # --- Steps 4 + 6: real LLM verb selection — two turns. -------------
+    api_key = os.environ['GOOGLE_API_KEY']
+    lm = dspy.LM(model='gemini/gemini-3-flash-preview', api_key=api_key, timeout=120)
+
+    predictor, _ = _build_predictor()
+    with dspy.context(lm=lm):
+        # Turn 1: agent observes the briefing → picks kv_get.
+        turn1 = predictor(
+            user_signal=(
+                f'The next-turn agent briefing surfaces this procedure: '
+                f'"{proc_key}" (mw_score={pre_mw:.3f}). The user just said: '
+                '"Open a PR for the bug fix we just finished." The agent should '
+                'first look up the procedure body before drafting.'
+            )
+        )
+
+    assert 'kv_get' in turn1.verb.lower(), (
+        f'Turn 1: agent picked {turn1.verb!r}. Expected memex_kv_get to read '
+        'the procedure body before acting on the user request.'
+    )
+
+    # --- Step 5: drive kv_get HTTP — confirm body returns. -----------
+    get_resp = client.get('/api/v1/kv/get', params={'key': proc_key})
+    assert get_resp.status_code == 200, get_resp.text
+    assert get_resp.json()['value'] == proc_body, (
+        'kv_get did not return the seeded procedure body — briefing → read path is broken.'
+    )
+
+    # Turn 2: agent has used the procedure successfully → close the loop.
+    with dspy.context(lm=lm):
+        turn2 = predictor(
+            user_signal=(
+                f'The agent just READ "{proc_key}" via memex_kv_get, drafted '
+                'the PR using that procedure body, and the PR was approved '
+                "with no edits. To keep the procedure's Memory Worth "
+                'calibrated, the agent should now record the outcome.'
+            )
+        )
+
+    assert 'record_outcome' in turn2.verb.lower(), (
+        f'Turn 2: agent picked {turn2.verb!r}. Expected memex_record_outcome '
+        'to close the loop after a successful use of the procedure.'
+    )
+
+    # --- Step 7: drive record_outcome via the service (no HTTP route). --
+    async def _close_loop_success():
+        engine = await _build_metastore_engine(postgres_url)
+        try:
+            outcomes = OutcomeService()
+            async with engine.session() as session:
+                await outcomes.record_outcome(
+                    session=session,
+                    unit_ids=None,
+                    success=True,
+                    vault_id=str(GLOBAL_VAULT_ID),
+                    target_type='kv_key',
+                    kv_key=proc_key,
+                )
+        finally:
+            await engine.close()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_close_loop_success())
+    finally:
+        loop.close()
+
+    # --- Step 8: re-render briefing — assert mw_score increased. ------
+    post_resp = client.get(
+        '/api/v1/kv/procedure-observations',
+        params={'vault_id': str(GLOBAL_VAULT_ID), 'limit': 20},
+    )
+    assert post_resp.status_code == 200, post_resp.text
+    post_rows = [r for r in post_resp.json() if r['kv_key'] == proc_key]
+    assert len(post_rows) == 1
+    post_mw = post_rows[0]['mw_score']
+    expected_post_mw = compute_mw_score(4, 1)  # 5/7 ≈ 0.7143
+    assert post_mw == pytest.approx(expected_post_mw, abs=1e-6), (
+        f'briefing post-state mw_score={post_mw} did not match expected '
+        f"4s/1f → {expected_post_mw}; the agent's record_outcome did not "
+        'propagate to the briefing surface.'
+    )
+    assert post_mw > pre_mw, (
+        f'mw_score did not move upward: pre={pre_mw}, post={post_mw}. '
+        'The full F14 loop (briefing → read → act → record_outcome → '
+        'counter increment → next-turn briefing reflects new score) is '
+        'broken — the load-bearing assertion of TC-F14-LLM-FULL-LOOP.'
+    )
+    # Visible delta for QA's stamp + paper trail.
+    print(
+        f'\n[TC-F14-LLM-FULL-LOOP] mw_score delta: pre={pre_mw:.4f} → '
+        f'post={post_mw:.4f} (Δ=+{post_mw - pre_mw:.4f}); '
+        f'success_co_count: 3 → 4, failure_co_count: 1 (unchanged).'
     )

--- a/tests/test_e2e_f29_outcomes_route.py
+++ b/tests/test_e2e_f29_outcomes_route.py
@@ -1,0 +1,328 @@
+"""End-to-end tests for F29 — POST /api/v1/outcomes/record.
+
+Covers the HTTP wire surface added so non-in-process clients (the Hermes
+plugin via ``RemoteMemexAPI``) can call ``MemexAPI.record_outcome``. The MCP
+tool calls the API in-process; this route gives remote callers parity.
+
+The F14 ADD-2 invariant (positional ``unit_ids`` + required ``success``)
+must hold across the new path — the route body forces ``success`` to be
+present and positional fields stay positional in the in-process call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import asyncpg
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _seed_unit(postgres_url: str) -> tuple[UUID, UUID]:
+    """Insert a MemoryUnit row directly. Returns (unit_id, vault_id)."""
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _seed() -> tuple[UUID, UUID]:
+        conn = await asyncpg.connect(dsn)
+        try:
+            vault_row = await conn.fetchrow("SELECT id FROM vaults WHERE name = 'global' LIMIT 1")
+            assert vault_row is not None, 'global vault missing — fixture broken'
+            vault_id = vault_row['id']
+            unit_id = uuid4()
+            await conn.execute(
+                'INSERT INTO memory_units '
+                '(id, vault_id, fact_type, text, status, is_deprioritized, intent_class, '
+                'risk_class, confidence, event_date, success_co_count, failure_co_count, '
+                'created_at, updated_at) '
+                "VALUES ($1, $2, 'observation', $3, 'active', FALSE, 'durable', 'none', 1.0, "
+                'NOW(), 0, 0, NOW(), NOW())',
+                unit_id,
+                vault_id,
+                f'F29 test unit {unit_id}',
+            )
+            return unit_id, vault_id
+        finally:
+            await conn.close()
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_seed())
+    finally:
+        loop.close()
+
+
+def _seed_kv_entry(postgres_url: str, key: str) -> None:
+    """Insert a kv_entries row so procedure_outcomes' FK to kv_entries.key is satisfied."""
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _seed() -> None:
+        conn = await asyncpg.connect(dsn)
+        try:
+            await conn.execute(
+                'INSERT INTO kv_entries (id, key, value, created_at, updated_at) '
+                'VALUES (gen_random_uuid(), $1, $2, NOW(), NOW())',
+                key,
+                '{"description": "f29 test"}',
+            )
+        finally:
+            await conn.close()
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_seed())
+    finally:
+        loop.close()
+
+
+def _read_unit_counters(postgres_url: str, unit_id: UUID) -> tuple[int, int]:
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _q() -> tuple[int, int]:
+        conn = await asyncpg.connect(dsn)
+        try:
+            row = await conn.fetchrow(
+                'SELECT success_co_count, failure_co_count FROM memory_units WHERE id = $1',
+                unit_id,
+            )
+            assert row is not None
+            return row['success_co_count'], row['failure_co_count']
+        finally:
+            await conn.close()
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_q())
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# memory_unit happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_memory_unit_success_increments_counter(client: TestClient, postgres_url: str):
+    """memory_unit mode: success=true bumps success_co_count."""
+    unit_id, vault_id = _seed_unit(postgres_url)
+    before_s, before_f = _read_unit_counters(postgres_url, unit_id)
+    assert (before_s, before_f) == (0, 0)
+
+    resp = client.post(
+        '/api/v1/outcomes/record',
+        json={
+            'success': True,
+            'unit_ids': [str(unit_id)],
+            'vault_id': str(vault_id),
+            'target_type': 'memory_unit',
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body['units_updated'] == 1
+
+    after_s, after_f = _read_unit_counters(postgres_url, unit_id)
+    assert (after_s, after_f) == (1, 0)
+
+
+@pytest.mark.integration
+def test_memory_unit_failure_increments_failure_counter(client: TestClient, postgres_url: str):
+    """memory_unit mode: success=false bumps failure_co_count, not success."""
+    unit_id, vault_id = _seed_unit(postgres_url)
+
+    resp = client.post(
+        '/api/v1/outcomes/record',
+        json={
+            'success': False,
+            'unit_ids': [str(unit_id)],
+            'vault_id': str(vault_id),
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    s, f = _read_unit_counters(postgres_url, unit_id)
+    assert (s, f) == (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# kv_key happy path (F14)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_kv_key_mode_writes_procedure_outcomes_row(client: TestClient, postgres_url: str):
+    """kv_key mode: increments procedure_outcomes counters and returns the row."""
+    _, vault_id = _seed_unit(postgres_url)
+    kv_key = f'procedure:test-verb:f29-{uuid4().hex[:8]}'
+    _seed_kv_entry(postgres_url, kv_key)
+
+    resp = client.post(
+        '/api/v1/outcomes/record',
+        json={
+            'success': True,
+            'kv_key': kv_key,
+            'vault_id': str(vault_id),
+            'target_type': 'kv_key',
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body['kv_key'] == kv_key
+    assert body['vault_id'] == str(vault_id)
+    assert body['success_co_count'] == 1
+    assert body['failure_co_count'] == 0
+    assert body.get('last_outcome_at') is not None
+
+
+# ---------------------------------------------------------------------------
+# Bad inputs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_unknown_vault_returns_400(client: TestClient):
+    """vault_id that resolves to nothing returns 400, not 500."""
+    resp = client.post(
+        '/api/v1/outcomes/record',
+        json={
+            'success': True,
+            'unit_ids': [str(uuid4())],
+            'vault_id': f'nonexistent-vault-{uuid4().hex[:8]}',
+        },
+    )
+    assert resp.status_code == 400
+    assert 'Unknown vault' in resp.json()['detail']
+
+
+@pytest.mark.integration
+def test_memory_unit_mode_without_unit_ids_returns_400(client: TestClient, postgres_url: str):
+    """memory_unit mode without unit_ids → 400 (caller error, not 500)."""
+    _, vault_id = _seed_unit(postgres_url)
+    resp = client.post(
+        '/api/v1/outcomes/record',
+        json={
+            'success': True,
+            'vault_id': str(vault_id),
+            'target_type': 'memory_unit',
+        },
+    )
+    assert resp.status_code == 400
+    assert 'memory_unit' in resp.json()['detail']
+
+
+@pytest.mark.integration
+def test_kv_key_mode_with_unit_ids_returns_400(client: TestClient, postgres_url: str):
+    """Mixing modes (kv_key + unit_ids) is rejected — silent counter divergence guard."""
+    unit_id, vault_id = _seed_unit(postgres_url)
+    resp = client.post(
+        '/api/v1/outcomes/record',
+        json={
+            'success': True,
+            'unit_ids': [str(unit_id)],
+            'kv_key': 'procedure:foo:bar',
+            'vault_id': str(vault_id),
+            'target_type': 'kv_key',
+        },
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.integration
+def test_missing_success_returns_422(client: TestClient, postgres_url: str):
+    """ADD-2 invariant: success has no default; omitting it is a validation error.
+
+    Mirrors the F14 contract test — a kwargless / minimal call site cannot
+    silently record a FAILURE outcome. The HTTP layer must enforce this same
+    invariant via Pydantic body validation (Field(...) with no default).
+    """
+    _, vault_id = _seed_unit(postgres_url)
+    resp = client.post(
+        '/api/v1/outcomes/record',
+        json={
+            'unit_ids': [str(uuid4())],
+            'vault_id': str(vault_id),
+        },
+    )
+    assert resp.status_code == 422, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Auth — write scope required
+# ---------------------------------------------------------------------------
+
+
+READER_KEY = secrets.token_urlsafe(32)
+WRITER_KEY = secrets.token_urlsafe(32)
+
+
+@pytest.fixture()
+def auth_client(postgres_container, _truncate_db) -> TestClient:
+    """TestClient with auth enabled. Mirrors test_e2e_auth_acl.py fixture."""
+    import os
+    from urllib.parse import urlparse
+
+    from memex_core.server import app
+
+    dsn = postgres_container.get_connection_url()
+    parsed = urlparse(dsn)
+    base_env = {
+        'MEMEX_LOAD_LOCAL_CONFIG': 'false',
+        'MEMEX_LOAD_GLOBAL_CONFIG': 'false',
+        'MEMEX_SERVER__META_STORE__TYPE': 'postgres',
+        'MEMEX_SERVER__META_STORE__INSTANCE__HOST': parsed.hostname or 'localhost',
+        'MEMEX_SERVER__META_STORE__INSTANCE__PORT': str(parsed.port or 5432),
+        'MEMEX_SERVER__META_STORE__INSTANCE__DATABASE': parsed.path.lstrip('/'),
+        'MEMEX_SERVER__META_STORE__INSTANCE__USER': parsed.username or 'test',
+        'MEMEX_SERVER__META_STORE__INSTANCE__PASSWORD': parsed.password or 'test',
+        'MEMEX_SERVER__MEMORY__REFLECTION__BACKGROUND_REFLECTION_ENABLED': 'false',
+        'MEMEX_SERVER__AUTH__ENABLED': 'true',
+        'MEMEX_SERVER__AUTH__KEYS': json.dumps(
+            [
+                {'key': WRITER_KEY, 'policy': 'writer', 'description': 'test-writer'},
+                {'key': READER_KEY, 'policy': 'reader', 'description': 'test-reader'},
+            ]
+        ),
+    }
+    with patch.dict(os.environ, base_env):
+        with TestClient(app) as c:
+            yield c
+
+
+@pytest.mark.integration
+def test_missing_key_returns_401(auth_client: TestClient):
+    """Auth enforced — no API key → 401."""
+    resp = auth_client.post(
+        '/api/v1/outcomes/record',
+        json={'success': True, 'unit_ids': [str(uuid4())], 'vault_id': 'global'},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.integration
+def test_reader_key_returns_403(auth_client: TestClient):
+    """Reader policy lacks write scope — 403."""
+    resp = auth_client.post(
+        '/api/v1/outcomes/record',
+        json={'success': True, 'unit_ids': [str(uuid4())], 'vault_id': 'global'},
+        headers={'X-API-Key': READER_KEY},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.integration
+def test_writer_key_accepted(auth_client: TestClient, postgres_url: str):
+    """Writer policy is sufficient for /outcomes/record."""
+    unit_id, vault_id = _seed_unit(postgres_url)
+    resp = auth_client.post(
+        '/api/v1/outcomes/record',
+        json={
+            'success': True,
+            'unit_ids': [str(unit_id)],
+            'vault_id': str(vault_id),
+        },
+        headers={'X-API-Key': WRITER_KEY},
+    )
+    assert resp.status_code == 200, resp.text

--- a/tests/test_f14_claude_code_skill.py
+++ b/tests/test_f14_claude_code_skill.py
@@ -1,0 +1,117 @@
+"""F14 — Claude Code plugin SKILL.md invariants (TC-F14-4).
+
+Locks the differentiated /remember + /recall blocks for the procedure: KV
+namespace per team-lead's approved draft 3. Two flavors of assertion:
+
+* Positive: each skill names the procedure: namespace and the right
+  surface for its register (write-side for remember, read-side for
+  recall).
+* Negative: the wrong surface does NOT bleed into the other skill —
+  remember does not advertise the read-side helper, recall does not
+  advertise the write-side helper.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _skills_dir() -> Path:
+    return Path(__file__).resolve().parent.parent / 'packages' / 'claude-code-plugin' / 'skills'
+
+
+def _read(slug: str) -> str:
+    return (_skills_dir() / slug / 'SKILL.md').read_text()
+
+
+# ---------------------------------------------------------------------------
+# /remember — write-side surface
+# ---------------------------------------------------------------------------
+
+
+def test_remember_documents_procedure_namespace_and_kv_write_path():
+    text = _read('remember')
+    # Procedure key shape MUST be named so an agent can self-discover the contract.
+    assert 'procedure:<verb>:<context-tag>' in text
+    # Write side: kv_write is the path for capturing a learned procedure.
+    assert 'memex_kv_write' in text
+    # Outcome pairing must close the loop (RFC-007 §155-185).
+    assert 'memex_record_outcome' in text
+    assert 'target_type="kv_key"' in text
+
+
+def test_remember_does_not_advertise_kv_get_include_history():
+    """``include_history=true`` is a READ-time concern; it does NOT belong
+    in /remember (which is the write-side capture skill). This guard fences
+    against accidental cross-pollination during future edits.
+    """
+    text = _read('remember')
+    # The write-side skill MAY mention reading history as a follow-up
+    # ("read prior versions with..."), but only as a one-line aside; the
+    # verbose recall instructions live in /recall.
+    forbidden_combinations = [
+        'BEFORE other surfaces',  # the recall-side instruction
+        'when the user asks "how do I X?"',  # the recall-side trigger
+    ]
+    for forbidden in forbidden_combinations:
+        assert forbidden not in text, (
+            f'/remember/SKILL.md MUST NOT contain {forbidden!r} '
+            '(belongs in /recall — keep the registers separated)'
+        )
+
+
+# ---------------------------------------------------------------------------
+# /recall — read-side surface
+# ---------------------------------------------------------------------------
+
+
+def test_recall_documents_procedure_namespace_and_kv_get_include_history():
+    text = _read('recall')
+    # Procedure key shape MUST be named.
+    assert 'procedure:<verb>:<context-tag>' in text
+    # Read side: kv_get with include_history=true is the recall flag.
+    assert 'include_history=true' in text
+    assert 'memex_kv_list(namespaces=["procedure"])' in text
+
+
+def test_recall_does_not_advertise_kv_write_for_procedures():
+    """Writing a procedure: key is the /remember register, not /recall.
+
+    Negative-grep regression fence per team-lead's draft-3 review:
+    recall/SKILL.md must NOT contain ``memex_kv_write`` paired with
+    ``procedure:``. Even though ``memex_kv_write`` is mentioned elsewhere
+    on the recall side, advertising it as the way to write a learned
+    procedure belongs to /remember.
+    """
+    text = _read('recall')
+    # Search for the specific cross-pollination signal: kv_write used for
+    # procedure: keys in the recall context.
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if 'memex_kv_write' in line and 'procedure:' in line:
+            raise AssertionError(
+                f'/recall/SKILL.md line {i + 1} pairs memex_kv_write with '
+                f'procedure:, which belongs in /remember: {line!r}'
+            )
+
+
+def test_recall_step_numbering_is_consecutive():
+    """Visible numbered steps (outside HTML comments) are 1, 2, 3, 4 in order.
+
+    F14 inserted step 4 (procedure recall) per team-lead's renumber call.
+    F32's step (currently inside an HTML comment, awaiting WS-diagnostics
+    activation) is renumbered to 5 so it becomes consecutive when
+    uncommented.
+    """
+    import re
+
+    text = _read('recall')
+    # Strip everything inside HTML comments — these are scheduled
+    # contributions from other workstreams, not visible to users yet.
+    visible = re.sub(r'<!--.*?-->', '', text, flags=re.DOTALL)
+
+    step_nums = [int(m) for m in re.findall(r'^(\d+)\.\s', visible, flags=re.MULTILINE)]
+    assert step_nums == [1, 2, 3, 4], (
+        f'visible steps in recall/SKILL.md must be 1-4 consecutive (post-F14 '
+        f'renumber); got {step_nums}'
+    )


### PR DESCRIPTION
## Summary

Third of 5 slices into `release/tier-a-cognitive-memory`. This slice ships:

- **F14** — Procedural memory: alembic 028 procedure_outcomes, validate_procedure_key, kv_get include_history, Hermes briefing procedural-observations block, memex procedure CLI, real-LLM TC validation
- **F6** — Lint subsystem: alembic 025 maintenance_proposals, LintService + 4 v1 SQL rules, periodic_lint_task scheduler, HTTP routes (status/findings/dismiss/resolve), CLI subcommands, Hermes pending-lint-findings briefing block, full 51-case test suite
- **F38** — ConsolidationService: alembic 027, ConsolidationTick orchestrator, scheduler registration, HTTP routes + CLI, AC-X-10 boot-discovery canary
- **F29** — Hermes record_outcome parity: HTTP route, client wrapper, MemexAPIProtocol extension, schema/handler

## Test plan

- [ ] CI green
- [ ] Hermes adversarial review fires + completes
- [ ] HIGH+MED patched (LOW skipped per slice-merge policy)
- [ ] Squash-merge once clean (or after 3 cycles with follow-ups filed)