### PR TITLE
fix(slice-2 follow-ups): broaden scheduler catch + log compute failures + resolve vault names (closes #94 #95 #96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,782%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,784%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,758%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,770%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,770%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,769%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,779%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,782%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,785%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,416%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,784%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,785%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/core/src/memex_core/processing/batch.py
+++ b/packages/core/src/memex_core/processing/batch.py
@@ -72,7 +72,12 @@ class JobManager:
             return
         exc = task.exception()
         if exc is not None:
-            logger.error('Batch job %s raised unhandled exception: %s', job_id, exc, exc_info=exc)
+            logger.error(
+                'Batch job %s raised unhandled exception: %s',
+                job_id,
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
     async def create_job(
         self,

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -99,12 +99,26 @@ async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
             for vault in vaults:
                 try:
                     await api.diagnostics.get_or_compute_manifold(vault.id, force_refresh=True)
-                except Exception as e:
+                except (OSError, RuntimeError, ValueError) as e:
                     logger.warning(
                         f'Scheduler: Manifold compute failed for vault {vault.name}: {e}'
                     )
-        except Exception as e:
+                except Exception:
+                    # Programming errors (AttributeError/TypeError/NameError) must not
+                    # silently poison the per-vault loop — log with full traceback and
+                    # continue so other vaults still get refreshed this tick.
+                    logger.exception(
+                        'Scheduler: Unexpected error refreshing manifold for vault %s',
+                        vault.name,
+                    )
+        except (OSError, RuntimeError, ValueError) as e:
             logger.error(f'Scheduler: Diagnostics refresh failed: {e}', exc_info=True)
+        except Exception:
+            # Programming errors at the outer level (e.g. attribute missing on api)
+            # are real bugs — log the full traceback then re-raise so AioClock's
+            # supervisor surfaces the failure rather than silently swallowing it.
+            logger.exception('Scheduler: Unexpected fatal error in diagnostics refresh task')
+            raise
 
 
 async def periodic_lint_task(api: 'MemexAPI'):

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -109,6 +109,9 @@ async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
                     # Programming errors (AttributeError/TypeError/NameError) must not
                     # silently poison the per-vault loop — log with full traceback and
                     # continue so other vaults still get refreshed this tick.
+                    # ``SystemExit`` / ``KeyboardInterrupt`` / ``asyncio.CancelledError``
+                    # are ``BaseException`` subclasses (not ``Exception``) and correctly
+                    # escape this handler so shutdown / cancellation still propagate.
                     logger.exception(
                         'Scheduler: Unexpected error refreshing manifold for vault %s',
                         vault.name,

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -101,7 +101,9 @@ async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
                     await api.diagnostics.get_or_compute_manifold(vault.id, force_refresh=True)
                 except (OSError, RuntimeError, ValueError) as e:
                     logger.warning(
-                        f'Scheduler: Manifold compute failed for vault {vault.name}: {e}'
+                        'Scheduler: Manifold compute failed for vault %s: %s',
+                        vault.name,
+                        e,
                     )
                 except Exception:
                     # Programming errors (AttributeError/TypeError/NameError) must not

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -103,7 +103,7 @@ async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
                     logger.warning(
                         f'Scheduler: Manifold compute failed for vault {vault.name}: {e}'
                     )
-        except (OSError, RuntimeError, ValueError) as e:
+        except Exception as e:
             logger.error(f'Scheduler: Diagnostics refresh failed: {e}', exc_info=True)
 
 

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -117,7 +117,7 @@ async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
                         vault.name,
                     )
         except (OSError, RuntimeError, ValueError) as e:
-            logger.error(f'Scheduler: Diagnostics refresh failed: {e}', exc_info=True)
+            logger.error('Scheduler: Diagnostics refresh failed: %s', e, exc_info=True)
         except Exception:
             # Programming errors at the outer level (e.g. attribute missing on api)
             # are real bugs — log the full traceback then re-raise so AioClock's

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -89,20 +89,12 @@ class DiagnosticsService(BaseService):
             task = asyncio.create_task(self._compute_and_cache(vault_id))
             self._pending[key] = task
 
-            def _on_done(_t: asyncio.Task[dict[str, Any]], k: str = key) -> None:
-                self._clear_registry(k)
-                if _t.cancelled():
-                    return
-                try:
-                    exc = _t.exception()
-                except asyncio.InvalidStateError:
-                    return
-                if exc is not None:
-                    logger.exception(
-                        'Diagnostics manifold compute failed for key %s',
-                        k,
-                        exc_info=(type(exc), exc, exc.__traceback__),
-                    )
+            def _on_done(
+                t: asyncio.Task[dict[str, Any]],
+                _service: 'DiagnosticsService' = self,
+                _key: str = key,
+            ) -> None:
+                _handle_diagnostics_task_completion(_service, _key, t)
 
             task.add_done_callback(_on_done)
             return 'computing', {'task_id': _task_id_for(task)}
@@ -154,3 +146,34 @@ class DiagnosticsService(BaseService):
 
 def _task_id_for(task: asyncio.Task[Any]) -> str:
     return f'{id(task):x}'
+
+
+def _handle_diagnostics_task_completion(
+    service: DiagnosticsService,
+    key: str,
+    task: asyncio.Task[dict[str, Any]],
+) -> None:
+    """Done-callback body for diagnostics UMAP compute tasks.
+
+    Extracted to module scope so unit tests can drive it directly without
+    monkey-patching ``Task.add_done_callback`` on a real asyncio.Task — the
+    closure-capture form is fragile under PyPy/uvloop. ``service`` and
+    ``key`` are passed explicitly; ``task`` is the completed task supplied
+    by the asyncio scheduler.
+    """
+    service._clear_registry(key)
+    if task.cancelled():
+        return
+    try:
+        exc = task.exception()
+    except asyncio.InvalidStateError:
+        return
+    if exc is not None:
+        # Use ``logger.error`` (not ``logger.exception``) because we are not
+        # inside an ``except`` block — the explicit exc_info tuple from the
+        # task's stored exception is what carries the traceback.
+        logger.error(
+            'Diagnostics manifold compute failed for key %s',
+            key,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from collections.abc import Callable
+from typing import Any, cast
 from uuid import UUID
 
 from memex_core.config import MemexConfig
@@ -95,7 +96,8 @@ class DiagnosticsService(BaseService):
             # creation and firing. See round-7/round-12 review notes.
             # The default-arg pattern means the callback is callable as
             # Callable[[Task], None] at runtime, but strict type checkers see the
-            # 3-param signature; the type-ignore on add_done_callback is required.
+            # 3-param signature; the cast at add_done_callback below pins the
+            # runtime contract so signature drift surfaces as a type error.
             def _on_done(
                 t: asyncio.Task[dict[str, Any]],
                 _service: 'DiagnosticsService' = self,
@@ -103,7 +105,10 @@ class DiagnosticsService(BaseService):
             ) -> None:
                 _handle_diagnostics_task_completion(_service, _key, t)
 
-            task.add_done_callback(_on_done)  # type: ignore[arg-type]
+            # Cast (not type:ignore) so that if `_on_done`'s real signature drifts from
+            # the early-binding default-arg form, mypy will fail at the cast — making
+            # the contract explicit instead of silently swallowing a wrong-arity call.
+            task.add_done_callback(cast(Callable[[asyncio.Task[dict[str, Any]]], None], _on_done))
             return 'computing', {'task_id': _task_id_for(task)}
 
     async def get_manifold_status(

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -91,6 +91,12 @@ class DiagnosticsService(BaseService):
 
             def _on_done(_t: asyncio.Task[dict[str, Any]], k: str = key) -> None:
                 self._clear_registry(k)
+                if not _t.cancelled():
+                    exc = _t.exception()
+                    if exc is not None:
+                        logger.exception(
+                            'Diagnostics manifold compute failed for key %s', k, exc_info=exc
+                        )
 
             task.add_done_callback(_on_done)
             return 'computing', {'task_id': _task_id_for(task)}

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -161,7 +161,14 @@ def _handle_diagnostics_task_completion(
     ``key`` are passed explicitly; ``task`` is the completed task supplied
     by the asyncio scheduler.
     """
-    service._clear_registry(key)
+    # Always run the registry clear, but never let a failure here bypass the
+    # cancelled / InvalidStateError / failure-logging branches below. A raise
+    # from ``_clear_registry`` would otherwise silently swallow the task's
+    # exception and leave both error branches unexecuted.
+    try:
+        service._clear_registry(key)
+    except Exception:
+        logger.exception('Failed to clear diagnostics registry for key=%s', key)
     if task.cancelled():
         return
     try:

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -93,6 +93,9 @@ class DiagnosticsService(BaseService):
             # definition time (early binding). A bare closure would late-bind, which
             # is fragile if a future refactor mutates self/key between callback
             # creation and firing. See round-7/round-12 review notes.
+            # The default-arg pattern means the callback is callable as
+            # Callable[[Task], None] at runtime, but strict type checkers see the
+            # 3-param signature; the type-ignore on add_done_callback is required.
             def _on_done(
                 t: asyncio.Task[dict[str, Any]],
                 _service: 'DiagnosticsService' = self,
@@ -100,7 +103,7 @@ class DiagnosticsService(BaseService):
             ) -> None:
                 _handle_diagnostics_task_completion(_service, _key, t)
 
-            task.add_done_callback(_on_done)
+            task.add_done_callback(_on_done)  # type: ignore[arg-type]
             return 'computing', {'task_id': _task_id_for(task)}
 
     async def get_manifold_status(

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -99,7 +99,9 @@ class DiagnosticsService(BaseService):
                     return
                 if exc is not None:
                     logger.exception(
-                        'Diagnostics manifold compute failed for key %s', k, exc_info=exc
+                        'Diagnostics manifold compute failed for key %s',
+                        k,
+                        exc_info=(type(exc), exc, exc.__traceback__),
                     )
 
             task.add_done_callback(_on_done)

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -91,12 +91,16 @@ class DiagnosticsService(BaseService):
 
             def _on_done(_t: asyncio.Task[dict[str, Any]], k: str = key) -> None:
                 self._clear_registry(k)
-                if not _t.cancelled():
+                if _t.cancelled():
+                    return
+                try:
                     exc = _t.exception()
-                    if exc is not None:
-                        logger.exception(
-                            'Diagnostics manifold compute failed for key %s', k, exc_info=exc
-                        )
+                except asyncio.InvalidStateError:
+                    return
+                if exc is not None:
+                    logger.exception(
+                        'Diagnostics manifold compute failed for key %s', k, exc_info=exc
+                    )
 
             task.add_done_callback(_on_done)
             return 'computing', {'task_id': _task_id_for(task)}

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -89,6 +89,10 @@ class DiagnosticsService(BaseService):
             task = asyncio.create_task(self._compute_and_cache(vault_id))
             self._pending[key] = task
 
+            # Default-argument capture is intentional: binds _service and _key at
+            # definition time (early binding). A bare closure would late-bind, which
+            # is fragile if a future refactor mutates self/key between callback
+            # creation and firing. See round-7/round-12 review notes.
             def _on_done(
                 t: asyncio.Task[dict[str, Any]],
                 _service: 'DiagnosticsService' = self,
@@ -131,14 +135,8 @@ class DiagnosticsService(BaseService):
         return await compute_manifold(self.metastore, self.filestore, vault_id)
 
     def _clear_registry(self, key: str) -> None:
-        # Plain ``def`` — intentionally NOT ``async``. Called from
-        # ``_handle_diagnostics_task_completion`` which is wired as an
-        # asyncio.Task done-callback (sync context). An ``async def`` here
-        # would silently return an unawaited coroutine. ``dict.pop`` is atomic
-        # in CPython's GIL-enabled build (default through 3.13); the registry
-        # needs no async coordination for this single-statement mutation.
-        # If/when the project adopts Python 3.13t (free-threaded, no GIL),
-        # revisit: registry mutation may need explicit locking.
+        # Sync ``def`` (called from a done-callback). ``dict.pop`` is atomic
+        # under the GIL; revisit if/when 3.13t (free-threaded) is adopted.
         self._pending.pop(key, None)
 
     async def shutdown(self) -> None:

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -135,8 +135,10 @@ class DiagnosticsService(BaseService):
         # ``_handle_diagnostics_task_completion`` which is wired as an
         # asyncio.Task done-callback (sync context). An ``async def`` here
         # would silently return an unawaited coroutine. ``dict.pop`` is atomic
-        # in CPython under the GIL; the registry needs no async coordination
-        # for this single-statement mutation.
+        # in CPython's GIL-enabled build (default through 3.13); the registry
+        # needs no async coordination for this single-statement mutation.
+        # If/when the project adopts Python 3.13t (free-threaded, no GIL),
+        # revisit: registry mutation may need explicit locking.
         self._pending.pop(key, None)
 
     async def shutdown(self) -> None:

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -131,6 +131,12 @@ class DiagnosticsService(BaseService):
         return await compute_manifold(self.metastore, self.filestore, vault_id)
 
     def _clear_registry(self, key: str) -> None:
+        # Plain ``def`` — intentionally NOT ``async``. Called from
+        # ``_handle_diagnostics_task_completion`` which is wired as an
+        # asyncio.Task done-callback (sync context). An ``async def`` here
+        # would silently return an unawaited coroutine. ``dict.pop`` is atomic
+        # in CPython under the GIL; the registry needs no async coordination
+        # for this single-statement mutation.
         self._pending.pop(key, None)
 
     async def shutdown(self) -> None:

--- a/packages/core/tests/unit/test_batch_manager.py
+++ b/packages/core/tests/unit/test_batch_manager.py
@@ -561,3 +561,95 @@ async def test_create_job_concurrent_empty_batch_rejected(manager, mock_api):
         f'all 5 concurrent empty-batch submissions must raise ValueError; '
         f'got types: {[type(r).__name__ for r in results]}'
     )
+
+
+# ---------------------------------------------------------------------------
+# Hermes round-5: _task_done_callback must capture exception + traceback in
+# the LogRecord. The previous form ``exc_info=exc`` (passing the exception
+# instance) silently dropped the traceback because the logging stdlib treats
+# a non-tuple non-True ``exc_info`` outside an ``except`` block as
+# ``sys.exc_info()`` — which returns ``(None, None, None)`` from a callback
+# fired off the asyncio loop, not the originating frame. The fix passes an
+# explicit ``(type, exc, exc.__traceback__)`` tuple; this test pins that.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_done_callback_captures_exception_traceback(manager, caplog):
+    """A background task that raises must produce a LogRecord whose
+    ``exc_info`` is populated and whose ``exc_text`` contains the
+    exception's traceback (the type name + originating frame). Without the
+    explicit ``(type, exc, exc.__traceback__)`` tuple, ``exc_text`` is empty
+    and operators get an exception message with no stack — making post-hoc
+    debugging of failed batch jobs much harder.
+    """
+    import asyncio
+    import logging
+
+    job_id = uuid4()
+
+    class _BatchProbeError(RuntimeError):
+        """Sentinel exception so the assertion is unambiguous."""
+
+    async def _raise() -> None:
+        raise _BatchProbeError('synthetic failure inside batch task')
+
+    task = asyncio.create_task(_raise())
+    # Drive the coroutine to completion so ``task.exception()`` is populated.
+    try:
+        await task
+    except _BatchProbeError:
+        pass
+
+    with caplog.at_level(logging.ERROR, logger='memex.core.processing.batch'):
+        manager._task_done_callback(job_id, task)
+
+    error_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.ERROR and r.name == 'memex.core.processing.batch'
+    ]
+    assert len(error_records) == 1, f'expected 1 ERROR record, got {len(error_records)}'
+    record = error_records[0]
+    # The bug: previously ``exc_info`` was ``None`` because logging resolved
+    # ``exc_info=<exception>`` via ``sys.exc_info()`` from a non-except frame.
+    assert record.exc_info is not None, (
+        'LogRecord.exc_info must be populated; otherwise the formatter has '
+        'no stack to render and operators see the exception message with no '
+        'traceback.'
+    )
+    # ``exc_text`` is lazily populated by Formatter.format(); force it.
+    formatter = logging.Formatter()
+    formatter.format(record)
+    assert record.exc_text, 'exc_text must contain the rendered traceback'
+    assert '_BatchProbeError' in record.exc_text, (
+        f'rendered traceback must reference the exception class; got: {record.exc_text!r}'
+    )
+    assert 'synthetic failure inside batch task' in record.exc_text, (
+        f'rendered traceback must include the exception message; got: {record.exc_text!r}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_done_callback_pops_active_task(manager):
+    """The callback must remove the job from ``_active_tasks`` whether the
+    task succeeded, raised, or was cancelled. Pinning the cleanup contract
+    so ``JobManager`` can't silently leak task references on the error
+    path that round-5 just instrumented.
+    """
+    import asyncio
+
+    job_id = uuid4()
+
+    async def _raise() -> None:
+        raise RuntimeError('boom')
+
+    task = asyncio.create_task(_raise())
+    try:
+        await task
+    except RuntimeError:
+        pass
+
+    manager._active_tasks[job_id] = task
+    manager._task_done_callback(job_id, task)
+    assert job_id not in manager._active_tasks

--- a/packages/core/tests/unit/test_diagnostics_on_done.py
+++ b/packages/core/tests/unit/test_diagnostics_on_done.py
@@ -29,11 +29,22 @@ import pytest
 
 
 def _make_service():
-    """Construct a ``DiagnosticsService`` without invoking the real ``__init__``.
+    """Construct a DiagnosticsService bypassing __init__ for unit-test isolation.
 
     Bypasses the dependency wiring (metastore/filestore/config) — only the
     registry state needed by ``get_or_compute_manifold`` and the done-callback
     is populated.
+
+    Tests using this helper exercise code paths that read ONLY:
+      - service._pending (dict[str, asyncio.Task])
+      - service._registry_lock (asyncio.Lock)
+
+    If production ``DiagnosticsService.__init__`` grows new attributes that are
+    read in the code paths under test (``get_or_compute_manifold``, ``_on_done``,
+    ``_handle_diagnostics_task_completion``, ``_clear_registry``), this helper
+    must set them explicitly OR the tests must be migrated to a real fixture.
+    Otherwise an ``AttributeError`` will surface in tests when production code
+    starts reading the new attribute (e.g. ``self._cache``).
     """
     from memex_core.services.diagnostics import DiagnosticsService
 

--- a/packages/core/tests/unit/test_diagnostics_on_done.py
+++ b/packages/core/tests/unit/test_diagnostics_on_done.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -109,33 +109,46 @@ async def test_on_done_swallows_invalid_state_error(caplog):
 
     This race (callback fires before task is in a terminal state) cannot be
     reproduced via the public API — the asyncio scheduler always marks the
-    task done before invoking done-callbacks. Instead we extract the real
-    callback the production code registered, then invoke it with a fake task
-    whose ``exception()`` raises ``InvalidStateError``.
+    task done before invoking done-callbacks. We capture the real callback at
+    the moment production code registers it by wrapping ``asyncio.create_task``
+    in the diagnostics module so the returned Task records what was passed to
+    ``add_done_callback``. This avoids reaching into the private
+    ``Task._callbacks`` attribute, which is undocumented CPython internals and
+    not portable across implementations (PyPy, uvloop).
     """
+    from memex_core.services import diagnostics as diagnostics_module
+
     service = _make_service()
     vault_id = uuid4()
     key = str(vault_id)
 
-    real_task_callbacks: list = []
+    captured_callbacks: list = []
 
     async def _slow(_vault_id):
         await asyncio.sleep(60)
 
     service._compute_and_cache = _slow  # type: ignore[method-assign]
 
-    status, _ = await service.get_or_compute_manifold(vault_id, force_refresh=True)
+    original_create_task = asyncio.create_task
+
+    def _wrap_create_task(coro, *args, **kwargs):
+        task = original_create_task(coro, *args, **kwargs)
+        original_add = task.add_done_callback
+
+        def _capture(cb, *cb_args, **cb_kwargs):
+            if getattr(cb, '__name__', '') == '_on_done':
+                captured_callbacks.append(cb)
+            return original_add(cb, *cb_args, **cb_kwargs)
+
+        task.add_done_callback = _capture  # type: ignore[method-assign]
+        return task
+
+    with patch.object(diagnostics_module.asyncio, 'create_task', _wrap_create_task):
+        status, _ = await service.get_or_compute_manifold(vault_id, force_refresh=True)
     assert status == 'computing'
     real_task = service._pending[key]
     try:
-        # Steal the registered callback. asyncio doesn't expose this directly,
-        # but `_callbacks` is the documented attribute used by `remove_done_callback`.
-        callbacks = list(getattr(real_task, '_callbacks', []))
-        for cb_entry in callbacks:
-            cb = cb_entry[0] if isinstance(cb_entry, tuple) else cb_entry
-            if getattr(cb, '__name__', '') == '_on_done':
-                real_task_callbacks.append(cb)
-        assert real_task_callbacks, 'production code must register an _on_done callback'
+        assert captured_callbacks, 'production code must register an _on_done callback'
 
         fake_task = MagicMock()
         fake_task.cancelled = MagicMock(return_value=False)
@@ -146,7 +159,7 @@ async def test_on_done_swallows_invalid_state_error(caplog):
         service._pending[key] = real_task
 
         with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
-            real_task_callbacks[0](fake_task)
+            captured_callbacks[0](fake_task)
 
         fake_task.exception.assert_called_once()
         assert key not in service._pending, 'registry must be cleared even on InvalidStateError'

--- a/packages/core/tests/unit/test_diagnostics_on_done.py
+++ b/packages/core/tests/unit/test_diagnostics_on_done.py
@@ -9,9 +9,11 @@ The callback is registered against the in-flight UMAP compute task. It must:
   task is normally done by the time the callback fires, but a hostile scheduler
   could in theory drop us in before completion).
 
-These tests exercise the callback directly by re-creating the closure shape
-used in ``DiagnosticsService.get_or_compute_manifold`` so we don't need a
-running compute or DB.
+The first three tests drive the real ``get_or_compute_manifold`` path so the
+production callback registered via ``task.add_done_callback(_on_done)`` is the
+one being exercised. The InvalidStateError test calls the registered callback
+directly with a fake task because that scheduler-race condition cannot be
+reproduced via the public API.
 """
 
 from __future__ import annotations
@@ -24,56 +26,46 @@ from uuid import uuid4
 import pytest
 
 
-def _build_callback(service):
-    """Re-create the ``_on_done`` closure for direct unit testing.
+def _make_service():
+    """Construct a ``DiagnosticsService`` without invoking the real ``__init__``.
 
-    Mirrors the body in
-    :meth:`memex_core.services.diagnostics.DiagnosticsService.get_or_compute_manifold`.
-    Updates here MUST track that source.
+    Bypasses the dependency wiring (metastore/filestore/config) — only the
+    registry state needed by ``get_or_compute_manifold`` and ``_on_done`` is
+    populated.
     """
-    from memex_core.services.diagnostics import logger as diag_logger  # noqa: F401
+    from memex_core.services.diagnostics import DiagnosticsService
 
-    key = 'test-key'
-
-    def _on_done(_t, k=key):
-        service._clear_registry(k)
-        if _t.cancelled():
-            return
-        try:
-            exc = _t.exception()
-        except asyncio.InvalidStateError:
-            return
-        if exc is not None:
-            from memex_core.services.diagnostics import logger as _logger
-
-            _logger.exception('Diagnostics manifold compute failed for key %s', k, exc_info=exc)
-
-    return _on_done, key
+    service = DiagnosticsService.__new__(DiagnosticsService)
+    service._pending = {}
+    service._registry_lock = asyncio.Lock()
+    return service
 
 
 @pytest.mark.asyncio
 async def test_on_done_logs_exception_for_failed_task(caplog):
-    """Real callback in get_or_compute_manifold must log on task failure."""
-    from memex_core.services.diagnostics import DiagnosticsService
+    """Real callback registered by get_or_compute_manifold must log on failure."""
+    service = _make_service()
+    vault_id = uuid4()
+    key = str(vault_id)
 
-    service = MagicMock(spec=DiagnosticsService)
-    service._clear_registry = MagicMock()
-
-    async def _boom():
+    async def _boom(_vault_id):
         raise RuntimeError('umap exploded')
 
-    task = asyncio.create_task(_boom())
-    try:
-        await task
-    except RuntimeError:
-        pass
-
-    callback, key = _build_callback(service)
+    service._compute_and_cache = _boom  # type: ignore[method-assign]
 
     with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
-        callback(task)
+        status, payload = await service.get_or_compute_manifold(vault_id, force_refresh=True)
+        assert status == 'computing'
+        # Drain the just-scheduled task so the registered _on_done fires.
+        task = service._pending.get(key)
+        assert task is not None, 'task must be registered before completion'
+        try:
+            await task
+        except RuntimeError:
+            pass
+        await asyncio.sleep(0)
 
-    service._clear_registry.assert_called_once_with(key)
+    assert key not in service._pending, 'registry must be cleared on completion'
     assert any(
         'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
     ), 'Failed task must be logged'
@@ -83,96 +75,87 @@ async def test_on_done_logs_exception_for_failed_task(caplog):
 @pytest.mark.asyncio
 async def test_on_done_skips_cancelled_task(caplog):
     """Cancelled tasks must clear registry but skip exception fetch + log."""
-    from memex_core.services.diagnostics import DiagnosticsService
+    service = _make_service()
+    vault_id = uuid4()
+    key = str(vault_id)
 
-    service = MagicMock(spec=DiagnosticsService)
-    service._clear_registry = MagicMock()
-
-    async def _slow():
+    async def _slow(_vault_id):
         await asyncio.sleep(60)
 
-    task = asyncio.create_task(_slow())
-    task.cancel()
-    try:
-        await task
-    except asyncio.CancelledError:
-        pass
-
-    callback, key = _build_callback(service)
+    service._compute_and_cache = _slow  # type: ignore[method-assign]
 
     with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
-        callback(task)
+        status, _ = await service.get_or_compute_manifold(vault_id, force_refresh=True)
+        assert status == 'computing'
+        task = service._pending.get(key)
+        assert task is not None
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        await asyncio.sleep(0)
 
-    service._clear_registry.assert_called_once_with(key)
+    assert key not in service._pending, 'registry must be cleared on cancellation'
     assert not any(
         'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
     ), 'Cancelled task must NOT log a failure message'
 
 
-def test_on_done_swallows_invalid_state_error(caplog):
-    """If ``_t.exception()`` raises InvalidStateError, the callback returns
-    without crashing or logging."""
-    from memex_core.services.diagnostics import DiagnosticsService
-
-    service = MagicMock(spec=DiagnosticsService)
-    service._clear_registry = MagicMock()
-
-    fake_task = MagicMock()
-    fake_task.cancelled = MagicMock(return_value=False)
-    fake_task.exception = MagicMock(side_effect=asyncio.InvalidStateError)
-
-    callback, key = _build_callback(service)
-
-    with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
-        callback(fake_task)
-
-    service._clear_registry.assert_called_once_with(key)
-    fake_task.exception.assert_called_once()
-    assert not any(
-        'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
-    ), 'InvalidStateError path must not emit a failure log'
-
-
 @pytest.mark.asyncio
-async def test_on_done_real_callback_in_get_or_compute_manifold(caplog):
-    """End-to-end: register a failing task on the real service and confirm the
-    real ``_on_done`` callback (not a copy) clears the registry and logs."""
-    from memex_core.services.diagnostics import DiagnosticsService
+async def test_on_done_swallows_invalid_state_error(caplog):
+    """If ``_t.exception()`` raises InvalidStateError, the registered callback
+    returns without crashing or logging.
 
-    service = DiagnosticsService.__new__(DiagnosticsService)
-    service._pending = {}
-    service._registry_lock = asyncio.Lock()
-
+    This race (callback fires before task is in a terminal state) cannot be
+    reproduced via the public API — the asyncio scheduler always marks the
+    task done before invoking done-callbacks. Instead we extract the real
+    callback the production code registered, then invoke it with a fake task
+    whose ``exception()`` raises ``InvalidStateError``.
+    """
+    service = _make_service()
     vault_id = uuid4()
     key = str(vault_id)
 
-    async def _boom():
-        raise RuntimeError('boom from real path')
+    real_task_callbacks: list = []
 
-    task = asyncio.create_task(_boom())
-    service._pending[key] = task
+    async def _slow(_vault_id):
+        await asyncio.sleep(60)
 
-    def _on_done(_t, k=key):
-        service._pending.pop(k, None)
-        if _t.cancelled():
-            return
+    service._compute_and_cache = _slow  # type: ignore[method-assign]
+
+    status, _ = await service.get_or_compute_manifold(vault_id, force_refresh=True)
+    assert status == 'computing'
+    real_task = service._pending[key]
+    try:
+        # Steal the registered callback. asyncio doesn't expose this directly,
+        # but `_callbacks` is the documented attribute used by `remove_done_callback`.
+        callbacks = list(getattr(real_task, '_callbacks', []))
+        for cb_entry in callbacks:
+            cb = cb_entry[0] if isinstance(cb_entry, tuple) else cb_entry
+            if getattr(cb, '__name__', '') == '_on_done':
+                real_task_callbacks.append(cb)
+        assert real_task_callbacks, 'production code must register an _on_done callback'
+
+        fake_task = MagicMock()
+        fake_task.cancelled = MagicMock(return_value=False)
+        fake_task.exception = MagicMock(side_effect=asyncio.InvalidStateError)
+
+        # Pre-populate the registry so we can confirm the callback clears it
+        # even when the task is in an InvalidState.
+        service._pending[key] = real_task
+
+        with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
+            real_task_callbacks[0](fake_task)
+
+        fake_task.exception.assert_called_once()
+        assert key not in service._pending, 'registry must be cleared even on InvalidStateError'
+        assert not any(
+            'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
+        ), 'InvalidStateError path must not emit a failure log'
+    finally:
+        real_task.cancel()
         try:
-            exc = _t.exception()
-        except asyncio.InvalidStateError:
-            return
-        if exc is not None:
-            from memex_core.services.diagnostics import logger as _logger
-
-            _logger.exception('Diagnostics manifold compute failed for key %s', k, exc_info=exc)
-
-    task.add_done_callback(_on_done)
-
-    with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
-        try:
-            await task
-        except RuntimeError:
+            await real_task
+        except asyncio.CancelledError:
             pass
-        await asyncio.sleep(0)
-
-    assert key not in service._pending, 'registry must be cleared on completion'
-    assert any('Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records)

--- a/packages/core/tests/unit/test_diagnostics_on_done.py
+++ b/packages/core/tests/unit/test_diagnostics_on_done.py
@@ -168,3 +168,81 @@ def test_on_done_swallows_invalid_state_error(caplog):
     assert not any(
         'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
     ), 'InvalidStateError path must not emit a failure log'
+
+
+def test_on_done_clear_registry_failure_does_not_swallow_task_exception(caplog):
+    """Round-10 regression: a failure inside ``_clear_registry`` MUST NOT
+    bypass the task-exception logging branch.
+
+    The done-callback wraps ``service._clear_registry(key)`` in try/except
+    specifically to defend against this swallow. If a future refactor drops
+    the wrapper (or replaces it with bare ``service._clear_registry(key)``),
+    the registry-clear exception would propagate out of the callback before
+    we ever reach ``task.exception()``, and the task's real failure would
+    never hit the logs. This test pins the defense by:
+
+    * mocking ``_clear_registry`` to raise ``RuntimeError('clear failed')``
+    * passing a task whose ``exception()`` returns the real task error
+    * asserting BOTH log records appear (registry-clear failure AND
+      original task exception, the latter with ``exc_info`` populated).
+    """
+    from memex_core.services import diagnostics as diagnostics_module
+    from memex_core.services.diagnostics import _handle_diagnostics_task_completion
+
+    service = _make_service()
+    vault_id = uuid4()
+    key = str(vault_id)
+
+    real_task_exc = RuntimeError('umap exploded')
+    fake_task = MagicMock()
+    fake_task.cancelled = MagicMock(return_value=False)
+    # Set ``__traceback__`` so the explicit exc_info tuple in the callback has
+    # a non-None traceback slot (matches what asyncio normally provides).
+    try:
+        raise real_task_exc
+    except RuntimeError as e:
+        captured = e
+    fake_task.exception = MagicMock(return_value=captured)
+
+    # Patch the bound method to raise; ``_handle_diagnostics_task_completion``
+    # calls ``service._clear_registry(key)`` so we replace the instance attribute.
+    def _boom(_key: str) -> None:
+        raise RuntimeError('clear failed')
+
+    service._clear_registry = _boom  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.ERROR, logger=diagnostics_module.logger.name):
+        _handle_diagnostics_task_completion(service, key, fake_task)
+
+    # (a) registry-clear failure must be logged with exc_info (logger.exception).
+    clear_records = [
+        rec for rec in caplog.records if 'Failed to clear diagnostics registry' in rec.getMessage()
+    ]
+    assert clear_records, 'registry-clear failure must produce a log record'
+    assert clear_records[0].exc_info is not None, (
+        'registry-clear failure must carry exc_info from logger.exception'
+    )
+    assert 'clear failed' in str(clear_records[0].exc_info[1])
+
+    # (b) original task exception must STILL be logged with exc_info — the
+    # whole point of the try/except wrapper around ``_clear_registry``.
+    task_records = [
+        rec for rec in caplog.records if 'Diagnostics manifold compute failed' in rec.getMessage()
+    ]
+    assert task_records, (
+        'task exception MUST be logged even when _clear_registry failed; '
+        'the try/except around _clear_registry exists precisely to prevent '
+        'this swallow'
+    )
+    assert task_records[0].exc_info is not None
+    assert task_records[0].exc_info[1] is captured
+    assert 'umap exploded' in str(task_records[0].exc_info[1])
+
+    # Two distinct records — one per failure surface.
+    assert len(clear_records) == 1
+    assert len(task_records) == 1
+    assert clear_records[0] is not task_records[0]
+
+    # ``task.exception()`` MUST have been consulted — proves we reached the
+    # post-clear branch even though clear raised.
+    fake_task.exception.assert_called_once()

--- a/packages/core/tests/unit/test_diagnostics_on_done.py
+++ b/packages/core/tests/unit/test_diagnostics_on_done.py
@@ -1,0 +1,178 @@
+"""Unit tests for the ``DiagnosticsService._on_done`` task callback.
+
+The callback is registered against the in-flight UMAP compute task. It must:
+
+* clear the registry entry for the vault key,
+* skip cancelled tasks (no logging, no exception fetch),
+* log a real exception via ``logger.exception``,
+* swallow ``asyncio.InvalidStateError`` from ``_t.exception()`` (defensive — the
+  task is normally done by the time the callback fires, but a hostile scheduler
+  could in theory drop us in before completion).
+
+These tests exercise the callback directly by re-creating the closure shape
+used in ``DiagnosticsService.get_or_compute_manifold`` so we don't need a
+running compute or DB.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+
+def _build_callback(service):
+    """Re-create the ``_on_done`` closure for direct unit testing.
+
+    Mirrors the body in
+    :meth:`memex_core.services.diagnostics.DiagnosticsService.get_or_compute_manifold`.
+    Updates here MUST track that source.
+    """
+    from memex_core.services.diagnostics import logger as diag_logger  # noqa: F401
+
+    key = 'test-key'
+
+    def _on_done(_t, k=key):
+        service._clear_registry(k)
+        if _t.cancelled():
+            return
+        try:
+            exc = _t.exception()
+        except asyncio.InvalidStateError:
+            return
+        if exc is not None:
+            from memex_core.services.diagnostics import logger as _logger
+
+            _logger.exception('Diagnostics manifold compute failed for key %s', k, exc_info=exc)
+
+    return _on_done, key
+
+
+@pytest.mark.asyncio
+async def test_on_done_logs_exception_for_failed_task(caplog):
+    """Real callback in get_or_compute_manifold must log on task failure."""
+    from memex_core.services.diagnostics import DiagnosticsService
+
+    service = MagicMock(spec=DiagnosticsService)
+    service._clear_registry = MagicMock()
+
+    async def _boom():
+        raise RuntimeError('umap exploded')
+
+    task = asyncio.create_task(_boom())
+    try:
+        await task
+    except RuntimeError:
+        pass
+
+    callback, key = _build_callback(service)
+
+    with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
+        callback(task)
+
+    service._clear_registry.assert_called_once_with(key)
+    assert any(
+        'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
+    ), 'Failed task must be logged'
+    assert any('umap exploded' in (rec.exc_text or '') for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_on_done_skips_cancelled_task(caplog):
+    """Cancelled tasks must clear registry but skip exception fetch + log."""
+    from memex_core.services.diagnostics import DiagnosticsService
+
+    service = MagicMock(spec=DiagnosticsService)
+    service._clear_registry = MagicMock()
+
+    async def _slow():
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(_slow())
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    callback, key = _build_callback(service)
+
+    with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
+        callback(task)
+
+    service._clear_registry.assert_called_once_with(key)
+    assert not any(
+        'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
+    ), 'Cancelled task must NOT log a failure message'
+
+
+def test_on_done_swallows_invalid_state_error(caplog):
+    """If ``_t.exception()`` raises InvalidStateError, the callback returns
+    without crashing or logging."""
+    from memex_core.services.diagnostics import DiagnosticsService
+
+    service = MagicMock(spec=DiagnosticsService)
+    service._clear_registry = MagicMock()
+
+    fake_task = MagicMock()
+    fake_task.cancelled = MagicMock(return_value=False)
+    fake_task.exception = MagicMock(side_effect=asyncio.InvalidStateError)
+
+    callback, key = _build_callback(service)
+
+    with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
+        callback(fake_task)
+
+    service._clear_registry.assert_called_once_with(key)
+    fake_task.exception.assert_called_once()
+    assert not any(
+        'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
+    ), 'InvalidStateError path must not emit a failure log'
+
+
+@pytest.mark.asyncio
+async def test_on_done_real_callback_in_get_or_compute_manifold(caplog):
+    """End-to-end: register a failing task on the real service and confirm the
+    real ``_on_done`` callback (not a copy) clears the registry and logs."""
+    from memex_core.services.diagnostics import DiagnosticsService
+
+    service = DiagnosticsService.__new__(DiagnosticsService)
+    service._pending = {}
+    service._registry_lock = asyncio.Lock()
+
+    vault_id = uuid4()
+    key = str(vault_id)
+
+    async def _boom():
+        raise RuntimeError('boom from real path')
+
+    task = asyncio.create_task(_boom())
+    service._pending[key] = task
+
+    def _on_done(_t, k=key):
+        service._pending.pop(k, None)
+        if _t.cancelled():
+            return
+        try:
+            exc = _t.exception()
+        except asyncio.InvalidStateError:
+            return
+        if exc is not None:
+            from memex_core.services.diagnostics import logger as _logger
+
+            _logger.exception('Diagnostics manifold compute failed for key %s', k, exc_info=exc)
+
+    task.add_done_callback(_on_done)
+
+    with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
+        try:
+            await task
+        except RuntimeError:
+            pass
+        await asyncio.sleep(0)
+
+    assert key not in service._pending, 'registry must be cleared on completion'
+    assert any('Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records)

--- a/packages/core/tests/unit/test_diagnostics_on_done.py
+++ b/packages/core/tests/unit/test_diagnostics_on_done.py
@@ -1,26 +1,28 @@
-"""Unit tests for the ``DiagnosticsService._on_done`` task callback.
+"""Unit tests for the diagnostics task-completion callback.
 
-The callback is registered against the in-flight UMAP compute task. It must:
+The callback (``_handle_diagnostics_task_completion``) is registered against
+the in-flight UMAP compute task. It must:
 
 * clear the registry entry for the vault key,
 * skip cancelled tasks (no logging, no exception fetch),
-* log a real exception via ``logger.exception``,
-* swallow ``asyncio.InvalidStateError`` from ``_t.exception()`` (defensive — the
-  task is normally done by the time the callback fires, but a hostile scheduler
-  could in theory drop us in before completion).
+* log a real exception with a populated traceback,
+* swallow ``asyncio.InvalidStateError`` from ``task.exception()`` (defensive —
+  the task is normally done by the time the callback fires, but a hostile
+  scheduler could in theory drop us in before completion).
 
-The first three tests drive the real ``get_or_compute_manifold`` path so the
-production callback registered via ``task.add_done_callback(_on_done)`` is the
-one being exercised. The InvalidStateError test calls the registered callback
-directly with a fake task because that scheduler-race condition cannot be
-reproduced via the public API.
+The first two tests drive the real ``get_or_compute_manifold`` path so the
+production callback registered via ``task.add_done_callback`` is the one
+being exercised. The InvalidStateError test calls the module-level
+``_handle_diagnostics_task_completion`` directly with a fake task — the
+callback was extracted to module scope precisely to avoid monkey-patching
+``Task.add_done_callback`` on a real asyncio.Task (fragile under PyPy/uvloop).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -30,8 +32,8 @@ def _make_service():
     """Construct a ``DiagnosticsService`` without invoking the real ``__init__``.
 
     Bypasses the dependency wiring (metastore/filestore/config) — only the
-    registry state needed by ``get_or_compute_manifold`` and ``_on_done`` is
-    populated.
+    registry state needed by ``get_or_compute_manifold`` and the done-callback
+    is populated.
     """
     from memex_core.services.diagnostics import DiagnosticsService
 
@@ -39,6 +41,20 @@ def _make_service():
     service._pending = {}
     service._registry_lock = asyncio.Lock()
     return service
+
+
+def _force_format_exc_text(records: list[logging.LogRecord]) -> None:
+    """Lazy-populate ``LogRecord.exc_text`` for any record carrying ``exc_info``.
+
+    ``LogCaptureHandler`` does not call ``Formatter.format()``, so ``exc_text``
+    stays ``None`` even when a traceback was logged. Without this, the assertion
+    ``'... in (rec.exc_text or "")`` silently passes for the wrong reason.
+    Mirrors ``test_batch_manager.test_task_done_callback_captures_exception_traceback``.
+    """
+    formatter = logging.Formatter()
+    for record in records:
+        if record.exc_info:
+            formatter.format(record)
 
 
 @pytest.mark.asyncio
@@ -56,7 +72,7 @@ async def test_on_done_logs_exception_for_failed_task(caplog):
     with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
         status, payload = await service.get_or_compute_manifold(vault_id, force_refresh=True)
         assert status == 'computing'
-        # Drain the just-scheduled task so the registered _on_done fires.
+        # Drain the just-scheduled task so the registered callback fires.
         task = service._pending.get(key)
         assert task is not None, 'task must be registered before completion'
         try:
@@ -69,7 +85,23 @@ async def test_on_done_logs_exception_for_failed_task(caplog):
     assert any(
         'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
     ), 'Failed task must be logged'
-    assert any('umap exploded' in (rec.exc_text or '') for rec in caplog.records)
+
+    # exc_info is populated at LogRecord construction time — assert on it
+    # directly rather than relying on lazily-formatted exc_text.
+    exc_info_records = [rec for rec in caplog.records if rec.exc_info]
+    assert exc_info_records, 'failed task must produce a record carrying exc_info'
+    assert any(
+        rec.exc_info is not None and 'umap exploded' in str(rec.exc_info[1])
+        for rec in exc_info_records
+    ), 'exc_info must reference the originating RuntimeError'
+
+    # Belt-and-braces: also force exc_text formatting and check it for parity
+    # with test_batch_manager (catches a regression where the explicit
+    # exc_info tuple is dropped and the formatter has no traceback to render).
+    _force_format_exc_text(caplog.records)
+    assert any('umap exploded' in (rec.exc_text or '') for rec in caplog.records), (
+        'rendered traceback must reference the exception message'
+    )
 
 
 @pytest.mark.asyncio
@@ -102,73 +134,37 @@ async def test_on_done_skips_cancelled_task(caplog):
     ), 'Cancelled task must NOT log a failure message'
 
 
-@pytest.mark.asyncio
-async def test_on_done_swallows_invalid_state_error(caplog):
-    """If ``_t.exception()`` raises InvalidStateError, the registered callback
-    returns without crashing or logging.
+def test_on_done_swallows_invalid_state_error(caplog):
+    """If ``task.exception()`` raises InvalidStateError, the callback returns
+    without crashing or logging.
 
     This race (callback fires before task is in a terminal state) cannot be
     reproduced via the public API — the asyncio scheduler always marks the
-    task done before invoking done-callbacks. We capture the real callback at
-    the moment production code registers it by wrapping ``asyncio.create_task``
-    in the diagnostics module so the returned Task records what was passed to
-    ``add_done_callback``. This avoids reaching into the private
-    ``Task._callbacks`` attribute, which is undocumented CPython internals and
-    not portable across implementations (PyPy, uvloop).
+    task done before invoking done-callbacks. The done-callback body lives at
+    module scope (``_handle_diagnostics_task_completion``) precisely so this
+    test can call it directly with a fake task. No monkey-patching of
+    ``Task.add_done_callback`` required, no reliance on CPython's
+    instance-level method replacement (fragile under PyPy/uvloop).
     """
-    from memex_core.services import diagnostics as diagnostics_module
+    from memex_core.services.diagnostics import _handle_diagnostics_task_completion
 
     service = _make_service()
     vault_id = uuid4()
     key = str(vault_id)
 
-    captured_callbacks: list = []
+    fake_task = MagicMock()
+    fake_task.cancelled = MagicMock(return_value=False)
+    fake_task.exception = MagicMock(side_effect=asyncio.InvalidStateError)
 
-    async def _slow(_vault_id):
-        await asyncio.sleep(60)
+    # Pre-populate the registry so we can confirm the callback clears it
+    # even when the task is in an InvalidState.
+    service._pending[key] = MagicMock(spec=asyncio.Task)
 
-    service._compute_and_cache = _slow  # type: ignore[method-assign]
+    with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
+        _handle_diagnostics_task_completion(service, key, fake_task)
 
-    original_create_task = asyncio.create_task
-
-    def _wrap_create_task(coro, *args, **kwargs):
-        task = original_create_task(coro, *args, **kwargs)
-        original_add = task.add_done_callback
-
-        def _capture(cb, *cb_args, **cb_kwargs):
-            if getattr(cb, '__name__', '') == '_on_done':
-                captured_callbacks.append(cb)
-            return original_add(cb, *cb_args, **cb_kwargs)
-
-        task.add_done_callback = _capture  # type: ignore[method-assign]
-        return task
-
-    with patch.object(diagnostics_module.asyncio, 'create_task', _wrap_create_task):
-        status, _ = await service.get_or_compute_manifold(vault_id, force_refresh=True)
-    assert status == 'computing'
-    real_task = service._pending[key]
-    try:
-        assert captured_callbacks, 'production code must register an _on_done callback'
-
-        fake_task = MagicMock()
-        fake_task.cancelled = MagicMock(return_value=False)
-        fake_task.exception = MagicMock(side_effect=asyncio.InvalidStateError)
-
-        # Pre-populate the registry so we can confirm the callback clears it
-        # even when the task is in an InvalidState.
-        service._pending[key] = real_task
-
-        with caplog.at_level(logging.ERROR, logger='memex.core.services.diagnostics'):
-            captured_callbacks[0](fake_task)
-
-        fake_task.exception.assert_called_once()
-        assert key not in service._pending, 'registry must be cleared even on InvalidStateError'
-        assert not any(
-            'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
-        ), 'InvalidStateError path must not emit a failure log'
-    finally:
-        real_task.cancel()
-        try:
-            await real_task
-        except asyncio.CancelledError:
-            pass
+    fake_task.exception.assert_called_once()
+    assert key not in service._pending, 'registry must be cleared even on InvalidStateError'
+    assert not any(
+        'Diagnostics manifold compute failed' in rec.getMessage() for rec in caplog.records
+    ), 'InvalidStateError path must not emit a failure log'

--- a/packages/core/tests/unit/test_scheduler.py
+++ b/packages/core/tests/unit/test_scheduler.py
@@ -235,3 +235,153 @@ async def test_vault_summary_task_no_summary_falls_through_to_is_stale(mock_bg_s
 
     api.vault_summary.update_summary.assert_awaited_once_with('vault-1')
     api.vault_summary.regenerate_summary.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# periodic_diagnostics_refresh_task — error-handling branches (Hermes round-2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch('memex_core.scheduler.background_session')
+async def test_diagnostics_refresh_continues_after_per_vault_unexpected_exception(
+    mock_bg_session,
+):
+    """Per-vault inner loop must continue when one vault raises an unexpected
+    programming error (AttributeError / NameError) so other vaults still
+    refresh this tick."""
+    from memex_core.scheduler import periodic_diagnostics_refresh_task
+
+    mock_bg_session.return_value.__aenter__ = AsyncMock(return_value='test-session')
+    mock_bg_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    vault_a = MagicMock()
+    vault_a.id = 'vault-a'
+    vault_a.name = 'alpha'
+    vault_b = MagicMock()
+    vault_b.id = 'vault-b'
+    vault_b.name = 'beta'
+    vault_c = MagicMock()
+    vault_c.id = 'vault-c'
+    vault_c.name = 'gamma'
+
+    api = MagicMock()
+    api.list_vaults = AsyncMock(return_value=[vault_a, vault_b, vault_c])
+
+    visited: list[str] = []
+
+    async def _compute(vault_id, *, force_refresh=False):
+        visited.append(vault_id)
+        if vault_id == 'vault-b':
+            raise AttributeError("'NoneType' has no attribute 'foo'")
+        return ('computing', {'task_id': 't'})
+
+    api.diagnostics = MagicMock()
+    api.diagnostics.get_or_compute_manifold = AsyncMock(side_effect=_compute)
+
+    await periodic_diagnostics_refresh_task(api)
+
+    assert visited == ['vault-a', 'vault-b', 'vault-c'], (
+        'inner loop must continue after AttributeError on vault-b'
+    )
+
+
+@pytest.mark.asyncio
+@patch('memex_core.scheduler.background_session')
+async def test_diagnostics_refresh_continues_after_per_vault_name_error(mock_bg_session):
+    """NameError in one vault must not stop the loop."""
+    from memex_core.scheduler import periodic_diagnostics_refresh_task
+
+    mock_bg_session.return_value.__aenter__ = AsyncMock(return_value='test-session')
+    mock_bg_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    vault_a = MagicMock(id='vault-a', name='alpha')
+    vault_b = MagicMock(id='vault-b', name='beta')
+
+    api = MagicMock()
+    api.list_vaults = AsyncMock(return_value=[vault_a, vault_b])
+
+    visited: list[str] = []
+
+    async def _compute(vault_id, *, force_refresh=False):
+        visited.append(vault_id)
+        if vault_id == 'vault-a':
+            raise NameError('undefined_symbol')
+        return ('computing', {'task_id': 't'})
+
+    api.diagnostics = MagicMock()
+    api.diagnostics.get_or_compute_manifold = AsyncMock(side_effect=_compute)
+
+    await periodic_diagnostics_refresh_task(api)
+
+    assert visited == ['vault-a', 'vault-b']
+
+
+@pytest.mark.asyncio
+@patch('memex_core.scheduler.background_session')
+async def test_diagnostics_refresh_outer_unexpected_exception_reraises(mock_bg_session):
+    """Outer-level unexpected exception (e.g. ``api.list_vaults`` raising an
+    AttributeError) must re-raise so the AioClock supervisor surfaces it,
+    rather than being silently swallowed."""
+    from memex_core.scheduler import periodic_diagnostics_refresh_task
+
+    mock_bg_session.return_value.__aenter__ = AsyncMock(return_value='test-session')
+    mock_bg_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    api = MagicMock()
+    api.list_vaults = AsyncMock(side_effect=AttributeError('api missing attribute'))
+
+    with pytest.raises(AttributeError, match='api missing attribute'):
+        await periodic_diagnostics_refresh_task(api)
+
+
+@pytest.mark.asyncio
+@patch('memex_core.scheduler.background_session')
+async def test_diagnostics_refresh_outer_known_exception_does_not_reraise(
+    mock_bg_session,
+):
+    """Outer-level *known* infrastructure exceptions (OSError/RuntimeError/
+    ValueError) are logged but NOT re-raised — they're treated as transient."""
+    from memex_core.scheduler import periodic_diagnostics_refresh_task
+
+    mock_bg_session.return_value.__aenter__ = AsyncMock(return_value='test-session')
+    mock_bg_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    api = MagicMock()
+    api.list_vaults = AsyncMock(side_effect=OSError('postgres unreachable'))
+
+    # Should NOT raise.
+    await periodic_diagnostics_refresh_task(api)
+
+
+@pytest.mark.asyncio
+@patch('memex_core.scheduler.background_session')
+async def test_diagnostics_refresh_per_vault_known_exception_continues(
+    mock_bg_session,
+):
+    """Per-vault OSError/RuntimeError/ValueError logs a warning but continues."""
+    from memex_core.scheduler import periodic_diagnostics_refresh_task
+
+    mock_bg_session.return_value.__aenter__ = AsyncMock(return_value='test-session')
+    mock_bg_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    vault_a = MagicMock(id='vault-a', name='alpha')
+    vault_b = MagicMock(id='vault-b', name='beta')
+
+    api = MagicMock()
+    api.list_vaults = AsyncMock(return_value=[vault_a, vault_b])
+
+    visited: list[str] = []
+
+    async def _compute(vault_id, *, force_refresh=False):
+        visited.append(vault_id)
+        if vault_id == 'vault-a':
+            raise OSError('disk full')
+        return ('computing', {'task_id': 't'})
+
+    api.diagnostics = MagicMock()
+    api.diagnostics.get_or_compute_manifold = AsyncMock(side_effect=_compute)
+
+    await periodic_diagnostics_refresh_task(api)
+
+    assert visited == ['vault-a', 'vault-b']

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3476,6 +3476,9 @@ def handle_memory_summarize_node(
             # the built-in `TimeoutError` in 3.11+) when the 10s budget is
             # exhausted. Surface a distinct message so a stuck backend doesn't
             # masquerade as a generic resolution failure.
+            # ORDERING INVARIANT: `TimeoutError` is a subclass of `OSError`
+            # (Python 3.3+). This handler MUST stay above any `except OSError:`
+            # branch — otherwise OSError would silently intercept timeouts.
             logger.warning(
                 'memex_memory_summarize_node: vault resolution timed out for identifier %r',
                 raw_vault,

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3498,16 +3498,19 @@ def handle_memory_summarize_node(
     # protocol-level return is ``UUID | None``. ``None`` is not a valid downstream
     # value for this handler, and ``isinstance(None, UUID)`` is ``False`` — so a
     # single ``not isinstance`` check catches both ``None`` and any other unexpected
-    # type and yields a clear ``'NoneType'`` diagnostic. Returning ``tool_error``
-    # matches every other error path in this handler and keeps the diagnostic
-    # intact instead of letting ``None`` flow into a downstream ``AttributeError``.
-    # A regular ``if``/``return`` (not ``assert``) ensures the check survives
-    # ``python -O``.
+    # type. Keep the diagnostic detail in the operator log; return a generic
+    # user-facing message that matches the obfuscation policy of the surrounding
+    # ValueError / KeyError / TimeoutError / generic-Exception paths in this
+    # handler instead of leaking the type name to the caller. A regular
+    # ``if``/``return`` (not ``assert``) ensures the check survives ``python -O``.
     if not isinstance(target_vault, UUID):
-        return tool_error(
-            f'Internal error: vault resolution returned unexpected type '
-            f'{type(target_vault).__name__} (expected UUID)'
+        logger.error(
+            'memex_memory_summarize_node: vault resolution returned unexpected '
+            'type %s (expected UUID, raw_input=%r)',
+            type(target_vault).__name__,
+            raw_vault,
         )
+        return tool_error('Internal error: vault resolution returned unexpected result')
 
     try:
         result = run_sync(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3479,6 +3479,16 @@ def handle_memory_summarize_node(
             )
             return tool_error('Failed to resolve vault identifier')
 
+    # Narrow ``target_vault`` to ``UUID | None``. ``api.resolve_vault_identifier``
+    # is contractually typed ``-> UUID`` (see memex_core.api / memex_common.client),
+    # but the protocol stub used here (line 110) types it as ``Any``. The assert
+    # documents the contract for mypy and surfaces a loud failure at the boundary
+    # if the contract is ever broken — instead of a confusing AttributeError
+    # deeper in ``api.summarize_node``.
+    assert target_vault is None or isinstance(target_vault, UUID), (
+        f'resolve_vault_identifier returned non-UUID: {type(target_vault).__name__}'
+    )
+
     try:
         result = run_sync(
             api.summarize_node(entity_uuid, scope=scope, vault_id=target_vault),

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3481,13 +3481,15 @@ def handle_memory_summarize_node(
 
     # Narrow ``target_vault`` to ``UUID | None``. ``api.resolve_vault_identifier``
     # is contractually typed ``-> UUID`` (see memex_core.api / memex_common.client),
-    # but the protocol stub used here (line 110) types it as ``Any``. The assert
-    # documents the contract for mypy and surfaces a loud failure at the boundary
-    # if the contract is ever broken — instead of a confusing AttributeError
-    # deeper in ``api.summarize_node``.
-    assert target_vault is None or isinstance(target_vault, UUID), (
-        f'resolve_vault_identifier returned non-UUID: {type(target_vault).__name__}'
-    )
+    # but the protocol stub used here (line 110) types it as ``Any``. The explicit
+    # ``raise TypeError`` documents the contract for mypy and surfaces a loud
+    # failure at the boundary if the contract is ever broken — instead of a
+    # confusing AttributeError deeper in ``api.summarize_node``. Using a real
+    # ``raise`` (not ``assert``) ensures the check survives ``python -O``.
+    if target_vault is not None and not isinstance(target_vault, UUID):
+        raise TypeError(
+            f'resolve_vault_identifier returned non-UUID: {type(target_vault).__name__}'
+        )
 
     try:
         result = run_sync(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3458,9 +3458,19 @@ def handle_memory_summarize_node(
                 raw_vault,
             )
             return tool_error('Vault not found or invalid identifier')
+        except TimeoutError:
+            # `run_sync` raises `concurrent.futures.TimeoutError` (aliased to
+            # the built-in `TimeoutError` in 3.11+) when the 10s budget is
+            # exhausted. Surface a distinct message so a stuck backend doesn't
+            # masquerade as a generic resolution failure.
+            logger.warning(
+                'memex_memory_summarize_node: vault resolution timed out for identifier %r',
+                raw_vault,
+            )
+            return tool_error('Vault resolution timed out')
         except Exception:
             # Catch-all for infrastructure failures (HTTP errors, network
-            # timeouts, backend exceptions). Surface a distinct message so
+            # errors, backend exceptions). Surface a distinct message so
             # genuine connectivity issues don't masquerade as missing-vault
             # errors.
             logger.exception(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3450,10 +3450,12 @@ def handle_memory_summarize_node(
         try:
             target_vault = run_sync(api.resolve_vault_identifier(str(raw_vault)), timeout=10.0)
         except (ValueError, KeyError):
+            # Routine "not found" / typo — the %r-formatted identifier in the
+            # message is sufficient for diagnosis. Skip exc_info to avoid
+            # noisy tracebacks for expected control-flow outcomes.
             logger.warning(
                 'memex_memory_summarize_node: vault not found for identifier %r',
                 raw_vault,
-                exc_info=True,
             )
             return tool_error('Vault not found or invalid identifier')
         except Exception:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3479,14 +3479,18 @@ def handle_memory_summarize_node(
             )
             return tool_error('Failed to resolve vault identifier')
 
-    # Narrow ``target_vault`` to ``UUID | None``. ``api.resolve_vault_identifier``
-    # is contractually typed ``-> UUID`` (see memex_core.api / memex_common.client),
-    # but the protocol stub used here (line 110) types it as ``Any``. Returning
-    # ``tool_error`` matches every other error path in this handler and keeps the
-    # diagnostic intact instead of relying on the invocation framework to surface
-    # a bare ``raise``. A regular ``if``/``return`` (not ``assert``) ensures the
-    # check survives ``python -O``.
-    if target_vault is not None and not isinstance(target_vault, UUID):
+    # Narrow ``target_vault`` to ``UUID``. ``api.resolve_vault_identifier`` is
+    # contractually typed ``-> UUID`` (see memex_core.api / memex_common.client),
+    # but the protocol stub used here (line 110) types it as ``Any`` and the
+    # protocol-level return is ``UUID | None``. ``None`` is not a valid downstream
+    # value for this handler, and ``isinstance(None, UUID)`` is ``False`` — so a
+    # single ``not isinstance`` check catches both ``None`` and any other unexpected
+    # type and yields a clear ``'NoneType'`` diagnostic. Returning ``tool_error``
+    # matches every other error path in this handler and keeps the diagnostic
+    # intact instead of letting ``None`` flow into a downstream ``AttributeError``.
+    # A regular ``if``/``return`` (not ``assert``) ensures the check survives
+    # ``python -O``.
+    if not isinstance(target_vault, UUID):
         return tool_error(
             f'Internal error: vault resolution returned unexpected type '
             f'{type(target_vault).__name__} (expected UUID)'

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3457,11 +3457,15 @@ def handle_memory_summarize_node(
             )
             return tool_error('Vault not found or invalid identifier')
         except Exception:
+            # Catch-all for infrastructure failures (HTTP errors, network
+            # timeouts, backend exceptions). Surface a distinct message so
+            # genuine connectivity issues don't masquerade as missing-vault
+            # errors.
             logger.exception(
                 'memex_memory_summarize_node: vault resolution failed for identifier %r',
                 raw_vault,
             )
-            return tool_error('Vault not found or invalid identifier')
+            return tool_error('Failed to resolve vault identifier')
 
     try:
         result = run_sync(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3449,8 +3449,19 @@ def handle_memory_summarize_node(
     else:
         try:
             target_vault = run_sync(api.resolve_vault_identifier(str(raw_vault)), timeout=10.0)
-        except (ValueError, KeyError) as e:
-            return tool_error(f'Invalid vault: {e}')
+        except (ValueError, KeyError):
+            logger.warning(
+                'memex_memory_summarize_node: vault not found for identifier %r',
+                raw_vault,
+                exc_info=True,
+            )
+            return tool_error('Vault not found or invalid identifier')
+        except Exception:
+            logger.exception(
+                'memex_memory_summarize_node: vault resolution failed for identifier %r',
+                raw_vault,
+            )
+            return tool_error('Vault not found or invalid identifier')
 
     try:
         result = run_sync(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3481,14 +3481,15 @@ def handle_memory_summarize_node(
 
     # Narrow ``target_vault`` to ``UUID | None``. ``api.resolve_vault_identifier``
     # is contractually typed ``-> UUID`` (see memex_core.api / memex_common.client),
-    # but the protocol stub used here (line 110) types it as ``Any``. The explicit
-    # ``raise TypeError`` documents the contract for mypy and surfaces a loud
-    # failure at the boundary if the contract is ever broken — instead of a
-    # confusing AttributeError deeper in ``api.summarize_node``. Using a real
-    # ``raise`` (not ``assert``) ensures the check survives ``python -O``.
+    # but the protocol stub used here (line 110) types it as ``Any``. Returning
+    # ``tool_error`` matches every other error path in this handler and keeps the
+    # diagnostic intact instead of relying on the invocation framework to surface
+    # a bare ``raise``. A regular ``if``/``return`` (not ``assert``) ensures the
+    # check survives ``python -O``.
     if target_vault is not None and not isinstance(target_vault, UUID):
-        raise TypeError(
-            f'resolve_vault_identifier returned non-UUID: {type(target_vault).__name__}'
+        return tool_error(
+            f'Internal error: vault resolution returned unexpected type '
+            f'{type(target_vault).__name__} (expected UUID)'
         )
 
     try:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3448,9 +3448,9 @@ def handle_memory_summarize_node(
         target_vault = vault_id
     else:
         try:
-            target_vault = UUID(str(raw_vault))
-        except ValueError:
-            return tool_error(f'Invalid vault UUID: {raw_vault}')
+            target_vault = run_sync(api.resolve_vault_identifier(str(raw_vault)), timeout=10.0)
+        except (ValueError, KeyError) as e:
+            return tool_error(f'Invalid vault: {e}')
 
     try:
         result = run_sync(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3449,13 +3449,26 @@ def handle_memory_summarize_node(
     else:
         try:
             target_vault = run_sync(api.resolve_vault_identifier(str(raw_vault)), timeout=10.0)
-        except (ValueError, KeyError):
-            # Routine "not found" / typo — the %r-formatted identifier in the
-            # message is sufficient for diagnosis. Skip exc_info to avoid
-            # noisy tracebacks for expected control-flow outcomes.
+        except ValueError as e:
+            # Malformed identifier — string failed to parse as a UUID or vault
+            # name (typo, bad format). Distinct log line from the KeyError path
+            # so operators can grep for "malformed" vs "not found" in
+            # log aggregators. User-facing tool_error stays generic for UX.
             logger.warning(
-                'memex_memory_summarize_node: vault not found for identifier %r',
+                'memex_memory_summarize_node: vault identifier malformed (input=%r): %s',
                 raw_vault,
+                e,
+            )
+            return tool_error('Vault not found or invalid identifier')
+        except KeyError as e:
+            # Identifier parsed cleanly but no vault with that id/name exists.
+            # Distinct log line from the ValueError path; same generic
+            # user-facing tool_error message for UX consistency.
+            logger.warning(
+                'memex_memory_summarize_node: vault identifier parsed but vault '
+                'not found (input=%r): %s',
+                raw_vault,
+                e,
             )
             return tool_error('Vault not found or invalid identifier')
         except TimeoutError:

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -3522,3 +3522,70 @@ def test_append_note_api_failure_returns_error(config, vault_id):
     )
     data = json.loads(out)
     assert 'error' in data or 'isError' in data, out
+
+
+# ---------------------------------------------------------------------------
+# handle_memory_summarize_node — vault resolution error paths (Hermes round-2)
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_node_value_error_on_vault_returns_not_found(config, vault_id):
+    """ValueError from resolve_vault_identifier surfaces as 'Vault not found'."""
+    api = Mock()
+    api.resolve_vault_identifier = AsyncMock(side_effect=ValueError('bad input'))
+    api.summarize_node = AsyncMock()
+
+    entity_id = uuid4()
+    out = dispatch(
+        'memex_memory_summarize_node',
+        {'entity_id': str(entity_id), 'vault_id': 'unknown-vault'},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'Vault not found' in data['error']
+    api.summarize_node.assert_not_called()
+
+
+def test_summarize_node_key_error_on_vault_returns_not_found(config, vault_id):
+    """KeyError from resolve_vault_identifier surfaces as 'Vault not found'."""
+    api = Mock()
+    api.resolve_vault_identifier = AsyncMock(side_effect=KeyError('missing'))
+    api.summarize_node = AsyncMock()
+
+    entity_id = uuid4()
+    out = dispatch(
+        'memex_memory_summarize_node',
+        {'entity_id': str(entity_id), 'vault_id': 'unknown-vault'},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'Vault not found' in data['error']
+    api.summarize_node.assert_not_called()
+
+
+def test_summarize_node_unexpected_exception_returns_generic_resolution_error(config, vault_id):
+    """Unexpected exceptions (e.g. infrastructure failures) surface a distinct
+    generic message — they must NOT masquerade as 'Vault not found'."""
+    api = Mock()
+    api.resolve_vault_identifier = AsyncMock(side_effect=RuntimeError('connection refused'))
+    api.summarize_node = AsyncMock()
+
+    entity_id = uuid4()
+    out = dispatch(
+        'memex_memory_summarize_node',
+        {'entity_id': str(entity_id), 'vault_id': 'some-vault'},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'Failed to resolve vault identifier' in data['error']
+    assert 'Vault not found' not in data['error']
+    api.summarize_node.assert_not_called()

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -3617,3 +3617,32 @@ def test_summarize_node_timeout_error_returns_distinct_timeout_message(config, v
     assert 'Vault not found' not in data['error']
     assert 'Failed to resolve vault identifier' not in data['error']
     api.summarize_node.assert_not_called()
+
+
+def test_summarize_node_none_target_vault_returns_internal_error(config, vault_id):
+    """Round-9 regression: when ``resolve_vault_identifier`` returns ``None``
+    (the protocol stub permits ``UUID | None``), the handler MUST surface a
+    clean ``tool_error`` rather than letting ``None`` flow into
+    ``api.summarize_node`` and produce a confusing call-site ``AttributeError``.
+    The single ``not isinstance(target_vault, UUID)`` guard catches this because
+    ``isinstance(None, UUID)`` is ``False`` and ``type(None).__name__`` is
+    ``'NoneType'``.
+    """
+    api = Mock()
+    api.resolve_vault_identifier = AsyncMock(return_value=None)
+    api.summarize_node = AsyncMock()
+
+    entity_id = uuid4()
+    out = dispatch(
+        'memex_memory_summarize_node',
+        {'entity_id': str(entity_id), 'vault_id': 'some-vault'},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'Internal error' in data['error']
+    assert 'NoneType' in data['error']
+    assert 'expected UUID' in data['error']
+    api.summarize_node.assert_not_called()

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -3589,3 +3589,31 @@ def test_summarize_node_unexpected_exception_returns_generic_resolution_error(co
     assert 'Failed to resolve vault identifier' in data['error']
     assert 'Vault not found' not in data['error']
     api.summarize_node.assert_not_called()
+
+
+def test_summarize_node_timeout_error_returns_distinct_timeout_message(config, vault_id):
+    """``TimeoutError`` from ``run_sync`` (10s budget exhausted) MUST surface a
+    distinct 'timed out' message — it must NOT masquerade as either the
+    'Vault not found' typo path or the generic 'Failed to resolve vault
+    identifier' infrastructure-failure path. ``run_sync`` raises
+    ``concurrent.futures.TimeoutError`` which is aliased to the built-in
+    ``TimeoutError`` in Python 3.11+, so the side_effect uses the built-in.
+    """
+    api = Mock()
+    api.resolve_vault_identifier = AsyncMock(side_effect=TimeoutError('vault resolve > 10s'))
+    api.summarize_node = AsyncMock()
+
+    entity_id = uuid4()
+    out = dispatch(
+        'memex_memory_summarize_node',
+        {'entity_id': str(entity_id), 'vault_id': 'slow-vault'},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert 'timed out' in data['error'].lower()
+    assert 'Vault not found' not in data['error']
+    assert 'Failed to resolve vault identifier' not in data['error']
+    api.summarize_node.assert_not_called()

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -3591,6 +3591,12 @@ def test_summarize_node_unexpected_exception_returns_generic_resolution_error(co
     api.summarize_node.assert_not_called()
 
 
+# NOTE: This test verifies the EXCEPTION-PATH handling — that a TimeoutError
+# raised from inside resolve_vault_identifier is caught and produces the
+# distinct 'Vault resolution timed out' tool_error. It does NOT exercise
+# run_sync's own timeout-after-N-seconds cancellation mechanism, which
+# would require a 10s slow-coroutine setup. The exception path is the
+# load-bearing assertion (run_sync is third-party / std-lib).
 def test_summarize_node_timeout_error_returns_distinct_timeout_message(config, vault_id):
     """``TimeoutError`` from ``run_sync`` (10s budget exhausted) MUST surface a
     distinct 'timed out' message — it must NOT masquerade as either the

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -3625,8 +3625,13 @@ def test_summarize_node_none_target_vault_returns_internal_error(config, vault_i
     clean ``tool_error`` rather than letting ``None`` flow into
     ``api.summarize_node`` and produce a confusing call-site ``AttributeError``.
     The single ``not isinstance(target_vault, UUID)`` guard catches this because
-    ``isinstance(None, UUID)`` is ``False`` and ``type(None).__name__`` is
-    ``'NoneType'``.
+    ``isinstance(None, UUID)`` is ``False``.
+
+    Round-11: the user-facing message is intentionally generic (matches the
+    obfuscation policy of sibling ValueError/KeyError/TimeoutError/Exception
+    paths). The type name (``'NoneType'``) is logged for operators, not
+    returned to the caller — so the assertion checks for the generic string
+    only.
     """
     api = Mock()
     api.resolve_vault_identifier = AsyncMock(return_value=None)
@@ -3643,6 +3648,8 @@ def test_summarize_node_none_target_vault_returns_internal_error(config, vault_i
     data = json.loads(out)
     assert 'error' in data
     assert 'Internal error' in data['error']
-    assert 'NoneType' in data['error']
-    assert 'expected UUID' in data['error']
+    assert 'unexpected result' in data['error']
+    # Type-name detail is now logged, NOT user-facing. Confirm we don't leak
+    # 'NoneType' (information disclosure) in the response.
+    assert 'NoneType' not in data['error']
     api.summarize_node.assert_not_called()


### PR DESCRIPTION
Resolves #94, #95, #96 — slice-2 cycle-4 MED follow-ups.

## Summary

- **#94** `scheduler.py` — broaden outer `except (OSError, RuntimeError, ValueError)` in `periodic_diagnostics_refresh_task` to `except Exception` so SQLAlchemy `DatabaseError` (and other unexpected exceptions) are logged rather than crashing the scheduler.
- **#95** `services/diagnostics.py` — `_on_done` callback now inspects `task.exception()` (when the task was not cancelled) and logs the failure with `logger.exception`, so background `_compute_and_cache` errors no longer disappear silently.
- **#96** `hermes-plugin/.../memex/tools.py` — `handle_memory_summarize_node` routes the user-supplied `vault_id` through `api.resolve_vault_identifier` (via `run_sync`), matching `handle_get_diagnostics_summary`. Friendly vault names are now accepted.

## Test plan

- [x] `uv run ruff check` on the 3 modified files (clean)
- [x] `uv run ruff format` applied to tools.py
- [x] `uv run pytest packages/core/tests/integration/test_int_f32_endpoints.py -x` (2 passed)
- [x] `uv run pytest packages/hermes-plugin/tests/ -k "summarize" -x` (3 passed, 376 deselected)