### PR TITLE
feat(agent-surface): F43 — codify §3.5 + §3.4.2 across MCP/Hermes/Claude Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,3 +187,26 @@ Async mode: `asyncio_mode = "auto"` — all async tests run automatically.
 - Use `patch.dict(os.environ, ...)` for config tests.
 - Ensure `ensure_db_env_vars` fixture is active for E2E tests.
 </constraint>
+
+## When the user reports an issue resolved (§3.5 5-step flow)
+
+When the user says "the X bug is fixed" / "we shipped Y" / "issue Z is no
+longer relevant", apply the **5-step resolution flow**: (1) disambiguate
+first if scope is ambiguous; (2) route by info quality (`memex_find_note`
+for title fragment, `memex_memory_search` only when title is unknown) AND
+pick a coverage path — Option A entity-anchored, Option B cross-note
+semantic with `top_k>=30`, or Option C single-note PageIndex traversal;
+(3) mandatory LLM judgment over candidates — never bulk-write; (4+5) paired
+writes (`memex_record_outcome(success=false)` AND
+`memex_memory_deprioritize`) against the LLM-judged-relevant subset only.
+The two verbs are orthogonal axes (MW gradient vs binary surface state).
+
+Authoritative agent guidance lives in three places (parity required per
+the agent-surface rule): the MCP tool descriptions
+(`packages/mcp/src/memex_mcp/_f43_descriptions.py`), the Hermes session
+briefing (`packages/hermes-plugin/.../briefing.py`
+`_RESOLUTION_FLOW_PRIMER`), and the Claude Code plugin rule
+(`packages/claude-code-plugin/rules/memory-resolution-flow.md`). For
+"how has my view on X evolved" / audit queries, use
+`memex_get_unit_history` or `memex_memory_search(apply_pre_filter=False)`
+— see the historical-routing rule in any of the three sources.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,983%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,011%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,974%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,983%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,011%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,592%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,518%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,974%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,592%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,011%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/claude-code-plugin/rules/memory-resolution-flow.md
+++ b/packages/claude-code-plugin/rules/memory-resolution-flow.md
@@ -1,0 +1,125 @@
+## Memory resolution flow — the 5-step pattern
+
+When the user reports an issue resolved ("the X bug is fixed", "we shipped Y",
+"issue Z is no longer relevant"), follow §3.5 of the cognitive-memory research
+report exactly. Skipping any step (especially Step 1 disambiguation or Step 3
+LLM judgment) leads to bulk-writing irrelevant units.
+
+### Step 1 — Disambiguate first
+
+If the scope is ambiguous, ASK before writing. Examples that warrant a
+clarification turn:
+
+- "telegram issues from yesterday" when there are three reflection notes
+  mentioning Telegram in the last week
+- "the auth bug we discussed" with no temporal anchor
+- multiple distinct issues conflated into one statement ("the issues are
+  fixed" — which ones?)
+
+### Step 2 — Route by info quality, then pick a coverage path
+
+| Information user supplied | Right tool |
+|---|---|
+| Title fragment ("yesterday's reflection") | `memex_find_note(query="...")` — title-fragment lookup, indexed, cheap |
+| Content only ("the standup notes about the deploy regression") | `memex_memory_search(query="...")` — full pipeline, expensive but right when title is unknown |
+
+Then pick ONE of three coverage paths:
+
+- **Option A — entity-anchored (highest recall when topic ↔ entity)**:
+  `memex_list_entities(query="telegram")` → `memex_get_entity_mentions(entity_id=...)`.
+  Structural traversal across every note; no semantic-rank miss.
+- **Option B — cross-note semantic (when no entity anchor)**:
+  `memex_memory_search(query="...", after="...", top_k=30)`. **CRITICAL: `top_k`
+  must be ≥30** — the default 5 is too narrow and will miss cross-note matches.
+- **Option C — single-note PageIndex traversal (provably one note)**:
+  `memex_get_page_indices(note_id)` → read chunk summaries → pick fix-relevant
+  chunks → `memex_get_memory_units(chunk_ids=[...])`. Captures every unit in
+  the chunk; semantic top-k can miss paraphrased mentions.
+
+### Step 3 — Mandatory LLM judgment (NEVER bulk-write)
+
+Whichever path returned candidates, READ the unit bodies and judge which ones
+actually correspond to the user's claim. Memory units are short by design
+(single fact / observation / event, ~1–3 sentences) — the search response IS
+the content; reading does not blow up context. The judgment cannot be skipped:
+a daily-reflection note contains episodic observations ("worked on memex 3h
+today") that look superficially relevant but are not fix-targets.
+
+### Steps 4 + 5 — Paired writes against the LLM-judged-relevant subset
+
+For each unit the LLM judged relevant, issue BOTH writes:
+
+```
+memex_record_outcome(unit_ids=[...], success=false, reason="user confirmed fixed")
+memex_memory_deprioritize(unit_id=..., reason="user confirmed fixed YYYY-MM-DD")
+```
+
+Both, against the SAME subset. The two verbs are orthogonal axes:
+
+| Tool | Question it answers | Cardinality | Reversible? |
+|------|---------------------|-------------|-------------|
+| `memex_record_outcome(success=...)` | "Did this memory help when retrieved?" | Append-only counter (compounds across retrievals) | No (audit log) |
+| `memex_memory_deprioritize(reason)` | "Should this surface by default at all?" | Binary state on the unit | Yes (`memex_memory_restore`) |
+
+You can want one without the other:
+
+- **outcome=false but no deprioritize**: gradient signal only — let MW
+  compound; perhaps a different query still legitimately wants this unit.
+- **deprioritize but no outcome**: verdict without judging past usefulness
+  ("correct when written but no longer relevant").
+- **BOTH** (the user-confirmed-fix case): negative-usefulness AND binary
+  verdict.
+
+### Imperfect recall is by design
+
+None of Options A/B/C give *provable* 100% recall on cross-note resolution.
+Semantic search misses paraphrases; entity traversal misses oblique references;
+chunk-scoped reads miss issues split across chunks. **F33 exploration is the
+safety net** — any unit that slipped past resolution will occasionally
+re-surface, the user re-confirms, and another `record_outcome(success=false)`
+compounds the MW penalty. User-driven resolution is a GRADIENT across many
+turns, not a one-shot delete.
+
+## Historical / audit-query routing rule
+
+The 5-step flow assumes the user is asking "what's true *now*". For queries
+about HOW THINGS CHANGED — "how has my view on X evolved", "what did I used to
+think about Y", "show me everything I believed about Z including the wrong
+stuff" — route differently.
+
+**Disambiguation triggers** (any of these → use the historical rule, NOT the
+resolution flow): "evolved", "used to", "history of", "what changed", "what
+did I think before", "audit", "show me everything", "show me the hidden ones",
+explicit time-window-with-no-filter intent.
+
+- **Ordered-chain timeline on a specific unit**:
+  `memex_get_unit_history(unit_id)` (F49) — graph walk through contradiction
+  links, returns predecessors in temporal order. Cleaner semantics than ranked
+  search for "evolution" queries.
+- **Broader audit / "show me everything including hidden stuff"**:
+  `memex_memory_search(query="...", apply_pre_filter=False)` — bypasses F40 +
+  F48 (MW + FSFM + confidence pre-filters) so contradicted,
+  behaviorally-failed, and decayed units appear. Post-reranker boosts (F47
+  confidence_boost, F1c MW) still apply, so contradicted units rank below
+  clean ones — which is correct ordering for audit queries.
+
+When the user says "the X issue is resolved" → resolution flow (Steps 1–5).
+When the user says "how has my position on X changed" → historical routing.
+Disambiguation is the agent's responsibility.
+
+## What is NOT a gap (do NOT request these)
+
+The resolution flow uses only existing primitives. Do NOT request any of the
+following — the existing tools + the orthogonal-axes composition are
+sufficient:
+
+- A combined `memex_resolve(unit_ids, reason)` endpoint. Hides the orthogonal
+  axes (gradient outcome vs binary surface state). Compose at the agent layer.
+- A `resolved_at` timestamp column. The maintenance ledger already records
+  when deprioritize fired; the note's `created_at` anchors the original
+  observation.
+- A `resolution_type` enum on deprioritize. Free text in `reason` carries the
+  same information without committing the schema to a closed taxonomy.
+- A `bulk-by-source` parameter on deprioritize. Agents iterate.
+- Note-level deprioritize. Notes are episodic anchors; deprioritization
+  applies to the derived units, not the source notes.

--- a/packages/claude-code-plugin/scripts/on_session_start.sh
+++ b/packages/claude-code-plugin/scripts/on_session_start.sh
@@ -26,13 +26,18 @@ else
     _project_root="$PWD"
 fi
 if [ -n "$_project_root" ]; then
-    _rules_src="$PLUGIN_ROOT/rules/memex.md"
-    _rules_dst="$_project_root/.claude/rules/memex.md"
-    if [ -f "$_rules_src" ]; then
-        if [ ! -f "$_rules_dst" ] || ! diff -q "$_rules_src" "$_rules_dst" >/dev/null 2>&1; then
-            mkdir -p "$(dirname "$_rules_dst")" 2>/dev/null || true
-            cp "$_rules_src" "$_rules_dst" 2>/dev/null || true
-        fi
+    _rules_src_dir="$PLUGIN_ROOT/rules"
+    _rules_dst_dir="$_project_root/.claude/rules"
+    if [ -d "$_rules_src_dir" ]; then
+        mkdir -p "$_rules_dst_dir" 2>/dev/null || true
+        for _rules_src in "$_rules_src_dir"/*.md; do
+            [ -f "$_rules_src" ] || continue
+            _rules_name="$(basename "$_rules_src")"
+            _rules_dst="$_rules_dst_dir/$_rules_name"
+            if [ ! -f "$_rules_dst" ] || ! diff -q "$_rules_src" "$_rules_dst" >/dev/null 2>&1; then
+                cp "$_rules_src" "$_rules_dst" 2>/dev/null || true
+            fi
+        done
     fi
 fi
 

--- a/packages/claude-code-plugin/scripts/on_session_start.sh
+++ b/packages/claude-code-plugin/scripts/on_session_start.sh
@@ -30,9 +30,18 @@ if [ -n "$_project_root" ]; then
     _rules_dst_dir="$_project_root/.claude/rules"
     if [ -d "$_rules_src_dir" ]; then
         mkdir -p "$_rules_dst_dir" 2>/dev/null || true
-        # Loops markdown rules; non-.md files are intentionally ignored to keep
-        # the install path simple. If we add yaml/json rule formats, broaden
-        # this glob.
+        # Warn loudly if a non-.md rule file is dropped into the source dir —
+        # the install loop only handles markdown, and silent skips would hide
+        # a missing rule when yaml/json formats are introduced.
+        for _foreign in "$_rules_src_dir"/*; do
+            [ -f "$_foreign" ] || continue
+            case "$_foreign" in
+                *.md) ;;
+                *)
+                    echo "memex on_session_start: ignoring non-.md rule file: $_foreign (extend the install loop to support new formats)" >&2
+                    ;;
+            esac
+        done
         for _rules_src in "$_rules_src_dir"/*.md; do
             [ -f "$_rules_src" ] || continue
             _rules_name="$(basename "$_rules_src")"

--- a/packages/claude-code-plugin/scripts/on_session_start.sh
+++ b/packages/claude-code-plugin/scripts/on_session_start.sh
@@ -30,6 +30,9 @@ if [ -n "$_project_root" ]; then
     _rules_dst_dir="$_project_root/.claude/rules"
     if [ -d "$_rules_src_dir" ]; then
         mkdir -p "$_rules_dst_dir" 2>/dev/null || true
+        # Loops markdown rules; non-.md files are intentionally ignored to keep
+        # the install path simple. If we add yaml/json rule formats, broaden
+        # this glob.
         for _rules_src in "$_rules_src_dir"/*.md; do
             [ -f "$_rules_src" ] || continue
             _rules_name="$(basename "$_rules_src")"

--- a/packages/claude-code-plugin/skills/recall/SKILL.md
+++ b/packages/claude-code-plugin/skills/recall/SKILL.md
@@ -20,6 +20,24 @@ You have been invoked via the `/recall` slash command.
    c. If still no results, call `memex_list_entities` to browse the knowledge graph.
    d. If nothing is found after all three strategies, say so — do not guess.
 
+   **Historical / audit-query routing rule (§3.4.2)** — when the user asks
+   HOW THINGS CHANGED rather than "what is true *now*", route differently.
+   Triggers: "evolved", "used to", "history of", "what changed", "what did I
+   think before", "audit", "show me everything", "show me the hidden ones".
+   - **Ordered-chain timeline on a specific unit**: call
+     `memex_get_unit_history(unit_id)` (F49) — graph walk through
+     contradiction links, oldest → newest. Cleaner than ranked search.
+   - **Broader audit / "show me everything including hidden stuff"**: call
+     `memex_memory_search(query="...", apply_pre_filter=False)` — bypasses
+     MW + FSFM + confidence pre-filters so contradicted, behaviorally-
+     failed, and decayed units appear. Post-reranker boosts (F47, F1c)
+     still apply, so contradicted units rank below clean ones — correct
+     for audit queries.
+
+   When the user says "the X issue is resolved", do NOT use this rule —
+   that's the resolution flow (see `/remember` skill +
+   `.claude/rules/memory-resolution-flow.md`).
+
 3. **Present results.**
    - Summarize the findings in a clear, readable format.
    - Include source Note IDs so the user can drill deeper with `memex_read_note`.

--- a/packages/claude-code-plugin/skills/remember/SKILL.md
+++ b/packages/claude-code-plugin/skills/remember/SKILL.md
@@ -52,6 +52,38 @@ that contaminates retrieval, prefer the **NON-DESTRUCTIVE** verb:
   it removes the unit from the entity graph and is irreversible. Prefer
   deprioritize unless the unit MUST leave the graph entirely.
 
+## When the user reports an issue resolved (§3.5 5-step flow)
+
+When the user says "the X bug is fixed", "we shipped Y", "issue Z is no longer
+relevant", apply the **5-step resolution flow** — see
+`.claude/rules/memory-resolution-flow.md` for the canonical text. The
+short version:
+
+1. **Disambiguate first** — if scope is ambiguous, ASK before writing.
+2. **Route by info quality + pick a coverage path**:
+   - Title fragment → `memex_find_note`; content only → `memex_memory_search`
+   - **(A) entity-anchored**: `memex_list_entities` → `memex_get_entity_mentions`
+   - **(B) cross-note semantic**: `memex_memory_search(top_k>=30, after=...)`
+     — `top_k` MUST be ≥30, default 5 misses cross-note matches
+   - **(C) single-note PageIndex**: `memex_get_page_indices` →
+     `memex_get_memory_units(chunk_ids=[...])`
+3. **Mandatory LLM judgment** — read candidate unit bodies, pick the
+   fix-relevant subset. Never bulk-write the raw candidate set.
+4. **+5. Paired writes against the LLM-judged-relevant subset only**:
+   `memex_record_outcome(unit_ids=[...], success=false, reason="...")` AND
+   `memex_memory_deprioritize(unit_id=..., reason="...")` against the
+   SAME subset.
+
+The two verbs are orthogonal axes (MW gradient vs binary surface state);
+user-confirmed-fix is BOTH signals at once. Imperfect cross-note recall is by
+design — F33 exploration is the safety net.
+
+For "how has my view on X evolved" / "what did I used to think about Y" /
+audit queries, do NOT use the resolution flow — use
+`memex_get_unit_history(unit_id)` for ordered chains, or
+`memex_memory_search(apply_pre_filter=False)` for broader audit. See
+`.claude/rules/memory-resolution-flow.md` for the full historical-routing rule.
+
 ## Capturing a learned procedure (procedure: KV namespace, F14)
 
 Some kinds of "remembering" are NOT a note — they are a compact, learned

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -88,6 +88,79 @@ class BriefingCache:
             self._ready.clear()
 
 
+_RESOLUTION_FLOW_PRIMER = """### When the user reports an issue resolved (§3.5 5-step flow)
+
+The 5-step flow turns a vague "X is fixed" into precise paired writes:
+
+1. **Disambiguate first.** If the scope is ambiguous — multiple candidate
+   notes, multiple candidate topics, or a topic that may span notes — ASK
+   before writing. Examples that warrant a clarification turn: "telegram
+   issues from yesterday" with three Telegram-mentioning notes; "the auth
+   bug we discussed" with no temporal anchor; "the issues are fixed" with
+   multiple distinct issues conflated.
+
+2. **Route by info quality.** Title-fragment known →
+   `memex_find_note(query="...")` (indexed, cheap). Title unknown, content
+   only → `memex_memory_search` (full pipeline, expensive but right). Then
+   pick a coverage path:
+   - **Option A — entity-anchored** (highest recall when topic ↔ entity):
+     `memex_list_entities(query="...")` → `memex_get_entity_mentions(entity_id=...)`.
+     Structural; no semantic-rank miss.
+   - **Option B — cross-note semantic** (no entity anchor):
+     `memex_memory_search(query="...", after="...", top_k=30)`. CRITICAL:
+     `top_k` must be **≥30** — the default 5 is too narrow.
+   - **Option C — single-note PageIndex traversal** (provably one note):
+     `memex_get_page_indices(note_id)` → pick fix-relevant chunk_ids →
+     `memex_get_memory_units(chunk_ids=[...])`. Captures every unit in the
+     chunk; semantic top-k can miss paraphrased mentions.
+
+3. **Mandatory LLM judgment over the candidate set.** READ the unit bodies
+   and judge which ones actually correspond to the user's claim. Memory
+   units are short (~1–3 sentences); reading does not blow up context. The
+   judgment cannot be skipped — daily-reflection notes contain episodic
+   observations ("worked on memex 3h today") that look superficially
+   relevant but are not fix-targets. NEVER bulk-write against the raw
+   candidate set.
+
+4. **+5. Paired writes against the LLM-judged-relevant subset only.** For
+   each unit the LLM judged relevant, issue BOTH writes:
+   `memex_record_outcome(unit_ids=[...], success=false, reason="...")` AND
+   `memex_memory_deprioritize(unit_id=..., reason="...")`. Same subset.
+
+**Orthogonal axes (MW is the gradient; deprioritize is the binary):**
+
+| Tool | Question it answers | Cardinality | Reversible? |
+|------|---------------------|-------------|-------------|
+| `memex_record_outcome(success=...)` | "Did this memory help when retrieved?" | Append-only counter | No (audit log) |
+| `memex_memory_deprioritize(reason)` | "Should this surface by default at all?" | Binary state | Yes (memory_restore) |
+
+User-confirmed-fix is BOTH signals at once. Don't collapse them into one
+combined call — keep the primitives orthogonal.
+
+**Imperfect recall is by design.** None of Options A/B/C give *provable*
+100% recall. F33 exploration is the safety net — units that slip past
+will re-surface, the user re-confirms, another `record_outcome(success=false)`
+compounds the MW penalty. User-driven resolution is a GRADIENT across many
+turns, not a one-shot delete.
+
+**Historical / audit-query routing rule (separate path).** When the user
+asks HOW THINGS CHANGED — "how has my view on X evolved", "what did I used
+to think about Y", "show me everything I believed about Z including the
+wrong stuff", or any of: "evolved", "used to", "history of", "what
+changed", "audit", "show me everything", "show me the hidden ones" — DO
+NOT use the resolution flow. Route differently:
+- Ordered chain on a specific unit → `memex_get_unit_history(unit_id)`
+  (graph walk through contradiction links, oldest → newest).
+- Broader audit / "show me everything including hidden stuff" →
+  `memex_memory_search(query="...", apply_pre_filter=False)` — bypasses
+  MW + FSFM + confidence pre-filters so contradicted, behaviorally-failed,
+  and decayed units appear. Post-reranker boosts still apply, so
+  contradicted units rank below clean ones — correct for audit queries.
+
+Disambiguation between resolution-flow and historical-routing is the
+agent's responsibility."""
+
+
 _STORAGE_MODEL_PRIMER = """### How Memex stores knowledge
 
 Three layers:
@@ -236,6 +309,7 @@ def format_briefing_block(
         lines.append(f'Project: `{project_id}` · **No vault bound to this project.**')
 
     lines.append('\n' + _STORAGE_MODEL_PRIMER)
+    lines.append('\n' + _RESOLUTION_FLOW_PRIMER)
 
     lines.append(
         f'\nSession note key: `{session_note_key}`. Use '

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
@@ -94,7 +94,7 @@ HISTORICAL_ROUTING_PROMPT_FRAGMENT = (
 )
 
 
-__all__ += [  # noqa: PLE0604 — extend the existing __all__ with F43 fragments
+__all__ += [
     'HISTORICAL_ROUTING_PROMPT_FRAGMENT',
     'RESOLUTION_FLOW_PROMPT_FRAGMENT',
 ]

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
@@ -46,3 +46,55 @@ DIAGNOSTICS_SUMMARY_PROMPT_FRAGMENT = (
     'cold), avg MW score, and top retrieved entities. Synchronous; surfaces '
     'F32 manifold status without waiting on UMAP compute.'
 )
+
+
+# --- F43 --- (5-step user-confirmed-fix resolution flow + historical routing)
+# Verb-pair scaffolding for Hermes turns that handle "the X is fixed" prompts.
+# A Hermes turn can lean on this structured prompt rather than free-form
+# generation — see briefing.py `_RESOLUTION_FLOW_PRIMER` for the canonical text
+# shown in the system prompt; this fragment is the same flow rendered as a
+# tool-call planning template.
+RESOLUTION_FLOW_PROMPT_FRAGMENT = (
+    'When the user reports an issue resolved (§3.5 5-step flow):\n'
+    '\n'
+    '  1. DISAMBIGUATE — if scope is ambiguous, ASK before writing.\n'
+    '  2. ROUTE — title-fragment → memex_find_note;\n'
+    '     content-only → memex_memory_search; then pick:\n'
+    '       (A) entity-anchored: memex_list_entities → memex_get_entity_mentions\n'
+    '       (B) cross-note semantic: memex_memory_search(top_k>=30, after=...)\n'
+    '       (C) single-note: memex_get_page_indices → memex_get_memory_units(chunk_ids=[...])\n'
+    '  3. JUDGE — read candidate unit bodies; LLM-pick the fix-relevant subset.\n'
+    '  4. RECORD — for each judged-relevant unit:\n'
+    "     memex_record_outcome(unit_ids=[...], success=False, reason='...')\n"
+    '  5. DEPRIORITIZE — for the SAME subset:\n'
+    "     memex_memory_deprioritize(unit_id=..., reason='...')\n"
+    '\n'
+    'BOTH writes (steps 4 + 5) against the SAME subset only — never bulk-write\n'
+    'against the raw candidate set. The two verbs are orthogonal axes:\n'
+    'record_outcome is the MW gradient (compounds across retrievals);\n'
+    'memory_deprioritize is the binary surface state (reversible via\n'
+    'memex_memory_restore). User-confirmed-fix is BOTH signals at once.'
+)
+
+
+# --- F43 --- (historical / audit-query routing rule)
+HISTORICAL_ROUTING_PROMPT_FRAGMENT = (
+    'When the user asks HOW THINGS CHANGED (not "what is true now"), do NOT\n'
+    'use the resolution flow. Triggers: "evolved", "used to", "history of",\n'
+    '"what changed", "what did I think before", "audit", "show me everything",\n'
+    '"show me the hidden ones".\n'
+    '\n'
+    '  - Ordered chain on a specific unit:\n'
+    '    `memex_get_unit_history(unit_id)` (F49) — graph walk through\n'
+    '    contradiction links, oldest → newest.\n'
+    '  - Broader audit / "show me everything including hidden stuff":\n'
+    "    `memex_memory_search(query='...', apply_pre_filter=False)` —\n"
+    '    bypasses MW + FSFM + confidence pre-filters; contradicted, decayed,\n'
+    '    and behaviorally-failed units appear. Post-reranker boosts still apply.'
+)
+
+
+__all__ += [  # noqa: PLE0604 — extend the existing __all__ with F43 fragments
+    'HISTORICAL_ROUTING_PROMPT_FRAGMENT',
+    'RESOLUTION_FLOW_PROMPT_FRAGMENT',
+]

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3423,7 +3423,16 @@ MEMORY_DEPRIORITIZE_SCHEMA: dict[str, Any] = {
         "Lower a memory unit's retrieval rank without deleting it (NON-DESTRUCTIVE). "
         'Use when a memory is misleading, outdated, or noise that contaminates retrieval. '
         'Companion to memex_memory_restore. Contrast with archive (destructive) — '
-        'prefer deprioritize unless the unit must leave the entity graph entirely.'
+        'prefer deprioritize unless the unit must leave the entity graph entirely. '
+        '\n\n'
+        'When the user reports an issue resolved, follow the §3.5 5-step flow '
+        '(see briefing): disambiguate first, route by info quality (Options A/B/C), '
+        'mandatory LLM judgment over candidates, then PAIRED writes — '
+        'memex_record_outcome(success=false) AND memex_memory_deprioritize against '
+        'the LLM-judged-relevant subset only. The two verbs are orthogonal axes '
+        '(MW gradient vs binary surface state); user-confirmed-fix is BOTH signals '
+        'at once. Imperfect cross-note recall is by design — F33 exploration is '
+        'the safety net.'
     ),
     'parameters': {
         'type': 'object',
@@ -3703,7 +3712,14 @@ RECORD_OUTCOME_SCHEMA: dict[str, Any] = {
         "unit_ids=[...]); set target_type='kv_key' with kv_key="
         "'procedure:<verb>:<context-tag>' to score a stored procedure. Call "
         'after you actually used the retrieved memory or the procedure.\n\n'
-        'Call generously. Silence provides no learning signal.'
+        'Call generously. Silence provides no learning signal.\n\n'
+        'When the user reports an issue resolved, follow the §3.5 5-step flow '
+        '(see briefing): disambiguate first, route by info quality (Options '
+        'A/B/C), mandatory LLM judgment over candidates, then PAIRED writes — '
+        'memex_record_outcome(success=false) AND memex_memory_deprioritize '
+        'against the LLM-judged-relevant subset only. The two verbs are '
+        'orthogonal axes (MW gradient vs binary surface state); user-confirmed-'
+        'fix is BOTH signals at once.'
     ),
     'parameters': {
         'type': 'object',

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3426,13 +3426,14 @@ MEMORY_DEPRIORITIZE_SCHEMA: dict[str, Any] = {
         'prefer deprioritize unless the unit must leave the entity graph entirely. '
         '\n\n'
         'When the user reports an issue resolved, follow the §3.5 5-step flow '
-        '(see briefing): disambiguate first, route by info quality (Options A/B/C), '
-        'mandatory LLM judgment over candidates, then PAIRED writes — '
-        'memex_record_outcome(success=false) AND memex_memory_deprioritize against '
-        'the LLM-judged-relevant subset only. The two verbs are orthogonal axes '
-        '(MW gradient vs binary surface state); user-confirmed-fix is BOTH signals '
-        'at once. Imperfect cross-note recall is by design — F33 exploration is '
-        'the safety net.'
+        '(see briefing): disambiguate first, route by info quality (Options A/B/C; '
+        'Option B requires top_k>=30), mandatory LLM judgment over candidates, then '
+        'PAIRED writes — memex_record_outcome(success=false) AND '
+        'memex_memory_deprioritize against the LLM-judged-relevant subset only. '
+        'The two verbs are orthogonal axes (MW gradient vs binary surface state); '
+        'user-confirmed-fix is BOTH signals at once. Imperfect cross-note recall is '
+        'by design — F33 exploration is the safety net. For HOW-THINGS-CHANGED '
+        'audit queries, route to memex_memory_search(apply_pre_filter=False) instead.'
     ),
     'parameters': {
         'type': 'object',
@@ -3715,11 +3716,14 @@ RECORD_OUTCOME_SCHEMA: dict[str, Any] = {
         'Call generously. Silence provides no learning signal.\n\n'
         'When the user reports an issue resolved, follow the §3.5 5-step flow '
         '(see briefing): disambiguate first, route by info quality (Options '
-        'A/B/C), mandatory LLM judgment over candidates, then PAIRED writes — '
-        'memex_record_outcome(success=false) AND memex_memory_deprioritize '
-        'against the LLM-judged-relevant subset only. The two verbs are '
-        'orthogonal axes (MW gradient vs binary surface state); user-confirmed-'
-        'fix is BOTH signals at once.'
+        'A/B/C; Option B requires top_k>=30), mandatory LLM judgment over '
+        'candidates, then PAIRED writes — memex_record_outcome(success=false) '
+        'AND memex_memory_deprioritize against the LLM-judged-relevant subset '
+        'only. The two verbs are orthogonal axes (MW gradient vs binary surface '
+        'state); user-confirmed-fix is BOTH signals at once. Imperfect '
+        'cross-note recall is by design — F33 exploration is the safety net. '
+        'For HOW-THINGS-CHANGED audit queries, route to '
+        'memex_memory_search(apply_pre_filter=False) instead.'
     ),
     'parameters': {
         'type': 'object',

--- a/packages/hermes-plugin/tests/test_briefing.py
+++ b/packages/hermes-plugin/tests/test_briefing.py
@@ -105,7 +105,12 @@ def test_format_block_skips_briefing_section_when_empty():
         session_note_key='k',
         kv_instructions_if_no_vault=False,
     )
-    assert '---' not in block
+    # F43 added the resolution-flow primer which uses markdown tables (the
+    # `|---|---|` row contains '---'). The intent of this test is "no
+    # briefing-section separator was appended" — that separator is the
+    # `\n---\n` literal added in format_briefing_block only when the
+    # `briefing` argument is non-empty.
+    assert '\n---\n' not in block
 
 
 # --- Routing-guide bullets (AC-087..AC-092) ---

--- a/packages/hermes-plugin/tests/test_briefing_f43_resolution_flow.py
+++ b/packages/hermes-plugin/tests/test_briefing_f43_resolution_flow.py
@@ -1,0 +1,106 @@
+"""F43 — Hermes briefing resolution-flow primer pinning.
+
+Asserts the Hermes session briefing carries the §3.5 5-step flow + §3.4.1
+axes table + §3.4.2 historical-routing rule. Pure string-contains; the
+matching ``@pytest.mark.llm``-driven verb-pair selection lives in
+``test_int_f43_briefing_llm.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memex_hermes_plugin.memex.briefing import (
+    _RESOLUTION_FLOW_PRIMER,
+    format_briefing_block,
+)
+from memex_hermes_plugin.memex.templates import (
+    HISTORICAL_ROUTING_PROMPT_FRAGMENT,
+    RESOLUTION_FLOW_PROMPT_FRAGMENT,
+)
+
+
+@pytest.mark.parametrize(
+    'kw',
+    [
+        '5-step flow',
+        'Disambiguate',
+        'memex_find_note',
+        'Option A',
+        'Option B',
+        'Option C',
+        '≥30',
+        'memex_get_memory_units',
+        'Mandatory LLM judgment',
+        'memex_record_outcome',
+        'memex_memory_deprioritize',
+        'F33',
+        'memex_get_unit_history',
+        'apply_pre_filter=False',
+        'evolved',
+        'used to',
+    ],
+)
+def test_resolution_flow_primer_includes_keyword(kw: str) -> None:
+    """The primer must mention each canonical §3.5 / §3.4.1 / §3.4.2 keyword."""
+    assert kw in _RESOLUTION_FLOW_PRIMER, (
+        f'Hermes resolution-flow primer is missing keyword {kw!r}. '
+        'See cognitive-memory-research-report.md §3.5 / §3.4.1 / §3.4.2.'
+    )
+
+
+def test_format_briefing_block_includes_resolution_flow_primer() -> None:
+    """The full briefing block (system prompt) embeds the primer."""
+    out = format_briefing_block(
+        briefing='',
+        vault_id='vault-x',
+        project_id='proj-x',
+        session_note_key='session:test',
+        kv_instructions_if_no_vault=False,
+    )
+    assert _RESOLUTION_FLOW_PRIMER in out, (
+        'format_briefing_block must include the resolution-flow primer alongside '
+        'the storage-model primer.'
+    )
+
+
+def test_resolution_flow_template_fragment_present() -> None:
+    """The verb-pair scaffolding template fragment carries the 5-step flow."""
+    assert 'DISAMBIGUATE' in RESOLUTION_FLOW_PROMPT_FRAGMENT
+    assert 'ROUTE' in RESOLUTION_FLOW_PROMPT_FRAGMENT
+    assert 'JUDGE' in RESOLUTION_FLOW_PROMPT_FRAGMENT
+    assert 'RECORD' in RESOLUTION_FLOW_PROMPT_FRAGMENT
+    assert 'DEPRIORITIZE' in RESOLUTION_FLOW_PROMPT_FRAGMENT
+    assert 'top_k>=30' in RESOLUTION_FLOW_PROMPT_FRAGMENT
+    assert 'memex_record_outcome' in RESOLUTION_FLOW_PROMPT_FRAGMENT
+    assert 'memex_memory_deprioritize' in RESOLUTION_FLOW_PROMPT_FRAGMENT
+
+
+def test_historical_routing_template_fragment_present() -> None:
+    """The historical-routing fragment names F49 + apply_pre_filter=False."""
+    assert 'memex_get_unit_history' in HISTORICAL_ROUTING_PROMPT_FRAGMENT
+    assert 'apply_pre_filter=False' in HISTORICAL_ROUTING_PROMPT_FRAGMENT
+    assert 'evolved' in HISTORICAL_ROUTING_PROMPT_FRAGMENT
+    assert 'audit' in HISTORICAL_ROUTING_PROMPT_FRAGMENT
+
+
+def test_hermes_record_outcome_schema_mentions_paired_writes() -> None:
+    """The Hermes record_outcome tool description references the paired-write rule."""
+    from memex_hermes_plugin.memex.tools import RECORD_OUTCOME_SCHEMA
+
+    desc = RECORD_OUTCOME_SCHEMA['description']
+    assert 'memex_memory_deprioritize' in desc, 'paired-write partner missing'
+    assert '5-step flow' in desc or 'PAIRED writes' in desc, (
+        'record_outcome schema should reference the §3.5 paired-write flow'
+    )
+
+
+def test_hermes_deprioritize_schema_mentions_paired_writes() -> None:
+    """The Hermes deprioritize tool description references the paired-write rule."""
+    from memex_hermes_plugin.memex.tools import MEMORY_DEPRIORITIZE_SCHEMA
+
+    desc = MEMORY_DEPRIORITIZE_SCHEMA['description']
+    assert 'memex_record_outcome' in desc, 'paired-write partner missing'
+    assert 'PAIRED writes' in desc or '5-step flow' in desc, (
+        'deprioritize schema should reference the §3.5 paired-write flow'
+    )

--- a/packages/hermes-plugin/tests/test_f43_cross_surface_parity.py
+++ b/packages/hermes-plugin/tests/test_f43_cross_surface_parity.py
@@ -21,8 +21,10 @@ from pathlib import Path
 
 import pytest
 
-from memex_hermes_plugin.memex.briefing import _RESOLUTION_FLOW_PRIMER
-from memex_mcp._f43_descriptions import (
+pytest.importorskip('memex_mcp')
+
+from memex_hermes_plugin.memex.briefing import _RESOLUTION_FLOW_PRIMER  # noqa: E402
+from memex_mcp._f43_descriptions import (  # noqa: E402
     MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
     MEMEX_RECORD_OUTCOME_DESCRIPTION,
 )

--- a/packages/hermes-plugin/tests/test_f43_cross_surface_parity.py
+++ b/packages/hermes-plugin/tests/test_f43_cross_surface_parity.py
@@ -1,11 +1,14 @@
 """F43 — cross-surface parity test.
 
-Asserts that the canonical §3.5 / §3.4.2 concepts appear in ALL THREE agent
+Asserts that the canonical §3.5 / §3.4.2 concepts appear in ALL FOUR agent
 surfaces:
 
   1. MCP tool descriptions (``memex_mcp._f43_descriptions``)
   2. Hermes session-briefing primer (``memex_hermes_plugin.memex.briefing``)
   3. Claude Code plugin rule (``packages/claude-code-plugin/rules/memory-resolution-flow.md``)
+  4. Hermes tool-schema descriptions (``memex_hermes_plugin.memex.tools``) —
+     concise paraphrase rendered as the LLM's tool-listing entries; required
+     so the verb-pair entries on Hermes match the briefing primer above.
 
 Per CLAUDE.md rule 24 (agent-surface parity): the resolution-flow guidance must
 not drift between surfaces. A failing assertion here indicates a real surface
@@ -24,6 +27,10 @@ import pytest
 pytest.importorskip('memex_mcp')
 
 from memex_hermes_plugin.memex.briefing import _RESOLUTION_FLOW_PRIMER  # noqa: E402
+from memex_hermes_plugin.memex.tools import (  # noqa: E402
+    MEMORY_DEPRIORITIZE_SCHEMA,
+    RECORD_OUTCOME_SCHEMA,
+)
 from memex_mcp._f43_descriptions import (  # noqa: E402
     MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
     MEMEX_RECORD_OUTCOME_DESCRIPTION,
@@ -35,18 +42,21 @@ _CC_RULE_PATH = (
 
 
 def _surfaces() -> dict[str, str]:
-    """Return the three surface texts keyed by surface name.
+    """Return the four surface texts keyed by surface name.
 
-    The MCP surface concatenates both descriptions because some concepts
-    naturally appear on only one of the two verbs in some phrasings — the
-    parity contract is "present somewhere in the verb pair", not "present
-    in each verb individually" (the per-verb parity is enforced by
-    test_f43_descriptions.py).
+    The MCP and Hermes-tools surfaces concatenate both descriptions because
+    some concepts naturally appear on only one of the two verbs in some
+    phrasings — the parity contract is "present somewhere in the verb pair",
+    not "present in each verb individually" (the per-verb parity is enforced
+    by test_f43_descriptions.py).
     """
     return {
         'mcp': MEMEX_RECORD_OUTCOME_DESCRIPTION + '\n' + MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
         'hermes': _RESOLUTION_FLOW_PRIMER,
         'claude_code': _CC_RULE_PATH.read_text(),
+        'hermes_tools': (
+            RECORD_OUTCOME_SCHEMA['description'] + '\n' + MEMORY_DEPRIORITIZE_SCHEMA['description']
+        ),
     }
 
 
@@ -54,10 +64,13 @@ def _surfaces() -> dict[str, str]:
 #   - mode='any': at least one phrasing must appear in the surface text.
 #   - mode='all': every phrasing must appear (used for paired concepts where
 #     both verbs / both phrases must co-occur).
+# The Hermes tool-schema surface uses a concise "Options A/B/C" shorthand for
+# the routing trio, so each per-letter concept accepts that shorthand as an
+# acceptable phrasing.
 _CONCEPTS: list[tuple[str, list[str], str]] = [
-    ('options_abc_a', ['Option A'], 'any'),
-    ('options_abc_b', ['Option B'], 'any'),
-    ('options_abc_c', ['Option C'], 'any'),
+    ('options_abc_a', ['Option A', 'Options A/B/C'], 'any'),
+    ('options_abc_b', ['Option B', 'Options A/B/C'], 'any'),
+    ('options_abc_c', ['Option C', 'Options A/B/C'], 'any'),
     (
         'top_k_at_least_30',
         ['top_k=30', 'top_k>=30', 'top_k >= 30', 'top_k must be ≥30', '`top_k` must be **≥30**'],
@@ -86,7 +99,7 @@ _CONCEPTS: list[tuple[str, list[str], str]] = [
     _CONCEPTS,
     ids=[c[0] for c in _CONCEPTS],
 )
-def test_concept_present_in_all_three_surfaces(
+def test_concept_present_in_all_surfaces(
     concept: str, phrase_options: list[str], mode: str
 ) -> None:
     """Every canonical concept must appear in every agent surface.

--- a/packages/hermes-plugin/tests/test_f43_cross_surface_parity.py
+++ b/packages/hermes-plugin/tests/test_f43_cross_surface_parity.py
@@ -1,0 +1,111 @@
+"""F43 — cross-surface parity test.
+
+Asserts that the canonical §3.5 / §3.4.2 concepts appear in ALL THREE agent
+surfaces:
+
+  1. MCP tool descriptions (``memex_mcp._f43_descriptions``)
+  2. Hermes session-briefing primer (``memex_hermes_plugin.memex.briefing``)
+  3. Claude Code plugin rule (``packages/claude-code-plugin/rules/memory-resolution-flow.md``)
+
+Per CLAUDE.md rule 24 (agent-surface parity): the resolution-flow guidance must
+not drift between surfaces. A failing assertion here indicates a real surface
+drift — fix the surface, do not relax the assertion.
+
+Source: cognitive-memory-research-report.md §3.5 + §3.4.1 + §3.4.2
+(added 2026-05-02).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memex_hermes_plugin.memex.briefing import _RESOLUTION_FLOW_PRIMER
+from memex_mcp._f43_descriptions import (
+    MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
+    MEMEX_RECORD_OUTCOME_DESCRIPTION,
+)
+
+_CC_RULE_PATH = (
+    Path(__file__).parents[2] / 'claude-code-plugin' / 'rules' / 'memory-resolution-flow.md'
+)
+
+
+def _surfaces() -> dict[str, str]:
+    """Return the three surface texts keyed by surface name.
+
+    The MCP surface concatenates both descriptions because some concepts
+    naturally appear on only one of the two verbs in some phrasings — the
+    parity contract is "present somewhere in the verb pair", not "present
+    in each verb individually" (the per-verb parity is enforced by
+    test_f43_descriptions.py).
+    """
+    return {
+        'mcp': MEMEX_RECORD_OUTCOME_DESCRIPTION + '\n' + MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
+        'hermes': _RESOLUTION_FLOW_PRIMER,
+        'claude_code': _CC_RULE_PATH.read_text(),
+    }
+
+
+# Each entry is (concept_id, list-of-acceptable-phrasings, mode).
+#   - mode='any': at least one phrasing must appear in the surface text.
+#   - mode='all': every phrasing must appear (used for paired concepts where
+#     both verbs / both phrases must co-occur).
+_CONCEPTS: list[tuple[str, list[str], str]] = [
+    ('options_abc_a', ['Option A'], 'any'),
+    ('options_abc_b', ['Option B'], 'any'),
+    ('options_abc_c', ['Option C'], 'any'),
+    (
+        'top_k_at_least_30',
+        ['top_k=30', 'top_k>=30', 'top_k >= 30', 'top_k must be ≥30', '`top_k` must be **≥30**'],
+        'any',
+    ),
+    (
+        'paired_writes',
+        ['memex_record_outcome', 'memex_memory_deprioritize'],
+        'all',
+    ),
+    (
+        'f33_safety_net',
+        ['F33 exploration is the safety net', 'F33 exploration', 'exploration safety net'],
+        'any',
+    ),
+    (
+        'apply_pre_filter_false',
+        ['apply_pre_filter=False', 'apply_pre_filter = False'],
+        'any',
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    'concept,phrase_options,mode',
+    _CONCEPTS,
+    ids=[c[0] for c in _CONCEPTS],
+)
+def test_concept_present_in_all_three_surfaces(
+    concept: str, phrase_options: list[str], mode: str
+) -> None:
+    """Every canonical concept must appear in every agent surface.
+
+    A failure here means a surface drifted from the §3.5 / §3.4.2 spec.
+    Update the offending surface; do NOT relax the assertion.
+    """
+    surfaces = _surfaces()
+    failures: list[str] = []
+    for surface_name, text in surfaces.items():
+        if mode == 'all':
+            missing = [p for p in phrase_options if p not in text]
+            if missing:
+                failures.append(f'{surface_name!r}: missing all-of phrases {missing!r}')
+        else:  # mode == 'any'
+            if not any(p in text for p in phrase_options):
+                failures.append(
+                    f'{surface_name!r}: none of the phrasings {phrase_options!r} appeared'
+                )
+    assert not failures, (
+        f'F43 cross-surface parity broke for concept {concept!r}:\n'
+        + '\n'.join('  - ' + f for f in failures)
+        + '\nSee cognitive-memory-research-report.md §3.5 + §3.4.1 + §3.4.2.'
+    )

--- a/packages/hermes-plugin/tests/test_int_f43_briefing_llm.py
+++ b/packages/hermes-plugin/tests/test_int_f43_briefing_llm.py
@@ -46,7 +46,18 @@ def _hermes_tools_with_routing() -> list[dict[str, Any]]:
     shorter than MCP's because the briefing teaches routing.
     """
 
-    def _tool(name: str, description: str, params: dict[str, Any]) -> dict[str, Any]:
+    def _tool(
+        name: str,
+        description: str,
+        params: dict[str, Any],
+        required: list[str] | None = None,
+    ) -> dict[str, Any]:
+        # The default `list(params.keys())[:1]` only marks the first parameter
+        # required, which is wrong for tools whose required set is multi-arg.
+        # Tools sourced from real schemas (RECORD_OUTCOME_SCHEMA etc.) use
+        # `parameters` directly and bypass this helper. For tools defined here,
+        # pass `required=` explicitly when the canonical required list is known
+        # (mirrors the MCP-side pattern in test_int_f43_resolution_flow_llm.py).
         return {
             'type': 'function',
             'function': {
@@ -55,7 +66,7 @@ def _hermes_tools_with_routing() -> list[dict[str, Any]]:
                 'parameters': {
                     'type': 'object',
                     'properties': params,
-                    'required': list(params.keys())[:1],
+                    'required': required if required is not None else list(params.keys())[:1],
                 },
             },
         }

--- a/packages/hermes-plugin/tests/test_int_f43_briefing_llm.py
+++ b/packages/hermes-plugin/tests/test_int_f43_briefing_llm.py
@@ -1,0 +1,357 @@
+"""F43 — Real-LLM golden tests against the Hermes briefing primer.
+
+Drives a real LLM agent turn ("Telegram notifications are now resolved") with
+the Hermes session-briefing system block in scope (which carries the
+``_RESOLUTION_FLOW_PRIMER`` + ``_STORAGE_MODEL_PRIMER`` per F43) and asserts
+the same canonical §3.5 Step 1-5 expectations as the MCP-side test.
+
+Skipped unless GEMINI_API_KEY / GOOGLE_API_KEY is set; uses the same model
+pinning as the rest of the repo's LLM-gated tests
+(gemini-3-flash-preview).
+
+Per CLAUDE.md (Markers): ``@pytest.mark.llm`` so the tests are gated out of
+the default CI lane.
+"""
+
+from __future__ import annotations
+
+import importlib.util as _ilu
+import json
+import os
+import uuid
+from typing import Any
+
+import pytest
+
+from memex_hermes_plugin.memex.briefing import format_briefing_block
+from memex_hermes_plugin.memex.tools import (
+    MEMORY_DEPRIORITIZE_SCHEMA,
+    RECORD_OUTCOME_SCHEMA,
+)
+
+_HAS_GEMINI_KEY = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+_HAS_LITELLM = _ilu.find_spec('litellm') is not None
+_SKIP_LLM_TESTS = bool(os.environ.get('SKIP_LLM_TESTS'))
+
+
+# ---------------------------------------------------------------------------
+# Hermes tool bundle — what a Hermes turn surfaces at the LLM.
+# ---------------------------------------------------------------------------
+
+
+def _hermes_tools_with_routing() -> list[dict[str, Any]]:
+    """Bundle Hermes record_outcome + deprioritize plus search/routing tools.
+
+    The Hermes briefing primer carries the §3.5 flow; tool descriptions are
+    shorter than MCP's because the briefing teaches routing.
+    """
+
+    def _tool(name: str, description: str, params: dict[str, Any]) -> dict[str, Any]:
+        return {
+            'type': 'function',
+            'function': {
+                'name': name,
+                'description': description,
+                'parameters': {
+                    'type': 'object',
+                    'properties': params,
+                    'required': list(params.keys())[:1],
+                },
+            },
+        }
+
+    return [
+        {
+            'type': 'function',
+            'function': {
+                'name': RECORD_OUTCOME_SCHEMA['name'],
+                'description': RECORD_OUTCOME_SCHEMA['description'],
+                'parameters': RECORD_OUTCOME_SCHEMA['parameters'],
+            },
+        },
+        {
+            'type': 'function',
+            'function': {
+                'name': MEMORY_DEPRIORITIZE_SCHEMA['name'],
+                'description': MEMORY_DEPRIORITIZE_SCHEMA['description'],
+                'parameters': MEMORY_DEPRIORITIZE_SCHEMA['parameters'],
+            },
+        },
+        _tool(
+            'memex_find_note',
+            'Find a note by title fragment.',
+            {'query': {'type': 'string'}},
+        ),
+        _tool(
+            'memex_memory_search',
+            'Cross-note semantic search; pass top_k to broaden the result window (default 5).',
+            {
+                'query': {'type': 'string'},
+                'top_k': {'type': 'integer'},
+                'after': {'type': 'string'},
+                'apply_pre_filter': {'type': 'boolean'},
+            },
+        ),
+        _tool(
+            'memex_list_entities',
+            'Search the entity graph by query string.',
+            {'query': {'type': 'string'}},
+        ),
+        _tool(
+            'memex_get_entity_mentions',
+            'Memory units mentioning the given entity.',
+            {'entity_id': {'type': 'string'}},
+        ),
+        _tool(
+            'memex_get_unit_history',
+            'Walk the contradiction graph backward (oldest -> newest).',
+            {'unit_id': {'type': 'string'}},
+        ),
+    ]
+
+
+def _briefing_system_message() -> str:
+    """The same system block Hermes injects at session start."""
+    return format_briefing_block(
+        briefing='',
+        vault_id='vault-test',
+        project_id='proj-test',
+        session_note_key='session:f43-llm-test',
+        kv_instructions_if_no_vault=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test (a) — disambiguate first.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llm
+@pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
+@pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
+@pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
+def test_hermes_briefing_drives_disambiguation_on_ambiguous_prompt() -> None:
+    import litellm
+
+    try:
+        resp = litellm.completion(
+            model='gemini/gemini-3-flash-preview',
+            messages=[
+                {'role': 'system', 'content': _briefing_system_message()},
+                {
+                    'role': 'system',
+                    'content': (
+                        'There are three reflection notes mentioning Telegram in the '
+                        'last week (cron output, briefing alerts, media bug). The user '
+                        'is making an ambiguous claim — apply the §3.5 Step 1 rule.'
+                    ),
+                },
+                {
+                    'role': 'user',
+                    'content': 'The Telegram notifications are now resolved.',
+                },
+            ],
+            tools=_hermes_tools_with_routing(),
+            tool_choice='auto',
+            temperature=0,
+            timeout=30,
+            api_key=os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'),
+        )
+    except Exception as exc:
+        if 'rate' in str(exc).lower() or '429' in str(exc):
+            pytest.skip(f'LLM rate-limited: {exc}')
+        raise
+
+    tool_calls = resp.choices[0].message.tool_calls or []
+    write_calls = [
+        tc
+        for tc in tool_calls
+        if tc.function.name in ('memex_record_outcome', 'memex_memory_deprioritize')
+    ]
+    assert not write_calls, (
+        f'agent issued a write ({[tc.function.name for tc in write_calls]}) on an '
+        'ambiguous prompt; Hermes briefing §3.5 Step 1 breach.'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test (b) — search before write when unit_ids are unknown.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llm
+@pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
+@pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
+@pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
+def test_hermes_briefing_drives_search_before_write() -> None:
+    import litellm
+
+    try:
+        resp = litellm.completion(
+            model='gemini/gemini-3-flash-preview',
+            messages=[
+                {'role': 'system', 'content': _briefing_system_message()},
+                {
+                    'role': 'system',
+                    'content': (
+                        'The user names a specific bug but you do NOT have unit_ids. '
+                        'Apply §3.5 Step 2 routing: title-fragment -> memex_find_note '
+                        'or content-only -> memex_memory_search BEFORE any write.'
+                    ),
+                },
+                {
+                    'role': 'user',
+                    'content': (
+                        "The Telegram media handler bug from yesterday's reflection is fixed."
+                    ),
+                },
+            ],
+            tools=_hermes_tools_with_routing(),
+            tool_choice='auto',
+            temperature=0,
+            timeout=30,
+            api_key=os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'),
+        )
+    except Exception as exc:
+        if 'rate' in str(exc).lower() or '429' in str(exc):
+            pytest.skip(f'LLM rate-limited: {exc}')
+        raise
+
+    tool_calls = resp.choices[0].message.tool_calls or []
+    assert tool_calls, f'no tool calls: {resp.choices[0].message!r}'
+    first = tool_calls[0].function.name
+    assert first in (
+        'memex_find_note',
+        'memex_memory_search',
+        'memex_list_entities',
+    ), f'agent first-called {first!r}; Hermes briefing §3.5 Step 2 breach.'
+    assert first not in (
+        'memex_record_outcome',
+        'memex_memory_deprioritize',
+    ), 'agent wrote before searching — Hermes §3.5 Step 2 breach.'
+
+
+# ---------------------------------------------------------------------------
+# Test (c) — Option B uses top_k >= 30.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llm
+@pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
+@pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
+@pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
+def test_hermes_briefing_option_b_uses_top_k_30() -> None:
+    import litellm
+
+    try:
+        resp = litellm.completion(
+            model='gemini/gemini-3-flash-preview',
+            messages=[
+                {'role': 'system', 'content': _briefing_system_message()},
+                {
+                    'role': 'system',
+                    'content': (
+                        'Use Option B (cross-note memex_memory_search) per the §3.5 '
+                        'flow. The briefing tells you top_k MUST be >= 30; the default '
+                        '5 is too narrow.'
+                    ),
+                },
+                {
+                    'role': 'user',
+                    'content': (
+                        'Run an Option-B cross-note search for "telegram media handler" '
+                        'with after="2026-04-22". Pick top_k correctly.'
+                    ),
+                },
+            ],
+            tools=_hermes_tools_with_routing(),
+            tool_choice='auto',
+            temperature=0,
+            timeout=30,
+            api_key=os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'),
+        )
+    except Exception as exc:
+        if 'rate' in str(exc).lower() or '429' in str(exc):
+            pytest.skip(f'LLM rate-limited: {exc}')
+        raise
+
+    tool_calls = resp.choices[0].message.tool_calls or []
+    search_calls = [tc for tc in tool_calls if tc.function.name == 'memex_memory_search']
+    assert search_calls, (
+        f'agent did not call memex_memory_search; calls: '
+        f'{[tc.function.name for tc in tool_calls]!r}'
+    )
+    args = json.loads(search_calls[0].function.arguments)
+    top_k = args.get('top_k')
+    assert isinstance(top_k, int) and top_k >= 30, (
+        f'agent set top_k={top_k!r}; Hermes briefing §3.5 Option B requires top_k>=30.'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test (d) — paired writes against the LLM-judged-relevant subset only.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llm
+@pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
+@pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
+@pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
+def test_hermes_briefing_paired_writes_against_subset() -> None:
+    import litellm
+
+    relevant_id = str(uuid.uuid4())
+    irrelevant_id = str(uuid.uuid4())
+    try:
+        resp = litellm.completion(
+            model='gemini/gemini-3-flash-preview',
+            messages=[
+                {'role': 'system', 'content': _briefing_system_message()},
+                {
+                    'role': 'system',
+                    'content': (
+                        'You have completed §3.5 Steps 1-3 and judged ONE unit '
+                        'relevant. Issue PAIRED writes (memex_record_outcome with '
+                        'success=false AND memex_memory_deprioritize) against ONLY '
+                        'that unit — never the irrelevant one.'
+                    ),
+                },
+                {
+                    'role': 'user',
+                    'content': (
+                        'Telegram media bug is fixed. Candidates after Step 3:\n'
+                        f'- {relevant_id}: "Telegram media handler crashes on .webp" '
+                        '(RELEVANT)\n'
+                        f'- {irrelevant_id}: "Worked on memex 3h today" (NOT RELEVANT)\n'
+                        'Issue paired writes for the relevant unit only.'
+                    ),
+                },
+            ],
+            tools=_hermes_tools_with_routing(),
+            tool_choice='auto',
+            temperature=0,
+            timeout=30,
+            api_key=os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'),
+        )
+    except Exception as exc:
+        if 'rate' in str(exc).lower() or '429' in str(exc):
+            pytest.skip(f'LLM rate-limited: {exc}')
+        raise
+
+    tool_calls = resp.choices[0].message.tool_calls or []
+    names = [tc.function.name for tc in tool_calls]
+
+    assert 'memex_record_outcome' in names, f'§3.5 Step 4 breach. Calls: {names!r}'
+    assert 'memex_memory_deprioritize' in names, f'§3.5 Step 5 breach. Calls: {names!r}'
+
+    for tc in tool_calls:
+        if tc.function.name not in ('memex_record_outcome', 'memex_memory_deprioritize'):
+            continue
+        args_str = tc.function.arguments
+        assert irrelevant_id not in args_str, (
+            f'agent wrote against the irrelevant unit; §3.5 Step 3 breach. '
+            f'Tool: {tc.function.name}, args: {args_str!r}'
+        )
+        assert relevant_id in args_str, (
+            f'agent did not target the relevant unit; tool: {tc.function.name}, args: {args_str!r}'
+        )

--- a/packages/hermes-plugin/tests/test_int_f43_briefing_llm.py
+++ b/packages/hermes-plugin/tests/test_int_f43_briefing_llm.py
@@ -9,6 +9,12 @@ Skipped unless GEMINI_API_KEY / GOOGLE_API_KEY is set; uses the same model
 pinning as the rest of the repo's LLM-gated tests
 (gemini-3-flash-preview).
 
+Note: Gemini's ``temperature=0`` is not strictly deterministic (the provider
+has an implicit minimum temperature and outputs can still vary across calls).
+Each test is wrapped with ``pytest.mark.flaky(reruns=2)`` so transient output
+drift does not red the suite; the assertions themselves are kept tool-name /
+numeric / UUID based so a one-off rephrasing does not falsely fail.
+
 Per CLAUDE.md (Markers): ``@pytest.mark.llm`` so the tests are gated out of
 the default CI lane.
 """
@@ -138,6 +144,7 @@ def _briefing_system_message() -> str:
 
 
 @pytest.mark.llm
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
 @pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
 @pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
@@ -191,6 +198,7 @@ def test_hermes_briefing_drives_disambiguation_on_ambiguous_prompt() -> None:
 
 
 @pytest.mark.llm
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
 @pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
 @pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
@@ -248,6 +256,7 @@ def test_hermes_briefing_drives_search_before_write() -> None:
 
 
 @pytest.mark.llm
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
 @pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
 @pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
@@ -305,6 +314,7 @@ def test_hermes_briefing_option_b_uses_top_k_30() -> None:
 
 
 @pytest.mark.llm
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
 @pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
 @pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')

--- a/packages/mcp/src/memex_mcp/_f1a_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_f1a_descriptions.py
@@ -18,5 +18,5 @@ MEMEX_RECORD_OUTCOME_DESCRIPTION = (
     'unit_ids=[...]); set target_type="kv_key" with kv_key='
     '"procedure:<verb>:<context-tag>" to score a stored procedure. Call '
     'after you actually used the retrieved memory or the procedure.\n\n'
-    'Call generously. Silence provides no learning signal.\n'
+    'Call generously. Silence provides no learning signal.'
 )

--- a/packages/mcp/src/memex_mcp/_f1a_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_f1a_descriptions.py
@@ -1,0 +1,22 @@
+"""Verbatim agent prompt text for F1a (record_outcome) tool.
+
+Sourced from cognitive-memory-research-report.md F1a (MW outcome verb). When
+the spec changes, the verbatim test fails — that is the contract.
+
+This is the canonical short description for ``memex_record_outcome``. F43
+imports it as a preamble before appending the §3.5 5-step flow + axes table
++ historical-routing rule, so a single source of truth governs both the
+standalone tool description and the F43-augmented composite.
+"""
+
+from __future__ import annotations
+
+MEMEX_RECORD_OUTCOME_DESCRIPTION = (
+    'Record whether previously retrieved memories or a stored procedure '
+    'contributed to a successful outcome. Default mode increments MW '
+    'counters on memory units (target_type="memory_unit", '
+    'unit_ids=[...]); set target_type="kv_key" with kv_key='
+    '"procedure:<verb>:<context-tag>" to score a stored procedure. Call '
+    'after you actually used the retrieved memory or the procedure.\n\n'
+    'Call generously. Silence provides no learning signal.\n'
+)

--- a/packages/mcp/src/memex_mcp/_f43_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_f43_descriptions.py
@@ -17,6 +17,10 @@ Both descriptions teach the same flow because both verbs participate in it.
 
 from __future__ import annotations
 
+from memex_mcp._f4_descriptions import (
+    MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION as _F4_DEPRIORITIZE_DESCRIPTION,
+)
+
 # ---------------------------------------------------------------------------
 # Shared section blocks (composed into both tool descriptions verbatim).
 # ---------------------------------------------------------------------------
@@ -184,21 +188,10 @@ MEMEX_RECORD_OUTCOME_DESCRIPTION = (
 # F4's deprioritize verb. The original short F4 description (kept as the
 # preamble so deprioritize discoverability for misleading/outdated/noise
 # units is unchanged) is followed by the same §3.5 flow + axes + history.
-_DEPRIORITIZE_PREAMBLE = (
-    "memory_deprioritize — Lower a memory unit's retrieval rank without deleting it.\n"
-    'Use when a memory is misleading, outdated, or noise that contaminates retrieval.\n'
-    '\n'
-    '- unit_id: the unit to deprioritize\n'
-    '- reason: brief text explanation (logged to maintenance ledger). Use this field\n'
-    '  liberally to capture WHY (e.g., "user confirmed issue fixed", "superseded by\n'
-    '  v2.3 release", "was wrong about deploy target"). Free text is sufficient — no\n'
-    '  enum needed.\n'
-    '\n'
-    'The unit remains accessible via include_deprioritized=true retrieval. To restore,\n'
-    'the user runs `memex memory restore <id>`. This is non-destructive — prefer it\n'
-    'over hard delete in almost all cases. Use sparingly: a small number of high-quality\n'
-    'deprioritizations is more valuable than aggressive pruning.\n'
-)
+# Imported from `_f4_descriptions` so there is a single source of truth; F4's
+# verbatim test (test_f4_tool_descriptions.py) pins the constant against the
+# spec, and F43 just appends a trailing newline for clean section separation.
+_DEPRIORITIZE_PREAMBLE = _F4_DEPRIORITIZE_DESCRIPTION + '\n'
 
 MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION = (
     _DEPRIORITIZE_PREAMBLE

--- a/packages/mcp/src/memex_mcp/_f43_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_f43_descriptions.py
@@ -158,10 +158,12 @@ _DO_NOT_ADD = (
 # `_f1a_descriptions` (single source of truth) so MW counter discoverability
 # stays in sync between the standalone tool description and the F43-augmented
 # composite. F1a's verbatim test pins the constant against the spec; F43
-# appends the §3.5 flow + axes table below it.
+# appends the §3.5 flow + axes table below it. The `\n\n` after the preamble
+# yields a blank line before the F43 section header — visually matches the
+# deprioritize sibling description (see `_DEPRIORITIZE_PREAMBLE` below).
 MEMEX_RECORD_OUTCOME_DESCRIPTION = (
     _RECORD_OUTCOME_PREAMBLE
-    + '\n'
+    + '\n\n'
     + '## When the user reports an issue resolved (§3.5 5-step flow)\n'
     + '\n'
     + _FLOW_HEADER

--- a/packages/mcp/src/memex_mcp/_f43_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_f43_descriptions.py
@@ -17,6 +17,9 @@ Both descriptions teach the same flow because both verbs participate in it.
 
 from __future__ import annotations
 
+from memex_mcp._f1a_descriptions import (
+    MEMEX_RECORD_OUTCOME_DESCRIPTION as _RECORD_OUTCOME_PREAMBLE,
+)
 from memex_mcp._f4_descriptions import (
     MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION as _F4_DEPRIORITIZE_DESCRIPTION,
 )
@@ -151,19 +154,11 @@ _DO_NOT_ADD = (
 # Composed tool descriptions (the strings the MCP server actually serves).
 # ---------------------------------------------------------------------------
 
-# F1a's outcome-recording verb. Original short docstring is preserved verbatim
-# at the top so MW counter discoverability is unchanged for non-resolution
-# call-sites; the §3.5 flow + axes table append below it.
-_RECORD_OUTCOME_PREAMBLE = (
-    'Record whether previously retrieved memories or a stored procedure '
-    'contributed to a successful outcome. Default mode increments MW '
-    'counters on memory units (target_type="memory_unit", '
-    'unit_ids=[...]); set target_type="kv_key" with kv_key='
-    '"procedure:<verb>:<context-tag>" to score a stored procedure. Call '
-    'after you actually used the retrieved memory or the procedure.\n\n'
-    'Call generously. Silence provides no learning signal.\n'
-)
-
+# F1a's outcome-recording verb. The original short docstring is imported from
+# `_f1a_descriptions` (single source of truth) so MW counter discoverability
+# stays in sync between the standalone tool description and the F43-augmented
+# composite. F1a's verbatim test pins the constant against the spec; F43
+# appends the §3.5 flow + axes table below it.
 MEMEX_RECORD_OUTCOME_DESCRIPTION = (
     _RECORD_OUTCOME_PREAMBLE
     + '\n'

--- a/packages/mcp/src/memex_mcp/_f43_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_f43_descriptions.py
@@ -1,0 +1,227 @@
+"""Verbatim agent prompt text for F43 — §3.5 5-step resolution flow + §3.4.2 historical routing.
+
+Sourced from cognitive-memory-research-report.md §3.5 ("User-driven memory
+resolution: how should agents invoke F4?") + §3.4.1 ("MW is the gradient;
+deprioritize is the binary") + §3.4.2 (historical-routing rule, added
+2026-05-02). When the spec changes, the verbatim test fails — that is the
+contract.
+
+Two surfaces touched:
+- ``MEMEX_RECORD_OUTCOME_DESCRIPTION`` — F1a's outcome verb, expanded with the
+  flow's step-by-step routing.
+- ``MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION`` — F4's binary verb, expanded with
+  the same flow + the orthogonal-axes table.
+
+Both descriptions teach the same flow because both verbs participate in it.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Shared section blocks (composed into both tool descriptions verbatim).
+# ---------------------------------------------------------------------------
+
+_FLOW_HEADER = (
+    'When the user reports an issue resolved ("the X bug is fixed", "we shipped\n'
+    'Y", "issue Z is no longer relevant"), follow the §3.5 5-step flow before\n'
+    'writing. Skipping any step (especially Step 1 disambiguation or Step 3 LLM\n'
+    'judgment) leads to bulk-writing irrelevant units.\n'
+)
+
+_FLOW_BODY = (
+    'Step 1 — Disambiguate first.\n'
+    '  If the scope is ambiguous (multiple candidate notes, multiple candidate\n'
+    '  topics, or a topic that may span notes), ASK before writing. Examples:\n'
+    "  'telegram issues from yesterday' when there are three reflection notes\n"
+    "  mentioning Telegram; 'the auth bug we discussed' with no temporal anchor;\n"
+    "  multiple distinct issues conflated into 'the issues are fixed'.\n"
+    '\n'
+    'Step 2 — Route by info quality and pick the cheapest path.\n'
+    '  Title-fragment known → `memex_find_note(query="…")` (indexed, cheap).\n'
+    '  Title unknown, content only → `memex_memory_search` (full pipeline,\n'
+    '  expensive but right when title-fragment lookup is unavailable). Then pick\n'
+    '  one of three coverage paths:\n'
+    '    Option A (entity-anchored, highest recall when topic ↔ entity):\n'
+    '      `memex_list_entities(query="…")` → `memex_get_entity_mentions(entity_id=…)`.\n'
+    '      Structural traversal; no semantic-rank miss.\n'
+    '    Option B (cross-note semantic, when no entity anchor):\n'
+    '      `memex_memory_search(query="…", after="…", top_k=30)`.\n'
+    '      CRITICAL: top_k must be ≥30 — the default 5 is too narrow and will\n'
+    '      miss cross-note matches.\n'
+    '    Option C (single-note PageIndex traversal, when scope is provably one note):\n'
+    '      `memex_get_page_indices(note_id)` → read chunk summaries → pick relevant\n'
+    '      chunks → `memex_get_memory_units(chunk_ids=[…])`. Captures every unit\n'
+    '      in the chunk; semantic top-k can miss paraphrased mentions.\n'
+    '\n'
+    'Step 3 — Mandatory LLM judgment over the candidate set.\n'
+    '  Whichever path returned candidates, READ the unit bodies and judge which\n'
+    "  ones actually correspond to the user's claim. Memory units are short by\n"
+    '  design (single fact / observation / event, ~1–3 sentences) — the search\n'
+    '  response IS the content; reading does not blow up context. The judgment\n'
+    '  CANNOT be skipped: a daily-reflection note contains episodic observations\n'
+    "  ('worked on memex 3h today') that look superficially relevant but are not\n"
+    '  fix-targets. NEVER bulk-write against the raw candidate set.\n'
+    '\n'
+    'Step 4+5 — Paired writes against the LLM-judged-relevant subset only.\n'
+    '  For each unit the LLM judged relevant, issue BOTH writes:\n'
+    '    `memex_record_outcome(unit_ids=[…], success=false, reason="…")` AND\n'
+    '    `memex_memory_deprioritize(unit_id=…, reason="…")`.\n'
+    '  Both, against the SAME subset. The two verbs are orthogonal axes — see\n'
+    '  the table below — and the user-confirmed-fix flow is BOTH signals at once\n'
+    '  (negative-usefulness + binary verdict to stop surfacing).\n'
+)
+
+_AXES_TABLE = (
+    'Orthogonal axes (verbatim from §3.4.1 — MW is the gradient; deprioritize is\n'
+    'the binary). The two verbs answer different questions; keep them separate:\n'
+    '\n'
+    '  | Tool                   | Question it answers           | Cardinality                | Reversible? |\n'
+    '  |------------------------|-------------------------------|----------------------------|-------------|\n'
+    '  | `memex_record_outcome` | "Did this memory help when    | Append-only counter        | No          |\n'
+    '  |   (success=…)          |  retrieved?"                  | (compounds across retrievals)| (audit log) |\n'
+    '  | `memex_memory_         | "Should this surface by       | Binary state on the unit   | Yes         |\n'
+    '  |   deprioritize`        |  default at all?"             |                            | (memory_restore) |\n'
+    '\n'
+    '  - outcome=false but no deprioritize: gradient signal only — let MW\n'
+    '    compound; perhaps a different query still legitimately wants this unit.\n'
+    '  - deprioritize but no outcome: verdict without judging past usefulness\n'
+    "    (e.g., 'correct when written but no longer relevant').\n"
+    '  - BOTH (the resolved-issue case): negative-usefulness AND binary verdict.\n'
+)
+
+_IMPERFECT_RECALL = (
+    'Imperfect recall is BY DESIGN. None of Options A/B/C give *provable* 100%\n'
+    'recall on cross-note resolution. Semantic search misses paraphrases; entity\n'
+    'traversal misses oblique references; chunk-scoped reads miss issues split\n'
+    'across chunks. This is fine — F33 exploration is the safety net. Any unit\n'
+    'that slipped past resolution will occasionally re-surface; the user re-\n'
+    'confirms; another `record_outcome(success=false)` compounds the MW penalty.\n'
+    'User-driven resolution is a GRADIENT across many turns, NOT a one-shot delete.\n'
+)
+
+_HISTORICAL_ROUTING = (
+    'Historical / audit-query routing rule (separate path from the resolution\n'
+    'flow above). The 5-step flow assumes the user is asking "what is true *now*".\n'
+    'For queries about HOW THINGS CHANGED — "how has my view on X evolved", "what\n'
+    'did I used to think about Y", "show me everything I believed about Z\n'
+    'including the wrong stuff" — route differently:\n'
+    '  - Ordered-chain timeline on a specific unit:\n'
+    '      `memex_get_unit_history(unit_id)` (F49) — graph walk through\n'
+    '      contradiction links, oldest → newest. Cleaner than ranked search.\n'
+    '  - Broader audit / "show me everything including hidden stuff":\n'
+    '      `memex_memory_search(query="…", apply_pre_filter=False)` — bypasses\n'
+    '      F40+F48 (MW + FSFM + confidence pre-filters) so contradicted,\n'
+    '      behaviorally-failed, and decayed units appear. Post-reranker boosts\n'
+    '      (F47 confidence_boost, F1c MW) still apply, so contradicted units\n'
+    '      rank below clean ones — which is correct for audit queries.\n'
+    '\n'
+    'Disambiguation triggers the agent should learn (any of these → use the\n'
+    'historical routing rule, NOT the resolution flow): "evolved", "used to",\n'
+    '"history of", "what changed", "what did I think before", "audit",\n'
+    '"show me everything", "show me the hidden ones", explicit time-window-\n'
+    'with-no-filter intent.\n'
+    '\n'
+    'When the user says "the X issue is resolved" → resolution flow (Steps 1–5).\n'
+    'When the user says "how has my position on X changed" → historical routing.\n'
+    "Disambiguation is the agent's responsibility.\n"
+)
+
+_DO_NOT_ADD = (
+    'Things this flow DOES NOT need (codified to resist scope creep — do NOT\n'
+    'request these as new endpoints or parameters; the existing primitives are\n'
+    'sufficient):\n'
+    '  - A combined `memex_resolve(unit_ids, reason)` endpoint. Hides the\n'
+    '    orthogonal axes. Compose at the agent layer.\n'
+    '  - A `resolved_at` timestamp column. The maintenance ledger already\n'
+    "    records when deprioritize fired; the note's `created_at` anchors the\n"
+    '    original observation.\n'
+    '  - A `resolution_type` enum on deprioritize. Free text in `reason`\n'
+    '    captures the same information without committing to a closed taxonomy.\n'
+    '  - A `bulk-by-source` parameter on deprioritize. Agents iterate.\n'
+    '  - Note-level deprioritize. Notes are episodic anchors; deprioritization\n'
+    '    applies to the derived units, not the source notes.\n'
+)
+
+
+# ---------------------------------------------------------------------------
+# Composed tool descriptions (the strings the MCP server actually serves).
+# ---------------------------------------------------------------------------
+
+# F1a's outcome-recording verb. Original short docstring is preserved verbatim
+# at the top so MW counter discoverability is unchanged for non-resolution
+# call-sites; the §3.5 flow + axes table append below it.
+_RECORD_OUTCOME_PREAMBLE = (
+    'Record whether previously retrieved memories or a stored procedure '
+    'contributed to a successful outcome. Default mode increments MW '
+    'counters on memory units (target_type="memory_unit", '
+    'unit_ids=[...]); set target_type="kv_key" with kv_key='
+    '"procedure:<verb>:<context-tag>" to score a stored procedure. Call '
+    'after you actually used the retrieved memory or the procedure.\n\n'
+    'Call generously. Silence provides no learning signal.\n'
+)
+
+MEMEX_RECORD_OUTCOME_DESCRIPTION = (
+    _RECORD_OUTCOME_PREAMBLE
+    + '\n'
+    + '## When the user reports an issue resolved (§3.5 5-step flow)\n'
+    + '\n'
+    + _FLOW_HEADER
+    + '\n'
+    + _FLOW_BODY
+    + '\n'
+    + _AXES_TABLE
+    + '\n'
+    + _IMPERFECT_RECALL
+    + '\n'
+    + '## Historical-routing rule (§3.4.2)\n'
+    + '\n'
+    + _HISTORICAL_ROUTING
+    + '\n'
+    + _DO_NOT_ADD
+)
+
+
+# F4's deprioritize verb. The original short F4 description (kept as the
+# preamble so deprioritize discoverability for misleading/outdated/noise
+# units is unchanged) is followed by the same §3.5 flow + axes + history.
+_DEPRIORITIZE_PREAMBLE = (
+    "memory_deprioritize — Lower a memory unit's retrieval rank without deleting it.\n"
+    'Use when a memory is misleading, outdated, or noise that contaminates retrieval.\n'
+    '\n'
+    '- unit_id: the unit to deprioritize\n'
+    '- reason: brief text explanation (logged to maintenance ledger). Use this field\n'
+    '  liberally to capture WHY (e.g., "user confirmed issue fixed", "superseded by\n'
+    '  v2.3 release", "was wrong about deploy target"). Free text is sufficient — no\n'
+    '  enum needed.\n'
+    '\n'
+    'The unit remains accessible via include_deprioritized=true retrieval. To restore,\n'
+    'the user runs `memex memory restore <id>`. This is non-destructive — prefer it\n'
+    'over hard delete in almost all cases. Use sparingly: a small number of high-quality\n'
+    'deprioritizations is more valuable than aggressive pruning.\n'
+)
+
+MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION = (
+    _DEPRIORITIZE_PREAMBLE
+    + '\n'
+    + '## When the user reports an issue resolved (§3.5 5-step flow)\n'
+    + '\n'
+    + _FLOW_HEADER
+    + '\n'
+    + _FLOW_BODY
+    + '\n'
+    + _AXES_TABLE
+    + '\n'
+    + _IMPERFECT_RECALL
+    + '\n'
+    + '## Historical-routing rule (§3.4.2)\n'
+    + '\n'
+    + _HISTORICAL_ROUTING
+    + '\n'
+    + _DO_NOT_ADD
+)
+
+
+__all__ = [
+    'MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION',
+    'MEMEX_RECORD_OUTCOME_DESCRIPTION',
+]

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3676,17 +3676,15 @@ async def memex_get_vault_summary(
         raise ToolError(f'Get vault summary failed: {e}')
 
 
+from memex_mcp._f43_descriptions import (
+    MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION as _F43_MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
+    MEMEX_RECORD_OUTCOME_DESCRIPTION as _F43_MEMEX_RECORD_OUTCOME_DESCRIPTION,
+)
+
+
 @mcp.tool(
     name='memex_record_outcome',
-    description=(
-        'Record whether previously retrieved memories or a stored procedure '
-        'contributed to a successful outcome. Default mode increments MW '
-        'counters on memory units (target_type="memory_unit", '
-        'unit_ids=[...]); set target_type="kv_key" with kv_key='
-        '"procedure:<verb>:<context-tag>" to score a stored procedure. Call '
-        'after you actually used the retrieved memory or the procedure.\n\n'
-        'Call generously. Silence provides no learning signal.'
-    ),
+    description=_F43_MEMEX_RECORD_OUTCOME_DESCRIPTION,
     tags={'write'},
     annotations={'readOnlyHint': False},
 )
@@ -3813,14 +3811,13 @@ if __name__ == '__main__':
 # --- F4 ---  (filled by WS-quick-wins)
 
 from memex_mcp._f4_descriptions import (
-    MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
     MEMEX_MEMORY_RESTORE_DESCRIPTION,
 )
 
 
 @mcp.tool(
     name='memex_memory_deprioritize',
-    description=MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
+    description=_F43_MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
     tags={'write', 'storage'},
     annotations={'readOnlyHint': False, 'destructiveHint': False, 'idempotentHint': True},
     timeout=30.0,

--- a/packages/mcp/tests/test_f43_descriptions.py
+++ b/packages/mcp/tests/test_f43_descriptions.py
@@ -1,0 +1,170 @@
+"""F43 — MCP tool description content pinning.
+
+Asserts that the F43 §3.5 5-step flow + §3.4.1 axes table + §3.4.2 historical
+routing rule are present verbatim in the registered descriptions of
+``memex_record_outcome`` and ``memex_memory_deprioritize``. Per CLAUDE.md
+rule 24 (agent-surface parity), the MCP layer is the primary surface.
+
+When the spec changes, these assertions fail — that is the contract.
+Source: cognitive-memory-research-report.md §3.5 + §3.4.1 + §3.4.2 (added
+2026-05-02).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memex_mcp._f43_descriptions import (
+    MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
+    MEMEX_RECORD_OUTCOME_DESCRIPTION,
+)
+
+
+# ---------------------------------------------------------------------------
+# Required content checkpoints — sourced from spec §3.5 worked example.
+# ---------------------------------------------------------------------------
+
+# Step 1 disambiguation (§3.5 Step 1).
+_S1_KEYWORDS = ('Disambiguate', 'ASK before writing')
+
+# Step 2 routing — must teach Options A/B/C and the top_k>=30 rule.
+_S2_KEYWORDS = (
+    'memex_find_note',
+    'memex_memory_search',
+    'Option A',
+    'Option B',
+    'Option C',
+    'memex_list_entities',
+    'memex_get_entity_mentions',
+    'memex_get_page_indices',
+    'memex_get_memory_units',
+    'top_k must be ≥30',
+)
+
+# Step 3 mandatory LLM judgment.
+_S3_KEYWORDS = ('Mandatory LLM judgment', 'NEVER bulk-write')
+
+# Steps 4+5 paired writes.
+_S45_KEYWORDS = (
+    'memex_record_outcome',
+    'memex_memory_deprioritize',
+    'SAME subset',
+)
+
+# Imperfect-recall framing + F33 safety net.
+_IMPERFECT_KEYWORDS = (
+    'Imperfect recall',
+    'F33',
+    'GRADIENT',
+)
+
+# Orthogonal-axes table from §3.4.1.
+_AXES_KEYWORDS = (
+    'orthogonal axes',
+    'MW is the gradient',
+    'binary',
+    'Append-only counter',
+    'memory_restore',
+)
+
+# Historical / audit-query routing rule (§3.4.2).
+_HISTORICAL_KEYWORDS = (
+    'memex_get_unit_history',
+    'apply_pre_filter=False',
+    'evolved',
+    'used to',
+    'history of',
+    'audit',
+    'show me everything',
+)
+
+# What is NOT a gap — codified scope-creep blockers.
+_DO_NOT_ADD_KEYWORDS = (
+    'memex_resolve',
+    'resolved_at',
+    'resolution_type',
+    'bulk-by-source',
+    'Note-level deprioritize',
+)
+
+
+def _assert_all_present(text: str, keywords: tuple[str, ...], section: str) -> None:
+    missing = [kw for kw in keywords if kw not in text]
+    assert not missing, (
+        f'F43 description is missing {section} keywords: {missing!r}.\n'
+        'See cognitive-memory-research-report.md §3.5 + §3.4.1 + §3.4.2.'
+    )
+
+
+@pytest.mark.parametrize(
+    'description',
+    [MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION, MEMEX_RECORD_OUTCOME_DESCRIPTION],
+    ids=['deprioritize', 'record_outcome'],
+)
+def test_description_includes_5_step_flow(description: str) -> None:
+    _assert_all_present(description, _S1_KEYWORDS, 'Step 1 (disambiguate)')
+    _assert_all_present(description, _S2_KEYWORDS, 'Step 2 (routing + Options A/B/C)')
+    _assert_all_present(description, _S3_KEYWORDS, 'Step 3 (mandatory LLM judgment)')
+    _assert_all_present(description, _S45_KEYWORDS, 'Steps 4+5 (paired writes)')
+
+
+@pytest.mark.parametrize(
+    'description',
+    [MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION, MEMEX_RECORD_OUTCOME_DESCRIPTION],
+    ids=['deprioritize', 'record_outcome'],
+)
+def test_description_includes_imperfect_recall_framing(description: str) -> None:
+    _assert_all_present(description, _IMPERFECT_KEYWORDS, 'imperfect-recall framing')
+
+
+@pytest.mark.parametrize(
+    'description',
+    [MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION, MEMEX_RECORD_OUTCOME_DESCRIPTION],
+    ids=['deprioritize', 'record_outcome'],
+)
+def test_description_includes_axes_table(description: str) -> None:
+    _assert_all_present(description, _AXES_KEYWORDS, 'orthogonal-axes table')
+
+
+@pytest.mark.parametrize(
+    'description',
+    [MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION, MEMEX_RECORD_OUTCOME_DESCRIPTION],
+    ids=['deprioritize', 'record_outcome'],
+)
+def test_description_includes_historical_routing(description: str) -> None:
+    _assert_all_present(description, _HISTORICAL_KEYWORDS, 'historical-routing rule')
+
+
+@pytest.mark.parametrize(
+    'description',
+    [MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION, MEMEX_RECORD_OUTCOME_DESCRIPTION],
+    ids=['deprioritize', 'record_outcome'],
+)
+def test_description_codifies_do_not_add_list(description: str) -> None:
+    _assert_all_present(description, _DO_NOT_ADD_KEYWORDS, 'do-NOT-add list')
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_tool_registered_with_f43_description() -> None:
+    """The MCP server registers memex_record_outcome with the F43 description."""
+    from memex_mcp.server import mcp
+
+    tool = await mcp.get_tool('memex_record_outcome')
+    assert tool is not None, 'memex_record_outcome tool not registered'
+    assert tool.description == MEMEX_RECORD_OUTCOME_DESCRIPTION, (
+        'memex_record_outcome registered description does not match the F43 '
+        'description constant. Check server.py wiring.'
+    )
+
+
+@pytest.mark.asyncio
+async def test_deprioritize_tool_registered_with_f43_description() -> None:
+    """The MCP server registers memex_memory_deprioritize with the F43 description."""
+    from memex_mcp.server import mcp
+
+    tool = await mcp.get_tool('memex_memory_deprioritize')
+    assert tool is not None, 'memex_memory_deprioritize tool not registered'
+    assert tool.description == MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION, (
+        'memex_memory_deprioritize registered description does not match the F43 '
+        'description constant. Check server.py wiring.'
+    )

--- a/packages/mcp/tests/test_f43_sequencing_gate.py
+++ b/packages/mcp/tests/test_f43_sequencing_gate.py
@@ -1,0 +1,40 @@
+"""F43 — Pre-merge sequencing-gate tests.
+
+Per BACKLOG line 116: F43's PR CI MUST verify that:
+  (a) `apply_pre_filter` is a valid parameter on `RetrievalRequest` (F40).
+  (b) `memex_get_unit_history` is a registered MCP tool (F49).
+
+These two trivial assertions catch the sequencing failure (F40 / F49 not yet
+on base) before the F43 real-LLM golden tests fail for the wrong reason.
+
+This is round-6 LOW deferral test sourced verbatim from the spec.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_apply_pre_filter_exists_on_retrieval_request():
+    """F40 must be on the base branch — pre-filter parameter on retrieval."""
+    from memex_common.schemas import RetrievalRequest
+
+    has_attr = hasattr(RetrievalRequest, 'apply_pre_filter')
+    in_fields = 'apply_pre_filter' in getattr(RetrievalRequest, 'model_fields', {})
+    assert has_attr or in_fields, (
+        'F40 (apply_pre_filter on RetrievalRequest) is not on the base branch. '
+        'F43 sequencing-gate failed: ship F40 first.'
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_unit_history_tool_registered():
+    """F49 must be on the base branch — graph-walk timeline tool registered."""
+    from memex_mcp.server import mcp
+
+    tools = await mcp._list_tools()
+    tool_names = [t.name for t in tools]
+    assert 'memex_get_unit_history' in tool_names, (
+        'F49 (memex_get_unit_history MCP tool) is not registered on the base branch. '
+        f'F43 sequencing-gate failed: ship F49 first. Registered tools: {sorted(tool_names)[:10]}...'
+    )

--- a/packages/mcp/tests/test_f43_sequencing_gate.py
+++ b/packages/mcp/tests/test_f43_sequencing_gate.py
@@ -32,9 +32,14 @@ async def test_get_unit_history_tool_registered():
     """F49 must be on the base branch — graph-walk timeline tool registered."""
     from memex_mcp.server import mcp
 
-    tools = await mcp._list_tools()
-    tool_names = [t.name for t in tools]
-    assert 'memex_get_unit_history' in tool_names, (
+    # Use the public ``get_tool`` API rather than ``list_tools``: the latter is
+    # filtered by the DiscoveryMode transform under progressive disclosure
+    # (auto-applied in this package's conftest), so it would only show the
+    # discovery surface (memex_tags / memex_search / memex_get_schema).
+    # ``get_tool`` returns the registered Tool object regardless of transforms,
+    # which is the right semantics for "is this tool registered?".
+    tool = await mcp.get_tool('memex_get_unit_history')
+    assert tool is not None and tool.name == 'memex_get_unit_history', (
         'F49 (memex_get_unit_history MCP tool) is not registered on the base branch. '
-        f'F43 sequencing-gate failed: ship F49 first. Registered tools: {sorted(tool_names)[:10]}...'
+        'F43 sequencing-gate failed: ship F49 first.'
     )

--- a/packages/mcp/tests/test_f4_tool_descriptions.py
+++ b/packages/mcp/tests/test_f4_tool_descriptions.py
@@ -44,13 +44,24 @@ def test_deprioritize_description_constant_matches_spec_verbatim():
 
 
 @pytest.mark.asyncio
-async def test_mcp_tool_registered_with_verbatim_description():
-    """The MCP tool registry surfaces the verbatim description."""
+async def test_mcp_tool_registered_with_verbatim_description_preamble():
+    """The MCP tool description starts with the F4 verbatim preamble.
+
+    F43 (cognitive-memory-research-report.md §3.5 + §3.4.2) extends the
+    deprioritize description with the 5-step user-confirmed-fix flow + the
+    historical-routing rule. The original F4 verbatim description is kept as
+    the preamble so the curate-memory-after-the-fact discoverability is
+    unchanged. The full description is asserted by F43's verbatim test
+    (test_f43_descriptions.py).
+    """
     from memex_mcp.server import mcp
 
     tool = await mcp.get_tool('memex_memory_deprioritize')
     assert tool is not None, 'memex_memory_deprioritize tool not registered'
-    assert tool.description == F4_DESCRIPTION_VERBATIM
+    assert tool.description.startswith(F4_DESCRIPTION_VERBATIM), (
+        'Registered description must start with the F4 verbatim preamble '
+        '(§4 F4 step 6); F43 may append additional sections after it.'
+    )
 
 
 @pytest.mark.asyncio

--- a/packages/mcp/tests/test_int_f43_resolution_flow_llm.py
+++ b/packages/mcp/tests/test_int_f43_resolution_flow_llm.py
@@ -1,0 +1,410 @@
+"""F43 — Real-LLM golden tests against the MCP tool descriptions.
+
+Drives a real LLM agent turn ("Telegram notifications are now resolved") with
+the F43 ``memex_record_outcome`` and ``memex_memory_deprioritize`` descriptions
+in scope and asserts the canonical §3.5 5-step flow expectations:
+
+  (a) Agent disambiguates first when scope is ambiguous.
+  (b) Agent calls ``memex_find_note`` (or ``memex_memory_search``) BEFORE any
+      write when the candidate set is unknown.
+  (c) For cross-note scope using Option B, top_k is set to >=30.
+  (d) Paired writes: ``memex_record_outcome(success=False)`` AND
+      ``memex_memory_deprioritize`` are issued, and only against the
+      LLM-judged-relevant subset (not every candidate).
+
+Each assertion has a 30s per-call timeout per round-6 LOW deferral.
+Skipped unless GEMINI_API_KEY / GOOGLE_API_KEY is set; uses the same model
+pinning as the rest of the repo's LLM-gated tests
+(gemini-3-flash-preview).
+
+Per CLAUDE.md (Markers): ``@pytest.mark.llm`` so the tests are gated out of
+the default CI lane.
+"""
+
+from __future__ import annotations
+
+import importlib.util as _ilu
+import json
+import os
+import uuid
+from typing import Any
+
+import pytest
+
+from memex_mcp._f43_descriptions import (
+    MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
+    MEMEX_RECORD_OUTCOME_DESCRIPTION,
+)
+
+_HAS_GEMINI_KEY = bool(os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'))
+_HAS_LITELLM = _ilu.find_spec('litellm') is not None
+_SKIP_LLM_TESTS = bool(os.environ.get('SKIP_LLM_TESTS'))
+
+
+# ---------------------------------------------------------------------------
+# Tool-schema bundle — what the LLM sees as the available tool set.
+# ---------------------------------------------------------------------------
+
+
+def _f43_tool_set() -> list[dict[str, Any]]:
+    """Bundle the tools the F43 flow can pick from.
+
+    Includes the pair under test (record_outcome + deprioritize) plus the
+    routing tools (find_note, memory_search, list_entities,
+    get_entity_mentions, get_page_indices, get_memory_units, get_unit_history)
+    so the model has to actually pick by description, not by lonely-verb-in-list.
+    """
+
+    def _tool(name: str, description: str, params: dict[str, Any]) -> dict[str, Any]:
+        return {
+            'type': 'function',
+            'function': {
+                'name': name,
+                'description': description,
+                'parameters': {
+                    'type': 'object',
+                    'properties': params,
+                    'required': list(params.keys())[:1],  # keep schemas valid
+                },
+            },
+        }
+
+    return [
+        _tool(
+            'memex_record_outcome',
+            MEMEX_RECORD_OUTCOME_DESCRIPTION,
+            {
+                'success': {'type': 'boolean'},
+                'unit_ids': {'type': 'array', 'items': {'type': 'string'}},
+                'reason': {'type': 'string'},
+            },
+        ),
+        _tool(
+            'memex_memory_deprioritize',
+            MEMEX_MEMORY_DEPRIORITIZE_DESCRIPTION,
+            {
+                'unit_id': {'type': 'string'},
+                'reason': {'type': 'string'},
+            },
+        ),
+        _tool(
+            'memex_find_note',
+            'Find a note by title fragment (indexed, cheap).',
+            {'query': {'type': 'string'}},
+        ),
+        _tool(
+            'memex_memory_search',
+            'Cross-note semantic search over memory units. Pass top_k to '
+            'broaden the result window (default 5).',
+            {
+                'query': {'type': 'string'},
+                'top_k': {'type': 'integer'},
+                'after': {'type': 'string'},
+                'apply_pre_filter': {'type': 'boolean'},
+            },
+        ),
+        _tool(
+            'memex_list_entities',
+            'Search the entity graph by query string.',
+            {'query': {'type': 'string'}},
+        ),
+        _tool(
+            'memex_get_entity_mentions',
+            'Return every memory unit mentioning the given entity.',
+            {'entity_id': {'type': 'string'}},
+        ),
+        _tool(
+            'memex_get_page_indices',
+            'Return chunk-level layout summary for a single note.',
+            {'note_id': {'type': 'string'}},
+        ),
+        _tool(
+            'memex_get_memory_units',
+            'Hydrate memory units by unit_ids OR chunk_ids.',
+            {
+                'unit_ids': {'type': 'array', 'items': {'type': 'string'}},
+                'chunk_ids': {'type': 'array', 'items': {'type': 'string'}},
+            },
+        ),
+        _tool(
+            'memex_get_unit_history',
+            'Walk the contradiction graph backward from a unit (oldest -> newest).',
+            {'unit_id': {'type': 'string'}},
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Test (a) — agent disambiguates first when scope is ambiguous.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llm
+@pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
+@pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
+@pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
+def test_ambiguous_resolution_prompts_clarification_before_write() -> None:
+    """Step 1 — disambiguate first.
+
+    Given an ambiguous prompt ("Telegram notifications are now resolved" — could
+    be the reflection cron, the briefing alerts, or the media-handling bug),
+    the agent should ASK before issuing any write.
+    """
+    import litellm
+
+    try:
+        resp = litellm.completion(
+            model='gemini/gemini-3-flash-preview',
+            messages=[
+                {
+                    'role': 'system',
+                    'content': (
+                        'You are an agent integrated with Memex. You have several '
+                        'reflection notes mentioning Telegram in the last week:\n'
+                        '- "Daily reflection 2026-04-29" mentions Telegram cron output\n'
+                        '- "Daily reflection 2026-04-30" mentions Telegram briefing alerts\n'
+                        '- "Debugging session 2026-04-30" mentions a Telegram media bug\n'
+                        'Pick a tool to call. If the scope is ambiguous, the §3.5 flow '
+                        'requires you to ASK the user FIRST rather than write. Only call '
+                        'memex_record_outcome / memex_memory_deprioritize after you know '
+                        'exactly which units the user means.'
+                    ),
+                },
+                {
+                    'role': 'user',
+                    'content': 'The Telegram notifications are now resolved.',
+                },
+            ],
+            tools=_f43_tool_set(),
+            tool_choice='auto',
+            temperature=0,
+            timeout=30,
+            api_key=os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'),
+        )
+    except Exception as exc:
+        if 'rate' in str(exc).lower() or '429' in str(exc):
+            pytest.skip(f'LLM rate-limited: {exc}')
+        raise
+
+    msg = resp.choices[0].message
+    tool_calls = msg.tool_calls or []
+    write_calls = [
+        tc
+        for tc in tool_calls
+        if tc.function.name in ('memex_record_outcome', 'memex_memory_deprioritize')
+    ]
+    assert not write_calls, (
+        f'Agent issued a write call ({[tc.function.name for tc in write_calls]}) '
+        'against an ambiguous scope without disambiguating first. §3.5 Step 1 '
+        'breach.'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test (b) — agent calls find_note (or memory_search) BEFORE any write.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llm
+@pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
+@pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
+@pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
+def test_resolution_calls_search_before_write_when_no_unit_ids_known() -> None:
+    """Step 2 — search before write.
+
+    Given a concrete-but-no-unit-ids prompt, the FIRST tool call should be a
+    routing/search call, not a write.
+    """
+    import litellm
+
+    try:
+        resp = litellm.completion(
+            model='gemini/gemini-3-flash-preview',
+            messages=[
+                {
+                    'role': 'system',
+                    'content': (
+                        'You are an agent integrated with Memex. The user is naming a '
+                        'specific bug ("Telegram media handler bug from yesterday\'s '
+                        'reflection") but you do NOT have memory unit IDs. Per the §3.5 '
+                        'flow, route by info quality: title-fragment known -> '
+                        'memex_find_note; content only -> memex_memory_search. Only '
+                        'after you have a candidate set should you write.'
+                    ),
+                },
+                {
+                    'role': 'user',
+                    'content': (
+                        "The Telegram media handler bug from yesterday's reflection is fixed."
+                    ),
+                },
+            ],
+            tools=_f43_tool_set(),
+            tool_choice='auto',
+            temperature=0,
+            timeout=30,
+            api_key=os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'),
+        )
+    except Exception as exc:
+        if 'rate' in str(exc).lower() or '429' in str(exc):
+            pytest.skip(f'LLM rate-limited: {exc}')
+        raise
+
+    tool_calls = resp.choices[0].message.tool_calls or []
+    assert tool_calls, f'no tool calls: {resp.choices[0].message!r}'
+    first = tool_calls[0].function.name
+    assert first in (
+        'memex_find_note',
+        'memex_memory_search',
+        'memex_list_entities',
+    ), (
+        f'agent first-called {first!r}; §3.5 Step 2 requires a routing/search call '
+        'before any write when unit_ids are unknown.'
+    )
+    # Negative assertion: no write call leads.
+    assert first not in (
+        'memex_record_outcome',
+        'memex_memory_deprioritize',
+    ), 'agent wrote before searching — §3.5 Step 2 breach.'
+
+
+# ---------------------------------------------------------------------------
+# Test (c) — Option B uses top_k >= 30.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llm
+@pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
+@pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
+@pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
+def test_cross_note_search_uses_top_k_at_least_30() -> None:
+    """Option B — cross-note semantic with top_k >= 30."""
+    import litellm
+
+    try:
+        resp = litellm.completion(
+            model='gemini/gemini-3-flash-preview',
+            messages=[
+                {
+                    'role': 'system',
+                    'content': (
+                        'You are an agent integrated with Memex. Use Option B '
+                        '(cross-note memex_memory_search) to gather candidates for the '
+                        '§3.5 resolution flow. The §3.5 spec says top_k MUST be >= 30; '
+                        'the default 5 is too narrow.'
+                    ),
+                },
+                {
+                    'role': 'user',
+                    'content': (
+                        'Do an Option-B cross-note semantic search for "telegram media '
+                        'handler" with after="2026-04-22" so we can resolve units '
+                        'across multiple notes. Pick top_k correctly.'
+                    ),
+                },
+            ],
+            tools=_f43_tool_set(),
+            tool_choice='auto',
+            temperature=0,
+            timeout=30,
+            api_key=os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'),
+        )
+    except Exception as exc:
+        if 'rate' in str(exc).lower() or '429' in str(exc):
+            pytest.skip(f'LLM rate-limited: {exc}')
+        raise
+
+    tool_calls = resp.choices[0].message.tool_calls or []
+    search_calls = [tc for tc in tool_calls if tc.function.name == 'memex_memory_search']
+    assert search_calls, (
+        f'agent did not call memex_memory_search (Option B): '
+        f'{[tc.function.name for tc in tool_calls]!r}'
+    )
+    args = json.loads(search_calls[0].function.arguments)
+    top_k = args.get('top_k')
+    assert isinstance(top_k, int), (
+        f'agent did not set top_k (got {top_k!r}); §3.5 Option B requires top_k>=30.'
+    )
+    assert top_k >= 30, (
+        f'agent set top_k={top_k}; §3.5 Option B requires top_k>=30 for cross-note '
+        'recall. Default 5 misses paraphrased mentions.'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test (d) — paired writes against the LLM-judged-relevant subset only.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llm
+@pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
+@pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
+@pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
+def test_resolution_issues_paired_writes_against_subset() -> None:
+    """Steps 4+5 — paired writes against the LLM-judged-relevant subset only."""
+    import litellm
+
+    relevant_id = str(uuid.uuid4())
+    irrelevant_id = str(uuid.uuid4())
+    try:
+        resp = litellm.completion(
+            model='gemini/gemini-3-flash-preview',
+            messages=[
+                {
+                    'role': 'system',
+                    'content': (
+                        'You are an agent integrated with Memex executing §3.5 Steps '
+                        '4+5. The user has confirmed a bug fix; you have already done '
+                        'Steps 1-3 and judged exactly ONE unit relevant. Issue PAIRED '
+                        'writes (memex_record_outcome with success=false AND '
+                        'memex_memory_deprioritize) against ONLY the relevant unit_id. '
+                        'Do NOT write against the irrelevant one — that breaches Step 3 '
+                        '(LLM judgment).'
+                    ),
+                },
+                {
+                    'role': 'user',
+                    'content': (
+                        'Telegram media bug is fixed. Candidate units after Step 3 '
+                        f'judgment:\n'
+                        f'- {relevant_id}: "Telegram media handler crashes on .webp" '
+                        '(RELEVANT)\n'
+                        f'- {irrelevant_id}: "Worked on memex 3h today" (NOT RELEVANT — '
+                        'episodic noise)\n'
+                        'Issue paired writes for the relevant unit only.'
+                    ),
+                },
+            ],
+            tools=_f43_tool_set(),
+            tool_choice='auto',
+            temperature=0,
+            timeout=30,
+            api_key=os.environ.get('GEMINI_API_KEY') or os.environ.get('GOOGLE_API_KEY'),
+        )
+    except Exception as exc:
+        if 'rate' in str(exc).lower() or '429' in str(exc):
+            pytest.skip(f'LLM rate-limited: {exc}')
+        raise
+
+    tool_calls = resp.choices[0].message.tool_calls or []
+    names = [tc.function.name for tc in tool_calls]
+
+    assert 'memex_record_outcome' in names, (
+        f'agent did not call record_outcome; §3.5 Step 4 breach. Calls: {names!r}'
+    )
+    assert 'memex_memory_deprioritize' in names, (
+        f'agent did not call memex_memory_deprioritize; §3.5 Step 5 breach. Calls: {names!r}'
+    )
+
+    # All write-call args must reference the relevant unit and never the irrelevant.
+    for tc in tool_calls:
+        if tc.function.name not in ('memex_record_outcome', 'memex_memory_deprioritize'):
+            continue
+        args_str = tc.function.arguments
+        assert irrelevant_id not in args_str, (
+            f'agent wrote against the irrelevant (episodic) unit; §3.5 Step 3 breach. '
+            f'Tool: {tc.function.name}, args: {args_str!r}'
+        )
+        assert relevant_id in args_str, (
+            f'agent did not target the relevant unit; tool: {tc.function.name}, args: {args_str!r}'
+        )

--- a/packages/mcp/tests/test_int_f43_resolution_flow_llm.py
+++ b/packages/mcp/tests/test_int_f43_resolution_flow_llm.py
@@ -55,7 +55,16 @@ def _f43_tool_set() -> list[dict[str, Any]]:
     so the model has to actually pick by description, not by lonely-verb-in-list.
     """
 
-    def _tool(name: str, description: str, params: dict[str, Any]) -> dict[str, Any]:
+    def _tool(
+        name: str,
+        description: str,
+        params: dict[str, Any],
+        required: list[str] | None = None,
+    ) -> dict[str, Any]:
+        # The default `list(params.keys())[:1]` only marks the first parameter
+        # required, which is wrong for tools whose required set is multi-arg
+        # (e.g. memex_record_outcome needs BOTH success AND unit_ids in
+        # memory_unit mode). Pass an explicit `required=` for those.
         return {
             'type': 'function',
             'function': {
@@ -64,7 +73,7 @@ def _f43_tool_set() -> list[dict[str, Any]]:
                 'parameters': {
                     'type': 'object',
                     'properties': params,
-                    'required': list(params.keys())[:1],  # keep schemas valid
+                    'required': required if required is not None else list(params.keys())[:1],
                 },
             },
         }
@@ -78,6 +87,7 @@ def _f43_tool_set() -> list[dict[str, Any]]:
                 'unit_ids': {'type': 'array', 'items': {'type': 'string'}},
                 'reason': {'type': 'string'},
             },
+            required=['success', 'unit_ids'],
         ),
         _tool(
             'memex_memory_deprioritize',
@@ -86,6 +96,7 @@ def _f43_tool_set() -> list[dict[str, Any]]:
                 'unit_id': {'type': 'string'},
                 'reason': {'type': 'string'},
             },
+            required=['unit_id'],
         ),
         _tool(
             'memex_find_note',

--- a/packages/mcp/tests/test_int_f43_resolution_flow_llm.py
+++ b/packages/mcp/tests/test_int_f43_resolution_flow_llm.py
@@ -17,6 +17,12 @@ Skipped unless GEMINI_API_KEY / GOOGLE_API_KEY is set; uses the same model
 pinning as the rest of the repo's LLM-gated tests
 (gemini-3-flash-preview).
 
+Note: Gemini's ``temperature=0`` is not strictly deterministic (the provider
+has an implicit minimum temperature and outputs can still vary across calls).
+Each test is wrapped with ``pytest.mark.flaky(reruns=2)`` so transient
+output drift does not red the suite; the assertions themselves are kept tool-
+name / numeric / UUID based so a one-off rephrasing does not falsely fail.
+
 Per CLAUDE.md (Markers): ``@pytest.mark.llm`` so the tests are gated out of
 the default CI lane.
 """
@@ -151,6 +157,7 @@ def _f43_tool_set() -> list[dict[str, Any]]:
 
 
 @pytest.mark.llm
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
 @pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
 @pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
@@ -217,6 +224,7 @@ def test_ambiguous_resolution_prompts_clarification_before_write() -> None:
 
 
 @pytest.mark.llm
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
 @pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
 @pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
@@ -285,6 +293,7 @@ def test_resolution_calls_search_before_write_when_no_unit_ids_known() -> None:
 
 
 @pytest.mark.llm
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
 @pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
 @pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')
@@ -348,6 +357,7 @@ def test_cross_note_search_uses_top_k_at_least_30() -> None:
 
 
 @pytest.mark.llm
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @pytest.mark.skipif(_SKIP_LLM_TESTS, reason='SKIP_LLM_TESTS=1 set')
 @pytest.mark.skipif(not _HAS_GEMINI_KEY, reason='GEMINI_API_KEY / GOOGLE_API_KEY not set')
 @pytest.mark.skipif(not _HAS_LITELLM, reason='litellm not installed')

--- a/tests/test_f43_claude_code_plugin_rules.py
+++ b/tests/test_f43_claude_code_plugin_rules.py
@@ -1,0 +1,106 @@
+"""F43 — Claude Code plugin rule + skill content pinning.
+
+The Claude Code plugin has no Python test harness, so this lives in the root
+tests dir. Asserts the new rule file (`rules/memory-resolution-flow.md`) and
+the updated skill descriptions (`skills/remember/SKILL.md`,
+`skills/recall/SKILL.md`) carry the §3.5 5-step flow + §3.4.1 axes table +
+§3.4.2 historical-routing rule.
+
+Source: BACKLOG.md F43 step 3 (Claude Code plugin scope).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[1] / 'packages' / 'claude-code-plugin'
+_RULE_FILE = _PLUGIN_ROOT / 'rules' / 'memory-resolution-flow.md'
+_REMEMBER_SKILL = _PLUGIN_ROOT / 'skills' / 'remember' / 'SKILL.md'
+_RECALL_SKILL = _PLUGIN_ROOT / 'skills' / 'recall' / 'SKILL.md'
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f'F43 expects {path} to exist (per BACKLOG step 3)'
+    return path.read_text()
+
+
+@pytest.mark.parametrize(
+    'kw',
+    [
+        'Disambiguate first',
+        'Route by info quality',
+        'Option A',
+        'Option B',
+        'Option C',
+        '`top_k`',
+        '≥30',
+        'Mandatory LLM judgment',
+        'memex_record_outcome',
+        'memex_memory_deprioritize',
+        'F33 exploration',
+        'safety net',
+        'Imperfect recall',
+        'memex_get_unit_history',
+        'apply_pre_filter=False',
+        'evolved',
+        'used to',
+        'audit',
+        'memex_resolve',
+        'resolved_at',
+        'resolution_type',
+        'bulk-by-source',
+        'Note-level deprioritize',
+    ],
+)
+def test_resolution_flow_rule_carries_keyword(kw: str) -> None:
+    """The new rule file teaches each canonical §3.5 / §3.4.1 / §3.4.2 keyword."""
+    text = _read(_RULE_FILE)
+    assert kw in text, (
+        f'Claude Code plugin rule file is missing keyword {kw!r}. '
+        'See cognitive-memory-research-report.md §3.5 / §3.4.1 / §3.4.2.'
+    )
+
+
+def test_remember_skill_references_resolution_flow() -> None:
+    """The /remember skill description points at the resolution flow."""
+    text = _read(_REMEMBER_SKILL)
+    assert 'When the user reports an issue resolved' in text
+    assert 'memex_record_outcome' in text
+    assert 'memex_memory_deprioritize' in text
+    # The skill uses short-form `(A)/(B)/(C)` references back to the rule file.
+    assert 'Option A' in text or '(A)' in text
+    assert 'Option B' in text or '(B)' in text
+    assert 'Option C' in text or '(C)' in text
+    assert 'top_k' in text
+    assert 'F33' in text
+    assert 'memex_get_unit_history' in text
+    assert 'apply_pre_filter=False' in text
+
+
+def test_recall_skill_references_historical_routing_rule() -> None:
+    """The /recall skill description teaches the historical-routing rule."""
+    text = _read(_RECALL_SKILL)
+    assert 'Historical' in text or 'historical' in text
+    assert 'memex_get_unit_history' in text
+    assert 'apply_pre_filter=False' in text
+    assert 'evolved' in text
+    assert 'audit' in text
+
+
+def test_session_start_hook_copies_all_rule_files() -> None:
+    """The on_session_start.sh hook auto-installs every *.md in rules/ (not just memex.md)."""
+    hook = _PLUGIN_ROOT / 'scripts' / 'on_session_start.sh'
+    text = _read(hook)
+    # Hook should iterate the rules directory rather than hard-coding memex.md only.
+    assert '/rules' in text, 'session-start hook should reference the rules dir'
+    assert 'for ' in text, (
+        'on_session_start.sh must iterate all rule files in rules/, not hard-code '
+        'memex.md only (otherwise memory-resolution-flow.md never lands in the '
+        'project .claude/rules/).'
+    )
+    # Negative: must not be hard-coded to a single rule file.
+    assert text.count('rules/memex.md') <= 1, (
+        'on_session_start.sh appears to hard-code memex.md instead of iterating *.md.'
+    )


### PR DESCRIPTION
## Summary

Codifies the cognitive-memory research report's §3.5 worked example
("User-driven memory resolution"), §3.4.1 axes-table ("MW is the gradient;
deprioritize is the binary"), and §3.4.2 historical-routing rule (added
2026-05-02) across **all four** agent-facing surfaces in a single PR per
CLAUDE.md rule 24 (parity required; partial PRs are non-mergeable).

The 5-step flow turns a vague "X is fixed" into precise paired writes:
**(1)** disambiguate first if scope is ambiguous; **(2)** route by info
quality (`memex_find_note` for title fragment, `memex_memory_search` only
when title is unknown) AND pick a coverage path — Option A entity-anchored,
Option B cross-note semantic with `top_k>=30`, or Option C single-note
PageIndex traversal; **(3)** mandatory LLM judgment over candidates —
never bulk-write; **(4+5)** paired writes (`memex_record_outcome(success=false)`
AND `memex_memory_deprioritize`) against the LLM-judged-relevant subset only.

## Surfaces touched (all four — single PR per CLAUDE.md rule 24)

1. **MCP server** (`packages/mcp`): new `_f43_descriptions.py` composes
   the §3.5 5-step flow + §3.4.1 axes table + §3.4.2 historical routing
   + do-NOT-add list into the registered descriptions of
   `memex_record_outcome` and `memex_memory_deprioritize`. Original F4
   verbatim preamble is preserved; F4 verbatim test relaxed to
   `description.startswith(F4_DESCRIPTION_VERBATIM)` so the F43 extension
   is welcomed.
2. **Hermes plugin** (`packages/hermes-plugin`): new `_RESOLUTION_FLOW_PRIMER`
   block in `briefing.py` (alongside the existing storage-model primer);
   `RESOLUTION_FLOW_PROMPT_FRAGMENT` and `HISTORICAL_ROUTING_PROMPT_FRAGMENT`
   verb-pair scaffolding in `templates.py`; tool schemas in `tools.py`
   mirror the new MCP paired-write rule.
3. **Claude Code plugin** (`packages/claude-code-plugin`): NEW rule file
   `rules/memory-resolution-flow.md`; `/remember` and `/recall` skill
   descriptions extended with the 5-step flow + historical-routing rule;
   `on_session_start.sh` hook iterates `rules/*.md` so the new rule
   auto-installs alongside `memex.md`.
4. **CLAUDE.md** (root): short "When the user reports an issue resolved"
   section pointing to the three above. ~22 lines.

## Spec anchors

- BACKLOG.md F43 entry — lines 96–116 on `release/tier-a-cognitive-memory`.
- `cognitive-memory-research-report.md` §3.5 — worked example, 5-step flow,
  axes table, "what's genuinely adjacent work" enumeration.
- `cognitive-memory-research-report.md` §3.4.1 — "MW is the gradient;
  deprioritize is the binary" subsection.
- `cognitive-memory-research-report.md` §3.4.2 — historical-routing rule
  (added 2026-05-02).

## Tests

**Pre-merge sequencing-gate (cheap, no LLM):**
- `packages/mcp/tests/test_f43_sequencing_gate.py` —
  `test_apply_pre_filter_exists_on_retrieval_request` (F40) and
  `test_get_unit_history_tool_registered` (F49). Trivial import-and-attribute
  checks that catch the F40/F49 not-on-base failure mode before the F43 PR
  opens. Both pass on this branch.

**Description-content pinning (cheap, no LLM):**
- `packages/mcp/tests/test_f43_descriptions.py` — 14 parametrized assertions
  on §3.5 / §3.4.1 / §3.4.2 keywords for both registered MCP tools.
- `packages/hermes-plugin/tests/test_briefing_f43_resolution_flow.py` —
  pinning on `_RESOLUTION_FLOW_PRIMER` + `format_briefing_block` integration
  + the two new template fragments + the `tools.py` schema parity.
- `tests/test_f43_claude_code_plugin_rules.py` — 22 keyword assertions on
  `rules/memory-resolution-flow.md`, plus `/remember` and `/recall`
  skill-content checks, plus the session-start hook auto-install assertion.

**Real-LLM golden tests (`@pytest.mark.llm` + `SKIP_LLM_TESTS=1` env gate):**
- `packages/mcp/tests/test_int_f43_resolution_flow_llm.py` — drives a real
  Gemini-3 turn against the full MCP tool surface; asserts (a) disambiguation
  before write on ambiguous prompts, (b) search-before-write when `unit_ids`
  are unknown, (c) Option B uses `top_k>=30`, (d) paired writes only against
  the LLM-judged-relevant subset (irrelevant episodic-noise units never
  appear in the write payloads). 30s per-call timeout per round-6 LOW
  deferral.
- `packages/hermes-plugin/tests/test_int_f43_briefing_llm.py` — same
  assertions but driven through Hermes briefing + plugin tool schemas.

**Important: real-LLM tests are env-gated (`@pytest.mark.llm` + `SKIP_LLM_TESTS`).**
They do NOT run in CI's default lane; CI's LLM job runs them. Hermes
briefing tests are also gated on `GEMINI_API_KEY` / `GOOGLE_API_KEY`
and `litellm` install per the existing F9 LLM-test pattern.

## Out of scope (resisted scope creep — codified in agent guidance as "do NOT add")

- Combined `memex_resolve(unit_ids, reason)` endpoint
- `resolved_at` timestamp column
- `resolution_type` enum on deprioritize
- `bulk-by-source` parameter on deprioritize
- Note-level deprioritize

The free-text `reason` field carries all the information a closed
taxonomy would have committed to.

Out-of-scope adjacent work (separate Hermes/Telegram integration ticket,
not a memory-core deliverable): Telegram cron-response handler.

## Test plan

- [x] `just prek` — green (ruff, ruff-format, mypy, badge update).
- [x] `pytest packages/mcp/tests/test_f43_*` — 16 passed.
- [x] `pytest packages/mcp/tests/test_f4_tool_descriptions.py` — 3 passed
      (F4 verbatim contract preserved).
- [x] `pytest packages/hermes-plugin/tests/test_briefing*` — green
      (plus the `_format_block_skips_briefing_section_when_empty` test
      relaxed to look for the `\n---\n` separator instead of any `---`,
      because F43's primer adds Markdown table separators).
- [x] `pytest tests/test_f43_claude_code_plugin_rules.py` — 26 passed.
- [x] Pre-merge sequencing gate: F40 + F49 both verified on base.
- [ ] Real-LLM tests run in CI's LLM job (env-gated locally).

## Pre-existing failures called out (NOT introduced by this PR)

The following 4 Hermes tests were already failing on
`origin/release/tier-a-cognitive-memory` before this branch — they assert
a hard-coded expected tool-name set that didn't get updated when F49
landed (`memex_get_unit_history` is now registered but the expected set
still excludes it). Confirmed reproducible on base via stashed-WIP test:
- `packages/hermes-plugin/tests/test_provider.py::test_get_tool_schemas_in_hybrid_mode`
- `packages/hermes-plugin/tests/test_provider.py::TestGetToolSchemasBeforeInitialize::*` (2)
- `packages/hermes-plugin/tests/test_tools.py::test_all_schemas_have_required_fields`

These should be patched by an F49 follow-up, not by F43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)