### PR TITLE
feat(mcp): F46 — chunk_ids on memex_get_memory_units

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,800%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,824%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,824%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,826%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -797,7 +797,14 @@ class RemoteMemexAPI:
         chunk_ids: list[UUID | str],
         vault_id: UUID | str,
     ) -> list[MemoryUnitDTO]:
-        """F46: fetch memory units belonging to the named chunks (vault-scoped)."""
+        """F46: fetch memory units belonging to the named chunks (vault-scoped).
+
+        Mirrors the service-layer short-circuit (see
+        ``memex_core.services.stats.StatsService.get_memory_units_by_chunks``)
+        so an empty input list never costs a network round-trip.
+        """
+        if not chunk_ids:
+            return []
         body = {
             'chunk_ids': [str(c) for c in chunk_ids],
             'vault_id': str(vault_id),

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -792,6 +792,19 @@ class RemoteMemexAPI:
         result = await self._get(f'memories/{unit_id}')
         return MemoryUnitDTO(**result)
 
+    async def get_memory_units_by_chunks(
+        self,
+        chunk_ids: list[UUID | str],
+        vault_id: UUID | str,
+    ) -> list[MemoryUnitDTO]:
+        """F46: fetch memory units belonging to the named chunks (vault-scoped)."""
+        body = {
+            'chunk_ids': [str(c) for c in chunk_ids],
+            'vault_id': str(vault_id),
+        }
+        result = await self._post('memories/by-chunks', body)
+        return [MemoryUnitDTO(**r) for r in result]
+
     async def delete_memory_unit(self, unit_id: UUID) -> bool:
         """Delete a memory unit and all associated data."""
         try:

--- a/packages/common/tests/test_client_get_memory_units_by_chunks.py
+++ b/packages/common/tests/test_client_get_memory_units_by_chunks.py
@@ -1,0 +1,71 @@
+"""Tests for RemoteMemexAPI.get_memory_units_by_chunks() — F46 HTTP wrapper.
+
+Covers the client-side short-circuit on an empty ``chunk_ids`` list (mirrors
+the service-layer guard in ``StatsService.get_memory_units_by_chunks``) so an
+empty batch never costs a network round-trip.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from memex_common.client import RemoteMemexAPI
+
+
+@pytest.fixture
+def mock_client():
+    """httpx.AsyncClient stub that records whether POST was called."""
+    client = AsyncMock(spec=httpx.AsyncClient)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_empty_chunk_ids_short_circuits_no_request(mock_client):
+    """Empty chunk_ids list returns [] without hitting the wire (MED-1)."""
+    api = RemoteMemexAPI(mock_client)
+    posted: dict = {'count': 0}
+
+    async def _post(path, json=None, **kwargs):
+        posted['count'] += 1
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = 200
+        response.headers = {'content-type': 'application/json'}
+        response.json.return_value = []
+        response.raise_for_status = MagicMock()
+        return response
+
+    mock_client.post = _post
+
+    result = await api.get_memory_units_by_chunks([], vault_id='vault-uuid')
+
+    assert result == []
+    assert posted['count'] == 0, 'empty chunk_ids must not trigger a HTTP POST'
+
+
+@pytest.mark.asyncio
+async def test_non_empty_chunk_ids_posts_to_by_chunks(mock_client):
+    """Non-empty chunk_ids forwards to /memories/by-chunks with serialized body."""
+    api = RemoteMemexAPI(mock_client)
+    captured: dict = {}
+
+    async def _post(path, json=None, **kwargs):
+        captured['path'] = path
+        captured['json'] = json
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = 200
+        response.headers = {'content-type': 'application/json'}
+        response.json.return_value = []
+        response.raise_for_status = MagicMock()
+        return response
+
+    mock_client.post = _post
+
+    await api.get_memory_units_by_chunks(
+        ['11111111-1111-1111-1111-111111111111'],
+        vault_id='22222222-2222-2222-2222-222222222222',
+    )
+
+    assert captured['path'] == 'memories/by-chunks'
+    assert captured['json']['chunk_ids'] == ['11111111-1111-1111-1111-111111111111']
+    assert captured['json']['vault_id'] == '22222222-2222-2222-2222-222222222222'

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1082,6 +1082,14 @@ class MemexAPI:
         """Get a memory unit by ID. Delegates to StatsService."""
         return await self._stats.get_memory_unit(unit_id)
 
+    async def get_memory_units_by_chunks(
+        self,
+        chunk_ids: list[UUID],
+        vault_id: UUID,
+    ) -> list[Any]:
+        """F46: get memory units belonging to the named chunks (vault-scoped)."""
+        return await self._stats.get_memory_units_by_chunks(chunk_ids, vault_id)
+
     async def delete_memory_unit(self, unit_id: UUID) -> bool:
         """Delete a memory unit. Delegates to StatsService."""
         return await self._stats.delete_memory_unit(unit_id)

--- a/packages/core/src/memex_core/server/memories.py
+++ b/packages/core/src/memex_core/server/memories.py
@@ -62,7 +62,12 @@ async def get_memory_units_by_chunks(
     try:
         units = await api.get_memory_units_by_chunks(request.chunk_ids, request.vault_id)
         return [build_memory_unit_dto(u) for u in units]
-    except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
+    except (MemexError, ValueError) as e:
+        # Hermes round-1 MED: narrowed from (KeyError, RuntimeError, OSError)
+        # which can mask genuine bugs (bad DTO dict access, filesystem errors)
+        # rather than client-visible errors. Service-layer raises MemexError
+        # subclasses for known failure modes; ValueError covers UUID/typing
+        # validation. Anything else propagates as a 500 with a logged stack.
         raise _handle_error(e, 'Failed to get memory units by chunks')
 
 

--- a/packages/core/src/memex_core/server/memories.py
+++ b/packages/core/src/memex_core/server/memories.py
@@ -34,6 +34,38 @@ logger = logging.getLogger('memex.core.server')
 router = APIRouter(prefix='/api/v1')
 
 
+class MemoryUnitsByChunksRequest(BaseModel):
+    """F46: batch lookup of memory units by chunk_id."""
+
+    chunk_ids: list[UUID] = Field(..., description='Chunk UUIDs to expand into memory units.')
+    vault_id: UUID = Field(
+        ...,
+        description=(
+            'Vault UUID to scope the lookup. REQUIRED — chunk-traversal must not '
+            'leak units from sibling vaults.'
+        ),
+    )
+
+
+@router.post(
+    '/memories/by-chunks',
+    response_model=list[MemoryUnitDTO],
+    dependencies=[Depends(require_read)],
+)
+async def get_memory_units_by_chunks(
+    request: Annotated[MemoryUnitsByChunksRequest, Body()],
+    api: Annotated[MemexAPI, Depends(get_api)],
+    auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
+) -> list[MemoryUnitDTO]:
+    """F46: get all memory units belonging to the named chunks (vault-scoped)."""
+    await check_vault_access(auth, [request.vault_id], api, permission=Permission.READ)
+    try:
+        units = await api.get_memory_units_by_chunks(request.chunk_ids, request.vault_id)
+        return [build_memory_unit_dto(u) for u in units]
+    except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
+        raise _handle_error(e, 'Failed to get memory units by chunks')
+
+
 @router.get('/memories/{id}', response_model=MemoryUnitDTO, dependencies=[Depends(require_read)])
 async def get_memory_unit(id: UUID, api: Annotated[MemexAPI, Depends(get_api)]):
     """Get memory unit details."""

--- a/packages/core/src/memex_core/services/stats.py
+++ b/packages/core/src/memex_core/services/stats.py
@@ -89,6 +89,31 @@ class StatsService(BaseService):
         async with self.metastore.session() as session:
             return await session.get(MemoryUnit, uid)
 
+    async def get_memory_units_by_chunks(
+        self,
+        chunk_ids: list[UUID],
+        vault_id: UUID,
+    ) -> list[Any]:
+        """Return all memory units whose ``chunk_id`` is in ``chunk_ids``, scoped to ``vault_id``.
+
+        Vault-scoping is mandatory — F46 chunk-traversal must not leak units
+        from sibling vaults that happen to reference the same chunk UUID.
+        """
+        from sqlmodel import select
+
+        from memex_core.memory.sql_models import MemoryUnit
+
+        if not chunk_ids:
+            return []
+
+        async with self.metastore.session() as session:
+            stmt = select(MemoryUnit).where(
+                col(MemoryUnit.chunk_id).in_(chunk_ids),
+                MemoryUnit.vault_id == vault_id,
+            )
+            result = await session.exec(stmt)
+            return list(result.all())
+
     async def delete_memory_unit(self, unit_id: UUID) -> bool:
         """Delete a memory unit and all associated data.
 

--- a/packages/core/tests/integration/test_int_get_memory_units_chunk_ids.py
+++ b/packages/core/tests/integration/test_int_get_memory_units_chunk_ids.py
@@ -1,0 +1,206 @@
+"""Integration tests for F46 ``get_memory_units_by_chunks`` (chunk→units traversal).
+
+Coverage:
+
+* Returns the memory units extracted from the requested chunks.
+* Returns an empty list when no chunk in the input matches.
+* Vault-scoping: a memory unit anchored to the same chunk_id but living in a
+  different vault is NOT returned (chunk_ids reused across vaults must not
+  leak — defensive guard since chunk_id is FK only, no vault constraint at
+  the schema level).
+* Empty ``chunk_ids`` short-circuits to an empty list.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from uuid import UUID, uuid4
+
+import pytest
+
+from memex_common.config import GLOBAL_VAULT_ID
+from memex_core.memory.sql_models import Chunk, MemoryUnit, Note, Vault
+
+pytestmark = [pytest.mark.integration]
+
+
+def _now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+async def _seed_chunk(session, *, vault_id: UUID, note_id: UUID, chunk_index: int = 0) -> Chunk:
+    chunk = Chunk(
+        id=uuid4(),
+        vault_id=vault_id,
+        note_id=note_id,
+        text=f'chunk-{chunk_index}',
+        content_hash=f'h-{uuid4().hex[:16]}',
+        embedding=[0.1] * 384,
+        chunk_index=chunk_index,
+    )
+    session.add(chunk)
+    await session.flush()
+    return chunk
+
+
+async def _seed_unit(
+    session, *, vault_id: UUID, note_id: UUID, chunk_id: UUID | None, text: str
+) -> MemoryUnit:
+    unit = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault_id,
+        note_id=note_id,
+        chunk_id=chunk_id,
+        text=text,
+        fact_type='world',
+        embedding=[0.1] * 384,
+        event_date=_now(),
+    )
+    session.add(unit)
+    await session.flush()
+    return unit
+
+
+@pytest.mark.asyncio
+async def test_returns_units_for_known_chunks(api, metastore, init_global_vault):
+    """Two chunks yield three memory units; all three are returned."""
+    note_id = uuid4()
+    async with metastore.session() as session:
+        session.add(Note(id=note_id, vault_id=GLOBAL_VAULT_ID, original_text='note body'))
+        await session.flush()
+
+        chunk_a = await _seed_chunk(
+            session, vault_id=GLOBAL_VAULT_ID, note_id=note_id, chunk_index=0
+        )
+        chunk_b = await _seed_chunk(
+            session, vault_id=GLOBAL_VAULT_ID, note_id=note_id, chunk_index=1
+        )
+
+        u1 = await _seed_unit(
+            session,
+            vault_id=GLOBAL_VAULT_ID,
+            note_id=note_id,
+            chunk_id=chunk_a.id,
+            text='unit from chunk A first',
+        )
+        u2 = await _seed_unit(
+            session,
+            vault_id=GLOBAL_VAULT_ID,
+            note_id=note_id,
+            chunk_id=chunk_a.id,
+            text='unit from chunk A second',
+        )
+        u3 = await _seed_unit(
+            session,
+            vault_id=GLOBAL_VAULT_ID,
+            note_id=note_id,
+            chunk_id=chunk_b.id,
+            text='unit from chunk B',
+        )
+        await session.commit()
+
+    units = await api.get_memory_units_by_chunks([chunk_a.id, chunk_b.id], GLOBAL_VAULT_ID)
+    returned_ids = {u.id for u in units}
+    assert returned_ids == {u1.id, u2.id, u3.id}
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_for_unknown_chunk(api, metastore, init_global_vault):
+    """An unknown chunk_id yields no units."""
+    units = await api.get_memory_units_by_chunks([uuid4()], GLOBAL_VAULT_ID)
+    assert units == []
+
+
+@pytest.mark.asyncio
+async def test_empty_chunk_ids_short_circuits(api, metastore, init_global_vault):
+    """An empty chunk_ids list returns an empty result without querying."""
+    units = await api.get_memory_units_by_chunks([], GLOBAL_VAULT_ID)
+    assert units == []
+
+
+@pytest.mark.asyncio
+async def test_http_route_returns_units(api, metastore, init_global_vault):
+    """The ``/api/v1/memories/by-chunks`` route returns the same vault-scoped result."""
+    from httpx import ASGITransport, AsyncClient
+
+    from memex_core.server import app
+
+    await api.initialize()
+    app.state.api = api
+
+    note_id = uuid4()
+    async with metastore.session() as session:
+        session.add(Note(id=note_id, vault_id=GLOBAL_VAULT_ID, original_text='note body'))
+        await session.flush()
+        chunk = await _seed_chunk(session, vault_id=GLOBAL_VAULT_ID, note_id=note_id, chunk_index=0)
+        unit = await _seed_unit(
+            session,
+            vault_id=GLOBAL_VAULT_ID,
+            note_id=note_id,
+            chunk_id=chunk.id,
+            text='via http route',
+        )
+        await session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url='http://test') as ac:
+        response = await ac.post(
+            '/api/v1/memories/by-chunks',
+            json={'chunk_ids': [str(chunk.id)], 'vault_id': str(GLOBAL_VAULT_ID)},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body, list)
+        assert any(row['id'] == str(unit.id) for row in body)
+        assert all(row['vault_id'] == str(GLOBAL_VAULT_ID) for row in body)
+
+
+@pytest.mark.asyncio
+async def test_vault_scoping_blocks_other_vault_units(api, metastore, init_global_vault):
+    """A unit anchored to the same chunk_id but in a different vault MUST NOT leak."""
+    other_vault_id = uuid4()
+    note_a = uuid4()
+    note_b = uuid4()
+
+    async with metastore.session() as session:
+        session.add(Vault(id=other_vault_id, name=f'vault-other-{uuid4().hex[:6]}'))
+        await session.flush()
+        session.add(Note(id=note_a, vault_id=GLOBAL_VAULT_ID, original_text='a'))
+        session.add(Note(id=note_b, vault_id=other_vault_id, original_text='b'))
+        await session.flush()
+
+        chunk_global = await _seed_chunk(
+            session, vault_id=GLOBAL_VAULT_ID, note_id=note_a, chunk_index=0
+        )
+        chunk_other = await _seed_chunk(
+            session, vault_id=other_vault_id, note_id=note_b, chunk_index=0
+        )
+
+        unit_global = await _seed_unit(
+            session,
+            vault_id=GLOBAL_VAULT_ID,
+            note_id=note_a,
+            chunk_id=chunk_global.id,
+            text='global vault unit',
+        )
+        unit_other = await _seed_unit(
+            session,
+            vault_id=other_vault_id,
+            note_id=note_b,
+            chunk_id=chunk_other.id,
+            text='other vault unit',
+        )
+        await session.commit()
+
+    units_global = await api.get_memory_units_by_chunks(
+        [chunk_global.id, chunk_other.id], GLOBAL_VAULT_ID
+    )
+    returned_ids_global = {u.id for u in units_global}
+    assert unit_global.id in returned_ids_global
+    assert unit_other.id not in returned_ids_global
+
+    units_other = await api.get_memory_units_by_chunks(
+        [chunk_global.id, chunk_other.id], other_vault_id
+    )
+    returned_ids_other = {u.id for u in units_other}
+    assert unit_other.id in returned_ids_other
+    assert unit_global.id not in returned_ids_other

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -2523,11 +2523,15 @@ def handle_get_memory_units(
     arg_vault = args.get('vault_id')
     target_vault: UUID | None = None
     if arg_vault:
+        # When the caller explicitly passes vault_id, an unparseable value
+        # MUST fail fast — silently falling back to the session-bound vault
+        # could return data from a different vault than the one the agent
+        # asked for (Wave 0 vault-scoping invariant).
         try:
             target_vault = UUID(str(arg_vault))
         except (ValueError, TypeError):
-            target_vault = None
-    if target_vault is None:
+            return tool_error(f'Invalid vault UUID: {arg_vault}')
+    else:
         target_vault = vault_id
     if target_vault is None:
         return json.dumps(

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -109,6 +109,7 @@ class MemexAPIProtocol(Protocol):
     async def get_entity_cooccurrences(self, *args: Any, **kwargs: Any) -> Any: ...
     async def get_entity_mentions(self, *args: Any, **kwargs: Any) -> Any: ...
     async def get_memory_unit(self, *args: Any, **kwargs: Any) -> Any: ...
+    async def get_memory_units_by_chunks(self, *args: Any, **kwargs: Any) -> Any: ...
     async def get_memory_links(self, *args: Any, **kwargs: Any) -> Any: ...
     async def get_lineage(self, *args: Any, **kwargs: Any) -> Any: ...
     async def deprioritize_memory_unit(self, *args: Any, **kwargs: Any) -> Any: ...
@@ -848,8 +849,10 @@ GET_ENTITIES_SCHEMA: dict[str, Any] = {
 GET_MEMORY_UNITS_SCHEMA: dict[str, Any] = {
     'name': 'memex_get_memory_units',
     'description': (
-        'Batch lookup of memory units (facts, events, observations) by ID. '
-        'Includes status and supersession info.'
+        'Batch lookup of memory units (facts, events, observations). Provide '
+        'exactly one of `unit_ids` (direct ID lookup) or `chunk_ids` (returns '
+        'all units extracted from the named chunks, vault-scoped). Includes '
+        'status and supersession info.'
     ),
     'parameters': {
         'type': 'object',
@@ -859,8 +862,23 @@ GET_MEMORY_UNITS_SCHEMA: dict[str, Any] = {
                 'items': {'type': 'string'},
                 'description': 'List of memory unit UUIDs to fetch.',
             },
+            'chunk_ids': {
+                'type': 'array',
+                'items': {'type': 'string'},
+                'description': (
+                    'List of chunk UUIDs. Returns all memory units extracted '
+                    'from these chunks, scoped to `vault_id`. Mutually '
+                    'exclusive with `unit_ids`.'
+                ),
+            },
+            'vault_id': {
+                'type': 'string',
+                'description': (
+                    'Vault UUID or name. Required when `chunk_ids` is set; '
+                    'ignored for the `unit_ids` path.'
+                ),
+            },
         },
-        'required': ['unit_ids'],
     },
 }
 
@@ -2448,33 +2466,87 @@ def _serialize_full_entity(ent: Any) -> dict[str, Any]:
 def handle_get_memory_units(
     api: MemexAPIProtocol, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
 ) -> str:
-    """Fetch memory units by ID.
+    """Fetch memory units by ID or by chunk_id (F46).
 
-    Issues one ``api.get_memory_unit`` call per ID — ``RemoteMemexAPI`` does
-    not currently expose a batch ``get_memory_units`` endpoint. If one is
-    added later, adopt the try-batch-then-fallback pattern used by
-    ``handle_get_entities`` (batch call wrapped in try/except, falling back
-    to the per-ID loop on failure).
+    Provide exactly one of ``unit_ids`` or ``chunk_ids``. The chunk-traversal
+    path is vault-scoped; an unknown chunk simply contributes nothing to the
+    result set.
     """
-    raw_ids = args.get('unit_ids') or []
-    uuids: list[UUID] = []
-    for uid_str in raw_ids:
+    raw_unit_ids = args.get('unit_ids')
+    raw_chunk_ids = args.get('chunk_ids')
+
+    has_unit_ids = raw_unit_ids is not None
+    has_chunk_ids = raw_chunk_ids is not None
+
+    if has_unit_ids == has_chunk_ids:
+        return json.dumps(
+            {
+                'error': (
+                    'Provide exactly one of `unit_ids` or `chunk_ids` (not both, not neither).'
+                ),
+                'results': [],
+            }
+        )
+
+    items: list[dict[str, Any]] = []
+
+    if has_unit_ids:
+        uuids: list[UUID] = []
+        for uid_str in raw_unit_ids or []:
+            try:
+                uuids.append(UUID(str(uid_str)))
+            except (ValueError, TypeError):
+                continue
+
+        for uid in uuids:
+            try:
+                unit = run_sync(api.get_memory_unit(uid), timeout=30.0)
+            except Exception as e:
+                logger.warning('get_memory_unit(%s) failed: %s', uid, e)
+                continue
+            if unit is None:
+                continue
+            items.append(_serialize_memory_unit_full(unit))
+
+        return json.dumps({'results': items})
+
+    chunk_uuids: list[UUID] = []
+    for cid_str in raw_chunk_ids or []:
         try:
-            uuids.append(UUID(str(uid_str)))
+            chunk_uuids.append(UUID(str(cid_str)))
         except (ValueError, TypeError):
             continue
 
-    items: list[dict[str, Any]] = []
-    # Singular per-ID loop — no batch API available; see docstring for the
-    # pattern to adopt if RemoteMemexAPI grows a batch variant.
-    for uid in uuids:
+    if not chunk_uuids:
+        return json.dumps({'results': []})
+
+    arg_vault = args.get('vault_id')
+    target_vault: UUID | None = None
+    if arg_vault:
         try:
-            unit = run_sync(api.get_memory_unit(uid), timeout=30.0)
-        except Exception as e:
-            logger.warning('get_memory_unit(%s) failed: %s', uid, e)
-            continue
-        if unit is None:
-            continue
+            target_vault = UUID(str(arg_vault))
+        except (ValueError, TypeError):
+            target_vault = None
+    if target_vault is None:
+        target_vault = vault_id
+    if target_vault is None:
+        return json.dumps(
+            {
+                'error': 'vault_id is required when chunk_ids is provided.',
+                'results': [],
+            }
+        )
+
+    try:
+        units = run_sync(
+            api.get_memory_units_by_chunks(chunk_uuids, target_vault),
+            timeout=30.0,
+        )
+    except Exception as e:
+        logger.warning('get_memory_units_by_chunks failed: %s', e)
+        return json.dumps({'results': []})
+
+    for unit in units or []:
         items.append(_serialize_memory_unit_full(unit))
 
     return json.dumps({'results': items})

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -1670,13 +1670,19 @@ def test_get_entities_all_invalid_short_circuits(config, vault_id):
 
 
 def test_get_memory_units_schema_shape():
-    """AC-064: ``GET_MEMORY_UNITS_SCHEMA`` requires ``unit_ids: list[str]``."""
+    """AC-064 + F46: ``unit_ids`` and ``chunk_ids`` are both array[str]; XOR enforced
+    at runtime, so neither is in ``required``."""
     props = GET_MEMORY_UNITS_SCHEMA['parameters']['properties']
     assert GET_MEMORY_UNITS_SCHEMA['name'] == 'memex_get_memory_units'
     assert 'unit_ids' in props
     assert props['unit_ids']['type'] == 'array'
     assert props['unit_ids']['items']['type'] == 'string'
-    assert GET_MEMORY_UNITS_SCHEMA['parameters']['required'] == ['unit_ids']
+    assert 'chunk_ids' in props
+    assert props['chunk_ids']['type'] == 'array'
+    assert props['chunk_ids']['items']['type'] == 'string'
+    assert 'vault_id' in props
+    assert props['vault_id']['type'] == 'string'
+    assert 'required' not in GET_MEMORY_UNITS_SCHEMA['parameters']
 
 
 # -- AC-065: singular loop --
@@ -1788,6 +1794,63 @@ def test_get_memory_units_contradictions_field_filters_by_relation(config, vault
     row = json.loads(out)['results'][0]
     assert len(row['contradictions']) == 1
     assert row['contradictions'][0]['relation'] == 'contradiction'
+
+
+# -- F46: chunk_ids path on memex_get_memory_units --
+
+
+def test_get_memory_units_chunk_ids_path_calls_batch_endpoint(config, vault_id):
+    """F46: ``chunk_ids`` routes to ``api.get_memory_units_by_chunks`` (vault-scoped)."""
+    api = Mock()
+    chunk_a = uuid4()
+    chunk_b = uuid4()
+    unit_a = _fake_memory_unit('from chunk A')
+    unit_b = _fake_memory_unit('from chunk B')
+    api.get_memory_units_by_chunks = AsyncMock(return_value=[unit_a, unit_b])
+
+    out = dispatch(
+        'memex_get_memory_units',
+        {'chunk_ids': [str(chunk_a), str(chunk_b)]},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert len(data['results']) == 2
+    api.get_memory_units_by_chunks.assert_awaited_once()
+    args = api.get_memory_units_by_chunks.call_args.args
+    assert args[0] == [chunk_a, chunk_b]
+    assert args[1] == vault_id
+
+
+def test_get_memory_units_xor_both_paths_rejected(config, vault_id):
+    """F46: providing both ``unit_ids`` and ``chunk_ids`` is a validation error."""
+    api = Mock()
+    out = dispatch(
+        'memex_get_memory_units',
+        {'unit_ids': [str(uuid4())], 'chunk_ids': [str(uuid4())]},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert data['results'] == []
+
+
+def test_get_memory_units_xor_neither_path_rejected(config, vault_id):
+    """F46: providing neither ``unit_ids`` nor ``chunk_ids`` is a validation error."""
+    api = Mock()
+    out = dispatch(
+        'memex_get_memory_units',
+        {},
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    data = json.loads(out)
+    assert 'error' in data
+    assert data['results'] == []
 
 
 # -- AC-067: get_memory_links schema --

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3011,7 +3011,7 @@ async def memex_get_memory_units(
             default=None,
             description=(
                 'Vault UUID or name. Required when `chunk_ids` is set; ignored '
-                'for the `unit_ids` path. Defaults to the active write vault.'
+                'for the `unit_ids` path. Defaults to the active read vault.'
             ),
         ),
     ] = None,
@@ -3053,7 +3053,11 @@ async def memex_get_memory_units(
         if not chunk_uuids:
             return []
 
-        vault_str = vault_id or _default_write_vault(ctx)
+        # Chunk traversal is a read operation — default to the active read
+        # vault (matches the convention used by other MCP read tools, e.g.
+        # memex_list_notes). Use the first read vault when multiple are
+        # configured; the agent can pass `vault_id` explicitly to override.
+        vault_str = vault_id or _default_read_vaults(ctx)[0]
         resolved_vault = await _resolve_vault_id(api, vault_str)
 
         units = await api.get_memory_units_by_chunks(chunk_uuids, resolved_vault)

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -2977,7 +2977,12 @@ async def memex_get_lineage(
 
 @mcp.tool(
     name='memex_get_memory_units',
-    description='Batch lookup of memory units by ID. Includes contradiction links and supersession info.',
+    description=(
+        'Batch lookup of memory units. Provide exactly one of '
+        '`unit_ids` (direct ID lookup) or `chunk_ids` (returns all units '
+        'extracted from the named chunks, vault-scoped). Includes '
+        'contradiction links and supersession info.'
+    ),
     tags={'storage'},
     annotations={'readOnlyHint': True},
     timeout=30.0,
@@ -2985,31 +2990,80 @@ async def memex_get_lineage(
 async def memex_get_memory_units(
     ctx: Context,
     unit_ids: Annotated[
-        list[str], BeforeValidator(_coerce_list), Field(description='List of memory unit UUIDs.')
-    ],
+        list[str] | None,
+        BeforeValidator(_coerce_list),
+        Field(default=None, description='List of memory unit UUIDs.'),
+    ] = None,
+    chunk_ids: Annotated[
+        list[str] | None,
+        BeforeValidator(_coerce_list),
+        Field(
+            default=None,
+            description=(
+                'List of chunk UUIDs. Returns all memory units extracted from '
+                'these chunks, scoped to `vault_id`. Mutually exclusive with `unit_ids`.'
+            ),
+        ),
+    ] = None,
+    vault_id: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                'Vault UUID or name. Required when `chunk_ids` is set; ignored '
+                'for the `unit_ids` path. Defaults to the active write vault.'
+            ),
+        ),
+    ] = None,
 ) -> list[McpFact | McpEvent | McpObservation]:
     """Retrieve multiple memory units with their contradiction context."""
+    if (unit_ids is None) == (chunk_ids is None):
+        raise ToolError('Provide exactly one of `unit_ids` or `chunk_ids` (not both, not neither).')
+
     try:
         api = get_api(ctx)
         output: list[McpFact | McpEvent | McpObservation] = []
-        for uid_str in unit_ids:
+
+        if unit_ids is not None:
+            for uid_str in unit_ids:
+                try:
+                    uuid_obj = UUID(uid_str)
+                except ValueError:
+                    continue
+
+                try:
+                    unit = await api.get_memory_unit(uuid_obj)
+                except Exception:
+                    continue
+
+                if unit is None:
+                    continue
+
+                output.append(_build_memory_unit_model(unit))
+
+            return output
+
+        chunk_uuids: list[UUID] = []
+        for cid_str in chunk_ids or []:
             try:
-                uuid_obj = UUID(uid_str)
+                chunk_uuids.append(UUID(cid_str))
             except ValueError:
                 continue
 
-            try:
-                unit = await api.get_memory_unit(uuid_obj)
-            except Exception:
-                continue
+        if not chunk_uuids:
+            return []
 
-            if unit is None:
-                continue
+        vault_str = vault_id or _default_write_vault(ctx)
+        resolved_vault = await _resolve_vault_id(api, vault_str)
 
+        units = await api.get_memory_units_by_chunks(chunk_uuids, resolved_vault)
+        for unit in units:
             output.append(_build_memory_unit_model(unit))
 
         return output
 
+    except ToolError:
+        raise
     except Exception as e:
         logger.error(f'Get memory units failed: {e}', exc_info=True)
         raise ToolError(f'Get memory units failed: {e}')

--- a/packages/mcp/tests/conftest.py
+++ b/packages/mcp/tests/conftest.py
@@ -37,6 +37,7 @@ def mock_api():
     mock.get_entity_cooccurrences = AsyncMock()
     mock.get_entities = AsyncMock()
     mock.get_memory_unit = AsyncMock()
+    mock.get_memory_units_by_chunks = AsyncMock(return_value=[])
     mock.get_nodes = AsyncMock()
     mock.get_note_metadata = AsyncMock()
     mock.get_notes_metadata = AsyncMock()

--- a/packages/mcp/tests/test_int_get_memory_units_chunk_ids.py
+++ b/packages/mcp/tests/test_int_get_memory_units_chunk_ids.py
@@ -1,0 +1,140 @@
+"""F46: ``memex_get_memory_units`` chunk_ids path + XOR validation.
+
+The mock-API substrate is sufficient to exercise the MCP-layer XOR guard
+and dispatch logic. End-to-end DB coverage of
+``api.get_memory_units_by_chunks`` (vault-scoping, chunk→units traversal)
+lives in
+``packages/core/tests/integration/test_int_get_memory_units_chunk_ids.py``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from uuid import UUID, uuid4
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from helpers import parse_tool_result
+from memex_common.schemas import FactTypes, MemoryUnitDTO
+
+
+def _build_unit(text: str, chunk_id: UUID, vault_id: UUID) -> MemoryUnitDTO:
+    return MemoryUnitDTO(
+        id=uuid4(),
+        text=text,
+        fact_type=FactTypes.WORLD,
+        status='active',
+        note_id=uuid4(),
+        vault_id=vault_id,
+        metadata={},
+        mentioned_at=dt.datetime(2025, 4, 1, tzinfo=dt.timezone.utc),
+        chunk_id=chunk_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_chunk_ids_path_returns_units(mock_api, mock_config, mcp_client):
+    """``chunk_ids`` invokes ``api.get_memory_units_by_chunks`` and returns its results."""
+    vault_uuid = uuid4()
+    mock_api.resolve_vault_identifier.return_value = vault_uuid
+
+    chunk_a = uuid4()
+    chunk_b = uuid4()
+    unit_a = _build_unit('from chunk A', chunk_a, vault_uuid)
+    unit_b = _build_unit('from chunk B', chunk_b, vault_uuid)
+    mock_api.get_memory_units_by_chunks.return_value = [unit_a, unit_b]
+
+    result = await mcp_client.call_tool(
+        'memex_get_memory_units',
+        {'chunk_ids': [str(chunk_a), str(chunk_b)], 'vault_id': 'my-vault'},
+    )
+    data = parse_tool_result(result)
+    assert len(data) == 2
+    texts = {u['text'] for u in data}
+    assert {'from chunk A', 'from chunk B'} == texts
+
+    mock_api.get_memory_units_by_chunks.assert_awaited_once()
+    call_args = mock_api.get_memory_units_by_chunks.call_args.args
+    assert call_args[0] == [chunk_a, chunk_b]
+    assert call_args[1] == vault_uuid
+
+
+@pytest.mark.asyncio
+async def test_chunk_ids_unknown_returns_empty(mock_api, mock_config, mcp_client):
+    """An unknown chunk_id yields an empty list, not an error."""
+    vault_uuid = uuid4()
+    mock_api.resolve_vault_identifier.return_value = vault_uuid
+    mock_api.get_memory_units_by_chunks.return_value = []
+
+    result = await mcp_client.call_tool(
+        'memex_get_memory_units',
+        {'chunk_ids': [str(uuid4())], 'vault_id': 'my-vault'},
+    )
+    data = parse_tool_result(result)
+    assert data == []
+
+
+@pytest.mark.asyncio
+async def test_unit_ids_path_unchanged(mock_api, mock_config, mcp_client):
+    """The legacy ``unit_ids`` path still routes to per-id ``api.get_memory_unit``."""
+    uid = uuid4()
+    unit = _build_unit('legacy', uuid4(), uuid4())
+    unit.id = uid
+    mock_api.get_memory_unit.return_value = unit
+
+    result = await mcp_client.call_tool('memex_get_memory_units', {'unit_ids': [str(uid)]})
+    data = parse_tool_result(result)
+    assert len(data) == 1
+    assert data[0]['id'] == str(uid)
+    mock_api.get_memory_units_by_chunks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_xor_both_provided_raises(mock_api, mock_config, mcp_client):
+    """Providing both ``unit_ids`` and ``chunk_ids`` is rejected."""
+    with pytest.raises(ToolError, match='exactly one'):
+        await mcp_client.call_tool(
+            'memex_get_memory_units',
+            {'unit_ids': [str(uuid4())], 'chunk_ids': [str(uuid4())]},
+        )
+
+
+@pytest.mark.asyncio
+async def test_xor_neither_provided_raises(mock_api, mock_config, mcp_client):
+    """Providing neither ``unit_ids`` nor ``chunk_ids`` is rejected."""
+    with pytest.raises(ToolError, match='exactly one'):
+        await mcp_client.call_tool('memex_get_memory_units', {})
+
+
+@pytest.mark.asyncio
+async def test_chunk_ids_invalid_uuids_silently_dropped(mock_api, mock_config, mcp_client):
+    """Invalid UUIDs in chunk_ids are skipped; only valid UUIDs reach the API."""
+    vault_uuid = uuid4()
+    mock_api.resolve_vault_identifier.return_value = vault_uuid
+    mock_api.get_memory_units_by_chunks.return_value = []
+    valid = uuid4()
+
+    result = await mcp_client.call_tool(
+        'memex_get_memory_units',
+        {'chunk_ids': ['not-a-uuid', str(valid)], 'vault_id': 'my-vault'},
+    )
+    data = parse_tool_result(result)
+    assert data == []
+    mock_api.get_memory_units_by_chunks.assert_awaited_once()
+    call_args = mock_api.get_memory_units_by_chunks.call_args.args
+    assert call_args[0] == [valid]
+
+
+@pytest.mark.asyncio
+async def test_chunk_ids_all_invalid_returns_empty_without_api_call(
+    mock_api, mock_config, mcp_client
+):
+    """If every chunk_id is malformed, no API call is made and result is empty."""
+    result = await mcp_client.call_tool(
+        'memex_get_memory_units',
+        {'chunk_ids': ['nope', 'still-not-a-uuid'], 'vault_id': 'my-vault'},
+    )
+    data = parse_tool_result(result)
+    assert data == []
+    mock_api.get_memory_units_by_chunks.assert_not_awaited()


### PR DESCRIPTION
## Summary

Extends `memex_get_memory_units` to accept a `chunk_ids` list in addition to `unit_ids` (mutually exclusive — exactly one). The chunk-traversal path expands chunks to their extracted memory units in a single round-trip, unblocking **F43's Option C** (memory_search → chunks → units) without N follow-up id lookups.

- New service method: `StatsService.get_memory_units_by_chunks(chunk_ids, vault_id)` — vault-scoped `SELECT * FROM memory_units WHERE chunk_id = ANY(:chunk_ids) AND vault_id = :vault_id`. No migration; the FK + btree index already exist (`packages/core/src/memex_core/memory/sql_models.py:690,710`).
- New HTTP route: `POST /api/v1/memories/by-chunks` with `vault_id` enforced via `check_vault_access` (`Permission.READ`).
- MCP tool: gains `chunk_ids` + `vault_id`, XOR validation, vault-scoped traversal.
- Hermes plugin: matching schema, handler, and `MemexAPIProtocol` entry — keeps agent-surface parity (CLAUDE.md rule 24).
- Claude Code plugin: only references the tool by name (not by signature), confirmed by repo-wide grep — no change needed.

## Surfaces touched

| Surface | File(s) |
|---|---|
| Service layer | `packages/core/src/memex_core/services/stats.py` |
| API facade | `packages/core/src/memex_core/api.py` |
| FastAPI route | `packages/core/src/memex_core/server/memories.py` |
| HTTP client | `packages/common/src/memex_common/client.py` |
| MCP tool | `packages/mcp/src/memex_mcp/server.py` |
| Hermes plugin | `packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py` |

## Tests

- `packages/core/tests/integration/test_int_get_memory_units_chunk_ids.py` (5 cases, real Postgres+pgvector via testcontainers):
  - returns expected MUs across multiple chunks
  - empty for unknown chunk_id
  - empty `chunk_ids` short-circuits
  - vault-scoping blocks other-vault units (chunks reused across vaults must not leak)
  - HTTP route end-to-end
- `packages/mcp/tests/test_int_get_memory_units_chunk_ids.py` (7 cases, mocked api):
  - chunk_ids path returns units
  - chunk_ids unknown returns empty
  - legacy unit_ids path unchanged (no chunk-API call)
  - XOR both → ToolError
  - XOR neither → ToolError
  - malformed UUID silently dropped from chunk_ids
  - all-malformed chunk_ids → empty without API call
- `packages/hermes-plugin/tests/test_tools.py` (3 new cases + updated AC-064): chunk_ids dispatch, XOR both, XOR neither.

`just prek`: clean. `pytest packages/mcp/tests/`: 390 passed. `pytest packages/hermes-plugin/tests/`: 370 passed. Targeted integration suite: 5 passed.

## Test plan

- [x] Service-layer integration tests pass against real Postgres
- [x] HTTP-route integration test exercises `/api/v1/memories/by-chunks` end-to-end
- [x] MCP-layer XOR validation rejects both/neither
- [x] Hermes-plugin handler dispatches chunk_ids via `get_memory_units_by_chunks`
- [x] Existing `memex_get_memory_units` unit tests still pass (legacy `unit_ids` path unchanged)
- [x] `just prek` clean
- [x] No drive-by edits; no comments beyond the one explaining vault-scoping intent

## Notes

- BACKLOG.md does not yet contain an F46 anchor — the precondition docs PR (#121, currently in close-out) lands the catalogue entries for F40-F49. This PR is content-independent and may merge in either order.
- Unblocks F43's Option C path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)