### PR TITLE
fix(hermes-plugin): F49 follow-up — register memex_get_unit_history in expected-tool-name tests

### DIFF
--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -183,6 +183,8 @@ def test_get_tool_schemas_in_hybrid_mode(provider_with_stubbed_api):
         # Tier A WS-locks (F9)
         'memex_memory_reconsolidate',
         'memex_memory_consolidate',
+        # Tier A WS-history (F49 — contradiction-graph timeline)
+        'memex_get_unit_history',
     }
     assert names == expected
 
@@ -199,7 +201,8 @@ class TestGetToolSchemasBeforeInitialize:
         """The v0.1.13 bug was returning []; we now return the full set
         pre-init. After Stream 6 + asset disk-handoff + memex_append_note +
         Tier A F4/F5 + F14/F29 + F32 diagnostics + F8 lint flags + F20 revisit
-        + F9 locks we register exactly 46 tools, and the assertion is strict equality.
+        + F9 locks + F49 history we register exactly 47 tools, and the
+        assertion is strict equality.
         """
         p = MemexMemoryProvider()
         # NOTE: no initialize() call.
@@ -263,6 +266,8 @@ class TestGetToolSchemasBeforeInitialize:
             # Tier A WS-locks (F9)
             'memex_memory_reconsolidate',
             'memex_memory_consolidate',
+            # Tier A WS-history (F49 — contradiction-graph timeline)
+            'memex_get_unit_history',
         }
         assert names == expected
 
@@ -277,9 +282,9 @@ class TestGetToolSchemasBeforeInitialize:
         """A fresh provider with no config always exposes tools. Only an
         initialized provider whose config explicitly says ``context`` hides them.
         """
-        # Pre-init: full 46-tool set (Stream 1-5 baseline + Tier A F4/F5 + F14/F29 + F32 diagnostics + F8 lint + F20 revisit + F9 locks).
+        # Pre-init: full 47-tool set (Stream 1-5 baseline + Tier A F4/F5 + F14/F29 + F32 diagnostics + F8 lint + F20 revisit + F9 locks + F49 history).
         p = MemexMemoryProvider()
-        assert len(p.get_tool_schemas()) == 46
+        assert len(p.get_tool_schemas()) == 47
 
         # After init in context mode: empty.
         monkeypatch.setenv('HERMES_HOME', str(tmp_path))

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -119,7 +119,7 @@ def _fake_entity(name: str = 'Rust') -> EntityDTO:
 
 
 def test_all_schemas_have_required_fields():
-    """All 46 tools (Streams 1-5 baseline + Tier A F4/F5 + F14/F29 + F32 diagnostics + F8 lint + F20 revisit + F9 locks)
+    """All 47 tools (Streams 1-5 baseline + Tier A F4/F5 + F14/F29 + F32 diagnostics + F8 lint + F20 revisit + F9 locks + F49 history)
     must be registered exactly (AC-086 + AC-008 + AC-X-10)."""
     names = {s['name'] for s in ALL_SCHEMAS}
     stream_1_baseline = {
@@ -188,6 +188,9 @@ def test_all_schemas_have_required_fields():
         'memex_memory_reconsolidate',
         'memex_memory_consolidate',
     }
+    tier_a_history = {
+        'memex_get_unit_history',
+    }
     expected = (
         stream_1_baseline
         | stream_2_read_discovery
@@ -199,6 +202,7 @@ def test_all_schemas_have_required_fields():
         | tier_a_linter
         | tier_a_revisit
         | tier_a_locks
+        | tier_a_history
     )
     assert names == expected
     for s in ALL_SCHEMAS:


### PR DESCRIPTION
## Summary
- F49 added the ``memex_get_unit_history`` MCP/Hermes tool but missed updating the expected-tool-name fixture set used by Hermes provider/tools tests.
- Adds ``memex_get_unit_history`` to the three expected sets in ``test_provider.py`` (hybrid mode + pre-init + count check) and a new ``tier_a_history`` group in ``test_tools.py``, bumping the count from 46 to 47.
- Test-fixture catch-up only — no F49 logic touched.

## Test plan
- [x] ``uv run pytest packages/hermes-plugin/tests/`` — 381 passed (was 377 passed, 4 failed).
- [x] ``just prek`` — clean (ruff, ruff-format, mypy, etc.).
- [x] Verified the four previously-failing tests now pass:
  - ``test_provider.py::test_get_tool_schemas_in_hybrid_mode``
  - ``test_provider.py::TestGetToolSchemasBeforeInitialize::test_returns_all_schemas_pre_init``
  - ``test_provider.py::TestGetToolSchemasBeforeInitialize::test_ever_only_empty_when_explicit_context_mode``
  - ``test_tools.py::test_all_schemas_have_required_fields``

Surface flagged in PR #128's report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)