### PR TITLE
feat(retrieval): F48 — pre-reranker confidence filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,529%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,916%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,518%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,529%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/core/src/memex_core/memory/retrieval/engine.py
+++ b/packages/core/src/memex_core/memory/retrieval/engine.py
@@ -142,6 +142,14 @@ def _build_pre_filter_clause(
             'FALSE)'
         )
 
+    # F48 — confidence branch (always on; column is NOT NULL DEFAULT 1.0,
+    # so cold-start units never match). Strict ``<`` keeps the 0.2 boundary
+    # safe. No COALESCE wrap needed: unlike FSFM, ``confidence`` cannot be
+    # NULL by schema, so SQL three-valued logic does not arise. The
+    # contradiction engine's α-stepping is itself the evidence-accumulation
+    # threshold — adding a separate count gate would double-count.
+    branches.append('memory_units.confidence < 0.2')
+
     if not branches:
         return None
 

--- a/packages/core/src/memex_core/memory/retrieval/engine.py
+++ b/packages/core/src/memex_core/memory/retrieval/engine.py
@@ -148,7 +148,7 @@ def _build_pre_filter_clause(
     # NULL by schema, so SQL three-valued logic does not arise. The
     # contradiction engine's α-stepping is itself the evidence-accumulation
     # threshold — adding a separate count gate would double-count.
-    branches.append('memory_units.confidence < 0.2')
+    branches.append('(memory_units.confidence < 0.2)')
 
     if not branches:
         return None

--- a/packages/core/tests/integration/memory/retrieval/test_int_f48_confidence_filter.py
+++ b/packages/core/tests/integration/memory/retrieval/test_int_f48_confidence_filter.py
@@ -1,0 +1,417 @@
+"""F48 — pre-reranker confidence filter integration tests.
+
+The pinning unit tests in
+``packages/core/tests/unit/memory/retrieval/test_f48_sql_builder.py`` lock
+down the SQL-builder shape; this file proves the predicate fires
+end-to-end and that:
+
+* Cold-start units (``confidence = 1.0``, the schema default) survive.
+* Boundary units (``confidence == 0.2``) survive — strict ``<`` semantics.
+* Strongly-contradicted units (``confidence < 0.2``) are pruned when
+  ``apply_pre_filter=True`` (the default).
+* The same units re-appear when ``apply_pre_filter=False`` (the F40 single
+  bypass also covers the F48 branch).
+* Vault scoping holds: vault A's search never sees vault B's units,
+  regardless of pre-filter state.
+* F44 — the F33 exploration bypass surfaces a low-confidence unit pruned
+  by F48 via the separate hydration path (the self-correction property
+  must hold for the F48 branch too — without F44's bypass, low-confidence
+  units would never re-validate).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.config import GLOBAL_VAULT_ID, RetrievalConfig
+from memex_common.types import FactTypes
+from memex_core.memory.models.embedding import get_embedding_model
+from memex_core.memory.retrieval.engine import RetrievalEngine
+from memex_core.memory.retrieval.models import RetrievalRequest
+from memex_core.memory.sql_models import Entity, MemoryUnit, Note, UnitEntity, Vault
+
+
+# Pre-merge sequencing gate — F40 must be on the base branch.
+assert 'apply_pre_filter' in RetrievalRequest.model_fields, (
+    'F48 requires F40 to be merged on the base branch — '
+    "RetrievalRequest must expose the 'apply_pre_filter' field."
+)
+
+
+@pytest.mark.integration
+class TestF48ConfidenceFilter:
+    """End-to-end coverage of the F48 confidence branch — five confidence
+    bands cover the round-3 review's critical cases:
+
+    * **1.0** (cold-start, schema default) — kept (1.0 > 0.2).
+    * **0.5** (mid) — kept.
+    * **0.2** (boundary) — kept (strict ``<``).
+    * **0.15** (filtered) — pruned.
+    * **0.0** (filtered) — pruned.
+    """
+
+    @pytest_asyncio.fixture(scope='class')
+    async def embedder(self):
+        return await get_embedding_model()
+
+    @pytest_asyncio.fixture
+    async def engine_no_rerank(self, embedder):
+        return RetrievalEngine(
+            embedder=embedder,
+            reranker=None,
+            retrieval_config=RetrievalConfig(exploration_epsilon=0.0, token_budget=0),
+        )
+
+    async def _seed_band(
+        self,
+        session: AsyncSession,
+        embedder,
+        *,
+        note_id: UUID,
+        entity_id: UUID,
+        vault_id: UUID,
+        text: str,
+        confidence: float,
+    ) -> UUID:
+        unit_id = uuid4()
+        embedding = embedder.encode([text])[0].tolist()
+        session.add(
+            MemoryUnit(
+                id=unit_id,
+                note_id=note_id,
+                text=text,
+                fact_type=FactTypes.WORLD,
+                embedding=embedding,
+                vault_id=vault_id,
+                event_date=datetime.now(timezone.utc),
+                confidence=confidence,
+            )
+        )
+        session.add(UnitEntity(unit_id=unit_id, entity_id=entity_id, vault_id=vault_id))
+        return unit_id
+
+    @pytest_asyncio.fixture
+    async def seeded_bands(self, session: AsyncSession, embedder):
+        """Seed five confidence bands sharing one topic."""
+        topic = 'Postgres replication lag tuning'
+        note = Note(id=uuid4(), original_text='F48 test corpus', vault_id=GLOBAL_VAULT_ID)
+        entity = Entity(id=uuid4(), canonical_name=topic)
+        session.add(note)
+        session.add(entity)
+        await session.flush()
+
+        cold_id = await self._seed_band(
+            session,
+            embedder,
+            note_id=note.id,
+            entity_id=entity.id,
+            vault_id=GLOBAL_VAULT_ID,
+            text='Postgres replication lag tuning fact one cold-start unit.',
+            confidence=1.0,
+        )
+        mid_id = await self._seed_band(
+            session,
+            embedder,
+            note_id=note.id,
+            entity_id=entity.id,
+            vault_id=GLOBAL_VAULT_ID,
+            text='Postgres replication lag tuning fact two mid confidence unit.',
+            confidence=0.5,
+        )
+        boundary_id = await self._seed_band(
+            session,
+            embedder,
+            note_id=note.id,
+            entity_id=entity.id,
+            vault_id=GLOBAL_VAULT_ID,
+            text='Postgres replication lag tuning fact three boundary unit.',
+            confidence=0.2,
+        )
+        pruned_low_id = await self._seed_band(
+            session,
+            embedder,
+            note_id=note.id,
+            entity_id=entity.id,
+            vault_id=GLOBAL_VAULT_ID,
+            text='Postgres replication lag tuning fact four contradicted unit.',
+            confidence=0.15,
+        )
+        pruned_zero_id = await self._seed_band(
+            session,
+            embedder,
+            note_id=note.id,
+            entity_id=entity.id,
+            vault_id=GLOBAL_VAULT_ID,
+            text='Postgres replication lag tuning fact five refuted unit.',
+            confidence=0.0,
+        )
+        await session.commit()
+
+        return {
+            'cold': cold_id,
+            'mid': mid_id,
+            'boundary': boundary_id,
+            'pruned_low': pruned_low_id,
+            'pruned_zero': pruned_zero_id,
+        }
+
+    async def test_pre_filter_prunes_low_confidence_units(
+        self, session: AsyncSession, engine_no_rerank, seeded_bands
+    ):
+        """``apply_pre_filter=True`` (default) prunes confidence < 0.2 and
+        keeps cold-start + mid + boundary units.
+
+        ``include_superseded=True`` is set on every request so the existing
+        post-hydration ``superseded_threshold=0.3`` filter does not mask
+        F48's effect. F48 lives upstream at the hydration layer; isolating
+        it from the downstream superseded filter is the right test
+        boundary."""
+        request = RetrievalRequest(
+            query='Postgres replication lag tuning',
+            limit=20,
+            vault_ids=[GLOBAL_VAULT_ID],
+            apply_pre_filter=True,
+            include_superseded=True,
+        )
+        results, _ = await engine_no_rerank.retrieve(session, request)
+        result_ids = {r.id for r in results}
+
+        assert seeded_bands['cold'] in result_ids, (
+            'F48 cold-start safeguard regressed — confidence=1.0 unit must '
+            'NEVER be filtered (1.0 > 0.2 by an order of magnitude).'
+        )
+        assert seeded_bands['mid'] in result_ids, (
+            'F48 over-prune: confidence=0.5 unit must survive (0.5 > 0.2).'
+        )
+        assert seeded_bands['boundary'] in result_ids, (
+            'F48 strict-< invariant broken: confidence=0.2 (boundary) must '
+            'survive — the spec settled on strict less-than (not <=).'
+        )
+        assert seeded_bands['pruned_low'] not in result_ids, (
+            'F48 regression: confidence=0.15 unit must be pruned (< 0.2).'
+        )
+        assert seeded_bands['pruned_zero'] not in result_ids, (
+            'F48 regression: confidence=0.0 unit must be pruned (< 0.2).'
+        )
+
+    async def test_apply_pre_filter_false_returns_pruned_units(
+        self, session: AsyncSession, engine_no_rerank, seeded_bands
+    ):
+        """The audit / lineage / historical-routing escape hatch — F40's
+        single-bypass flag also drops the F48 branch, so previously-pruned
+        low-confidence units re-appear."""
+        request = RetrievalRequest(
+            query='Postgres replication lag tuning',
+            limit=20,
+            vault_ids=[GLOBAL_VAULT_ID],
+            apply_pre_filter=False,
+            include_superseded=True,
+        )
+        results, _ = await engine_no_rerank.retrieve(session, request)
+        result_ids = {r.id for r in results}
+
+        for key in (
+            'cold',
+            'mid',
+            'boundary',
+            'pruned_low',
+            'pruned_zero',
+        ):
+            assert seeded_bands[key] in result_ids, (
+                f'apply_pre_filter=False must surface every band, including '
+                f'{key!r}; missing from {result_ids}.'
+            )
+
+
+@pytest.mark.integration
+class TestF48VaultScoping:
+    """The F48 confidence filter must not leak between vaults. The
+    predicate sits at the hydration layer downstream of the strategy
+    layer's vault scoping — this test pins the composition."""
+
+    @pytest_asyncio.fixture(scope='class')
+    async def embedder(self):
+        return await get_embedding_model()
+
+    async def test_confidence_filter_respects_vault_scope(self, session: AsyncSession, embedder):
+        """Two vaults; same low-confidence unit pattern in each. Searching
+        one vault must not see the other's units, regardless of
+        pre-filter state."""
+        v_a = Vault(id=uuid4(), name='vault-a-f48')
+        v_b = Vault(id=uuid4(), name='vault-b-f48')
+        session.add(v_a)
+        session.add(v_b)
+        await session.flush()
+
+        async def _seed_pair(vault_id: UUID, label: str) -> tuple[UUID, UUID]:
+            note = Note(id=uuid4(), original_text=f'F48 vault {label}', vault_id=vault_id)
+            entity = Entity(id=uuid4(), canonical_name=f'F48-Topic-{label}')
+            session.add(note)
+            session.add(entity)
+            await session.flush()
+
+            high_text = f'Vault {label} high-confidence well-validated guidance.'
+            high_id = uuid4()
+            session.add(
+                MemoryUnit(
+                    id=high_id,
+                    note_id=note.id,
+                    text=high_text,
+                    fact_type=FactTypes.WORLD,
+                    embedding=embedder.encode([high_text])[0].tolist(),
+                    vault_id=vault_id,
+                    event_date=datetime.now(timezone.utc),
+                    confidence=1.0,
+                )
+            )
+            session.add(UnitEntity(unit_id=high_id, entity_id=entity.id, vault_id=vault_id))
+
+            low_text = f'Vault {label} low-confidence contradicted guidance.'
+            low_id = uuid4()
+            session.add(
+                MemoryUnit(
+                    id=low_id,
+                    note_id=note.id,
+                    text=low_text,
+                    fact_type=FactTypes.WORLD,
+                    embedding=embedder.encode([low_text])[0].tolist(),
+                    vault_id=vault_id,
+                    event_date=datetime.now(timezone.utc),
+                    confidence=0.05,
+                )
+            )
+            session.add(UnitEntity(unit_id=low_id, entity_id=entity.id, vault_id=vault_id))
+            return high_id, low_id
+
+        a_high, a_low = await _seed_pair(v_a.id, 'A')
+        b_high, b_low = await _seed_pair(v_b.id, 'B')
+        await session.commit()
+
+        engine = RetrievalEngine(
+            embedder=embedder,
+            reranker=None,
+            retrieval_config=RetrievalConfig(exploration_epsilon=0.0, token_budget=0),
+        )
+
+        for apply_pre_filter in (True, False):
+            results_a, _ = await engine.retrieve(
+                session,
+                RetrievalRequest(
+                    query='vault contradicted guidance',
+                    limit=20,
+                    vault_ids=[v_a.id],
+                    apply_pre_filter=apply_pre_filter,
+                    include_superseded=True,
+                ),
+            )
+            ids_a = {r.id for r in results_a}
+            assert b_high not in ids_a and b_low not in ids_a, (
+                f'vault-scoping violation under apply_pre_filter={apply_pre_filter}: '
+                f"vault A search returned vault B's units."
+            )
+
+
+@pytest.mark.integration
+class TestF48ExplorationBypass:
+    """F44 — F33 exploration bypass must keep low-confidence units
+    re-discoverable. Without this, F48 would make confidence monotonic
+    once a unit dipped below 0.2 (no path back to re-validation)."""
+
+    @pytest_asyncio.fixture(scope='class')
+    async def embedder(self):
+        return await get_embedding_model()
+
+    async def test_low_confidence_unit_re_surfaces_via_exploration(
+        self, session: AsyncSession, embedder
+    ):
+        """A unit with ``confidence < 0.2`` AND ``< 5 outcomes`` is the
+        F48 ∩ F33 region: F48 prunes it from the main path, F33's
+        exploration eligibility window covers it, and F44's separate
+        hydration path bypasses F40+F48 — so the unit re-surfaces. Without
+        the F44 bypass, F48 would silently shrink F33's candidate pool."""
+        topic = 'Kafka consumer rebalance protocol'
+
+        note = Note(id=uuid4(), original_text='F48 self-correction', vault_id=GLOBAL_VAULT_ID)
+        entity = Entity(id=uuid4(), canonical_name=topic)
+        session.add(note)
+        session.add(entity)
+        await session.flush()
+
+        # Filler high-confidence units to keep the result set crowded.
+        for i in range(3):
+            uid = uuid4()
+            text = f'{topic} canonical pattern {i} (well-validated).'
+            session.add(
+                MemoryUnit(
+                    id=uid,
+                    note_id=note.id,
+                    text=text,
+                    fact_type=FactTypes.WORLD,
+                    embedding=embedder.encode([text])[0].tolist(),
+                    vault_id=GLOBAL_VAULT_ID,
+                    event_date=datetime.now(timezone.utc),
+                    success_co_count=20,
+                    failure_co_count=0,
+                    confidence=1.0,
+                )
+            )
+            session.add(UnitEntity(unit_id=uid, entity_id=entity.id, vault_id=GLOBAL_VAULT_ID))
+
+        # The F48 ∩ F33 target: low confidence (pruned by F48 main path),
+        # zero outcomes (eligible for F33 exploration injection — F33's
+        # threshold is total outcomes < 5).
+        bypass_target_id = uuid4()
+        text_bypass = f'{topic} ancient observation that contradiction-engine downgraded.'
+        session.add(
+            MemoryUnit(
+                id=bypass_target_id,
+                note_id=note.id,
+                text=text_bypass,
+                fact_type=FactTypes.WORLD,
+                embedding=embedder.encode([text_bypass])[0].tolist(),
+                vault_id=GLOBAL_VAULT_ID,
+                event_date=datetime.now(timezone.utc),
+                success_co_count=0,
+                failure_co_count=0,
+                confidence=0.05,
+            )
+        )
+        session.add(
+            UnitEntity(unit_id=bypass_target_id, entity_id=entity.id, vault_id=GLOBAL_VAULT_ID)
+        )
+        await session.commit()
+
+        engine = RetrievalEngine(
+            embedder=embedder,
+            reranker=None,
+            retrieval_config=RetrievalConfig(
+                exploration_epsilon=1.0,
+                exploration_max_injections=2,
+                exploration_low_mw_threshold=5,
+                token_budget=0,
+            ),
+        )
+
+        results, _ = await engine.retrieve(
+            session,
+            RetrievalRequest(
+                query=f'{topic} rebalance behaviour',
+                limit=2,
+                vault_ids=[GLOBAL_VAULT_ID],
+                apply_pre_filter=True,
+                include_superseded=True,
+            ),
+        )
+
+        result_ids = {r.id for r in results}
+        assert bypass_target_id in result_ids, (
+            'F48 + F44 regression: a low-confidence unit pruned by F48 must '
+            'still re-surface via the F33 exploration bypass when '
+            'apply_pre_filter=True. Without this, F48 makes confidence '
+            'monotonic — the unit can never re-validate via F33 self-correction.'
+        )

--- a/packages/core/tests/unit/memory/retrieval/test_f48_sql_builder.py
+++ b/packages/core/tests/unit/memory/retrieval/test_f48_sql_builder.py
@@ -49,7 +49,7 @@ class TestF48ConfidenceBranch:
         )
         assert clause is not None
         sql = str(clause)
-        assert 'memory_units.confidence < 0.2' in sql, (
+        assert '(memory_units.confidence < 0.2)' in sql, (
             f'F48 regression: confidence branch missing from rendered SQL when '
             f'apply_pre_filter=True. Got: {sql!r}'
         )
@@ -62,7 +62,7 @@ class TestF48ConfidenceBranch:
         )
         assert clause is not None
         sql = str(clause)
-        assert 'memory_units.confidence < 0.2' in sql
+        assert '(memory_units.confidence < 0.2)' in sql
         assert 'importance' in sql
         assert 'stability' in sql
 
@@ -88,7 +88,7 @@ class TestF48ConfidenceBranch:
         )
         assert clause is not None
         sql = str(clause)
-        assert ' OR memory_units.confidence < 0.2' in sql, (
+        assert ' OR (memory_units.confidence < 0.2)' in sql, (
             f'F48 branch must be OR-joined to the predicate; got {sql!r}'
         )
 

--- a/packages/core/tests/unit/memory/retrieval/test_f48_sql_builder.py
+++ b/packages/core/tests/unit/memory/retrieval/test_f48_sql_builder.py
@@ -1,0 +1,150 @@
+"""F48 — pinning tests for the confidence pre-filter branch.
+
+F48 extends F40's ``WHERE NOT (...)`` predicate with a third OR'd branch:
+``memory_units.confidence < 0.2``. The branch is always active (not gated
+by a config flag) because the column ships with a ``NOT NULL DEFAULT 1.0``
+constraint — cold-start units never match. The ``apply_pre_filter`` flag
+inherited from F40 is the single bypass for all three branches.
+
+Round-3 review settled the strict ``<`` semantics: α-stepping in the
+contradiction engine IS the evidence accumulation, so a count-gate would
+double-count. Reaching ``confidence < 0.2`` already requires multiple
+contradiction events.
+
+These tests pin:
+
+1. The substring ``confidence < 0.2`` appears in the rendered SQL when
+   ``apply_pre_filter=True`` (regardless of FSFM flag — the branch is
+   always-on).
+2. The substring is absent when ``apply_pre_filter=False`` (entire clause
+   drops out via the F40 single-bypass flag).
+3. No COALESCE wrap is emitted around the confidence branch — column is
+   NOT NULL so SQL three-valued logic does not arise.
+4. Pre-merge sequencing: F40 must be merged before F48 — assert
+   ``apply_pre_filter`` exists on ``RetrievalRequest``.
+"""
+
+from __future__ import annotations
+
+from memex_core.memory.retrieval.engine import _build_pre_filter_clause
+from memex_core.memory.retrieval.models import RetrievalRequest
+
+
+# Pre-merge sequencing gate (module-level — fails import if F40 not merged).
+assert (
+    hasattr(RetrievalRequest, 'model_fields')
+    and 'apply_pre_filter' in RetrievalRequest.model_fields
+), (
+    'F48 requires F40 to be merged on the base branch — '
+    "RetrievalRequest must expose the 'apply_pre_filter' field."
+)
+
+
+class TestF48ConfidenceBranch:
+    def test_confidence_branch_in_sql_when_apply_pre_filter_true_fsfm_off(self) -> None:
+        """The confidence branch is always-on — no config flag gates it."""
+        clause = _build_pre_filter_clause(
+            apply_pre_filter=True,
+            fsfm_branch_enabled=False,
+        )
+        assert clause is not None
+        sql = str(clause)
+        assert 'memory_units.confidence < 0.2' in sql, (
+            f'F48 regression: confidence branch missing from rendered SQL when '
+            f'apply_pre_filter=True. Got: {sql!r}'
+        )
+
+    def test_confidence_branch_in_sql_when_fsfm_on(self) -> None:
+        """F48 composes alongside the FSFM branch; both must be present."""
+        clause = _build_pre_filter_clause(
+            apply_pre_filter=True,
+            fsfm_branch_enabled=True,
+        )
+        assert clause is not None
+        sql = str(clause)
+        assert 'memory_units.confidence < 0.2' in sql
+        assert 'importance' in sql
+        assert 'stability' in sql
+
+    def test_confidence_branch_absent_when_apply_pre_filter_false(self) -> None:
+        """F40's single-bypass flag drops every branch (MW + FSFM + F48)
+        in one go — the entire ``WHERE NOT (...)`` clause is omitted."""
+        for fsfm in (False, True):
+            clause = _build_pre_filter_clause(
+                apply_pre_filter=False,
+                fsfm_branch_enabled=fsfm,
+            )
+            assert clause is None, (
+                f'apply_pre_filter=False must drop the entire predicate '
+                f'(fsfm_branch_enabled={fsfm}); got {clause!r}'
+            )
+
+    def test_confidence_branch_or_joined(self) -> None:
+        """The third branch joins via ``OR`` — either signal is sufficient
+        grounds to skip the cross-encoder."""
+        clause = _build_pre_filter_clause(
+            apply_pre_filter=True,
+            fsfm_branch_enabled=False,
+        )
+        assert clause is not None
+        sql = str(clause)
+        assert ' OR memory_units.confidence < 0.2' in sql, (
+            f'F48 branch must be OR-joined to the predicate; got {sql!r}'
+        )
+
+    def test_confidence_branch_uses_strict_less_than(self) -> None:
+        """Round-2 review settled strict ``<`` (not ``<=``) so the 0.2
+        boundary stays on the kept side. A unit with confidence==0.2
+        survives the filter."""
+        clause = _build_pre_filter_clause(
+            apply_pre_filter=True,
+            fsfm_branch_enabled=False,
+        )
+        assert clause is not None
+        sql = str(clause)
+        assert 'confidence < 0.2' in sql
+        assert 'confidence <= 0.2' not in sql, (
+            'F48 must use strict < (not <=); the 0.2 boundary is kept.'
+        )
+
+    def test_confidence_branch_has_no_coalesce_wrap(self) -> None:
+        """``confidence`` is NOT NULL DEFAULT 1.0 — three-valued logic does
+        not arise. A COALESCE wrap would be defensive noise; the spec is
+        explicit that no wrap is needed."""
+        clause = _build_pre_filter_clause(
+            apply_pre_filter=True,
+            fsfm_branch_enabled=False,
+        )
+        assert clause is not None
+        sql = str(clause)
+        # Locate the confidence branch substring; nothing immediately
+        # surrounding it should be a COALESCE call.
+        assert 'COALESCE(memory_units.confidence' not in sql, (
+            'F48 confidence branch must NOT be COALESCE-wrapped — column is '
+            'NOT NULL DEFAULT 1.0 so SQL three-valued logic does not arise.'
+        )
+
+    def test_cold_start_schema_invariant(self) -> None:
+        """Pinning the cold-start invariant at the schema level: the column
+        is ``NOT NULL DEFAULT 1.0``. If either invariant ever weakens, the
+        F48 branch could either NULL-poison the surrounding ``NOT (...)``
+        (TVL) or filter cold-start rows — both regressions."""
+        from memex_core.memory.sql_models import MemoryUnit
+
+        confidence_col = MemoryUnit.__table__.columns['confidence']
+        assert confidence_col.nullable is False, (
+            'F48 cold-start invariant: memory_units.confidence must be NOT NULL '
+            'so the F48 branch never sees NULL inputs.'
+        )
+        server_default = confidence_col.server_default
+        assert server_default is not None, (
+            'F48 cold-start invariant: memory_units.confidence must declare a '
+            'server_default so DB-side inserts (raw SQL paths) get the safe value.'
+        )
+        default_text = (
+            str(server_default.arg) if hasattr(server_default, 'arg') else str(server_default)
+        )
+        assert '1.0' in default_text or '1' == default_text.strip(), (
+            f'F48 cold-start invariant: memory_units.confidence server_default '
+            f'must be 1.0 (strictly > 0.2 threshold). Got: {default_text!r}'
+        )


### PR DESCRIPTION
## Summary

Extends F40's hydration `WHERE NOT (...)` predicate with a third OR'd branch: `memory_units.confidence < 0.2`. Strongly-contradicted units get heavily multiplied down by F47's post-reranker boost — pruning them before the cross-encoder reclaims the wasted compute.

## Key decisions (settled across review rounds)

- **Always-on branch**, no separate config flag. `confidence` is `NOT NULL DEFAULT 1.0` (schema invariant), so cold-start units never match the strict `<` 0.2 threshold and SQL three-valued logic does not arise. No COALESCE wrap needed (unlike FSFM).
- **No evidence threshold**. The α-stepping inside the contradiction engine is itself the evidence accumulation — reaching `confidence < 0.2` already requires ≥5 contradict-only events or ≥9 weaken-only events. Adding a count gate would double-count.
- **Single bypass inherited from F40**. Setting `apply_pre_filter=False` drops the entire `WHERE NOT (...)` clause — every branch (MW + FSFM + confidence) is bypassed in one go.
- **F44 exploration bypass already covers F48** — F33's separate hydration path omits the predicate, so low-confidence units pruned by F48 still get re-validation cycles. Confidence cannot become monotonic.

## Pre-merge sequencing

- F40 (#123) — merged on base. Provides the predicate infrastructure + `apply_pre_filter` flag.
- F47 (#125) — merged on base. Validated the confidence ranking signal direction (post-reranker boost) before this PR uses it as a filter.

Both unit and integration test files include a module-level assertion that `apply_pre_filter` exists on `RetrievalRequest`, fail-fast if either dependency disappears.

## Tests

- `packages/core/tests/unit/memory/retrieval/test_f48_sql_builder.py` — 7 SQL-string pinning tests:
  - branch present in SQL when `apply_pre_filter=True` (FSFM off and on)
  - branch absent when `apply_pre_filter=False`
  - OR-joined with existing branches
  - strict `<` (not `<=`)
  - no COALESCE wrap
  - cold-start schema invariant: `NOT NULL DEFAULT 1.0`

- `packages/core/tests/integration/memory/retrieval/test_int_f48_confidence_filter.py` — 4 end-to-end tests across five confidence bands (1.0 / 0.5 / 0.2 / 0.15 / 0.0):
  - main-path prune: <0.2 dropped, ≥0.2 kept (boundary survives strict <)
  - `apply_pre_filter=False` re-surfaces every band
  - vault scoping holds under both pre-filter states
  - F44 exploration self-correction: low-confidence + cold-start unit re-surfaces via F33 bypass

## Test plan

- [x] `uv run pytest packages/core/tests/unit/memory/retrieval/test_f48_sql_builder.py` — 7/7 pass
- [x] `uv run pytest packages/core/tests/integration/memory/retrieval/test_int_f48_confidence_filter.py` — 4/4 pass
- [x] `uv run pytest packages/core/tests/unit/memory/retrieval/test_f40_sql_builder.py` — F40 tests still green (12/12)
- [x] `uv run pytest packages/core/tests/{unit,integration}/memory/retrieval/` (excluding pre-existing test_int_exploration F33 failure) — 493 passed
- [x] `just prek` — ruff + ruff-format + mypy all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)