### PR TITLE
fix(lint): tier-a follow-ups C — issues #99, #100, #109

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,768%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,769%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,758%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,759%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -395,16 +395,21 @@ class LintService(BaseService):
             try:
                 await session.commit()
             except Exception as exc:
-                successful_rule_count = sum(
-                    1 for r in results if r.error is None and r.findings_emitted > 0
-                )
-                committed_findings = sum(r.findings_emitted for r in results if r.error is None)
+                # The outer commit failed — findings from successful rules
+                # were NOT persisted. Name the variables accordingly:
+                # ``findings_at_risk`` is the count of findings that were
+                # emitted by successful rules but lost when the commit
+                # failed. ``successful_rule_count`` counts every rule that
+                # completed without raising, including those that emitted
+                # zero findings (still a meaningful "ran cleanly" signal).
+                findings_at_risk = sum(r.findings_emitted for r in results if r.error is None)
+                successful_rule_count = sum(1 for r in results if r.error is None)
                 logger.warning(
                     'lint tick: outer commit failed after per-rule SAVEPOINTs; '
                     'findings from successful rules may have been lost '
-                    '(successful_rules=%d, committed_findings=%d, error=%s)',
+                    '(findings_at_risk=%d, successful_rules=%d, error=%s)',
+                    findings_at_risk,
                     successful_rule_count,
-                    committed_findings,
                     exc,
                     exc_info=True,
                 )
@@ -572,7 +577,7 @@ class LintService(BaseService):
             # reports `lint.py:531:21` and `--^` underlines through L533.
             result = await session.execute(
                 text(
-                    'UPDATE maintenance_proposals '  # noqa: S608 — see invariant above (anchor verified at this line)
+                    'UPDATE maintenance_proposals '  # noqa: S608
                     'SET status = :new, resolved_at = now(), resolved_by = :actor '
                     f"WHERE id = :id AND status = 'pending'{where_extra}"
                 ),
@@ -654,7 +659,7 @@ class LintService(BaseService):
         # through the closing string.
         where_sql = ' AND '.join(clauses)
         stmt = text(
-            f'SELECT id, vault_id, lint_type, target_type, target_id, rule_name, '  # noqa: S608 — see invariant above (anchor verified at this line)
+            f'SELECT id, vault_id, lint_type, target_type, target_id, rule_name, '  # noqa: S608
             f'evidence, suggested_action, status, source, created_at, resolved_at, '
             f'resolved_by '
             f'FROM maintenance_proposals WHERE {where_sql} '

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -204,7 +204,7 @@ _COLD_LOW_MW_UNIT_SQL = f"""
       AND (mu.success_co_count + mu.failure_co_count) >= 5
       AND {_MW_SCORE_EXPR} < 0.3
       AND mu.updated_at < (now() - interval '30 days')
-"""
+"""  # noqa: S608
 
 
 _SENSITIVE_UNREVIEWED_UNIT_SQL = """
@@ -505,7 +505,7 @@ class LintService(BaseService):
         async with self.metastore.session() as session:
             result = await session.execute(
                 text(
-                    'UPDATE maintenance_proposals '
+                    'UPDATE maintenance_proposals '  # noqa: S608
                     'SET status = :new, resolved_at = now(), resolved_by = :actor '
                     f"WHERE id = :id AND status = 'pending'{where_extra}"
                 ),
@@ -573,7 +573,7 @@ class LintService(BaseService):
 
         where_sql = ' AND '.join(clauses)
         stmt = text(
-            f'SELECT id, vault_id, lint_type, target_type, target_id, rule_name, '
+            f'SELECT id, vault_id, lint_type, target_type, target_id, rule_name, '  # noqa: S608
             f'evidence, suggested_action, status, source, created_at, resolved_at, '
             f'resolved_by '
             f'FROM maintenance_proposals WHERE {where_sql} '

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -520,9 +520,15 @@ class LintService(BaseService):
             params['vault_id'] = str(vault_id)
 
         async with self.metastore.session() as session:
+            # Safety invariant for S608: ``where_extra`` is either '' or the
+            # literal string ' AND vault_id = :vault_id' (set on lines 517-520).
+            # No user-controlled value is ever interpolated into the SQL
+            # string — ``vault_id``, ``new_status``, ``finding_id``, and
+            # ``actor`` all flow through the bound ``params`` dict via :name
+            # placeholders. ``new_status`` is allowlist-validated on L509.
             result = await session.execute(
                 text(
-                    'UPDATE maintenance_proposals '  # noqa: S608
+                    'UPDATE maintenance_proposals '  # noqa: S608 — see invariant above
                     'SET status = :new, resolved_at = now(), resolved_by = :actor '
                     f"WHERE id = :id AND status = 'pending'{where_extra}"
                 ),
@@ -588,9 +594,17 @@ class LintService(BaseService):
             params['cursor_ts'] = cursor_ts
             params['cursor_id'] = str(cursor_id)
 
+        # Safety invariant for S608: every entry appended to ``clauses`` (lines
+        # 575-589) is a hard-coded literal SQL fragment — no f-string contains
+        # a value derived from ``status``, ``vault_id``, ``lint_type``,
+        # ``target_type``, or ``cursor``. All user-controlled values flow
+        # exclusively through the ``params`` dict via :name bind parameters.
+        # ``status`` is allowlist-validated on L557 and ``limit`` is bounded on
+        # L559-561, so ``where_sql`` is provably constructed from a closed set
+        # of literal strings.
         where_sql = ' AND '.join(clauses)
         stmt = text(
-            f'SELECT id, vault_id, lint_type, target_type, target_id, rule_name, '  # noqa: S608
+            f'SELECT id, vault_id, lint_type, target_type, target_id, rule_name, '  # noqa: S608 — see invariant above
             f'evidence, suggested_action, status, source, created_at, resolved_at, '
             f'resolved_by '
             f'FROM maintenance_proposals WHERE {where_sql} '

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -343,6 +343,8 @@ class LintService(BaseService):
             for spec in rules:
                 # Per-rule SAVEPOINT so a failing rule rolls back only its own
                 # findings — successful rules still persist on the outer commit.
+                # Fallback timer for the error path; happy-path uses the
+                # ``duration_seconds`` value computed inside ``_run_one``.
                 start = time.perf_counter()
                 try:
                     async with session.begin_nested():

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -188,6 +188,20 @@ _ORPHAN_MENTAL_MODEL_SQL = """
 """
 
 
+# Safety invariant for S608: the only interpolations in this f-string are
+# ``_MW_SCORE_EXPR`` (a module-private literal at line 166 — a fixed
+# arithmetic expression with no user input). ``vault_id`` is bound via the
+# :name placeholder and never interpolated. No user-controlled value is ever
+# spliced into the SQL text.
+#
+# noqa placement: ruff 0.14.x anchors S608 on the FIRST physical line of a
+# multi-line concatenated string, but for triple-quoted strings the
+# diagnostic span covers BOTH the opening and closing ``"""`` lines, and an
+# inline comment on the opening line would become part of the string body.
+# The noqa therefore sits on the closing ``"""`` line — verified empirically
+# by stripping the marker (ruff reports the diagnostic anchored at the
+# opening line and underlines through the closing line, and the
+# closing-line noqa successfully suppresses).
 _COLD_LOW_MW_UNIT_SQL = f"""
     SELECT
         mu.id::text AS target_id,
@@ -204,7 +218,7 @@ _COLD_LOW_MW_UNIT_SQL = f"""
       AND (mu.success_co_count + mu.failure_co_count) >= 5
       AND {_MW_SCORE_EXPR} < 0.3
       AND mu.updated_at < (now() - interval '30 days')
-"""  # noqa: S608
+"""  # noqa: S608 — see invariant above (anchor verified at this line)
 
 
 _SENSITIVE_UNREVIEWED_UNIT_SQL = """

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -309,6 +309,7 @@ class RuleRunResult:
     lint_type: LintType
     findings_emitted: int
     duration_seconds: float
+    error: str | None = None
 
 
 @dataclass
@@ -342,14 +343,28 @@ class LintService(BaseService):
             for spec in rules:
                 # Per-rule SAVEPOINT so a failing rule rolls back only its own
                 # findings — successful rules still persist on the outer commit.
+                start = time.perf_counter()
                 try:
                     async with session.begin_nested():
                         results.append(await self._run_one(session, spec, vault_id))
-                except Exception:
+                except Exception as exc:
                     logger.exception(
                         'Lint rule %s failed for vault %s; continuing with remaining rules',
                         spec.name,
                         vault_id,
+                    )
+                    # Record the failure in the summary so callers can
+                    # distinguish "rule ran with no findings" from "rule did
+                    # not complete". The SAVEPOINT has already rolled back
+                    # any partial inserts for this rule.
+                    results.append(
+                        RuleRunResult(
+                            rule_name=spec.name,
+                            lint_type=spec.lint_type,
+                            findings_emitted=0,
+                            duration_seconds=time.perf_counter() - start,
+                            error=str(exc),
+                        )
                     )
                     continue
             await session.commit()

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -340,7 +340,18 @@ class LintService(BaseService):
         results: list[RuleRunResult] = []
         async with self.metastore.session() as session:
             for spec in rules:
-                results.append(await self._run_one(session, spec, vault_id))
+                # Per-rule SAVEPOINT so a failing rule rolls back only its own
+                # findings — successful rules still persist on the outer commit.
+                try:
+                    async with session.begin_nested():
+                        results.append(await self._run_one(session, spec, vault_id))
+                except Exception:
+                    logger.exception(
+                        'Lint rule %s failed for vault %s; continuing with remaining rules',
+                        spec.name,
+                        vault_id,
+                    )
+                    continue
             await session.commit()
         return LintRunSummary(vault_id=vault_id, rules=results)
 

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -526,9 +526,14 @@ class LintService(BaseService):
             # string — ``vault_id``, ``new_status``, ``finding_id``, and
             # ``actor`` all flow through the bound ``params`` dict via :name
             # placeholders. ``new_status`` is allowlist-validated on L509.
+            #
+            # noqa placement: ruff anchors S608 on the FIRST physical line of
+            # the multi-line concatenated string (line 531), so the noqa below
+            # is on the correct line. Verified by stripping the marker — ruff
+            # reports `lint.py:531:21` and `--^` underlines through L533.
             result = await session.execute(
                 text(
-                    'UPDATE maintenance_proposals '  # noqa: S608 — see invariant above
+                    'UPDATE maintenance_proposals '  # noqa: S608 — see invariant above (anchor verified at this line)
                     'SET status = :new, resolved_at = now(), resolved_by = :actor '
                     f"WHERE id = :id AND status = 'pending'{where_extra}"
                 ),
@@ -602,9 +607,15 @@ class LintService(BaseService):
         # ``status`` is allowlist-validated on L557 and ``limit`` is bounded on
         # L559-561, so ``where_sql`` is provably constructed from a closed set
         # of literal strings.
+        #
+        # noqa placement: ruff anchors S608 on the FIRST physical line of the
+        # multi-line concatenated string (the line below), so the noqa is on
+        # the correct line. Verified by stripping the marker — ruff reports
+        # `lint.py:611:13` (the `f'SELECT ...'` line) and `--^` underlines
+        # through the closing string.
         where_sql = ' AND '.join(clauses)
         stmt = text(
-            f'SELECT id, vault_id, lint_type, target_type, target_id, rule_name, '  # noqa: S608 — see invariant above
+            f'SELECT id, vault_id, lint_type, target_type, target_id, rule_name, '  # noqa: S608 — see invariant above (anchor verified at this line)
             f'evidence, suggested_action, status, source, created_at, resolved_at, '
             f'resolved_by '
             f'FROM maintenance_proposals WHERE {where_sql} '

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -354,6 +354,15 @@ class LintService(BaseService):
         """
         results: list[RuleRunResult] = []
         async with self.metastore.session() as session:
+            # SAVEPOINT loop: per-rule ``begin_nested`` isolates a failing rule's
+            # rollback from previously-emitted findings. Caveat: an asyncpg
+            # *protocol* error (vs. a logical SQL error like a constraint
+            # violation) can leave the underlying connection in an unusable
+            # state — the SAVEPOINT rollback succeeds logically, but the outer
+            # ``commit()`` below may still fail and lose findings from earlier
+            # successful rules. The outer commit is therefore wrapped in a
+            # try/except that warns (with the count of successful rules) and
+            # re-raises so the caller still sees the tick failed.
             for spec in rules:
                 # Per-rule SAVEPOINT so a failing rule rolls back only its own
                 # findings — successful rules still persist on the outer commit.
@@ -383,7 +392,23 @@ class LintService(BaseService):
                         )
                     )
                     continue
-            await session.commit()
+            try:
+                await session.commit()
+            except Exception as exc:
+                successful_rule_count = sum(
+                    1 for r in results if r.error is None and r.findings_emitted > 0
+                )
+                committed_findings = sum(r.findings_emitted for r in results if r.error is None)
+                logger.warning(
+                    'lint tick: outer commit failed after per-rule SAVEPOINTs; '
+                    'findings from successful rules may have been lost '
+                    '(successful_rules=%d, committed_findings=%d, error=%s)',
+                    successful_rule_count,
+                    committed_findings,
+                    exc,
+                    exc_info=True,
+                )
+                raise
         return LintRunSummary(vault_id=vault_id, rules=results)
 
     async def _run_one(

--- a/packages/core/tests/integration/services/test_int_lint.py
+++ b/packages/core/tests/integration/services/test_int_lint.py
@@ -19,6 +19,7 @@ Three cases:
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -322,3 +323,54 @@ async def test_count_pending_global_excludes_vault_scoped_rows(session: AsyncSes
     # Vault count should be exactly 4 (the seeded rules; the global row excluded).
     vault_count = await api.lint.count_pending(vault_id)
     assert vault_count == 4
+
+
+@pytest.mark.asyncio
+async def test_run_rules_records_failed_rule_in_summary(session: AsyncSession, api) -> None:
+    """A rule whose execution raises must appear in the summary with ``error``
+    set, so callers can distinguish "rule ran, no findings" from "rule did
+    not run". Surviving rules still emit their findings normally.
+    """
+    vault_id, _ = await _seed_all_rules_fire(session)
+
+    real_run_one = api.lint._run_one
+    target_rule = 'cold_low_mw_unit'
+
+    async def _flaky_run_one(session, spec, v):
+        if spec.name == target_rule:
+            raise RuntimeError('synthetic rule failure')
+        return await real_run_one(session, spec, v)
+
+    with patch.object(api.lint, '_run_one', side_effect=_flaky_run_one):
+        summary = await api.lint.run_rules(vault_id)
+
+    by_rule = {r.rule_name: r for r in summary.rules}
+    assert target_rule in by_rule, 'failed rule must still appear in summary.rules'
+    failed = by_rule[target_rule]
+    assert failed.error is not None
+    assert 'synthetic rule failure' in failed.error
+    assert failed.findings_emitted == 0
+
+    # Surviving rules still recorded normally, with no error.
+    for name in (
+        'orphan_mental_model',
+        'sensitive_unreviewed_unit',
+        'dangling_entity_ref_in_unit',
+    ):
+        assert name in by_rule, f'rule {name} should still have run'
+        assert by_rule[name].error is None
+        assert by_rule[name].findings_emitted == 1
+
+    # Failed rule's SAVEPOINT rolled back: no ledger row for cold_low_mw_unit.
+    rows = (
+        (
+            await session.execute(
+                text('SELECT rule_name FROM maintenance_proposals WHERE vault_id = :v'),
+                {'v': str(vault_id)},
+            )
+        )
+        .mappings()
+        .all()
+    )
+    rule_names = {row['rule_name'] for row in rows}
+    assert target_rule not in rule_names

--- a/packages/core/tests/integration/services/test_int_lint.py
+++ b/packages/core/tests/integration/services/test_int_lint.py
@@ -158,16 +158,24 @@ async def _seed_all_rules_fire(session: AsyncSession) -> tuple[UUID, dict[str, s
     await session.execute(
         text('ALTER TABLE unit_entities DROP CONSTRAINT unit_entities_entity_id_fkey')
     )
-    await session.execute(text('DELETE FROM entities WHERE id = :id'), {'id': str(dangling_ent.id)})
-    await session.commit()
-    await session.execute(
-        text(
-            'ALTER TABLE unit_entities ADD CONSTRAINT unit_entities_entity_id_fkey '
-            'FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE '
-            'NOT VALID'
+    try:
+        await session.execute(
+            text('DELETE FROM entities WHERE id = :id'), {'id': str(dangling_ent.id)}
         )
-    )
-    await session.commit()
+        await session.commit()
+    finally:
+        # Always restore the FK so a mid-fixture failure can't leave the
+        # schema with a dropped constraint that bleeds into other tests.
+        # NOT VALID is required because the dangling row deliberately
+        # remains for the lint rule to detect.
+        await session.execute(
+            text(
+                'ALTER TABLE unit_entities ADD CONSTRAINT unit_entities_entity_id_fkey '
+                'FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE '
+                'NOT VALID'
+            )
+        )
+        await session.commit()
 
     targets = {
         'orphan_mental_model': str(orphan_mm.id),

--- a/packages/core/tests/integration/services/test_int_lint.py
+++ b/packages/core/tests/integration/services/test_int_lint.py
@@ -156,21 +156,26 @@ async def _seed_all_rules_fire(session: AsyncSession) -> tuple[UUID, dict[str, s
     )
     session.add(ue)
     await session.commit()
+    # Commit the DROP CONSTRAINT in its own transaction so a later rollback on
+    # the DELETE path cannot undo it. If the DROP and DELETE shared a
+    # transaction, ``session.rollback()`` in the except branch would also
+    # discard the DROP, leaving the FK in place — and the finally's ADD
+    # CONSTRAINT would then raise (duplicate constraint), masking the
+    # original DELETE failure. The intermediate "FK temporarily missing"
+    # state between commits is acceptable for a test fixture; the finally
+    # always restores it.
     await session.execute(
         text('ALTER TABLE unit_entities DROP CONSTRAINT unit_entities_entity_id_fkey')
     )
+    await session.commit()
     try:
         await session.execute(
             text('DELETE FROM entities WHERE id = :id'), {'id': str(dangling_ent.id)}
         )
         await session.commit()
     except Exception:
-        # Only roll back on the error path. SQLAlchemy puts the session in a
-        # "needs rollback" state when the DELETE/commit fails, and a
-        # subsequent ALTER would itself raise, silently dropping the
-        # FK-restore. An unconditional rollback in ``finally`` would discard
-        # any uncommitted work the caller had pending if the DELETE
-        # succeeded — restrict it to the failure case only.
+        # SQLAlchemy puts the session in a "needs rollback" state when the
+        # DELETE/commit fails; clear it so the finally's ALTER can run.
         await session.rollback()
         raise
     finally:

--- a/packages/core/tests/integration/services/test_int_lint.py
+++ b/packages/core/tests/integration/services/test_int_lint.py
@@ -169,6 +169,11 @@ async def _seed_all_rules_fire(session: AsyncSession) -> tuple[UUID, dict[str, s
         # schema with a dropped constraint that bleeds into other tests.
         # NOT VALID is required because the dangling row deliberately
         # remains for the lint rule to detect.
+        # Roll back first: if the DELETE above raised, SQLAlchemy puts the
+        # session in a "needs rollback" state and the subsequent ALTER would
+        # itself raise, silently dropping the FK-restore and bleeding schema
+        # corruption into other tests.
+        await session.rollback()
         await session.execute(
             text(
                 'ALTER TABLE unit_entities ADD CONSTRAINT unit_entities_entity_id_fkey '

--- a/packages/core/tests/integration/services/test_int_lint.py
+++ b/packages/core/tests/integration/services/test_int_lint.py
@@ -164,16 +164,20 @@ async def _seed_all_rules_fire(session: AsyncSession) -> tuple[UUID, dict[str, s
             text('DELETE FROM entities WHERE id = :id'), {'id': str(dangling_ent.id)}
         )
         await session.commit()
+    except Exception:
+        # Only roll back on the error path. SQLAlchemy puts the session in a
+        # "needs rollback" state when the DELETE/commit fails, and a
+        # subsequent ALTER would itself raise, silently dropping the
+        # FK-restore. An unconditional rollback in ``finally`` would discard
+        # any uncommitted work the caller had pending if the DELETE
+        # succeeded — restrict it to the failure case only.
+        await session.rollback()
+        raise
     finally:
         # Always restore the FK so a mid-fixture failure can't leave the
         # schema with a dropped constraint that bleeds into other tests.
         # NOT VALID is required because the dangling row deliberately
         # remains for the lint rule to detect.
-        # Roll back first: if the DELETE above raised, SQLAlchemy puts the
-        # session in a "needs rollback" state and the subsequent ALTER would
-        # itself raise, silently dropping the FK-restore and bleeding schema
-        # corruption into other tests.
-        await session.rollback()
         await session.execute(
             text(
                 'ALTER TABLE unit_entities ADD CONSTRAINT unit_entities_entity_id_fkey '


### PR DESCRIPTION
## Summary

Three independent follow-ups in the F6 lint subsystem:

- **#99** — `LintService.run_rules` now wraps each rule in a `session.begin_nested()` SAVEPOINT. A failing rule rolls back only its own findings; the loop logs and continues so successful rules still persist on the outer commit.
- **#100** — The integration fixture that drops `unit_entities_entity_id_fkey` (so a dangling row can fire the rule) now restores the constraint in a `finally` block. A mid-fixture failure no longer leaves the FK permanently dropped across subsequent tests.
- **#109** — The three f-string SQL composition sites in `services/lint.py` (lines 207, 506, 574) now carry `# noqa: S608`, matching the existing `server/lint.py:115` pattern. Inputs are server-controlled; the f-string content is built from constants and validated parameters only.

## Test plan

- [x] `uv run ruff check packages/core/src/memex_core/services/lint.py` — clean (default + `--select S608`)
- [x] `uv run pytest packages/core/tests/unit/test_lint_*.py` — 29 passed
- [x] `uv run pytest packages/core/tests/integration/services/test_int_lint.py` — 4 passed
- [x] Pre-commit hooks (ruff, ruff-format, mypy) — green on every commit

Closes #99
Closes #100
Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)