### PR TITLE
feat(retrieval): server-side intent_class + risk_class filter (closes #92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,758%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,770%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,803%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,800%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,786%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,789%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,785%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,786%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,789%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,803%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,770%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,774%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,774%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,785%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import logging
 import pathlib as plb
-import sys
 from typing import Annotated
 from uuid import UUID
 import itertools
@@ -626,6 +625,26 @@ async def search_memory(
 
     ref_dt = _dt.fromisoformat(reference_date).replace(tzinfo=_tz.utc) if reference_date else None
 
+    # Validate intent / risk against allowed values BEFORE the API call so
+    # users see a clean error instead of a server 422.
+    intent_value: str | None = None
+    if intent:
+        allowed_intents = {'permanent', 'durable', 'ephemeral'}
+        intent_value = intent.lower()
+        if intent_value not in allowed_intents:
+            console.print(
+                f'[red]Invalid --intent {intent!r}. Allowed: {sorted(allowed_intents)}[/red]'
+            )
+            return
+
+    risk_value: str | None = None
+    if risk:
+        allowed_risks = {'none', 'sensitive', 'private', 'safety'}
+        risk_value = risk.lower()
+        if risk_value not in allowed_risks:
+            console.print(f'[red]Invalid --risk {risk!r}. Allowed: {sorted(allowed_risks)}[/red]')
+            return
+
     async with get_api_context(config) as api:
         try:
             results = await api.search(
@@ -638,46 +657,14 @@ async def search_memory(
                 source_context=source_context,
                 reference_date=ref_dt,
                 expand_query=expand,
+                intent_class=intent_value,
+                risk_class=risk_value,
             )
         except Exception as e:
             handle_api_error(e)
 
-        unfiltered_count = len(results)
-        filter_active = bool(intent or risk)
-
-        if intent:
-            allowed_intents = {'permanent', 'durable', 'ephemeral'}
-            wanted = intent.lower()
-            if wanted not in allowed_intents:
-                console.print(
-                    f'[red]Invalid --intent {intent!r}. Allowed: {sorted(allowed_intents)}[/red]'
-                )
-                return
-            results = [u for u in results if getattr(u, 'intent_class', 'durable') == wanted]
-
-        if risk:
-            allowed_risks = {'none', 'sensitive', 'private', 'safety'}
-            wanted_risk = risk.lower()
-            if wanted_risk not in allowed_risks:
-                console.print(
-                    f'[red]Invalid --risk {risk!r}. Allowed: {sorted(allowed_risks)}[/red]'
-                )
-                return
-            results = [u for u in results if getattr(u, 'risk_class', 'none') == wanted_risk]
-
         if not results:
-            if filter_active and unfiltered_count == limit:
-                # Client-side filter may have eliminated everything from a
-                # truncated page. Warn so the user can widen the search.
-                # Server-side filter is tracked as a follow-up (PR #91 cycle3 MED-2).
-                print(
-                    f'No results matched filter, but {unfiltered_count} unfiltered hits '
-                    'returned (filter applied client-side, results may be truncated; '
-                    'consider --limit to expand search)',
-                    file=sys.stderr,
-                )
-            else:
-                console.print('[yellow]No results found.[/yellow]')
+            console.print('[yellow]No results found.[/yellow]')
             return
 
         if minimal:

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -644,7 +644,7 @@ async def search_memory(
             console.print(
                 f'[red]Invalid --intent {intent!r}. Allowed: {sorted(VALID_INTENT_CLASSES)}[/red]'
             )
-            return
+            raise typer.Exit(1)
         intent_value = IntentClass(intent_str)
 
     risk_value: RiskClass | None = None
@@ -654,7 +654,7 @@ async def search_memory(
             console.print(
                 f'[red]Invalid --risk {risk!r}. Allowed: {sorted(VALID_RISK_CLASSES)}[/red]'
             )
-            return
+            raise typer.Exit(1)
         risk_value = RiskClass(risk_str)
 
     async with get_api_context(config) as api:

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -626,23 +626,26 @@ async def search_memory(
     ref_dt = _dt.fromisoformat(reference_date).replace(tzinfo=_tz.utc) if reference_date else None
 
     # Validate intent / risk against allowed values BEFORE the API call so
-    # users see a clean error instead of a server 422.
+    # users see a clean error instead of a server 422. Allowed sets are
+    # canonical in memex_common.schemas (derived from IntentClass / RiskClass).
+    from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
+
     intent_value: str | None = None
     if intent:
-        allowed_intents = {'permanent', 'durable', 'ephemeral'}
         intent_value = intent.lower()
-        if intent_value not in allowed_intents:
+        if intent_value not in VALID_INTENT_CLASSES:
             console.print(
-                f'[red]Invalid --intent {intent!r}. Allowed: {sorted(allowed_intents)}[/red]'
+                f'[red]Invalid --intent {intent!r}. Allowed: {sorted(VALID_INTENT_CLASSES)}[/red]'
             )
             return
 
     risk_value: str | None = None
     if risk:
-        allowed_risks = {'none', 'sensitive', 'private', 'safety'}
         risk_value = risk.lower()
-        if risk_value not in allowed_risks:
-            console.print(f'[red]Invalid --risk {risk!r}. Allowed: {sorted(allowed_risks)}[/red]')
+        if risk_value not in VALID_RISK_CLASSES:
+            console.print(
+                f'[red]Invalid --risk {risk!r}. Allowed: {sorted(VALID_RISK_CLASSES)}[/red]'
+            )
             return
 
     async with get_api_context(config) as api:

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -628,25 +628,34 @@ async def search_memory(
     # Validate intent / risk against allowed values BEFORE the API call so
     # users see a clean error instead of a server 422. Allowed sets are
     # canonical in memex_common.schemas (derived from IntentClass / RiskClass).
-    from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
+    # We coerce to the enum after validation to match the typed
+    # RemoteMemexAPI.search signature (IntentClass | None / RiskClass | None).
+    from memex_common.schemas import (
+        IntentClass,
+        RiskClass,
+        VALID_INTENT_CLASSES,
+        VALID_RISK_CLASSES,
+    )
 
-    intent_value: str | None = None
+    intent_value: IntentClass | None = None
     if intent:
-        intent_value = intent.lower()
-        if intent_value not in VALID_INTENT_CLASSES:
+        intent_str = intent.lower()
+        if intent_str not in VALID_INTENT_CLASSES:
             console.print(
                 f'[red]Invalid --intent {intent!r}. Allowed: {sorted(VALID_INTENT_CLASSES)}[/red]'
             )
             return
+        intent_value = IntentClass(intent_str)
 
-    risk_value: str | None = None
+    risk_value: RiskClass | None = None
     if risk:
-        risk_value = risk.lower()
-        if risk_value not in VALID_RISK_CLASSES:
+        risk_str = risk.lower()
+        if risk_str not in VALID_RISK_CLASSES:
             console.print(
                 f'[red]Invalid --risk {risk!r}. Allowed: {sorted(VALID_RISK_CLASSES)}[/red]'
             )
             return
+        risk_value = RiskClass(risk_str)
 
     async with get_api_context(config) as api:
         try:

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -638,7 +638,7 @@ async def search_memory(
     )
 
     intent_value: IntentClass | None = None
-    if intent:
+    if intent is not None:
         intent_str = intent.lower()
         if intent_str not in VALID_INTENT_CLASSES:
             console.print(
@@ -648,7 +648,7 @@ async def search_memory(
         intent_value = IntentClass(intent_str)
 
     risk_value: RiskClass | None = None
-    if risk:
+    if risk is not None:
         risk_str = risk.lower()
         if risk_str not in VALID_RISK_CLASSES:
             console.print(

--- a/packages/cli/tests/test_memory_cli.py
+++ b/packages/cli/tests/test_memory_cli.py
@@ -185,3 +185,62 @@ def test_memory_view_multi_partial_error(runner, mock_api, mock_config, monkeypa
     assert result.exit_code == 0
     assert 'Good one' in result.stdout
     assert 'Error' in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# memory search — server-side intent / risk filter (issue #92)
+# ---------------------------------------------------------------------------
+
+
+def test_memory_search_intent_forwarded_to_api(runner, mock_api, mock_config, monkeypatch):
+    """`--intent ephemeral` must be forwarded to api.search; no client-side filtering."""
+    uid = uuid4()
+    mock_api.search.return_value = [
+        MemoryUnitDTO(id=uid, text='hit', fact_type='world', intent_class='ephemeral'),
+    ]
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(app, ['search', 'query', '--intent', 'ephemeral'], obj=mock_config)
+    assert result.exit_code == 0
+    mock_api.search.assert_called_once()
+    kwargs = mock_api.search.call_args.kwargs
+    assert kwargs.get('intent_class') == 'ephemeral'
+    assert kwargs.get('risk_class') is None
+
+
+def test_memory_search_risk_forwarded_to_api(runner, mock_api, mock_config, monkeypatch):
+    """`--risk sensitive` must be forwarded to api.search; no client-side filtering."""
+    uid = uuid4()
+    mock_api.search.return_value = [
+        MemoryUnitDTO(id=uid, text='hit', fact_type='world', risk_class='sensitive'),
+    ]
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(app, ['search', 'query', '--risk', 'sensitive'], obj=mock_config)
+    assert result.exit_code == 0
+    mock_api.search.assert_called_once()
+    kwargs = mock_api.search.call_args.kwargs
+    assert kwargs.get('risk_class') == 'sensitive'
+    assert kwargs.get('intent_class') is None
+
+
+def test_memory_search_intent_invalid_rejected_locally(runner, mock_api, mock_config, monkeypatch):
+    """Bad --intent values must be rejected before the API roundtrip."""
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(app, ['search', 'q', '--intent', 'bogus'], obj=mock_config)
+    assert 'Invalid --intent' in result.stdout
+    mock_api.search.assert_not_called()
+
+
+def test_memory_search_no_client_side_filter_warning(runner, mock_api, mock_config, monkeypatch):
+    """Server-side filter means we never emit the "filter applied client-side" warning."""
+    mock_api.search.return_value = []  # server returned 0 hits
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(app, ['search', 'query', '--intent', 'ephemeral'], obj=mock_config)
+    assert result.exit_code == 0
+    # Old behavior printed a warning about client-side filtering — must be gone.
+    assert 'filter applied client-side' not in result.stdout
+    assert 'filter applied client-side' not in (result.stderr or '')
+    assert 'No results found' in result.stdout

--- a/packages/cli/tests/test_memory_cli.py
+++ b/packages/cli/tests/test_memory_cli.py
@@ -194,6 +194,8 @@ def test_memory_view_multi_partial_error(runner, mock_api, mock_config, monkeypa
 
 def test_memory_search_intent_forwarded_to_api(runner, mock_api, mock_config, monkeypatch):
     """`--intent ephemeral` must be forwarded to api.search; no client-side filtering."""
+    from memex_common.schemas import IntentClass
+
     uid = uuid4()
     mock_api.search.return_value = [
         MemoryUnitDTO(id=uid, text='hit', fact_type='world', intent_class='ephemeral'),
@@ -204,12 +206,16 @@ def test_memory_search_intent_forwarded_to_api(runner, mock_api, mock_config, mo
     assert result.exit_code == 0
     mock_api.search.assert_called_once()
     kwargs = mock_api.search.call_args.kwargs
-    assert kwargs.get('intent_class') == 'ephemeral'
+    # CLI coerces validated string to the typed enum at the boundary so the
+    # RemoteMemexAPI.search signature (IntentClass | None) is satisfied.
+    assert kwargs.get('intent_class') == IntentClass.EPHEMERAL
     assert kwargs.get('risk_class') is None
 
 
 def test_memory_search_risk_forwarded_to_api(runner, mock_api, mock_config, monkeypatch):
     """`--risk sensitive` must be forwarded to api.search; no client-side filtering."""
+    from memex_common.schemas import RiskClass
+
     uid = uuid4()
     mock_api.search.return_value = [
         MemoryUnitDTO(id=uid, text='hit', fact_type='world', risk_class='sensitive'),
@@ -220,7 +226,9 @@ def test_memory_search_risk_forwarded_to_api(runner, mock_api, mock_config, monk
     assert result.exit_code == 0
     mock_api.search.assert_called_once()
     kwargs = mock_api.search.call_args.kwargs
-    assert kwargs.get('risk_class') == 'sensitive'
+    # CLI coerces validated string to the typed enum at the boundary so the
+    # RemoteMemexAPI.search signature (RiskClass | None) is satisfied.
+    assert kwargs.get('risk_class') == RiskClass.SENSITIVE
     assert kwargs.get('intent_class') is None
 
 

--- a/packages/cli/tests/test_memory_cli.py
+++ b/packages/cli/tests/test_memory_cli.py
@@ -233,11 +233,22 @@ def test_memory_search_risk_forwarded_to_api(runner, mock_api, mock_config, monk
 
 
 def test_memory_search_intent_invalid_rejected_locally(runner, mock_api, mock_config, monkeypatch):
-    """Bad --intent values must be rejected before the API roundtrip."""
+    """Bad --intent values must be rejected before the API roundtrip with exit code 1."""
     monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
 
     result = runner.invoke(app, ['search', 'q', '--intent', 'bogus'], obj=mock_config)
+    assert result.exit_code == 1
     assert 'Invalid --intent' in result.stdout
+    mock_api.search.assert_not_called()
+
+
+def test_memory_search_risk_invalid_rejected_locally(runner, mock_api, mock_config, monkeypatch):
+    """Bad --risk values must be rejected before the API roundtrip with exit code 1."""
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(app, ['search', 'q', '--risk', 'bogus'], obj=mock_config)
+    assert result.exit_code == 1
+    assert 'Invalid --risk' in result.stdout
     mock_api.search.assert_not_called()
 
 

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -322,10 +322,16 @@ class RemoteMemexAPI:
         source_context: str | None = None,
         reference_date: dt.datetime | None = None,
         expand_query: bool = False,
-        intent_class: IntentClass | str | None = None,
-        risk_class: RiskClass | str | None = None,
+        intent_class: IntentClass | None = None,
+        risk_class: RiskClass | None = None,
     ) -> list[MemoryUnitDTO]:
-        """Search for memories."""
+        """Search for memories.
+
+        ``intent_class`` and ``risk_class`` are typed as the canonical enums
+        (``IntentClass`` / ``RiskClass``). Callers holding a validated string
+        (e.g. CLI / MCP / Hermes after their own pre-flight check) should
+        construct the enum at the boundary: ``IntentClass(value)``.
+        """
         request = RetrievalRequest(
             query=query,
             limit=limit,

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -29,12 +29,14 @@ from memex_common.schemas import (
     DefaultVaultsResponse,
     DueUnitDTO,
     FindNoteResult,
+    IntentClass,
     MemoryLinkDTO,
     NoteAppendRequest,
     NoteAppendResponse,
     NoteCreateDTO,
     ReflectionResultDTO,
     MemoryUnitDTO,
+    RiskClass,
     VaultDTO,
     VaultSummaryDTO,
     ReflectionQueueDTO,
@@ -320,6 +322,8 @@ class RemoteMemexAPI:
         source_context: str | None = None,
         reference_date: dt.datetime | None = None,
         expand_query: bool = False,
+        intent_class: IntentClass | str | None = None,
+        risk_class: RiskClass | str | None = None,
     ) -> list[MemoryUnitDTO]:
         """Search for memories."""
         request = RetrievalRequest(
@@ -337,6 +341,8 @@ class RemoteMemexAPI:
             source_context=source_context,
             reference_date=reference_date,
             expand_query=expand_query,
+            intent_class=intent_class,
+            risk_class=risk_class,
         )
         result = await self._post('memories/search', request)
         return [MemoryUnitDTO(**r) for r in result]

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -243,6 +243,22 @@ class RetrievalRequest(BaseModel):
         ),
     )
 
+    # Intent / risk class filtering (write-time classifier; F25)
+    intent_class: IntentClass | None = Field(
+        default=None,
+        description=(
+            'Filter MemoryUnits by intent_class (permanent | durable | ephemeral). '
+            'None disables the filter.'
+        ),
+    )
+    risk_class: RiskClass | None = Field(
+        default=None,
+        description=(
+            'Filter MemoryUnits by risk_class (none | sensitive | private | safety). '
+            'None disables the filter.'
+        ),
+    )
+
     # Query expansion
     expand_query: bool = Field(
         default=False,

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -3,7 +3,7 @@
 import datetime as dt
 import re
 from enum import Enum
-from typing import Any, Annotated
+from typing import Any, Annotated, Literal
 from uuid import UUID
 from pydantic import (
     BaseModel,
@@ -82,6 +82,22 @@ class RiskClass(str, Enum):
 
 VALID_INTENT_CLASSES: frozenset[str] = frozenset(c.value for c in IntentClass)
 VALID_RISK_CLASSES: frozenset[str] = frozenset(c.value for c in RiskClass)
+
+
+# Canonical ``Literal`` aliases for use as type annotations across packages
+# (MCP tool params, DSPy classifier signatures, etc.). mypy requires
+# ``Literal[...]`` arguments to be compile-time string literals — we cannot
+# unpack a runtime expression like ``Literal[*tuple(c.value for c in IntentClass)]``
+# without losing static-type narrowing — so the values are still hand-listed here.
+# However, divergence between these aliases and the ``IntentClass`` /
+# ``RiskClass`` enums is caught at test time (see
+# ``packages/common/tests/test_enum_literal_parity.py``) which asserts
+# ``typing.get_args(IntentLiteral) == tuple(c.value for c in IntentClass)``.
+# This collapses three+ duplicate definitions (MCP server, DSPy classifier,
+# Hermes JSON schema) into ONE canonical definition; downstream importers
+# reference these names instead of re-typing the value tuple.
+IntentLiteral = Literal['permanent', 'durable', 'ephemeral']
+RiskLiteral = Literal['none', 'sensitive', 'private', 'safety']
 
 
 class LineageDirection(str, Enum):

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -80,6 +80,10 @@ class RiskClass(str, Enum):
     SAFETY = 'safety'
 
 
+VALID_INTENT_CLASSES: frozenset[str] = frozenset(c.value for c in IntentClass)
+VALID_RISK_CLASSES: frozenset[str] = frozenset(c.value for c in RiskClass)
+
+
 class LineageDirection(str, Enum):
     """Direction of lineage traversal."""
 

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -198,6 +198,31 @@ class RetainContent(VaultMixin):
 class RetrievalRequest(BaseModel):
     """
     Unified request object for memory retrieval.
+
+    NOTE — dual-model architecture (intentional):
+    There are TWO ``RetrievalRequest`` classes in the codebase:
+
+    1. ``memex_common.schemas.RetrievalRequest`` (this class) — the
+       **wire / protocol** model. It is the public Pydantic schema used by
+       the FastAPI server (request body), the ``RemoteMemexAPI`` HTTP client,
+       and the OpenAPI spec. Enum-typed fields (``intent_class: IntentClass``,
+       ``risk_class: RiskClass``) act as a self-documenting contract for
+       external callers.
+    2. ``memex_core.memory.retrieval.models.RetrievalRequest`` — the
+       **internal / storage** model (SQLModel). It is built inside the
+       ``SearchService`` from already-validated primitives, so it carries
+       ``intent_class: str | None`` / ``risk_class: str | None`` and
+       enforces the same value set via a ``model_validator`` against the
+       canonical ``VALID_INTENT_CLASSES`` / ``VALID_RISK_CLASSES`` frozensets.
+
+    The boundary conversion happens in
+    ``memex_core/server/retrieval.py::search_memories`` which unpacks the
+    enum via ``request.intent_class.value if request.intent_class else None``
+    before calling ``MemexAPI.search``.
+
+    If you need to add or rename a class value, update ``IntentClass`` /
+    ``RiskClass`` in this module — both ``VALID_INTENT_CLASSES`` (here) and
+    the model_validator in the core model derive from those enums.
     """
 
     query: str = Field(..., description='The search query or context string.')

--- a/packages/common/tests/test_enum_literal_parity.py
+++ b/packages/common/tests/test_enum_literal_parity.py
@@ -71,6 +71,12 @@ class TestMCPServerParity:
         """
         from memex_mcp.server import memex_memory_search
 
+        # FastMCP's ``FunctionTool`` exposes the original function via ``.fn``.
+        # This is FastMCP's documented accessor today, but it is an
+        # implementation detail of the wrapper — if FastMCP changes the API
+        # (e.g. renames ``.fn`` or moves the original callable behind a method),
+        # this test and any sibling test that uses ``.fn`` will need to be
+        # updated. Tracked: revisit if FastMCP exposes a stable accessor.
         underlying = getattr(memex_memory_search, 'fn', memex_memory_search)
         return get_type_hints(underlying, include_extras=True)
 

--- a/packages/common/tests/test_enum_literal_parity.py
+++ b/packages/common/tests/test_enum_literal_parity.py
@@ -1,0 +1,148 @@
+"""Round-5 regression guard: canonical-source parity for IntentClass / RiskClass.
+
+The Hermes round-5 review flagged a DRY violation: the ``permanent | durable |
+ephemeral`` and ``none | sensitive | private | safety`` value lists were
+duplicated across:
+
+- ``memex_common.schemas.IntentClass`` / ``RiskClass`` (canonical Python enums)
+- ``memex_common.schemas.IntentLiteral`` / ``RiskLiteral`` (canonical Literal aliases)
+- ``memex_mcp.server`` (MCP tool ``Literal[...]`` annotations)
+- ``memex_hermes_plugin.memex.tools`` (JSON Schema ``enum: [...]`` lists)
+- ``memex_core.memory.extraction.classifier`` (DSPy signature Literal aliases)
+
+After the round-5 patch the downstream sites all import from
+``memex_common.schemas`` — but mypy refuses to accept a runtime-computed
+``Literal[*tuple(c.value for c in IntentClass)]`` as a valid type alias,
+so ``IntentLiteral`` / ``RiskLiteral`` are still hand-typed in a single
+canonical location. This test asserts they cannot drift from the enum
+without a test failure: adding or renaming a value in ``IntentClass`` /
+``RiskClass`` without also updating the Literal aliases (or vice versa) is
+caught here.
+
+Also asserts the MCP ``Annotated`` parameter types derive from the same
+canonical source. Hermes plugin JSON Schema parity has its own test under
+``packages/hermes-plugin/tests/test_enum_schema_parity.py`` because Hermes
+modules require runtime stubs that only the hermes-plugin conftest installs.
+"""
+
+from typing import Annotated, get_args, get_origin, get_type_hints
+
+import pytest
+
+
+class TestEnumLiteralParity:
+    """The canonical Literal aliases in memex_common.schemas must equal the enums."""
+
+    def test_intent_literal_matches_intent_class(self) -> None:
+        from memex_common.schemas import IntentClass, IntentLiteral
+
+        assert get_args(IntentLiteral) == tuple(c.value for c in IntentClass), (
+            'IntentLiteral has drifted from IntentClass. Update both in '
+            'memex_common.schemas — they must enumerate identical values.'
+        )
+
+    def test_risk_literal_matches_risk_class(self) -> None:
+        from memex_common.schemas import RiskClass, RiskLiteral
+
+        assert get_args(RiskLiteral) == tuple(c.value for c in RiskClass), (
+            'RiskLiteral has drifted from RiskClass. Update both in '
+            'memex_common.schemas — they must enumerate identical values.'
+        )
+
+    def test_valid_intent_classes_matches_intent_class(self) -> None:
+        from memex_common.schemas import VALID_INTENT_CLASSES, IntentClass
+
+        assert VALID_INTENT_CLASSES == frozenset(c.value for c in IntentClass)
+
+    def test_valid_risk_classes_matches_risk_class(self) -> None:
+        from memex_common.schemas import VALID_RISK_CLASSES, RiskClass
+
+        assert VALID_RISK_CLASSES == frozenset(c.value for c in RiskClass)
+
+
+class TestMCPServerParity:
+    """MCP search tool intent/risk parameter Literal types must derive from canonical aliases."""
+
+    def _get_search_hints(self) -> dict[str, object]:
+        """Resolve type hints on the underlying ``memex_memory_search`` function.
+
+        ``@mcp.tool`` wraps the function in a ``FunctionTool``; the original
+        callable is exposed via ``.fn`` (FastMCP's standard accessor).
+        """
+        from memex_mcp.server import memex_memory_search
+
+        underlying = getattr(memex_memory_search, 'fn', memex_memory_search)
+        return get_type_hints(underlying, include_extras=True)
+
+    def test_mcp_search_intent_class_uses_canonical_literal(self) -> None:
+        try:
+            from memex_common.schemas import IntentLiteral
+        except ImportError:
+            pytest.skip('memex_common not installed in this environment')
+        try:
+            hints = self._get_search_hints()
+        except ImportError:
+            pytest.skip('memex_mcp not installed in this environment')
+        intent_hint = hints['intent_class']
+        # intent_class is Annotated[IntentLiteral | None, Field(...)] — extract
+        # the underlying union and assert IntentLiteral is one of its members.
+        assert get_origin(intent_hint) is Annotated, (
+            'intent_class hint should be Annotated[...]; got: ' + repr(intent_hint)
+        )
+        union_type = get_args(intent_hint)[0]
+        union_members = get_args(union_type)
+        assert IntentLiteral in union_members, (
+            'MCP memex_memory_search intent_class param does not reference '
+            'the canonical IntentLiteral; saw union members: ' + repr(union_members)
+        )
+
+    def test_mcp_search_risk_class_uses_canonical_literal(self) -> None:
+        try:
+            from memex_common.schemas import RiskLiteral
+        except ImportError:
+            pytest.skip('memex_common not installed in this environment')
+        try:
+            hints = self._get_search_hints()
+        except ImportError:
+            pytest.skip('memex_mcp not installed in this environment')
+        risk_hint = hints['risk_class']
+        assert get_origin(risk_hint) is Annotated, (
+            'risk_class hint should be Annotated[...]; got: ' + repr(risk_hint)
+        )
+        union_type = get_args(risk_hint)[0]
+        union_members = get_args(union_type)
+        assert RiskLiteral in union_members, (
+            'MCP memex_memory_search risk_class param does not reference '
+            'the canonical RiskLiteral; saw union members: ' + repr(union_members)
+        )
+
+
+class TestClassifierParity:
+    """The DSPy classifier signature must derive its Literal types from the canonical aliases."""
+
+    def test_classifier_intent_literal_is_canonical(self) -> None:
+        from memex_common.schemas import IntentLiteral as CanonicalIntentLiteral
+        from memex_core.memory.extraction.classifier import IntentLiteral
+
+        assert IntentLiteral is CanonicalIntentLiteral, (
+            'Classifier IntentLiteral is not the canonical alias from '
+            'memex_common.schemas — it has been re-defined locally.'
+        )
+
+    def test_classifier_risk_literal_is_canonical(self) -> None:
+        from memex_common.schemas import RiskLiteral as CanonicalRiskLiteral
+        from memex_core.memory.extraction.classifier import RiskLiteral
+
+        assert RiskLiteral is CanonicalRiskLiteral
+
+    def test_classifier_intent_values_matches_canonical(self) -> None:
+        from memex_common.schemas import IntentClass
+        from memex_core.memory.extraction.classifier import INTENT_VALUES
+
+        assert INTENT_VALUES == tuple(c.value for c in IntentClass)
+
+    def test_classifier_risk_values_matches_canonical(self) -> None:
+        from memex_common.schemas import RiskClass
+        from memex_core.memory.extraction.classifier import RISK_VALUES
+
+        assert RISK_VALUES == tuple(c.value for c in RiskClass)

--- a/packages/common/tests/test_enum_literal_parity.py
+++ b/packages/common/tests/test_enum_literal_parity.py
@@ -121,8 +121,14 @@ class TestClassifierParity:
     """The DSPy classifier signature must derive its Literal types from the canonical aliases."""
 
     def test_classifier_intent_literal_is_canonical(self) -> None:
-        from memex_common.schemas import IntentLiteral as CanonicalIntentLiteral
-        from memex_core.memory.extraction.classifier import IntentLiteral
+        try:
+            from memex_common.schemas import IntentLiteral as CanonicalIntentLiteral
+        except ImportError:
+            pytest.skip('memex_common not installed in this environment')
+        try:
+            from memex_core.memory.extraction.classifier import IntentLiteral
+        except ImportError:
+            pytest.skip('memex_core not installed in this environment')
 
         assert IntentLiteral is CanonicalIntentLiteral, (
             'Classifier IntentLiteral is not the canonical alias from '
@@ -130,19 +136,37 @@ class TestClassifierParity:
         )
 
     def test_classifier_risk_literal_is_canonical(self) -> None:
-        from memex_common.schemas import RiskLiteral as CanonicalRiskLiteral
-        from memex_core.memory.extraction.classifier import RiskLiteral
+        try:
+            from memex_common.schemas import RiskLiteral as CanonicalRiskLiteral
+        except ImportError:
+            pytest.skip('memex_common not installed in this environment')
+        try:
+            from memex_core.memory.extraction.classifier import RiskLiteral
+        except ImportError:
+            pytest.skip('memex_core not installed in this environment')
 
         assert RiskLiteral is CanonicalRiskLiteral
 
     def test_classifier_intent_values_matches_canonical(self) -> None:
-        from memex_common.schemas import IntentClass
-        from memex_core.memory.extraction.classifier import INTENT_VALUES
+        try:
+            from memex_common.schemas import IntentClass
+        except ImportError:
+            pytest.skip('memex_common not installed in this environment')
+        try:
+            from memex_core.memory.extraction.classifier import INTENT_VALUES
+        except ImportError:
+            pytest.skip('memex_core not installed in this environment')
 
         assert INTENT_VALUES == tuple(c.value for c in IntentClass)
 
     def test_classifier_risk_values_matches_canonical(self) -> None:
-        from memex_common.schemas import RiskClass
-        from memex_core.memory.extraction.classifier import RISK_VALUES
+        try:
+            from memex_common.schemas import RiskClass
+        except ImportError:
+            pytest.skip('memex_common not installed in this environment')
+        try:
+            from memex_core.memory.extraction.classifier import RISK_VALUES
+        except ImportError:
+            pytest.skip('memex_core not installed in this environment')
 
         assert RISK_VALUES == tuple(c.value for c in RiskClass)

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1156,6 +1156,8 @@ class MemexAPI:
         source_context: str | None = None,
         reference_date: datetime | None = None,
         expand_query: bool = False,
+        intent_class: str | None = None,
+        risk_class: str | None = None,
     ) -> tuple[list[MemoryUnit], Any]:
         """Search with reranking. Delegates to SearchService."""
         return await self._search.search(
@@ -1174,6 +1176,8 @@ class MemexAPI:
             source_context=source_context,
             reference_date=reference_date,
             expand_query=expand_query,
+            intent_class=intent_class,
+            risk_class=risk_class,
         )
 
     async def summarize_search_results(self, query: str, texts: list[str]) -> str:

--- a/packages/core/src/memex_core/memory/extraction/classifier.py
+++ b/packages/core/src/memex_core/memory/extraction/classifier.py
@@ -28,10 +28,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Literal
 
 import dspy
 
+from memex_common.schemas import (
+    IntentClass,
+    IntentLiteral,
+    RiskClass,
+    RiskLiteral,
+)
 from memex_core.llm import run_dspy_operation
 from memex_core.memory.extraction.models import ProcessedFact
 from memex_core.metrics import (
@@ -42,14 +47,16 @@ from memex_core.metrics import (
 
 logger = logging.getLogger('memex.core.memory.extraction.classifier')
 
-INTENT_VALUES = ('permanent', 'durable', 'ephemeral')
-RISK_VALUES = ('none', 'sensitive', 'private', 'safety')
+# Derived from the canonical IntentClass / RiskClass enums in
+# memex_common.schemas — adding/renaming an enum value updates these tuples
+# automatically. The DEFAULT_* constants are intentionally explicit (rather
+# than positional indices) so a future enum reordering cannot silently flip
+# the default behavior.
+INTENT_VALUES: tuple[str, ...] = tuple(c.value for c in IntentClass)
+RISK_VALUES: tuple[str, ...] = tuple(c.value for c in RiskClass)
 
-DEFAULT_INTENT = 'durable'
-DEFAULT_RISK = 'none'
-
-IntentLiteral = Literal['permanent', 'durable', 'ephemeral']
-RiskLiteral = Literal['none', 'sensitive', 'private', 'safety']
+DEFAULT_INTENT = IntentClass.DURABLE.value
+DEFAULT_RISK = RiskClass.NONE.value
 
 
 class ClassifyMemoryUnit(dspy.Signature):

--- a/packages/core/src/memex_core/memory/retrieval/engine.py
+++ b/packages/core/src/memex_core/memory/retrieval/engine.py
@@ -353,6 +353,12 @@ class RetrievalEngine:
         if request.source_context:
             filters['source_context'] = request.source_context
 
+        # Thread intent_class / risk_class filters (write-time classifier; F25)
+        if request.intent_class:
+            filters['intent_class'] = request.intent_class
+        if request.risk_class:
+            filters['risk_class'] = request.risk_class
+
         # Pre-compute NER entities off the event loop so graph strategies don't block
         t0 = _t()
         if self.ner_model is not None:

--- a/packages/core/src/memex_core/memory/retrieval/engine.py
+++ b/packages/core/src/memex_core/memory/retrieval/engine.py
@@ -354,9 +354,9 @@ class RetrievalEngine:
             filters['source_context'] = request.source_context
 
         # Thread intent_class / risk_class filters (write-time classifier; F25)
-        if request.intent_class:
+        if request.intent_class is not None:
             filters['intent_class'] = request.intent_class
-        if request.risk_class:
+        if request.risk_class is not None:
             filters['risk_class'] = request.risk_class
 
         # Pre-compute NER entities off the event loop so graph strategies don't block

--- a/packages/core/src/memex_core/memory/retrieval/models.py
+++ b/packages/core/src/memex_core/memory/retrieval/models.py
@@ -4,9 +4,16 @@ from typing import Any, Self
 from pydantic import Field, model_validator
 from sqlmodel import SQLModel
 
+from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
+
+__all__ = [
+    'RetrievalRequest',
+    'VALID_STRATEGIES',
+    'VALID_INTENT_CLASSES',
+    'VALID_RISK_CLASSES',
+]
+
 VALID_STRATEGIES = frozenset({'semantic', 'keyword', 'graph', 'temporal', 'mental_model'})
-VALID_INTENT_CLASSES = frozenset({'permanent', 'durable', 'ephemeral'})
-VALID_RISK_CLASSES = frozenset({'none', 'sensitive', 'private', 'safety'})
 
 
 class RetrievalRequest(SQLModel):

--- a/packages/core/src/memex_core/memory/retrieval/models.py
+++ b/packages/core/src/memex_core/memory/retrieval/models.py
@@ -5,6 +5,8 @@ from pydantic import Field, model_validator
 from sqlmodel import SQLModel
 
 VALID_STRATEGIES = frozenset({'semantic', 'keyword', 'graph', 'temporal', 'mental_model'})
+VALID_INTENT_CLASSES = frozenset({'permanent', 'durable', 'ephemeral'})
+VALID_RISK_CLASSES = frozenset({'none', 'sensitive', 'private', 'safety'})
 
 
 class RetrievalRequest(SQLModel):
@@ -112,6 +114,22 @@ class RetrievalRequest(SQLModel):
         ),
     )
 
+    # Intent / risk class filtering (write-time classifier; F25)
+    intent_class: str | None = Field(
+        default=None,
+        description=(
+            'Filter MemoryUnits by intent_class (permanent | durable | ephemeral). '
+            'None disables the filter.'
+        ),
+    )
+    risk_class: str | None = Field(
+        default=None,
+        description=(
+            'Filter MemoryUnits by risk_class (none | sensitive | private | safety). '
+            'None disables the filter.'
+        ),
+    )
+
     # Tag filtering
     tags: list[str] | None = Field(
         default=None, description='Only return results from notes with ALL of these tags.'
@@ -128,4 +146,14 @@ class RetrievalRequest(SQLModel):
                     f'Invalid strategy names: {sorted(invalid)}. '
                     f'Valid strategies: {sorted(VALID_STRATEGIES)}'
                 )
+        if self.intent_class is not None and self.intent_class not in VALID_INTENT_CLASSES:
+            raise ValueError(
+                f'Invalid intent_class: {self.intent_class!r}. '
+                f'Valid values: {sorted(VALID_INTENT_CLASSES)}'
+            )
+        if self.risk_class is not None and self.risk_class not in VALID_RISK_CLASSES:
+            raise ValueError(
+                f'Invalid risk_class: {self.risk_class!r}. '
+                f'Valid values: {sorted(VALID_RISK_CLASSES)}'
+            )
         return self

--- a/packages/core/src/memex_core/memory/retrieval/models.py
+++ b/packages/core/src/memex_core/memory/retrieval/models.py
@@ -9,9 +9,11 @@ from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
 __all__ = [
     'RetrievalRequest',
     'VALID_STRATEGIES',
-    'VALID_INTENT_CLASSES',
-    'VALID_RISK_CLASSES',
 ]
+# ``VALID_INTENT_CLASSES`` / ``VALID_RISK_CLASSES`` are imported above for use
+# in the ``model_validator`` below but deliberately NOT re-exported. The
+# canonical home is ``memex_common.schemas`` — re-exporting here would create
+# a second public import path and risk future drift (round-7 review).
 
 VALID_STRATEGIES = frozenset({'semantic', 'keyword', 'graph', 'temporal', 'mental_model'})
 

--- a/packages/core/src/memex_core/memory/retrieval/models.py
+++ b/packages/core/src/memex_core/memory/retrieval/models.py
@@ -19,6 +19,21 @@ VALID_STRATEGIES = frozenset({'semantic', 'keyword', 'graph', 'temporal', 'menta
 class RetrievalRequest(SQLModel):
     """
     Unified request object for memory retrieval.
+
+    NOTE — dual-model architecture (intentional):
+    This is the **internal / storage** ``RetrievalRequest`` (SQLModel),
+    distinct from the wire/protocol model in
+    ``memex_common.schemas.RetrievalRequest``. The wire model is enum-typed
+    (``IntentClass`` / ``RiskClass``) for the public API; this model carries
+    ``intent_class: str | None`` / ``risk_class: str | None`` because it is
+    constructed inside ``SearchService`` from already-validated primitives
+    (the FastAPI route in ``memex_core/server/retrieval.py`` unpacks the
+    wire-model enums via ``.value`` at the boundary).
+
+    Value parity is enforced by the ``model_validator`` below against the
+    canonical ``VALID_INTENT_CLASSES`` / ``VALID_RISK_CLASSES`` frozensets,
+    which are derived from the same ``IntentClass`` / ``RiskClass`` enums in
+    ``memex_common.schemas``. Add new class values there, not here.
     """
 
     query: str = Field(..., description='The search query or context string.')

--- a/packages/core/src/memex_core/memory/retrieval/models.py
+++ b/packages/core/src/memex_core/memory/retrieval/models.py
@@ -158,7 +158,13 @@ class RetrievalRequest(SQLModel):
     )
 
     @model_validator(mode='after')
-    def validate_strategies(self) -> Self:
+    def validate_request_fields(self) -> Self:
+        """Cross-field validator: strategies, intent_class, risk_class.
+
+        Originally named ``validate_strategies`` when only ``strategies`` was
+        validated; renamed in round-5 review to reflect that it now also
+        validates intent/risk class membership against the canonical enum sets.
+        """
         if self.strategies is not None:
             if len(self.strategies) == 0:
                 raise ValueError('strategies list must not be empty')

--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -643,6 +643,15 @@ class MentalModelStrategy:
         # those facets. If a write-time risk/intent filter must constrain
         # mental-model retrieval in the future, the join would need to fan out
         # through the contributing MemoryUnits — out of scope for issue #92.
+        intent_class = kwargs.get('intent_class')
+        risk_class = kwargs.get('risk_class')
+        if intent_class is not None or risk_class is not None:
+            logger.debug(
+                'Intent/risk filters silently skipped for mental_model strategy '
+                '(intent_class=%s, risk_class=%s) — out-of-scope per issue #92',
+                intent_class,
+                risk_class,
+            )
 
         if query_embedding is None:
             # Fallback to name match if no embedding

--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -113,10 +113,10 @@ def apply_intent_risk_filter(statement: Select, **kwargs: Any) -> Select:
     against the ``IntentClass`` / ``RiskClass`` enums).
     """
     intent_class = kwargs.get('intent_class')
-    if intent_class:
+    if intent_class is not None:
         statement = statement.where(col(MemoryUnit.intent_class) == intent_class)
     risk_class = kwargs.get('risk_class')
-    if risk_class:
+    if risk_class is not None:
         statement = statement.where(col(MemoryUnit.risk_class) == risk_class)
     return statement
 

--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -111,6 +111,20 @@ def apply_intent_risk_filter(statement: Select, **kwargs: Any) -> Select:
     Both filters are independent and additive — pass either, both, or neither.
     Values are not validated here (validation happens at the API/CLI boundary
     against the ``IntentClass`` / ``RiskClass`` enums).
+
+    NULL semantics: this filter uses strict SQL equality (``column = :value``),
+    so rows with ``NULL`` in ``intent_class`` or ``risk_class`` are excluded
+    when the corresponding filter is active. This is by design and matches
+    the legacy client-side filter (``getattr(u, 'intent_class', 'durable') ==
+    wanted`` likewise excluded ``None`` values, because the attribute exists
+    on the model — ``getattr``'s default is only returned when the attribute
+    is missing entirely). In production, NULLs cannot occur: the F25
+    migration (``024_intent_risk_classifier``) adds both columns as
+    ``NOT NULL`` with ``server_default`` (``'durable'`` / ``'none'``) and a
+    CHECK constraint pinning values to the enum domain, so existing rows
+    are backfilled and new rows are rejected if NULL is attempted. A persistent
+    NULL would therefore indicate genuinely-unclassified data that should not
+    silently match a specific intent/risk query.
     """
     intent_class = kwargs.get('intent_class')
     if intent_class is not None:

--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -621,6 +621,14 @@ class MentalModelStrategy:
         # Generic filters generally don't apply to MentalModels in the same way (no fact_type),
         # so we skip apply_generic_filters here or check column existence.
         # MentalModels don't have 'fact_type', so we skip it.
+        #
+        # NOTE: apply_context_filter / apply_intent_risk_filter are intentionally
+        # NOT applied here. ``context``, ``intent_class`` and ``risk_class`` are
+        # MemoryUnit columns (set at write time per F25); MentalModel rows are
+        # synthesised by reflection across many memory units and don't carry
+        # those facets. If a write-time risk/intent filter must constrain
+        # mental-model retrieval in the future, the join would need to fan out
+        # through the contributing MemoryUnits — out of scope for issue #92.
 
         if query_embedding is None:
             # Fallback to name match if no embedding

--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -105,6 +105,22 @@ def apply_context_filter(statement: Select, **kwargs: Any) -> Select:
     return statement
 
 
+def apply_intent_risk_filter(statement: Select, **kwargs: Any) -> Select:
+    """Filter MemoryUnits by ``intent_class`` and ``risk_class`` when set.
+
+    Both filters are independent and additive — pass either, both, or neither.
+    Values are not validated here (validation happens at the API/CLI boundary
+    against the ``IntentClass`` / ``RiskClass`` enums).
+    """
+    intent_class = kwargs.get('intent_class')
+    if intent_class:
+        statement = statement.where(col(MemoryUnit.intent_class) == intent_class)
+    risk_class = kwargs.get('risk_class')
+    if risk_class:
+        statement = statement.where(col(MemoryUnit.risk_class) == risk_class)
+    return statement
+
+
 def _apply_as_of_filter(statement: Select, **kwargs: Any) -> Select:
     """Filter EntityCooccurrence rows by temporal validity when ``as_of`` is set.
 
@@ -153,6 +169,7 @@ class SemanticStrategy:
         statement = apply_vault_filters(statement, MemoryUnit.vault_id, **kwargs)
         statement = apply_generic_filters(statement, **kwargs)
         statement = apply_context_filter(statement, **kwargs)
+        statement = apply_intent_risk_filter(statement, **kwargs)
 
         if query_embedding is None:
             # If no embedding, this strategy is effectively disabled
@@ -193,6 +210,7 @@ class KeywordStrategy:
         statement = apply_vault_filters(statement, MemoryUnit.vault_id, **kwargs)
         statement = apply_generic_filters(statement, **kwargs)
         statement = apply_context_filter(statement, **kwargs)
+        statement = apply_intent_risk_filter(statement, **kwargs)
 
         return (
             statement.add_columns(rank.label('score'))
@@ -503,11 +521,13 @@ class EntityCooccurrenceGraphStrategy:
         select_first = apply_vault_filters(select_first, MemoryUnit.vault_id, **kwargs)
         select_first = apply_generic_filters(select_first, **kwargs)
         select_first = apply_context_filter(select_first, **kwargs)
+        select_first = apply_intent_risk_filter(select_first, **kwargs)
 
         select_second = apply_date_filters(select_second, MemoryUnit.event_date, **kwargs)
         select_second = apply_vault_filters(select_second, MemoryUnit.vault_id, **kwargs)
         select_second = apply_generic_filters(select_second, **kwargs)
         select_second = apply_context_filter(select_second, **kwargs)
+        select_second = apply_intent_risk_filter(select_second, **kwargs)
 
         # 2. 1st Order Memories (Direct Link)
         # V2 Scoring: 1.0 + Temporal Decay
@@ -638,6 +658,7 @@ class TemporalStrategy:
         statement = apply_vault_filters(statement, MemoryUnit.vault_id, **kwargs)
         statement = apply_generic_filters(statement, **kwargs)
         statement = apply_context_filter(statement, **kwargs)
+        statement = apply_intent_risk_filter(statement, **kwargs)
 
         return statement.order_by(desc(col(MemoryUnit.event_date))).limit(limit)
 

--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -646,9 +646,10 @@ class MentalModelStrategy:
         intent_class = kwargs.get('intent_class')
         risk_class = kwargs.get('risk_class')
         if intent_class is not None or risk_class is not None:
-            logger.debug(
-                'Intent/risk filters silently skipped for mental_model strategy '
-                '(intent_class=%s, risk_class=%s) — out-of-scope per issue #92',
+            logger.warning(
+                'Mental-model strategy ignores intent/risk filters (intent_class=%s, risk_class=%s); '
+                'results will mix unfiltered mental-model units with filtered units from other strategies. '
+                'Out-of-scope per issue #92 — see strategies.py for rationale.',
                 intent_class,
                 risk_class,
             )

--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Protocol, Any, runtime_checkable
 from uuid import UUID
 
@@ -34,6 +35,26 @@ from memex_core.memory.sql_models import (
 from memex_core.memory.sql_models import MentalModel
 
 logger = logging.getLogger('memex.core.memory.retrieval.strategies')
+
+
+# Warn-once helper for the mental-model strategy's intent/risk filter no-op.
+# ``lru_cache`` memoises by the argument tuple, so repeat calls with the same
+# (intent_class, risk_class) combination silently return None after the first
+# warning is emitted. A different combination warns again, since it is a new
+# cache key. ``maxsize=64`` comfortably bounds the realistic key space
+# (3 intent values x 4 risk values x None combinations = 20 distinct keys).
+# Defined at module scope (not as a method) because ``lru_cache`` on bound
+# methods retains ``self`` in the cache, which is a known footgun.
+@lru_cache(maxsize=64)
+def _warn_mental_model_filters_skipped(intent_class: str | None, risk_class: str | None) -> None:
+    logger.warning(
+        'Mental-model strategy ignores intent/risk filters (intent_class=%s, risk_class=%s); '
+        'results will mix unfiltered mental-model units with filtered units from other strategies. '
+        'Out-of-scope per issue #92.',
+        intent_class,
+        risk_class,
+    )
+
 
 # Maximum exponent magnitude for temporal decay to prevent Postgres NUMERIC underflow.
 # power(2, -996) ~ 1e-300 which is near the minimum representable NUMERIC value.
@@ -646,13 +667,9 @@ class MentalModelStrategy:
         intent_class = kwargs.get('intent_class')
         risk_class = kwargs.get('risk_class')
         if intent_class is not None or risk_class is not None:
-            logger.warning(
-                'Mental-model strategy ignores intent/risk filters (intent_class=%s, risk_class=%s); '
-                'results will mix unfiltered mental-model units with filtered units from other strategies. '
-                'Out-of-scope per issue #92 — see strategies.py for rationale.',
-                intent_class,
-                risk_class,
-            )
+            # Warn-once per (intent_class, risk_class) tuple — see
+            # ``_warn_mental_model_filters_skipped`` for caching rationale.
+            _warn_mental_model_filters_skipped(intent_class, risk_class)
 
         if query_embedding is None:
             # Fallback to name match if no embedding

--- a/packages/core/src/memex_core/server/retrieval.py
+++ b/packages/core/src/memex_core/server/retrieval.py
@@ -55,6 +55,8 @@ async def search_memories(
             source_context=request.source_context,
             reference_date=request.reference_date,
             expand_query=request.expand_query,
+            intent_class=request.intent_class.value if request.intent_class else None,
+            risk_class=request.risk_class.value if request.risk_class else None,
         )
         t_search = time.monotonic() - t0
 

--- a/packages/core/src/memex_core/server/retrieval.py
+++ b/packages/core/src/memex_core/server/retrieval.py
@@ -55,8 +55,12 @@ async def search_memories(
             source_context=request.source_context,
             reference_date=request.reference_date,
             expand_query=request.expand_query,
-            intent_class=request.intent_class.value if request.intent_class else None,
-            risk_class=request.risk_class.value if request.risk_class else None,
+            # Use ``is not None`` rather than truthiness — IntentClass /
+            # RiskClass subclass ``str``, so an enum member with value ``''``
+            # would be falsy and silently coerce to None. No such member
+            # exists today, but the explicit check is the safe idiom.
+            intent_class=request.intent_class.value if request.intent_class is not None else None,
+            risk_class=request.risk_class.value if request.risk_class is not None else None,
         )
         t_search = time.monotonic() - t0
 

--- a/packages/core/src/memex_core/services/search.py
+++ b/packages/core/src/memex_core/services/search.py
@@ -72,6 +72,8 @@ class SearchService:
         source_context: str | None = None,
         reference_date: dt.datetime | None = None,
         expand_query: bool = False,
+        intent_class: str | None = None,
+        risk_class: str | None = None,
     ) -> tuple[list[MemoryUnit], Any]:
         """
         Convenience method for search with reranking.
@@ -108,6 +110,8 @@ class SearchService:
             source_context=source_context,
             reference_date=reference_date,
             expand_query=expand_query,
+            intent_class=intent_class,
+            risk_class=risk_class,
         )
 
         async with self.metastore.session() as session:

--- a/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
+++ b/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
@@ -10,7 +10,7 @@ import pytest_asyncio
 from datetime import datetime, timezone
 from uuid import uuid4
 
-from sqlalchemy import text
+from sqlalchemy import delete, text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from memex_common.config import GLOBAL_VAULT_ID
@@ -146,24 +146,17 @@ class TestIntentRiskFilter:
                 'safety_id': safety_id,
             }
         finally:
-            # Explicit teardown — defends against state leak across tests
-            # even if the autouse `clean_tables` fixture is ever bypassed.
-            await session.execute(
-                text('DELETE FROM unit_entities WHERE unit_id = ANY(CAST(:ids AS uuid[]))'),
-                {'ids': [str(u) for u in unit_ids]},
-            )
-            await session.execute(
-                text('DELETE FROM memory_units WHERE id = ANY(CAST(:ids AS uuid[]))'),
-                {'ids': [str(u) for u in unit_ids]},
-            )
-            await session.execute(
-                text('DELETE FROM entities WHERE id = CAST(:id AS uuid)'),
-                {'id': str(entity_id)},
-            )
-            await session.execute(
-                text('DELETE FROM notes WHERE id = CAST(:id AS uuid)'),
-                {'id': str(note_id)},
-            )
+            # Explicit teardown — defends against state leak across tests even
+            # if the autouse ``clean_tables`` fixture is ever bypassed. Uses
+            # ORM ``delete()`` rather than raw ``text()`` because asyncpg can
+            # mis-serialise Python lists passed to ``text()`` array binds
+            # (round-7 review: the previous ``ANY(CAST(:ids AS uuid[]))``
+            # form raised ``syntax error at or near "{"`` at runtime; the
+            # ``TRUNCATE`` in ``clean_tables`` was masking the broken path).
+            await session.execute(delete(UnitEntity).where(UnitEntity.unit_id.in_(unit_ids)))
+            await session.execute(delete(MemoryUnit).where(MemoryUnit.id.in_(unit_ids)))
+            await session.execute(delete(Entity).where(Entity.id == entity_id))
+            await session.execute(delete(Note).where(Note.id == note_id))
             await session.commit()
 
     async def test_intent_filter_permanent(

--- a/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
+++ b/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
@@ -277,14 +277,6 @@ class TestIntentRiskFilter:
         ):
             assert seeded_units[key] in result_ids
 
-    async def test_invalid_intent_class_rejected(self):
-        with pytest.raises(ValueError, match='Invalid intent_class'):
-            RetrievalRequest(query='x', intent_class='not-a-real-class')
-
-    async def test_invalid_risk_class_rejected(self):
-        with pytest.raises(ValueError, match='Invalid risk_class'):
-            RetrievalRequest(query='x', risk_class='not-a-real-class')
-
 
 @pytest.mark.integration
 class TestIntentRiskNullSemantics:

--- a/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
+++ b/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
@@ -1,0 +1,233 @@
+"""Integration tests for issue #92 — server-side intent_class / risk_class filter.
+
+Verifies that intent_class and risk_class filters apply at the SQL level so the
+search HTTP endpoint returns ONLY matching memory units (not a truncated page
+that the CLI then has to filter again).
+"""
+
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.config import GLOBAL_VAULT_ID
+from memex_common.types import FactTypes
+from memex_core.memory.models.embedding import get_embedding_model
+from memex_core.memory.retrieval.engine import RetrievalEngine
+from memex_core.memory.retrieval.models import RetrievalRequest
+from memex_core.memory.sql_models import Entity, MemoryUnit, Note, UnitEntity
+
+
+@pytest.mark.integration
+class TestIntentRiskFilter:
+    @pytest_asyncio.fixture(scope='class')
+    async def embedder(self):
+        return await get_embedding_model()
+
+    @pytest_asyncio.fixture
+    async def engine_instance(self, embedder):
+        return RetrievalEngine(embedder=embedder)
+
+    @pytest_asyncio.fixture
+    async def seeded_units(self, session: AsyncSession):
+        """Create units spanning every (intent_class, risk_class) combo we want to filter on."""
+        vault_id = GLOBAL_VAULT_ID
+        note_id = uuid4()
+        entity_id = uuid4()
+
+        permanent_id = uuid4()
+        durable_id = uuid4()
+        ephemeral_id = uuid4()
+        sensitive_id = uuid4()
+        private_id = uuid4()
+
+        note = Note(id=note_id, original_text='intent risk filter test note', vault_id=vault_id)
+        emb = [0.1] * 384
+        now = datetime.now(timezone.utc)
+
+        units = [
+            MemoryUnit(
+                id=permanent_id,
+                note_id=note_id,
+                text='Permanent fact about classification',
+                fact_type=FactTypes.WORLD,
+                embedding=emb,
+                vault_id=vault_id,
+                event_date=now,
+                intent_class='permanent',
+                risk_class='none',
+            ),
+            MemoryUnit(
+                id=durable_id,
+                note_id=note_id,
+                text='Durable fact about classification',
+                fact_type=FactTypes.WORLD,
+                embedding=emb,
+                vault_id=vault_id,
+                event_date=now,
+                intent_class='durable',
+                risk_class='none',
+            ),
+            MemoryUnit(
+                id=ephemeral_id,
+                note_id=note_id,
+                text='Ephemeral fact about classification',
+                fact_type=FactTypes.WORLD,
+                embedding=emb,
+                vault_id=vault_id,
+                event_date=now,
+                intent_class='ephemeral',
+                risk_class='none',
+            ),
+            MemoryUnit(
+                id=sensitive_id,
+                note_id=note_id,
+                text='Sensitive fact about classification',
+                fact_type=FactTypes.WORLD,
+                embedding=emb,
+                vault_id=vault_id,
+                event_date=now,
+                intent_class='durable',
+                risk_class='sensitive',
+            ),
+            MemoryUnit(
+                id=private_id,
+                note_id=note_id,
+                text='Private fact about classification',
+                fact_type=FactTypes.WORLD,
+                embedding=emb,
+                vault_id=vault_id,
+                event_date=now,
+                intent_class='durable',
+                risk_class='private',
+            ),
+        ]
+        entity = Entity(id=entity_id, canonical_name='Classification')
+
+        session.add(note)
+        for unit in units:
+            session.add(unit)
+        session.add(entity)
+        for uid in (permanent_id, durable_id, ephemeral_id, sensitive_id, private_id):
+            session.add(UnitEntity(unit_id=uid, entity_id=entity_id, vault_id=vault_id))
+        await session.commit()
+
+        return {
+            'permanent_id': permanent_id,
+            'durable_id': durable_id,
+            'ephemeral_id': ephemeral_id,
+            'sensitive_id': sensitive_id,
+            'private_id': private_id,
+        }
+
+    async def test_intent_filter_permanent(
+        self, session: AsyncSession, engine_instance, seeded_units
+    ):
+        request = RetrievalRequest(
+            query='classification',
+            limit=10,
+            vault_ids=[GLOBAL_VAULT_ID],
+            intent_class='permanent',
+        )
+        results, _ = await engine_instance.retrieve(session, request)
+
+        result_ids = {r.id for r in results}
+        assert seeded_units['permanent_id'] in result_ids
+        # Only permanent should pass — durable/ephemeral/sensitive/private all excluded
+        for key in ('durable_id', 'ephemeral_id', 'sensitive_id', 'private_id'):
+            assert seeded_units[key] not in result_ids
+
+    async def test_intent_filter_ephemeral(
+        self, session: AsyncSession, engine_instance, seeded_units
+    ):
+        request = RetrievalRequest(
+            query='classification',
+            limit=10,
+            vault_ids=[GLOBAL_VAULT_ID],
+            intent_class='ephemeral',
+        )
+        results, _ = await engine_instance.retrieve(session, request)
+
+        result_ids = {r.id for r in results}
+        assert seeded_units['ephemeral_id'] in result_ids
+        for key in ('permanent_id', 'durable_id', 'sensitive_id', 'private_id'):
+            assert seeded_units[key] not in result_ids
+
+    async def test_risk_filter_sensitive(
+        self, session: AsyncSession, engine_instance, seeded_units
+    ):
+        request = RetrievalRequest(
+            query='classification',
+            limit=10,
+            vault_ids=[GLOBAL_VAULT_ID],
+            risk_class='sensitive',
+        )
+        results, _ = await engine_instance.retrieve(session, request)
+
+        result_ids = {r.id for r in results}
+        assert seeded_units['sensitive_id'] in result_ids
+        for key in ('permanent_id', 'durable_id', 'ephemeral_id', 'private_id'):
+            assert seeded_units[key] not in result_ids
+
+    async def test_risk_filter_private(self, session: AsyncSession, engine_instance, seeded_units):
+        request = RetrievalRequest(
+            query='classification',
+            limit=10,
+            vault_ids=[GLOBAL_VAULT_ID],
+            risk_class='private',
+        )
+        results, _ = await engine_instance.retrieve(session, request)
+
+        result_ids = {r.id for r in results}
+        assert seeded_units['private_id'] in result_ids
+        for key in ('permanent_id', 'durable_id', 'ephemeral_id', 'sensitive_id'):
+            assert seeded_units[key] not in result_ids
+
+    async def test_combined_intent_and_risk_filter(
+        self, session: AsyncSession, engine_instance, seeded_units
+    ):
+        request = RetrievalRequest(
+            query='classification',
+            limit=10,
+            vault_ids=[GLOBAL_VAULT_ID],
+            intent_class='durable',
+            risk_class='sensitive',
+        )
+        results, _ = await engine_instance.retrieve(session, request)
+
+        result_ids = {r.id for r in results}
+        # Only the durable+sensitive unit should remain
+        assert seeded_units['sensitive_id'] in result_ids
+        for key in ('permanent_id', 'durable_id', 'ephemeral_id', 'private_id'):
+            assert seeded_units[key] not in result_ids
+
+    async def test_no_filter_returns_all_intents(
+        self, session: AsyncSession, engine_instance, seeded_units
+    ):
+        request = RetrievalRequest(
+            query='classification',
+            limit=10,
+            vault_ids=[GLOBAL_VAULT_ID],
+        )
+        results, _ = await engine_instance.retrieve(session, request)
+
+        result_ids = {r.id for r in results}
+        # All five units should be returned (no filter applied)
+        for key in (
+            'permanent_id',
+            'durable_id',
+            'ephemeral_id',
+            'sensitive_id',
+            'private_id',
+        ):
+            assert seeded_units[key] in result_ids
+
+    async def test_invalid_intent_class_rejected(self):
+        with pytest.raises(ValueError, match='Invalid intent_class'):
+            RetrievalRequest(query='x', intent_class='not-a-real-class')
+
+    async def test_invalid_risk_class_rejected(self):
+        with pytest.raises(ValueError, match='Invalid risk_class'):
+            RetrievalRequest(query='x', risk_class='not-a-real-class')

--- a/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
+++ b/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
@@ -386,20 +386,25 @@ class TestIntentRiskNullSemantics:
         )
         await session.commit()
 
-        result = await session.execute(
-            text('SELECT intent_class, risk_class FROM memory_units WHERE id = CAST(:id AS uuid)'),
-            {'id': str(unit_id)},
-        )
-        row = result.one()
-        assert row.intent_class == 'durable'
-        assert row.risk_class == 'none'
-
-        await session.execute(
-            text('DELETE FROM memory_units WHERE id = CAST(:id AS uuid)'),
-            {'id': str(unit_id)},
-        )
-        await session.execute(
-            text('DELETE FROM notes WHERE id = CAST(:id AS uuid)'),
-            {'id': str(note_id)},
-        )
-        await session.commit()
+        try:
+            result = await session.execute(
+                text(
+                    'SELECT intent_class, risk_class FROM memory_units WHERE id = CAST(:id AS uuid)'
+                ),
+                {'id': str(unit_id)},
+            )
+            row = result.one()
+            assert row.intent_class == 'durable'
+            assert row.risk_class == 'none'
+        finally:
+            # Cleanup must run even if the assertions above fail, otherwise the
+            # committed rows leak into sibling tests.
+            await session.execute(
+                text('DELETE FROM memory_units WHERE id = CAST(:id AS uuid)'),
+                {'id': str(unit_id)},
+            )
+            await session.execute(
+                text('DELETE FROM notes WHERE id = CAST(:id AS uuid)'),
+                {'id': str(note_id)},
+            )
+            await session.commit()

--- a/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
+++ b/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
@@ -10,6 +10,7 @@ import pytest_asyncio
 from datetime import datetime, timezone
 from uuid import uuid4
 
+from sqlalchemy import text
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from memex_common.config import GLOBAL_VAULT_ID
@@ -42,6 +43,7 @@ class TestIntentRiskFilter:
         ephemeral_id = uuid4()
         sensitive_id = uuid4()
         private_id = uuid4()
+        safety_id = uuid4()
 
         note = Note(id=note_id, original_text='intent risk filter test note', vault_id=vault_id)
         emb = [0.1] * 384
@@ -103,24 +105,66 @@ class TestIntentRiskFilter:
                 intent_class='durable',
                 risk_class='private',
             ),
+            MemoryUnit(
+                id=safety_id,
+                note_id=note_id,
+                text='Safety fact about classification',
+                fact_type=FactTypes.WORLD,
+                embedding=emb,
+                vault_id=vault_id,
+                event_date=now,
+                intent_class='durable',
+                risk_class='safety',
+            ),
         ]
         entity = Entity(id=entity_id, canonical_name='Classification')
+
+        unit_ids = (
+            permanent_id,
+            durable_id,
+            ephemeral_id,
+            sensitive_id,
+            private_id,
+            safety_id,
+        )
 
         session.add(note)
         for unit in units:
             session.add(unit)
         session.add(entity)
-        for uid in (permanent_id, durable_id, ephemeral_id, sensitive_id, private_id):
+        for uid in unit_ids:
             session.add(UnitEntity(unit_id=uid, entity_id=entity_id, vault_id=vault_id))
         await session.commit()
 
-        return {
-            'permanent_id': permanent_id,
-            'durable_id': durable_id,
-            'ephemeral_id': ephemeral_id,
-            'sensitive_id': sensitive_id,
-            'private_id': private_id,
-        }
+        try:
+            yield {
+                'permanent_id': permanent_id,
+                'durable_id': durable_id,
+                'ephemeral_id': ephemeral_id,
+                'sensitive_id': sensitive_id,
+                'private_id': private_id,
+                'safety_id': safety_id,
+            }
+        finally:
+            # Explicit teardown — defends against state leak across tests
+            # even if the autouse `clean_tables` fixture is ever bypassed.
+            await session.execute(
+                text('DELETE FROM unit_entities WHERE unit_id = ANY(CAST(:ids AS uuid[]))'),
+                {'ids': [str(u) for u in unit_ids]},
+            )
+            await session.execute(
+                text('DELETE FROM memory_units WHERE id = ANY(CAST(:ids AS uuid[]))'),
+                {'ids': [str(u) for u in unit_ids]},
+            )
+            await session.execute(
+                text('DELETE FROM entities WHERE id = CAST(:id AS uuid)'),
+                {'id': str(entity_id)},
+            )
+            await session.execute(
+                text('DELETE FROM notes WHERE id = CAST(:id AS uuid)'),
+                {'id': str(note_id)},
+            )
+            await session.commit()
 
     async def test_intent_filter_permanent(
         self, session: AsyncSession, engine_instance, seeded_units
@@ -135,8 +179,8 @@ class TestIntentRiskFilter:
 
         result_ids = {r.id for r in results}
         assert seeded_units['permanent_id'] in result_ids
-        # Only permanent should pass — durable/ephemeral/sensitive/private all excluded
-        for key in ('durable_id', 'ephemeral_id', 'sensitive_id', 'private_id'):
+        # Only permanent should pass — every other intent class is excluded
+        for key in ('durable_id', 'ephemeral_id', 'sensitive_id', 'private_id', 'safety_id'):
             assert seeded_units[key] not in result_ids
 
     async def test_intent_filter_ephemeral(
@@ -152,7 +196,7 @@ class TestIntentRiskFilter:
 
         result_ids = {r.id for r in results}
         assert seeded_units['ephemeral_id'] in result_ids
-        for key in ('permanent_id', 'durable_id', 'sensitive_id', 'private_id'):
+        for key in ('permanent_id', 'durable_id', 'sensitive_id', 'private_id', 'safety_id'):
             assert seeded_units[key] not in result_ids
 
     async def test_risk_filter_sensitive(
@@ -168,7 +212,7 @@ class TestIntentRiskFilter:
 
         result_ids = {r.id for r in results}
         assert seeded_units['sensitive_id'] in result_ids
-        for key in ('permanent_id', 'durable_id', 'ephemeral_id', 'private_id'):
+        for key in ('permanent_id', 'durable_id', 'ephemeral_id', 'private_id', 'safety_id'):
             assert seeded_units[key] not in result_ids
 
     async def test_risk_filter_private(self, session: AsyncSession, engine_instance, seeded_units):
@@ -182,7 +226,22 @@ class TestIntentRiskFilter:
 
         result_ids = {r.id for r in results}
         assert seeded_units['private_id'] in result_ids
-        for key in ('permanent_id', 'durable_id', 'ephemeral_id', 'sensitive_id'):
+        for key in ('permanent_id', 'durable_id', 'ephemeral_id', 'sensitive_id', 'safety_id'):
+            assert seeded_units[key] not in result_ids
+
+    async def test_risk_filter_safety(self, session: AsyncSession, engine_instance, seeded_units):
+        """Risk class 'safety' is the most security-critical — verify isolation explicitly."""
+        request = RetrievalRequest(
+            query='classification',
+            limit=10,
+            vault_ids=[GLOBAL_VAULT_ID],
+            risk_class='safety',
+        )
+        results, _ = await engine_instance.retrieve(session, request)
+
+        result_ids = {r.id for r in results}
+        assert seeded_units['safety_id'] in result_ids
+        for key in ('permanent_id', 'durable_id', 'ephemeral_id', 'sensitive_id', 'private_id'):
             assert seeded_units[key] not in result_ids
 
     async def test_combined_intent_and_risk_filter(
@@ -200,7 +259,7 @@ class TestIntentRiskFilter:
         result_ids = {r.id for r in results}
         # Only the durable+sensitive unit should remain
         assert seeded_units['sensitive_id'] in result_ids
-        for key in ('permanent_id', 'durable_id', 'ephemeral_id', 'private_id'):
+        for key in ('permanent_id', 'durable_id', 'ephemeral_id', 'private_id', 'safety_id'):
             assert seeded_units[key] not in result_ids
 
     async def test_no_filter_returns_all_intents(
@@ -214,13 +273,14 @@ class TestIntentRiskFilter:
         results, _ = await engine_instance.retrieve(session, request)
 
         result_ids = {r.id for r in results}
-        # All five units should be returned (no filter applied)
+        # All six units should be returned (no filter applied)
         for key in (
             'permanent_id',
             'durable_id',
             'ephemeral_id',
             'sensitive_id',
             'private_id',
+            'safety_id',
         ):
             assert seeded_units[key] in result_ids
 

--- a/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
+++ b/packages/core/tests/integration/memory/retrieval/test_int_intent_risk_filter.py
@@ -291,3 +291,130 @@ class TestIntentRiskFilter:
     async def test_invalid_risk_class_rejected(self):
         with pytest.raises(ValueError, match='Invalid risk_class'):
             RetrievalRequest(query='x', risk_class='not-a-real-class')
+
+
+@pytest.mark.integration
+class TestIntentRiskNullSemantics:
+    """Round-5 regression guard for NULL ``intent_class`` / ``risk_class`` semantics.
+
+    The server-side filter uses strict SQL equality (``column = :value``), so rows
+    with NULL classifications would be excluded when a filter is active. The legacy
+    client-side filter (``getattr(u, 'intent_class', 'durable') == wanted``) was
+    behaviorally equivalent — ``getattr``'s default fires only when the attribute
+    is missing, never when it is the literal ``None``. Migrating from client- to
+    server-side filtering therefore preserves the original semantics.
+
+    These tests assert the F25 schema invariants that make this safe in production:
+    ``intent_class`` and ``risk_class`` are ``NOT NULL`` with ``server_default``
+    backfills, plus CHECK constraints pinning values to the enum domain. If these
+    invariants ever regress, the filter's NULL-exclusion behavior could leak.
+    """
+
+    async def test_intent_class_rejects_null_at_db_level(self, session: AsyncSession):
+        """The NOT NULL constraint must reject INSERTs with intent_class = NULL."""
+        note_id = uuid4()
+        unit_id = uuid4()
+        await session.execute(
+            text(
+                'INSERT INTO notes (id, original_text, vault_id) '
+                'VALUES (CAST(:id AS uuid), :txt, CAST(:vault AS uuid))'
+            ),
+            {'id': str(note_id), 'txt': 'null-semantics test', 'vault': str(GLOBAL_VAULT_ID)},
+        )
+        with pytest.raises(Exception, match=r'(?i)null|not[- ]null'):
+            await session.execute(
+                text(
+                    'INSERT INTO memory_units '
+                    '(id, note_id, text, fact_type, vault_id, event_date, intent_class) '
+                    'VALUES (CAST(:id AS uuid), CAST(:note AS uuid), :txt, :ft, '
+                    'CAST(:vault AS uuid), now(), NULL)'
+                ),
+                {
+                    'id': str(unit_id),
+                    'note': str(note_id),
+                    'txt': 'should fail',
+                    'ft': FactTypes.WORLD.value,
+                    'vault': str(GLOBAL_VAULT_ID),
+                },
+            )
+        await session.rollback()
+
+    async def test_risk_class_rejects_null_at_db_level(self, session: AsyncSession):
+        """The NOT NULL constraint must reject INSERTs with risk_class = NULL."""
+        note_id = uuid4()
+        unit_id = uuid4()
+        await session.execute(
+            text(
+                'INSERT INTO notes (id, original_text, vault_id) '
+                'VALUES (CAST(:id AS uuid), :txt, CAST(:vault AS uuid))'
+            ),
+            {'id': str(note_id), 'txt': 'null-semantics test', 'vault': str(GLOBAL_VAULT_ID)},
+        )
+        with pytest.raises(Exception, match=r'(?i)null|not[- ]null'):
+            await session.execute(
+                text(
+                    'INSERT INTO memory_units '
+                    '(id, note_id, text, fact_type, vault_id, event_date, risk_class) '
+                    'VALUES (CAST(:id AS uuid), CAST(:note AS uuid), :txt, :ft, '
+                    'CAST(:vault AS uuid), now(), NULL)'
+                ),
+                {
+                    'id': str(unit_id),
+                    'note': str(note_id),
+                    'txt': 'should fail',
+                    'ft': FactTypes.WORLD.value,
+                    'vault': str(GLOBAL_VAULT_ID),
+                },
+            )
+        await session.rollback()
+
+    async def test_intent_class_default_is_durable(self, session: AsyncSession):
+        """An INSERT that omits intent_class/risk_class must be backfilled by server_default.
+
+        This guarantees pre-F25 rows (added before the columns existed) are
+        seen as ``intent_class='durable'`` / ``risk_class='none'`` rather than
+        ``NULL``, matching the legacy client-side filter's implicit assumption.
+        """
+        note_id = uuid4()
+        unit_id = uuid4()
+        await session.execute(
+            text(
+                'INSERT INTO notes (id, original_text, vault_id) '
+                'VALUES (CAST(:id AS uuid), :txt, CAST(:vault AS uuid))'
+            ),
+            {'id': str(note_id), 'txt': 'default test', 'vault': str(GLOBAL_VAULT_ID)},
+        )
+        await session.execute(
+            text(
+                'INSERT INTO memory_units '
+                '(id, note_id, text, fact_type, vault_id, event_date) '
+                'VALUES (CAST(:id AS uuid), CAST(:note AS uuid), :txt, :ft, '
+                'CAST(:vault AS uuid), now())'
+            ),
+            {
+                'id': str(unit_id),
+                'note': str(note_id),
+                'txt': 'default-backfill row',
+                'ft': FactTypes.WORLD.value,
+                'vault': str(GLOBAL_VAULT_ID),
+            },
+        )
+        await session.commit()
+
+        result = await session.execute(
+            text('SELECT intent_class, risk_class FROM memory_units WHERE id = CAST(:id AS uuid)'),
+            {'id': str(unit_id)},
+        )
+        row = result.one()
+        assert row.intent_class == 'durable'
+        assert row.risk_class == 'none'
+
+        await session.execute(
+            text('DELETE FROM memory_units WHERE id = CAST(:id AS uuid)'),
+            {'id': str(unit_id)},
+        )
+        await session.execute(
+            text('DELETE FROM notes WHERE id = CAST(:id AS uuid)'),
+            {'id': str(note_id)},
+        )
+        await session.commit()

--- a/packages/core/tests/unit/memory/retrieval/test_intent_risk_validation.py
+++ b/packages/core/tests/unit/memory/retrieval/test_intent_risk_validation.py
@@ -1,0 +1,23 @@
+"""Unit tests for ``RetrievalRequest`` intent_class / risk_class validation.
+
+These tests instantiate ``RetrievalRequest`` directly and assert that the
+post-init model validator rejects values outside the canonical enum sets.
+They do not touch the database or the retrieval engine, so they belong in
+the unit suite (``pytest -m 'not integration'``); previously they lived
+inside an ``@pytest.mark.integration``-marked class and were silently
+skipped by unit-only CI runs.
+"""
+
+import pytest
+
+from memex_core.memory.retrieval.models import RetrievalRequest
+
+
+class TestIntentRiskValidation:
+    async def test_invalid_intent_class_rejected(self):
+        with pytest.raises(ValueError, match='Invalid intent_class'):
+            RetrievalRequest(query='x', intent_class='not-a-real-class')
+
+    async def test_invalid_risk_class_rejected(self):
+        with pytest.raises(ValueError, match='Invalid risk_class'):
+            RetrievalRequest(query='x', risk_class='not-a-real-class')

--- a/packages/core/tests/unit/memory/retrieval/test_intent_risk_validation.py
+++ b/packages/core/tests/unit/memory/retrieval/test_intent_risk_validation.py
@@ -14,10 +14,10 @@ from memex_core.memory.retrieval.models import RetrievalRequest
 
 
 class TestIntentRiskValidation:
-    async def test_invalid_intent_class_rejected(self):
+    def test_invalid_intent_class_rejected(self):
         with pytest.raises(ValueError, match='Invalid intent_class'):
             RetrievalRequest(query='x', intent_class='not-a-real-class')
 
-    async def test_invalid_risk_class_rejected(self):
+    def test_invalid_risk_class_rejected(self):
         with pytest.raises(ValueError, match='Invalid risk_class'):
             RetrievalRequest(query='x', risk_class='not-a-real-class')

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -44,7 +44,14 @@ from memex_common.asset_cache import (
 )
 from memex_common.asset_resize import validate_and_resize
 from memex_common.revisit import reject_bool_quality
-from memex_common.schemas import NoteAppendRequest
+from memex_common.schemas import IntentClass, NoteAppendRequest, RiskClass
+
+
+# Canonical-source-derived JSON Schema enum lists. Sourced from the
+# ``IntentClass`` / ``RiskClass`` enums in ``memex_common.schemas`` so adding
+# or renaming a class value does not silently desync the Hermes tool surface.
+_INTENT_ENUM_VALUES: list[str] = [c.value for c in IntentClass]
+_RISK_ENUM_VALUES: list[str] = [c.value for c in RiskClass]
 from tools.registry import tool_error  # type: ignore[import-not-found]
 
 from .async_bridge import run_sync
@@ -266,12 +273,12 @@ RECALL_SCHEMA: dict[str, Any] = {
             },
             'intent_class': {
                 'type': 'string',
-                'enum': ['permanent', 'durable', 'ephemeral'],
+                'enum': _INTENT_ENUM_VALUES,
                 'description': ('Filter by intent class. Omit to return all classes.'),
             },
             'risk_class': {
                 'type': 'string',
-                'enum': ['none', 'sensitive', 'private', 'safety'],
+                'enum': _RISK_ENUM_VALUES,
                 'description': ('Filter by risk class. Omit to return all classes.'),
             },
         },
@@ -403,7 +410,7 @@ RETAIN_SCHEMA: dict[str, Any] = {
             },
             'intent_class': {
                 'type': 'string',
-                'enum': ['permanent', 'durable', 'ephemeral'],
+                'enum': _INTENT_ENUM_VALUES,
                 'description': (
                     'Intent override for all extracted facts. "permanent" = enduring '
                     'preferences/conventions (kept indefinitely); "durable" (default) '
@@ -413,7 +420,7 @@ RETAIN_SCHEMA: dict[str, Any] = {
             },
             'risk_class': {
                 'type': 'string',
-                'enum': ['none', 'private', 'sensitive', 'safety'],
+                'enum': _RISK_ENUM_VALUES,
                 'description': (
                     'Risk override for all extracted facts. "none" (default); '
                     '"private" = PII/secrets; "sensitive" = restricted topic; '

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -1574,17 +1574,13 @@ def handle_memory_search(
     vault_ids = _resolve_vault_ids(api, args, vault_id)
 
     # Allowed sets are canonical in memex_common.schemas (derived from the
-    # IntentClass / RiskClass enums). Imported lazily to keep the module
-    # import surface lean for handler discovery. After the local string
-    # check we coerce to the enum so we satisfy RemoteMemexAPI.search's
-    # IntentClass | None / RiskClass | None signature without relying on
-    # implicit Pydantic coercion downstream.
-    from memex_common.schemas import (
-        IntentClass,
-        RiskClass,
-        VALID_INTENT_CLASSES,
-        VALID_RISK_CLASSES,
-    )
+    # IntentClass / RiskClass enums). ``IntentClass`` / ``RiskClass`` are
+    # already imported at module scope (used to derive the JSON-schema enum
+    # lists); only the ``VALID_*`` frozensets need a local import here.
+    # After the local string check we coerce to the enum so we satisfy
+    # ``RemoteMemexAPI.search``'s ``IntentClass | None`` / ``RiskClass | None``
+    # signature without relying on implicit Pydantic coercion downstream.
+    from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
 
     raw_intent = args.get('intent_class') or None
     if raw_intent is not None and raw_intent not in VALID_INTENT_CLASSES:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -264,6 +264,16 @@ RECALL_SCHEMA: dict[str, Any] = {
                     'level (default: false).'
                 ),
             },
+            'intent_class': {
+                'type': 'string',
+                'enum': ['permanent', 'durable', 'ephemeral'],
+                'description': ('Filter by intent class. Omit to return all classes.'),
+            },
+            'risk_class': {
+                'type': 'string',
+                'enum': ['none', 'sensitive', 'private', 'safety'],
+                'description': ('Filter by risk class. Omit to return all classes.'),
+            },
         },
         'required': ['query'],
     },
@@ -1556,6 +1566,17 @@ def handle_memory_search(
     tags = args.get('tags') or None
     vault_ids = _resolve_vault_ids(api, args, vault_id)
 
+    intent_class = args.get('intent_class') or None
+    if intent_class is not None and intent_class not in {'permanent', 'durable', 'ephemeral'}:
+        return tool_error(
+            f'Invalid intent_class: {intent_class!r}. Valid values: permanent | durable | ephemeral'
+        )
+    risk_class = args.get('risk_class') or None
+    if risk_class is not None and risk_class not in {'none', 'sensitive', 'private', 'safety'}:
+        return tool_error(
+            f'Invalid risk_class: {risk_class!r}. Valid values: none | sensitive | private | safety'
+        )
+
     try:
         results = run_sync(
             api.search(
@@ -1569,6 +1590,8 @@ def handle_memory_search(
                 after=_parse_iso(args.get('after')),
                 before=_parse_iso(args.get('before')),
                 tags=tags,
+                intent_class=intent_class,
+                risk_class=risk_class,
             ),
             timeout=60.0,
         )

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -44,7 +44,13 @@ from memex_common.asset_cache import (
 )
 from memex_common.asset_resize import validate_and_resize
 from memex_common.revisit import reject_bool_quality
-from memex_common.schemas import IntentClass, NoteAppendRequest, RiskClass
+from memex_common.schemas import (
+    VALID_INTENT_CLASSES,
+    VALID_RISK_CLASSES,
+    IntentClass,
+    NoteAppendRequest,
+    RiskClass,
+)
 from tools.registry import tool_error  # type: ignore[import-not-found]
 
 from .async_bridge import run_sync
@@ -1574,14 +1580,11 @@ def handle_memory_search(
     vault_ids = _resolve_vault_ids(api, args, vault_id)
 
     # Allowed sets are canonical in memex_common.schemas (derived from the
-    # IntentClass / RiskClass enums). ``IntentClass`` / ``RiskClass`` are
-    # already imported at module scope (used to derive the JSON-schema enum
-    # lists); only the ``VALID_*`` frozensets need a local import here.
-    # After the local string check we coerce to the enum so we satisfy
-    # ``RemoteMemexAPI.search``'s ``IntentClass | None`` / ``RiskClass | None``
-    # signature without relying on implicit Pydantic coercion downstream.
-    from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
-
+    # IntentClass / RiskClass enums). After the local string check we coerce
+    # to the enum so we satisfy ``RemoteMemexAPI.search``'s
+    # ``IntentClass | None`` / ``RiskClass | None`` signature without relying
+    # on implicit Pydantic coercion downstream.
+    #
     # Use ``is not None`` rather than truthiness — IntentClass / RiskClass
     # subclass ``str``, so a hypothetical enum member with value ``''`` would
     # be falsy and silently coerce to None. Matches the convention in

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -1566,15 +1566,22 @@ def handle_memory_search(
     tags = args.get('tags') or None
     vault_ids = _resolve_vault_ids(api, args, vault_id)
 
+    # Allowed sets are canonical in memex_common.schemas (derived from the
+    # IntentClass / RiskClass enums). Imported lazily to keep the module
+    # import surface lean for handler discovery.
+    from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
+
     intent_class = args.get('intent_class') or None
-    if intent_class is not None and intent_class not in {'permanent', 'durable', 'ephemeral'}:
+    if intent_class is not None and intent_class not in VALID_INTENT_CLASSES:
         return tool_error(
-            f'Invalid intent_class: {intent_class!r}. Valid values: permanent | durable | ephemeral'
+            f'Invalid intent_class: {intent_class!r}. '
+            f'Valid values: {" | ".join(sorted(VALID_INTENT_CLASSES))}'
         )
     risk_class = args.get('risk_class') or None
-    if risk_class is not None and risk_class not in {'none', 'sensitive', 'private', 'safety'}:
+    if risk_class is not None and risk_class not in VALID_RISK_CLASSES:
         return tool_error(
-            f'Invalid risk_class: {risk_class!r}. Valid values: none | sensitive | private | safety'
+            f'Invalid risk_class: {risk_class!r}. '
+            f'Valid values: {" | ".join(sorted(VALID_RISK_CLASSES))}'
         )
 
     try:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -45,13 +45,6 @@ from memex_common.asset_cache import (
 from memex_common.asset_resize import validate_and_resize
 from memex_common.revisit import reject_bool_quality
 from memex_common.schemas import IntentClass, NoteAppendRequest, RiskClass
-
-
-# Canonical-source-derived JSON Schema enum lists. Sourced from the
-# ``IntentClass`` / ``RiskClass`` enums in ``memex_common.schemas`` so adding
-# or renaming a class value does not silently desync the Hermes tool surface.
-_INTENT_ENUM_VALUES: list[str] = [c.value for c in IntentClass]
-_RISK_ENUM_VALUES: list[str] = [c.value for c in RiskClass]
 from tools.registry import tool_error  # type: ignore[import-not-found]
 
 from .async_bridge import run_sync
@@ -59,6 +52,13 @@ from .config import HermesMemexConfig
 from .templates import HERMES_USER_NOTE_TEMPLATE
 
 logger = logging.getLogger(__name__)
+
+
+# Canonical-source-derived JSON Schema enum lists. Sourced from the
+# ``IntentClass`` / ``RiskClass`` enums in ``memex_common.schemas`` so adding
+# or renaming a class value does not silently desync the Hermes tool surface.
+_INTENT_ENUM_VALUES: list[str] = [c.value for c in IntentClass]
+_RISK_ENUM_VALUES: list[str] = [c.value for c in RiskClass]
 
 
 # ---------------------------------------------------------------------------
@@ -1582,20 +1582,24 @@ def handle_memory_search(
     # signature without relying on implicit Pydantic coercion downstream.
     from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
 
-    raw_intent = args.get('intent_class') or None
+    # Use ``is not None`` rather than truthiness — IntentClass / RiskClass
+    # subclass ``str``, so a hypothetical enum member with value ``''`` would
+    # be falsy and silently coerce to None. Matches the convention in
+    # ``memex_core.server.retrieval``.
+    raw_intent = args.get('intent_class')
     if raw_intent is not None and raw_intent not in VALID_INTENT_CLASSES:
         return tool_error(
             f'Invalid intent_class: {raw_intent!r}. '
             f'Valid values: {" | ".join(sorted(VALID_INTENT_CLASSES))}'
         )
-    raw_risk = args.get('risk_class') or None
+    raw_risk = args.get('risk_class')
     if raw_risk is not None and raw_risk not in VALID_RISK_CLASSES:
         return tool_error(
             f'Invalid risk_class: {raw_risk!r}. '
             f'Valid values: {" | ".join(sorted(VALID_RISK_CLASSES))}'
         )
-    intent_class = IntentClass(raw_intent) if raw_intent else None
-    risk_class = RiskClass(raw_risk) if raw_risk else None
+    intent_class = IntentClass(raw_intent) if raw_intent is not None else None
+    risk_class = RiskClass(raw_risk) if raw_risk is not None else None
 
     try:
         results = run_sync(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -1568,21 +1568,31 @@ def handle_memory_search(
 
     # Allowed sets are canonical in memex_common.schemas (derived from the
     # IntentClass / RiskClass enums). Imported lazily to keep the module
-    # import surface lean for handler discovery.
-    from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
+    # import surface lean for handler discovery. After the local string
+    # check we coerce to the enum so we satisfy RemoteMemexAPI.search's
+    # IntentClass | None / RiskClass | None signature without relying on
+    # implicit Pydantic coercion downstream.
+    from memex_common.schemas import (
+        IntentClass,
+        RiskClass,
+        VALID_INTENT_CLASSES,
+        VALID_RISK_CLASSES,
+    )
 
-    intent_class = args.get('intent_class') or None
-    if intent_class is not None and intent_class not in VALID_INTENT_CLASSES:
+    raw_intent = args.get('intent_class') or None
+    if raw_intent is not None and raw_intent not in VALID_INTENT_CLASSES:
         return tool_error(
-            f'Invalid intent_class: {intent_class!r}. '
+            f'Invalid intent_class: {raw_intent!r}. '
             f'Valid values: {" | ".join(sorted(VALID_INTENT_CLASSES))}'
         )
-    risk_class = args.get('risk_class') or None
-    if risk_class is not None and risk_class not in VALID_RISK_CLASSES:
+    raw_risk = args.get('risk_class') or None
+    if raw_risk is not None and raw_risk not in VALID_RISK_CLASSES:
         return tool_error(
-            f'Invalid risk_class: {risk_class!r}. '
+            f'Invalid risk_class: {raw_risk!r}. '
             f'Valid values: {" | ".join(sorted(VALID_RISK_CLASSES))}'
         )
+    intent_class = IntentClass(raw_intent) if raw_intent else None
+    risk_class = RiskClass(raw_risk) if raw_risk else None
 
     try:
         results = run_sync(

--- a/packages/hermes-plugin/tests/test_enum_schema_parity.py
+++ b/packages/hermes-plugin/tests/test_enum_schema_parity.py
@@ -1,0 +1,57 @@
+"""Round-5 regression guard: Hermes JSON Schema enum lists must match the canonical enums.
+
+The Hermes plugin's tool surface declares ``intent_class`` and ``risk_class``
+JSON Schema ``enum: [...]`` lists. Before the round-5 patch these were
+hand-typed string literals — adding or renaming a value in
+``memex_common.schemas.IntentClass`` / ``RiskClass`` would silently desync
+the tool surface.
+
+After the patch the lists are derived at module load from the canonical
+enums (``[c.value for c in IntentClass]``). These tests assert the
+derivation holds — if the values diverge for any reason, this test fails.
+
+Lives in the hermes-plugin tests dir (rather than common) because importing
+``memex_hermes_plugin.memex.tools`` requires the Hermes ``agent`` /
+``tools.registry`` stubs registered by ``conftest.py``.
+"""
+
+from __future__ import annotations
+
+from memex_common.schemas import IntentClass, RiskClass
+
+from memex_hermes_plugin.memex.tools import (
+    RECALL_SCHEMA,
+    RETAIN_SCHEMA,
+)
+
+
+class TestHermesJsonSchemaParity:
+    """JSON Schema enum lists in tool definitions must derive from the canonical enums."""
+
+    def test_recall_tool_intent_enum_matches_canonical(self) -> None:
+        """RECALL_SCHEMA backs ``memex_memory_search``."""
+        intent_field = RECALL_SCHEMA['parameters']['properties']['intent_class']
+        assert intent_field['enum'] == [c.value for c in IntentClass], (
+            'memex_memory_search intent_class enum has drifted from '
+            'IntentClass. The list should be derived via [c.value for c in '
+            'IntentClass] — not hand-typed.'
+        )
+
+    def test_recall_tool_risk_enum_matches_canonical(self) -> None:
+        risk_field = RECALL_SCHEMA['parameters']['properties']['risk_class']
+        assert risk_field['enum'] == [c.value for c in RiskClass], (
+            'memex_memory_search risk_class enum has drifted from RiskClass.'
+        )
+
+    def test_retain_tool_intent_enum_matches_canonical(self) -> None:
+        """RETAIN_SCHEMA backs ``memex_add_note``."""
+        intent_field = RETAIN_SCHEMA['parameters']['properties']['intent_class']
+        assert intent_field['enum'] == [c.value for c in IntentClass], (
+            'memex_add_note intent_class enum has drifted from IntentClass.'
+        )
+
+    def test_retain_tool_risk_enum_matches_canonical(self) -> None:
+        risk_field = RETAIN_SCHEMA['parameters']['properties']['risk_class']
+        assert risk_field['enum'] == [c.value for c in RiskClass], (
+            'memex_add_note risk_class enum has drifted from RiskClass.'
+        )

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -1638,6 +1638,25 @@ async def memex_memory_search(
             ),
         ),
     ] = False,
+    intent_class: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                'Filter by intent class: permanent | durable | ephemeral. None disables the filter.'
+            ),
+        ),
+    ] = None,
+    risk_class: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                'Filter by risk class: none | sensitive | private | safety. '
+                'None disables the filter.'
+            ),
+        ),
+    ] = None,
 ) -> list[McpFact | McpEvent | McpObservation]:
     """Search Memex for relevant information."""
     try:
@@ -1666,6 +1685,8 @@ async def memex_memory_search(
             source_context=source_context,
             reference_date=ref_dt,
             expand_query=expand_query,
+            intent_class=intent_class,
+            risk_class=risk_class,
         )
 
         if not results:

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -1671,6 +1671,20 @@ async def memex_memory_search(
         before_dt = _to_utc_datetime(_dt.fromisoformat(before)) if before else None
         ref_dt = _to_utc_datetime(_dt.fromisoformat(reference_date)) if reference_date else None
 
+        # Validate intent_class / risk_class locally so MCP callers see a
+        # clean ToolError instead of a server 422. Mirrors the CLI and
+        # Hermes-plugin pattern; canonical sets live in memex_common.schemas.
+        from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
+
+        if intent_class is not None and intent_class not in VALID_INTENT_CLASSES:
+            raise ToolError(
+                f'Invalid intent_class={intent_class!r}. Allowed: {sorted(VALID_INTENT_CLASSES)}'
+            )
+        if risk_class is not None and risk_class not in VALID_RISK_CLASSES:
+            raise ToolError(
+                f'Invalid risk_class={risk_class!r}. Allowed: {sorted(VALID_RISK_CLASSES)}'
+            )
+
         results = await api.search(
             query=query,
             limit=limit,

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -6,7 +6,7 @@ import asyncio
 import base64
 import time
 from dataclasses import dataclass, field
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from uuid import UUID
 from datetime import datetime
 import mimetypes
@@ -1639,7 +1639,7 @@ async def memex_memory_search(
         ),
     ] = False,
     intent_class: Annotated[
-        str | None,
+        Literal['permanent', 'durable', 'ephemeral'] | None,
         Field(
             default=None,
             description=(
@@ -1648,7 +1648,7 @@ async def memex_memory_search(
         ),
     ] = None,
     risk_class: Annotated[
-        str | None,
+        Literal['none', 'sensitive', 'private', 'safety'] | None,
         Field(
             default=None,
             description=(

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -6,7 +6,7 @@ import asyncio
 import base64
 import time
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 from uuid import UUID
 from datetime import datetime
 import mimetypes
@@ -66,12 +66,14 @@ from memex_mcp.models import (
 from memex_common.templates import TemplateRegistry, BUILTIN_PROMPTS_DIR
 from memex_common.schemas import (
     BatchJobStatus,
+    IntentLiteral,
     LineageDirection,
     LineageResponse,
     NoteAppendRequest,
     NoteCreateDTO,
     PageIndexDTO,
     PageMetadataDTO,
+    RiskLiteral,
     TOCNodeDTO,
     filter_toc,
 )
@@ -1639,7 +1641,7 @@ async def memex_memory_search(
         ),
     ] = False,
     intent_class: Annotated[
-        Literal['permanent', 'durable', 'ephemeral'] | None,
+        IntentLiteral | None,
         Field(
             default=None,
             description=(
@@ -1648,7 +1650,7 @@ async def memex_memory_search(
         ),
     ] = None,
     risk_class: Annotated[
-        Literal['none', 'sensitive', 'private', 'safety'] | None,
+        RiskLiteral | None,
         Field(
             default=None,
             description=(
@@ -1671,9 +1673,14 @@ async def memex_memory_search(
         before_dt = _to_utc_datetime(_dt.fromisoformat(before)) if before else None
         ref_dt = _to_utc_datetime(_dt.fromisoformat(reference_date)) if reference_date else None
 
-        # Validate intent_class / risk_class locally so MCP callers see a
-        # clean ToolError instead of a server 422. Mirrors the CLI and
-        # Hermes-plugin pattern; canonical sets live in memex_common.schemas.
+        # Defense-in-depth: FastMCP+Pydantic rejects invalid Literal values
+        # upstream (the IntentLiteral / RiskLiteral annotations on the
+        # parameters above), so this check is unreachable for real MCP
+        # callers. We keep it as a safety net for direct-call paths that
+        # bypass schema validation — tests that pass raw strings, internal
+        # Python callers invoking the underlying ``.fn``, etc. — and to
+        # surface a clean ToolError (not a 422) at the boundary. Mirrors
+        # the CLI/Hermes-plugin pattern; canonical sets in memex_common.schemas.
         from memex_common.schemas import (
             VALID_INTENT_CLASSES,
             VALID_RISK_CLASSES,

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -1674,7 +1674,12 @@ async def memex_memory_search(
         # Validate intent_class / risk_class locally so MCP callers see a
         # clean ToolError instead of a server 422. Mirrors the CLI and
         # Hermes-plugin pattern; canonical sets live in memex_common.schemas.
-        from memex_common.schemas import VALID_INTENT_CLASSES, VALID_RISK_CLASSES
+        from memex_common.schemas import (
+            VALID_INTENT_CLASSES,
+            VALID_RISK_CLASSES,
+            IntentClass,
+            RiskClass,
+        )
 
         if intent_class is not None and intent_class not in VALID_INTENT_CLASSES:
             raise ToolError(
@@ -1699,8 +1704,8 @@ async def memex_memory_search(
             source_context=source_context,
             reference_date=ref_dt,
             expand_query=expand_query,
-            intent_class=intent_class,
-            risk_class=risk_class,
+            intent_class=IntentClass(intent_class) if intent_class is not None else None,
+            risk_class=RiskClass(risk_class) if risk_class is not None else None,
         )
 
         if not results:

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -6,7 +6,7 @@ import asyncio
 import base64
 import time
 from dataclasses import dataclass, field
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 from uuid import UUID
 from datetime import datetime
 import mimetypes
@@ -1688,11 +1688,17 @@ async def memex_memory_search(
             RiskClass,
         )
 
-        if intent_class is not None and intent_class not in VALID_INTENT_CLASSES:
+        # Widen to ``str`` so mypy doesn't flag the membership check as unreachable.
+        # The Literal annotations on ``intent_class`` / ``risk_class`` constrain
+        # values for FastMCP+Pydantic callers, which would make mypy treat the
+        # ``not in`` branch as dead code; the cast preserves the defense-in-depth
+        # check for direct-call paths (tests, internal Python via ``.fn``) that
+        # bypass schema validation.
+        if intent_class is not None and cast(str, intent_class) not in VALID_INTENT_CLASSES:
             raise ToolError(
                 f'Invalid intent_class={intent_class!r}. Allowed: {sorted(VALID_INTENT_CLASSES)}'
             )
-        if risk_class is not None and risk_class not in VALID_RISK_CLASSES:
+        if risk_class is not None and cast(str, risk_class) not in VALID_RISK_CLASSES:
             raise ToolError(
                 f'Invalid risk_class={risk_class!r}. Allowed: {sorted(VALID_RISK_CLASSES)}'
             )

--- a/packages/mcp/tests/test_intent_risk_validation.py
+++ b/packages/mcp/tests/test_intent_risk_validation.py
@@ -64,7 +64,8 @@ async def test_memory_search_invalid_risk_class_raises_tool_error():
 
 @pytest.mark.asyncio
 async def test_memory_search_valid_intent_class_passes_through():
-    """A valid intent_class must be forwarded to api.search verbatim."""
+    """A valid intent_class must be coerced to IntentClass before reaching api.search."""
+    from memex_common.schemas import IntentClass
     from memex_mcp.server import memex_memory_search
 
     mock_api = AsyncMock()
@@ -82,12 +83,13 @@ async def test_memory_search_valid_intent_class_passes_through():
 
     mock_api.search.assert_called_once()
     kwargs = mock_api.search.call_args.kwargs
-    assert kwargs['intent_class'] == 'ephemeral'
+    assert kwargs['intent_class'] == IntentClass.EPHEMERAL
 
 
 @pytest.mark.asyncio
 async def test_memory_search_valid_risk_class_passes_through():
-    """A valid risk_class must be forwarded to api.search verbatim."""
+    """A valid risk_class must be coerced to RiskClass before reaching api.search."""
+    from memex_common.schemas import RiskClass
     from memex_mcp.server import memex_memory_search
 
     mock_api = AsyncMock()
@@ -105,4 +107,4 @@ async def test_memory_search_valid_risk_class_passes_through():
 
     mock_api.search.assert_called_once()
     kwargs = mock_api.search.call_args.kwargs
-    assert kwargs['risk_class'] == 'sensitive'
+    assert kwargs['risk_class'] == RiskClass.SENSITIVE

--- a/packages/mcp/tests/test_intent_risk_validation.py
+++ b/packages/mcp/tests/test_intent_risk_validation.py
@@ -1,0 +1,108 @@
+"""Local validation of intent_class / risk_class on memex_memory_search (issue #92).
+
+The CLI and Hermes plugin validate against ``VALID_INTENT_CLASSES`` /
+``VALID_RISK_CLASSES`` before the API call. The MCP server does the same so
+tool consumers see a clean ``ToolError`` instead of an HTTP 422 from the
+Pydantic-driven server boundary.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+
+def _make_ctx():
+    ctx = MagicMock()
+    ctx.session_id = 'test-session'
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_memory_search_invalid_intent_class_raises_tool_error():
+    """An unknown intent_class must surface as ToolError before reaching the API."""
+    from memex_mcp.server import memex_memory_search
+
+    mock_api = AsyncMock()
+    mock_api.search = AsyncMock(return_value=[])
+    ctx = _make_ctx()
+
+    with (
+        patch('memex_mcp.server.get_api', return_value=mock_api),
+        patch('memex_mcp.server._default_read_vaults', return_value=['vault-1']),
+        patch('memex_mcp.server._validate_vault_ids'),
+        patch('memex_mcp.server._resolve_vault_ids', new_callable=AsyncMock, return_value=['vid']),
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await memex_memory_search(ctx=ctx, query='q', intent_class='bogus')
+
+    assert 'Invalid intent_class' in str(exc_info.value)
+    mock_api.search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_memory_search_invalid_risk_class_raises_tool_error():
+    """An unknown risk_class must surface as ToolError before reaching the API."""
+    from memex_mcp.server import memex_memory_search
+
+    mock_api = AsyncMock()
+    mock_api.search = AsyncMock(return_value=[])
+    ctx = _make_ctx()
+
+    with (
+        patch('memex_mcp.server.get_api', return_value=mock_api),
+        patch('memex_mcp.server._default_read_vaults', return_value=['vault-1']),
+        patch('memex_mcp.server._validate_vault_ids'),
+        patch('memex_mcp.server._resolve_vault_ids', new_callable=AsyncMock, return_value=['vid']),
+    ):
+        with pytest.raises(ToolError) as exc_info:
+            await memex_memory_search(ctx=ctx, query='q', risk_class='nope')
+
+    assert 'Invalid risk_class' in str(exc_info.value)
+    mock_api.search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_memory_search_valid_intent_class_passes_through():
+    """A valid intent_class must be forwarded to api.search verbatim."""
+    from memex_mcp.server import memex_memory_search
+
+    mock_api = AsyncMock()
+    mock_api.search = AsyncMock(return_value=[])
+    mock_api.get_notes_metadata = AsyncMock(return_value=[])
+    ctx = _make_ctx()
+
+    with (
+        patch('memex_mcp.server.get_api', return_value=mock_api),
+        patch('memex_mcp.server._default_read_vaults', return_value=['vault-1']),
+        patch('memex_mcp.server._validate_vault_ids'),
+        patch('memex_mcp.server._resolve_vault_ids', new_callable=AsyncMock, return_value=['vid']),
+    ):
+        await memex_memory_search(ctx=ctx, query='q', intent_class='ephemeral')
+
+    mock_api.search.assert_called_once()
+    kwargs = mock_api.search.call_args.kwargs
+    assert kwargs['intent_class'] == 'ephemeral'
+
+
+@pytest.mark.asyncio
+async def test_memory_search_valid_risk_class_passes_through():
+    """A valid risk_class must be forwarded to api.search verbatim."""
+    from memex_mcp.server import memex_memory_search
+
+    mock_api = AsyncMock()
+    mock_api.search = AsyncMock(return_value=[])
+    mock_api.get_notes_metadata = AsyncMock(return_value=[])
+    ctx = _make_ctx()
+
+    with (
+        patch('memex_mcp.server.get_api', return_value=mock_api),
+        patch('memex_mcp.server._default_read_vaults', return_value=['vault-1']),
+        patch('memex_mcp.server._validate_vault_ids'),
+        patch('memex_mcp.server._resolve_vault_ids', new_callable=AsyncMock, return_value=['vid']),
+    ):
+        await memex_memory_search(ctx=ctx, query='q', risk_class='sensitive')
+
+    mock_api.search.assert_called_once()
+    kwargs = mock_api.search.call_args.kwargs
+    assert kwargs['risk_class'] == 'sensitive'


### PR DESCRIPTION
## Summary

Resolves #92 — moves \`memex memory search\` intent/risk filter from CLI client-side to server-side.

- Adds \`intent_class\` / \`risk_class\` fields to the shared \`RetrievalRequest\` schema, the in-engine \`RetrievalRequest\`, and a new \`apply_intent_risk_filter()\` helper that runs in Semantic / Keyword / Graph (1st + 2nd order) / Temporal SQL strategies.
- Plumbs the two filter values through \`MemexAPI.search\` → \`SearchService\` → \`RetrievalEngine\` → all five strategies, plus the \`/api/v1/memories/search\` route, \`RemoteMemexAPI\` client, and the \`memex_memory_search\` MCP/Hermes tools.
- CLI \`memex memory search --intent X\` now sends the filter to the API instead of post-filtering Python results.
- Drops the truncation-warning workaround added in PR #91 cycle 3 (no longer needed).
- Validation: \`RetrievalRequest\` (in-engine) rejects bad enum values via Pydantic \`model_validator\`. CLI also pre-validates so users get a friendly error before the round-trip.
- Mental-Model strategy intentionally skipped (no \`intent_class\` column on \`mental_models\`, mirroring the existing \`apply_generic_filters\` skip pattern).

## Test plan
- [x] New integration test \`test_int_intent_risk_filter.py\` (8 cases) covers single-filter, combined-filter, no-filter, and validation rejection — all green.
- [x] New CLI tests in \`test_memory_cli.py\` (4 cases) confirm \`--intent\` / \`--risk\` are forwarded to \`api.search\` and the old client-side-filter warning is gone.
- [x] Existing retrieval integration suite (104 search/retrieval tests) green.
- [x] Existing CLI memory suite (21 tests) green.
- [x] Existing MCP (80) + Hermes (38) search/memory tests green.
- [ ] CI green (unit + integration)
- [ ] Hermes adversarial review
- [ ] HIGH+MED patched, LOW skipped
- [ ] Squash-merge once clean

Closes #92.