### PR TITLE
feat(cli): F7 — memex lint review interactive CLI

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -98,7 +98,7 @@ Total scope: ~22-30 weeks for Tier S+A (incl. ~2-day Wave 0) + ~3-4w for Tier-A 
 - [x] **F6** — Maintenance ledger + rule-based linter (4-6w) — runs under existing `MEMEX_LEADER_LOCK_ID` — see report §4 F6 (shipped 2026-05-01 via memory_augmentation)
 - [x] **F8** — `memex_get_lint_flags` MCP (1-2w) — depends on F6 — see report §4 F8 (shipped 2026-05-01 via memory_augmentation)
 - [x] **F10** — Surprise-gated LLM lint (3-5w) — depends on F2 + F6; LLM cost-capped per vault — see report §4 F10 (shipped 2026-05-01 via memory_augmentation; polarity discrimination deferred to F10b)
-- [ ] **F7** — `memex lint review` interactive CLI (1-2w, promoted 2026-05-02) — see report §4 F7 + Issue #18 Comment 1. Human-side parity verb for F8's agent-driven lint triage; analogous to `git add -p`. **Concrete scope:**
+- [x] **F7** — `memex lint review` interactive CLI (1-2w, promoted 2026-05-02; shipped 2026-05-03) — see report §4 F7 + Issue #18 Comment 1. Human-side parity verb for F8's agent-driven lint triage; analogous to `git add -p`. **Concrete scope:**
   - Extend `packages/cli/src/memex_cli/lint.py:27` with a new `@app.command('review')` subcommand alongside the existing four (`status`, `findings`, `dismiss`, `resolve`).
   - Optional new module `packages/cli/src/memex_cli/lint_review.py` for the per-finding render + prompt loop, kept narrow so the four shipped subcommands stay simple.
   - Reuse `_resolve_scope` (`lint.py:37`) for `--vault / --global / --all` flag handling so behaviour matches `lint findings`.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,062%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,644%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,646%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,647%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,644%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,645%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,645%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,646%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/cognitive-memory-research-report.md
+++ b/cognitive-memory-research-report.md
@@ -1211,6 +1211,10 @@ low-risk ones (deprioritize, mark stale).
 
 #### F7. `memex lint review` interactive CLI
 
+**Status:** shipped 2026-05-03 via `wave-15/F7-lint-review-cli` (PR pending). Concrete code locations after merge:
+- `packages/cli/src/memex_cli/lint.py` — `@app.command('review')` registered alongside `status` / `findings` / `dismiss` / `resolve`.
+- `packages/cli/src/memex_cli/lint_review.py` — per-finding render + prompt loop module.
+
 **1. Source citation:**
 - Issue #18 Comment 1 (JasperHG90, 2026-04-28): *"We also build a `memex lint review` interactive command (analogous to `git add -p`) for users who prefer to review the flags manually without an agent."*
 - §3.5 (this report) *Worked example: cron reflection → user-driven resolution* — F7 is the human-side parity verb for the agent-driven F8 / `memex_get_lint_flags` flow. Where F8 lets an agent triage the maintenance ledger, F7 lets a human do the same triage without an agent in the loop.

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -238,7 +238,17 @@ async def lint_review_cmd(
     ] = False,
     limit: Annotated[
         int,
-        typer.Option('--limit', min=1, max=500, help='Max findings to review this session.'),
+        typer.Option(
+            '--limit',
+            min=1,
+            max=500,
+            help=(
+                'Max findings to fetch from the server. With ``--global``, the '
+                'global filter is applied client-side AFTER this cap, so a '
+                'global session may surface fewer than --limit findings if '
+                'vault-scoped findings dominate; raise --limit to compensate.'
+            ),
+        ),
     ] = 50,
 ):
     """Walk pending findings interactively (analogous to ``git add -p``).
@@ -247,6 +257,10 @@ async def lint_review_cmd(
     written. Pass ``--apply`` to flip accepted findings to ``resolved`` and
     dismissed findings to ``dismissed`` via the same service paths used by
     ``memex lint resolve`` / ``memex lint dismiss``.
+
+    Note: ``--global`` filters client-side after the server-side ``--limit``
+    cap (mirrors ``memex lint findings``). A server-side ``vault_id IS NULL``
+    filter is tracked as a follow-up; bump ``--limit`` if needed.
     """
     scope = _resolve_scope(vault, is_global, is_all)
     if lint_type is not None and lint_type not in {

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -6,6 +6,8 @@ Subcommands:
 * ``memex lint findings [--type ...]`` — list findings.
 * ``memex lint dismiss <finding_id>`` — flip to dismissed.
 * ``memex lint resolve <finding_id>`` — flip to resolved.
+* ``memex lint review [--vault X | --global | --all] [--apply]`` —
+  interactive triage (F7).
 
 The maintenance ledger is read-only from the agent surface (F8 ships the
 MCP tool); this CLI is for human inspection and reconciliation.
@@ -20,6 +22,7 @@ from rich.console import Console
 from rich.table import Table
 
 from memex_common.config import MemexConfig
+from memex_cli.lint_review import render_summary, run_review_loop
 from memex_cli.utils import async_command, get_api_context, handle_api_error, parse_uuid
 
 console = Console()
@@ -201,3 +204,91 @@ async def lint_resolve_cmd(
             handle_api_error(e)
             return
     console.print(f'[green]resolved:[/green] {payload["finding_id"]}')
+
+
+@app.command('review')
+@async_command
+async def lint_review_cmd(
+    ctx: typer.Context,
+    vault: Annotated[
+        str | None,
+        typer.Option('--vault', help='Vault UUID or name to scope to.'),
+    ] = None,
+    is_global: Annotated[
+        bool,
+        typer.Option('--global/--no-global', help='Review only global (vault_id NULL) findings.'),
+    ] = False,
+    is_all: Annotated[
+        bool,
+        typer.Option('--all/--no-all', help='Review pending findings across every scope.'),
+    ] = False,
+    lint_type: Annotated[
+        str | None,
+        typer.Option(
+            '--type',
+            help='Filter by lint_type: structural, quality, governance, schema.',
+        ),
+    ] = None,
+    apply: Annotated[
+        bool,
+        typer.Option(
+            '--apply',
+            help='Actually write resolutions; otherwise dry-run preview only.',
+        ),
+    ] = False,
+    limit: Annotated[
+        int,
+        typer.Option('--limit', min=1, max=500, help='Max findings to review this session.'),
+    ] = 50,
+):
+    """Walk pending findings interactively (analogous to ``git add -p``).
+
+    Default is dry-run: verdicts are collected and summarised but nothing is
+    written. Pass ``--apply`` to flip accepted findings to ``resolved`` and
+    dismissed findings to ``dismissed`` via the same service paths used by
+    ``memex lint resolve`` / ``memex lint dismiss``.
+    """
+    scope = _resolve_scope(vault, is_global, is_all)
+    if lint_type is not None and lint_type not in {
+        'structural',
+        'quality',
+        'governance',
+        'schema',
+    }:
+        console.print(f'[red]Unknown --type: {lint_type!r}[/red]')
+        raise typer.Exit(2)
+
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            vault_id: str | None = None
+            if scope == 'vault' and vault is not None:
+                vault_id = str(await api.resolve_vault_identifier(vault))
+            payload = await api.lint_findings(
+                vault_id=vault_id,
+                lint_type=lint_type,
+                status='pending',
+                limit=limit,
+            )
+        except Exception as e:
+            handle_api_error(e)
+            return
+
+        findings = payload.get('findings', [])
+        if scope == 'global':
+            findings = [f for f in findings if f.get('vault_id') in (None, '')]
+
+        if not apply:
+            console.print(
+                '[dim]Dry-run mode — no resolutions will be written. '
+                'Pass --apply to persist verdicts.[/dim]'
+            )
+
+        summary = await run_review_loop(
+            findings,
+            apply=apply,
+            api=api,
+            console=console,
+        )
+
+    render_summary(console, summary, apply=apply)

--- a/packages/cli/src/memex_cli/lint_review.py
+++ b/packages/cli/src/memex_cli/lint_review.py
@@ -137,8 +137,12 @@ async def run_review_loop(
 
     for idx, finding in enumerate(findings, start=1):
         _render_finding(console, idx, total, finding)
+        finding_id = finding.get('id') or ''
+        if not finding_id:
+            console.print(f'[red]Finding at position {idx} is missing ``id`` — skipping.[/red]')
+            summary.skipped.append('')
+            continue
         verdict = await asyncio.to_thread(_prompt_verdict, console)
-        finding_id = finding.get('id', '')
 
         if verdict == 'q':
             summary.quit_early = True

--- a/packages/cli/src/memex_cli/lint_review.py
+++ b/packages/cli/src/memex_cli/lint_review.py
@@ -13,7 +13,7 @@ Defaults to dry-run preview. ``--apply`` is required to write.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Protocol
 
 import typer
 from rich.console import Console
@@ -23,6 +23,20 @@ from rich.table import Table
 
 _VALID_KEYS = {'a', 'd', 's', 'q'}
 _DEFAULT_KEY = 's'
+
+
+class LintApplyProto(Protocol):
+    """Minimal API surface ``run_review_loop`` writes through.
+
+    Narrower than the full ``RemoteMemexAPI`` so type-checkers catch
+    signature drift between this CLI and the API client. Both methods
+    return a dict from the resolve/dismiss endpoint; ``run_review_loop``
+    ignores the payload and only cares about success vs raised exception.
+    """
+
+    async def lint_resolve(self, finding_id: str) -> dict[str, Any]: ...
+
+    async def lint_dismiss(self, finding_id: str) -> dict[str, Any]: ...
 
 
 @dataclass
@@ -103,7 +117,7 @@ async def run_review_loop(
     findings: list[dict[str, Any]],
     *,
     apply: bool,
-    api: Any,
+    api: LintApplyProto,
     console: Console,
 ) -> ReviewSummary:
     """Walk the user through ``findings``; collect verdicts; optionally apply.

--- a/packages/cli/src/memex_cli/lint_review.py
+++ b/packages/cli/src/memex_cli/lint_review.py
@@ -174,8 +174,10 @@ def render_summary(console: Console, summary: ReviewSummary, *, apply: bool) -> 
     table = Table(title='lint review summary')
     table.add_column('verdict')
     table.add_column('count', justify='right')
-    table.add_row('accepted (would resolve)', str(len(summary.accepted)))
-    table.add_row('dismissed (would dismiss)', str(len(summary.dismissed)))
+    accept_label = 'accepted' if apply else 'accepted (would resolve)'
+    dismiss_label = 'dismissed' if apply else 'dismissed (would dismiss)'
+    table.add_row(accept_label, str(len(summary.accepted)))
+    table.add_row(dismiss_label, str(len(summary.dismissed)))
     table.add_row('skipped', str(len(summary.skipped)))
     if apply:
         table.add_row('applied (resolved)', str(len(summary.applied_resolved)))

--- a/packages/cli/src/memex_cli/lint_review.py
+++ b/packages/cli/src/memex_cli/lint_review.py
@@ -1,0 +1,179 @@
+"""F7 — interactive prompt loop for ``memex lint review``.
+
+Pure UX layer. Reads pending findings via the same client method as
+``memex lint findings``; for each one, renders a per-finding card and
+asks the user for a verdict. Resolutions go through the existing
+``api.lint_dismiss`` / ``api.lint_resolve`` paths so the audit footprint
+(``maintenance_proposals.status`` flip + ``resolved_at`` + ``resolved_by``
+columns) is identical to the corresponding direct CLI subcommand.
+
+Defaults to dry-run preview. ``--apply`` is required to write.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+
+_VALID_KEYS = {'a', 'd', 's', 'q'}
+_DEFAULT_KEY = 's'
+
+
+@dataclass
+class ReviewSummary:
+    """Verdicts collected from a single review session."""
+
+    accepted: list[str] = field(default_factory=list)
+    dismissed: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    applied_resolved: list[str] = field(default_factory=list)
+    applied_dismissed: list[str] = field(default_factory=list)
+    apply_errors: list[tuple[str, str]] = field(default_factory=list)
+    quit_early: bool = False
+
+    @property
+    def reviewed(self) -> int:
+        return len(self.accepted) + len(self.dismissed) + len(self.skipped)
+
+
+def _render_finding(console: Console, index: int, total: int, finding: dict[str, Any]) -> None:
+    """Render a single finding as a rich panel: header + evidence + suggested action."""
+    rule = finding.get('rule_name', '?')
+    lint_type = finding.get('lint_type', '?')
+    target_type = finding.get('target_type', '?')
+    target_id = finding.get('target_id', '?')
+    vault_id = finding.get('vault_id') or '(global)'
+    created_at = finding.get('created_at', '')
+    suggested_action = finding.get('suggested_action', '')
+    evidence = finding.get('evidence') or {}
+
+    header = (
+        f'[bold]{rule}[/bold]  '
+        f'[cyan]{lint_type}[/cyan] / [dim]{target_type}[/dim]  '
+        f'[dim]vault={vault_id}[/dim]'
+    )
+
+    body = Table.grid(padding=(0, 1))
+    body.add_column(style='dim', no_wrap=True)
+    body.add_column(overflow='fold')
+    body.add_row('id', finding.get('id', '?'))
+    body.add_row('target', str(target_id))
+    if created_at:
+        body.add_row('created', str(created_at))
+    if evidence:
+        for k, v in evidence.items():
+            body.add_row(str(k), str(v))
+    if suggested_action:
+        body.add_row('action', suggested_action)
+
+    console.print(
+        Panel(
+            body,
+            title=f'[{index}/{total}] {header}',
+            title_align='left',
+            border_style='yellow',
+        )
+    )
+
+
+def _prompt_verdict(console: Console) -> str:
+    """Single-keypress verdict prompt. Returns one of {a, d, s, q}.
+
+    Re-prompts on invalid input. Empty input (Enter) defaults to skip.
+    """
+    while True:
+        raw = typer.prompt(
+            '[a]ccept / [d]ismiss / [s]kip / [q]uit',
+            default=_DEFAULT_KEY,
+            show_default=True,
+        )
+        key = (raw or _DEFAULT_KEY).strip().lower()[:1]
+        if key in _VALID_KEYS:
+            return key
+        console.print('[red]Invalid choice. Pick one of a / d / s / q.[/red]')
+
+
+async def run_review_loop(
+    findings: list[dict[str, Any]],
+    *,
+    apply: bool,
+    api: Any,
+    console: Console,
+) -> ReviewSummary:
+    """Walk the user through ``findings``; collect verdicts; optionally apply.
+
+    Per-finding errors when ``apply=True`` are captured into ``summary.apply_errors``
+    and the loop continues — one bad finding shouldn't abort the session.
+    """
+    summary = ReviewSummary()
+    total = len(findings)
+    if total == 0:
+        console.print('[dim]No pending findings to review.[/dim]')
+        return summary
+
+    for idx, finding in enumerate(findings, start=1):
+        _render_finding(console, idx, total, finding)
+        verdict = _prompt_verdict(console)
+        finding_id = finding.get('id', '')
+
+        if verdict == 'q':
+            summary.quit_early = True
+            console.print('[dim]Quitting review.[/dim]')
+            break
+        if verdict == 's':
+            summary.skipped.append(finding_id)
+            continue
+        if verdict == 'a':
+            summary.accepted.append(finding_id)
+            if apply:
+                try:
+                    await api.lint_resolve(finding_id)
+                    summary.applied_resolved.append(finding_id)
+                    console.print(f'[green]resolved:[/green] {finding_id}')
+                except Exception as e:
+                    summary.apply_errors.append((finding_id, str(e)))
+                    console.print(f'[red]apply failed for {finding_id}:[/red] {e}')
+            continue
+        if verdict == 'd':
+            summary.dismissed.append(finding_id)
+            if apply:
+                try:
+                    await api.lint_dismiss(finding_id)
+                    summary.applied_dismissed.append(finding_id)
+                    console.print(f'[yellow]dismissed:[/yellow] {finding_id}')
+                except Exception as e:
+                    summary.apply_errors.append((finding_id, str(e)))
+                    console.print(f'[red]apply failed for {finding_id}:[/red] {e}')
+            continue
+
+    return summary
+
+
+def render_summary(console: Console, summary: ReviewSummary, *, apply: bool) -> None:
+    """Print a final summary table and a per-mode footer."""
+    table = Table(title='lint review summary')
+    table.add_column('verdict')
+    table.add_column('count', justify='right')
+    table.add_row('accepted (would resolve)', str(len(summary.accepted)))
+    table.add_row('dismissed (would dismiss)', str(len(summary.dismissed)))
+    table.add_row('skipped', str(len(summary.skipped)))
+    if apply:
+        table.add_row('applied (resolved)', str(len(summary.applied_resolved)))
+        table.add_row('applied (dismissed)', str(len(summary.applied_dismissed)))
+        if summary.apply_errors:
+            table.add_row('apply errors', str(len(summary.apply_errors)))
+    console.print(table)
+
+    if not apply:
+        would = len(summary.accepted) + len(summary.dismissed)
+        console.print(
+            f'[dim]Dry-run: would have applied {would} actions. Re-run with --apply to write.[/dim]'
+        )
+    if summary.quit_early:
+        console.print('[dim]Session ended early via quit.[/dim]')

--- a/packages/cli/src/memex_cli/lint_review.py
+++ b/packages/cli/src/memex_cli/lint_review.py
@@ -16,6 +16,7 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+import structlog
 import typer
 from rich.console import Console
 from rich.panel import Panel
@@ -24,6 +25,8 @@ from rich.table import Table
 
 _VALID_KEYS = {'a', 'd', 's', 'q'}
 _DEFAULT_KEY = 's'
+
+_logger = structlog.get_logger(__name__)
 
 
 class LintApplyProto(Protocol):
@@ -152,6 +155,11 @@ async def run_review_loop(
                     summary.applied_resolved.append(finding_id)
                     console.print(f'[green]resolved:[/green] {finding_id}')
                 except Exception as e:
+                    _logger.exception(
+                        'lint_review.apply_failed',
+                        finding_id=finding_id,
+                        verdict='accept',
+                    )
                     summary.apply_errors.append((finding_id, str(e)))
                     console.print(f'[red]apply failed for {finding_id}:[/red] {e}')
             continue
@@ -163,6 +171,11 @@ async def run_review_loop(
                     summary.applied_dismissed.append(finding_id)
                     console.print(f'[yellow]dismissed:[/yellow] {finding_id}')
                 except Exception as e:
+                    _logger.exception(
+                        'lint_review.apply_failed',
+                        finding_id=finding_id,
+                        verdict='dismiss',
+                    )
                     summary.apply_errors.append((finding_id, str(e)))
                     console.print(f'[red]apply failed for {finding_id}:[/red] {e}')
             continue

--- a/packages/cli/src/memex_cli/lint_review.py
+++ b/packages/cli/src/memex_cli/lint_review.py
@@ -12,6 +12,7 @@ Defaults to dry-run preview. ``--apply`` is required to write.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
@@ -133,7 +134,7 @@ async def run_review_loop(
 
     for idx, finding in enumerate(findings, start=1):
         _render_finding(console, idx, total, finding)
-        verdict = _prompt_verdict(console)
+        verdict = await asyncio.to_thread(_prompt_verdict, console)
         finding_id = finding.get('id', '')
 
         if verdict == 'q':

--- a/packages/cli/tests/test_lint_review_unit.py
+++ b/packages/cli/tests/test_lint_review_unit.py
@@ -177,6 +177,24 @@ def test_apply_with_dismiss_calls_dismiss_path(runner, mock_config, mock_api, st
     assert mock_api.lint_resolve.await_count == 0
 
 
+def test_empty_findings_short_circuits(runner, mock_config, mock_api, strip_ansi):
+    """Empty findings list → loop exits immediately, no API mutations, summary still prints."""
+    mock_api.lint_findings = AsyncMock(return_value={'count': 0, 'findings': []})
+    mock_api.lint_resolve = AsyncMock()
+    mock_api.lint_dismiss = AsyncMock()
+
+    with patch('memex_cli.lint.get_api_context') as gac:
+        gac.return_value.__aenter__.return_value = mock_api
+        gac.return_value.__aexit__.return_value = None
+        result = runner.invoke(app, ['review', '--all'], obj=mock_config, input='')
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    text = strip_ansi(result.stdout).lower()
+    assert 'no pending findings' in text
+    assert mock_api.lint_resolve.await_count == 0
+    assert mock_api.lint_dismiss.await_count == 0
+
+
 def test_apply_error_isolated_per_finding(runner, mock_config, mock_api, strip_ansi):
     """One ``lint_resolve`` raising must NOT abort the loop.
 

--- a/packages/cli/tests/test_lint_review_unit.py
+++ b/packages/cli/tests/test_lint_review_unit.py
@@ -177,6 +177,39 @@ def test_apply_with_dismiss_calls_dismiss_path(runner, mock_config, mock_api, st
     assert mock_api.lint_resolve.await_count == 0
 
 
+def test_missing_id_skips_finding_without_prompting(runner, mock_config, mock_api, strip_ansi):
+    """Finding without ``id`` is skipped + flagged; loop never prompts on the bad row."""
+    bad_findings = [
+        # No 'id' key at all — defensive guard must catch this.
+        {
+            'lint_type': 'quality',
+            'rule_name': 'malformed_no_id',
+            'target_type': 'memory_unit',
+            'target_id': 'unit-zzz',
+            'evidence': {},
+            'suggested_action': 'inspect',
+            'status': 'pending',
+        },
+        _FINDINGS[0],
+    ]
+    mock_api.lint_findings = AsyncMock(
+        return_value={'count': len(bad_findings), 'findings': bad_findings}
+    )
+    mock_api.lint_resolve = AsyncMock()
+    mock_api.lint_dismiss = AsyncMock()
+
+    with patch('memex_cli.lint.get_api_context') as gac:
+        gac.return_value.__aenter__.return_value = mock_api
+        gac.return_value.__aexit__.return_value = None
+        result = runner.invoke(app, ['review', '--all', '--apply'], obj=mock_config, input='s\n')
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    text = strip_ansi(result.stdout).lower()
+    assert 'missing' in text and 'id' in text
+    assert mock_api.lint_resolve.await_count == 0
+    assert mock_api.lint_dismiss.await_count == 0
+
+
 def test_empty_findings_short_circuits(runner, mock_config, mock_api, strip_ansi):
     """Empty findings list → loop exits immediately, no API mutations, summary still prints."""
     mock_api.lint_findings = AsyncMock(return_value={'count': 0, 'findings': []})

--- a/packages/cli/tests/test_lint_review_unit.py
+++ b/packages/cli/tests/test_lint_review_unit.py
@@ -1,0 +1,199 @@
+"""F7 — unit tests for ``memex lint review`` prompt-loop verdict collection.
+
+These tests drive the CLI via Typer's ``CliRunner`` with simulated stdin
+and a mocked ``RemoteMemexAPI``. They cover:
+
+  - all-skip session collects 0 verdicts and writes nothing.
+  - one accept + skip(s) → exactly one resolve call when ``--apply`` is set.
+  - quit on first finding exits cleanly without traversing the rest.
+  - invalid keypress re-prompts (still yields a valid verdict).
+  - dry-run default never invokes ``lint_resolve`` / ``lint_dismiss``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from memex_cli.lint import app
+
+
+_FINDINGS = [
+    {
+        'id': '11111111-1111-1111-1111-111111111111',
+        'lint_type': 'quality',
+        'rule_name': 'cold_low_mw_unit',
+        'target_type': 'memory_unit',
+        'target_id': 'unit-aaa',
+        'vault_id': '22222222-2222-2222-2222-222222222222',
+        'evidence': {'mw_score': 0.18, 'success_co_count': 1, 'failure_co_count': 6},
+        'suggested_action': 'Deprioritize the unit; 5+ outcomes with low MW.',
+        'created_at': '2026-04-30T12:00:00+00:00',
+        'status': 'pending',
+        'source': 'rule',
+    },
+    {
+        'id': '33333333-3333-3333-3333-333333333333',
+        'lint_type': 'structural',
+        'rule_name': 'orphan_mental_model',
+        'target_type': 'mental_model',
+        'target_id': 'mm-bbb',
+        'vault_id': '22222222-2222-2222-2222-222222222222',
+        'evidence': {'observation_count': 3, 'linked_active_units': 0},
+        'suggested_action': 'Archive the orphan mental model.',
+        'created_at': '2026-04-29T08:00:00+00:00',
+        'status': 'pending',
+        'source': 'rule',
+    },
+    {
+        'id': '44444444-4444-4444-4444-444444444444',
+        'lint_type': 'governance',
+        'rule_name': 'sensitive_unreviewed_unit',
+        'target_type': 'memory_unit',
+        'target_id': 'unit-ccc',
+        'vault_id': '22222222-2222-2222-2222-222222222222',
+        'evidence': {'risk_class': 'sensitive'},
+        'suggested_action': 'Review the sensitive unit; no review in 30+ days.',
+        'created_at': '2026-04-28T08:00:00+00:00',
+        'status': 'pending',
+        'source': 'rule',
+    },
+]
+
+
+def _patched_api(mock_api):
+    """Wire ``lint_findings`` to return our fixture set; stub the resolve/dismiss verbs."""
+    mock_api.lint_findings = AsyncMock(
+        return_value={'count': len(_FINDINGS), 'findings': _FINDINGS}
+    )
+    mock_api.lint_resolve = AsyncMock(
+        side_effect=lambda fid: {'finding_id': fid, 'status': 'resolved'}
+    )
+    mock_api.lint_dismiss = AsyncMock(
+        side_effect=lambda fid: {'finding_id': fid, 'status': 'dismissed'}
+    )
+    return mock_api
+
+
+def _invoke(runner, mock_api, mock_config, args, stdin):
+    with patch('memex_cli.lint.get_api_context') as gac:
+        gac.return_value.__aenter__.return_value = _patched_api(mock_api)
+        gac.return_value.__aexit__.return_value = None
+        return runner.invoke(app, args, obj=mock_config, input=stdin)
+
+
+# ---------------------------------------------------------------------------
+# verdict collection
+# ---------------------------------------------------------------------------
+
+
+def test_all_skip_session_collects_no_verdicts(runner, mock_config, mock_api, strip_ansi):
+    """Three skips → 0 accepts, 0 dismisses, 3 skipped, no API mutation calls."""
+    result = _invoke(runner, mock_api, mock_config, ['review', '--all'], stdin='s\ns\ns\n')
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    text = strip_ansi(result.stdout)
+    assert 'skipped' in text.lower()
+    assert mock_api.lint_resolve.await_count == 0
+    assert mock_api.lint_dismiss.await_count == 0
+
+
+def test_one_accept_two_skips_resolves_only_first_when_apply(
+    runner, mock_config, mock_api, strip_ansi
+):
+    """``a, s, s`` with ``--apply`` → exactly one resolve call, no dismiss calls."""
+    result = _invoke(
+        runner, mock_api, mock_config, ['review', '--all', '--apply'], stdin='a\ns\ns\n'
+    )
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    assert mock_api.lint_resolve.await_count == 1
+    mock_api.lint_resolve.assert_awaited_with(_FINDINGS[0]['id'])
+    assert mock_api.lint_dismiss.await_count == 0
+
+
+def test_quit_early_exits_without_traversing_rest(runner, mock_config, mock_api, strip_ansi):
+    """``q`` on the first finding → loop exits, summary prints, no API mutation."""
+    result = _invoke(runner, mock_api, mock_config, ['review', '--all', '--apply'], stdin='q\n')
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    text = strip_ansi(result.stdout)
+    assert 'quit' in text.lower() or 'ended early' in text.lower()
+    assert mock_api.lint_resolve.await_count == 0
+    assert mock_api.lint_dismiss.await_count == 0
+
+
+def test_invalid_keypress_reprompts(runner, mock_config, mock_api, strip_ansi):
+    """``z`` (invalid) → re-prompt; subsequent ``s`` accepted; loop progresses."""
+    stdin = 'z\ns\ns\ns\n'
+    result = _invoke(runner, mock_api, mock_config, ['review', '--all'], stdin=stdin)
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    text = strip_ansi(result.stdout)
+    assert 'invalid' in text.lower()
+    assert mock_api.lint_resolve.await_count == 0
+    assert mock_api.lint_dismiss.await_count == 0
+
+
+def test_dry_run_collects_verdicts_without_calling_apply(runner, mock_config, mock_api, strip_ansi):
+    """Without ``--apply``, accept + dismiss collect verdicts but never call the API."""
+    result = _invoke(runner, mock_api, mock_config, ['review', '--all'], stdin='a\nd\ns\n')
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    text = strip_ansi(result.stdout)
+    assert 'dry-run' in text.lower() or 'would have applied' in text.lower()
+    assert mock_api.lint_resolve.await_count == 0
+    assert mock_api.lint_dismiss.await_count == 0
+
+
+def test_review_rejects_multiple_scope_flags(runner, mock_config, strip_ansi):
+    """Passing both ``--vault`` and ``--global`` exits with code 2."""
+    result = runner.invoke(
+        app,
+        ['review', '--vault', '00000000-0000-0000-0000-000000000001', '--global'],
+        obj=mock_config,
+    )
+    assert result.exit_code == 2
+    assert 'at most one' in (strip_ansi(result.stdout) + strip_ansi(result.stderr or '')).lower()
+
+
+def test_review_rejects_unknown_lint_type(runner, mock_config, strip_ansi):
+    """Unknown ``--type`` exits with code 2 (mirrors ``lint findings``)."""
+    result = runner.invoke(app, ['review', '--type', 'bogus'], obj=mock_config)
+    assert result.exit_code == 2
+    assert 'unknown' in strip_ansi(result.stdout).lower()
+
+
+def test_apply_with_dismiss_calls_dismiss_path(runner, mock_config, mock_api, strip_ansi):
+    """``d`` verdict with ``--apply`` calls ``lint_dismiss`` (not ``lint_resolve``)."""
+    result = _invoke(
+        runner, mock_api, mock_config, ['review', '--all', '--apply'], stdin='d\ns\ns\n'
+    )
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    assert mock_api.lint_dismiss.await_count == 1
+    mock_api.lint_dismiss.assert_awaited_with(_FINDINGS[0]['id'])
+    assert mock_api.lint_resolve.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# help-text fence
+# ---------------------------------------------------------------------------
+
+
+def test_review_help_documents_apply_and_scope(runner, strip_ansi):
+    """``memex lint review --help`` advertises ``--apply`` and the scope flags."""
+    result = runner.invoke(app, ['review', '--help'])
+    assert result.exit_code == 0
+    text = strip_ansi(result.stdout)
+    assert '--apply' in text
+    assert '--vault' in text
+
+
+@pytest.mark.parametrize('flag', ['--global', '--all'])
+def test_review_help_lists_each_scope_flag(runner, strip_ansi, flag):
+    """Each scope flag is documented in --help."""
+    result = runner.invoke(app, ['review', '--help'])
+    assert result.exit_code == 0
+    assert flag in strip_ansi(result.stdout)

--- a/packages/cli/tests/test_lint_review_unit.py
+++ b/packages/cli/tests/test_lint_review_unit.py
@@ -177,6 +177,45 @@ def test_apply_with_dismiss_calls_dismiss_path(runner, mock_config, mock_api, st
     assert mock_api.lint_resolve.await_count == 0
 
 
+def test_apply_error_isolated_per_finding(runner, mock_config, mock_api, strip_ansi):
+    """One ``lint_resolve`` raising must NOT abort the loop.
+
+    Verdicts: ``a, a, s`` with ``--apply``. The first resolve call raises;
+    the second succeeds. The session must traverse all three findings,
+    surface the failure (``apply failed``), and still print a final summary
+    that records the error count.
+    """
+    mock_api.lint_findings = AsyncMock(
+        return_value={'count': len(_FINDINGS), 'findings': _FINDINGS}
+    )
+    mock_api.lint_dismiss = AsyncMock(
+        side_effect=lambda fid: {'finding_id': fid, 'status': 'dismissed'}
+    )
+
+    call_count = {'n': 0}
+
+    async def _flaky_resolve(fid):
+        call_count['n'] += 1
+        if call_count['n'] == 1:
+            raise RuntimeError('boom')
+        return {'finding_id': fid, 'status': 'resolved'}
+
+    mock_api.lint_resolve = AsyncMock(side_effect=_flaky_resolve)
+
+    with patch('memex_cli.lint.get_api_context') as gac:
+        gac.return_value.__aenter__.return_value = mock_api
+        gac.return_value.__aexit__.return_value = None
+        result = runner.invoke(
+            app, ['review', '--all', '--apply'], obj=mock_config, input='a\na\ns\n'
+        )
+
+    assert result.exit_code == 0, strip_ansi(result.stdout)
+    text = strip_ansi(result.stdout).lower()
+    assert 'apply failed' in text
+    assert 'apply errors' in text
+    assert mock_api.lint_resolve.await_count == 2
+
+
 # ---------------------------------------------------------------------------
 # help-text fence
 # ---------------------------------------------------------------------------

--- a/tests/test_int_lint_review_apply.py
+++ b/tests/test_int_lint_review_apply.py
@@ -1,0 +1,242 @@
+"""F7 — integration test for ``memex lint review --apply``.
+
+Spins up a real Postgres via testcontainers (root ``conftest.py``), seeds
+``MaintenanceProposal`` rows, and drives the CLI end-to-end. Three cases:
+
+  1. ``--apply`` with verdicts ``a, s`` → first row resolved, second untouched.
+  2. Audit-log invariant: a finding driven through ``memex lint resolve <id>``
+     and a finding driven through ``memex lint review --apply`` (accept) must
+     yield equivalent rows on the resolution-relevant columns.
+  3. Dry-run: ``a, a`` without ``--apply`` → both rows still pending.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+from urllib.parse import urlparse
+from uuid import UUID, uuid4
+
+import asyncpg
+import pytest
+from httpx import ASGITransport, AsyncClient
+from typer.testing import CliRunner
+
+from memex_cli import app
+from memex_common.client import RemoteMemexAPI
+from memex_core.server import app as server_app
+
+
+runner = CliRunner()
+
+
+@asynccontextmanager
+async def _mock_api_context(*_args, **_kwargs):
+    """Route CLI requests through the in-process FastAPI app via ASGITransport.
+
+    Mirrors the pattern in ``tests/test_e2e_cli.py``.
+    """
+    from memex_core.server import lifespan
+
+    async with lifespan(server_app):
+        async with AsyncClient(
+            transport=ASGITransport(app=server_app),
+            base_url='http://test/api/v1/',
+        ) as client:
+            yield RemoteMemexAPI(client)
+
+
+def _setup_env(postgres_container):
+    dsn = postgres_container.get_connection_url()
+    parsed = urlparse(dsn)
+    os.environ['MEMEX_SERVER__META_STORE__TYPE'] = 'postgres'
+    os.environ['MEMEX_SERVER__META_STORE__INSTANCE__HOST'] = parsed.hostname or 'localhost'
+    os.environ['MEMEX_SERVER__META_STORE__INSTANCE__PORT'] = str(parsed.port or 5432)
+    os.environ['MEMEX_SERVER__META_STORE__INSTANCE__DATABASE'] = parsed.path.lstrip('/')
+    os.environ['MEMEX_SERVER__META_STORE__INSTANCE__USER'] = parsed.username or 'test'
+    os.environ['MEMEX_SERVER__META_STORE__INSTANCE__PASSWORD'] = parsed.password or 'test'
+
+
+_CLI_OVERRIDES = [
+    '--set',
+    'server_url=http://test',
+    '--set',
+    'server.meta_store.type=postgres',
+    '--set',
+    'server.meta_store.instance.host=localhost',
+    '--set',
+    'server.meta_store.instance.database=dummy',
+    '--set',
+    'server.meta_store.instance.user=dummy',
+    '--set',
+    'server.meta_store.instance.password=dummy',
+    '--set',
+    'server.memory.extraction.model.model=gemini/gemini-3-flash-preview',
+]
+
+
+def _seed_two_pending_findings(postgres_url: str) -> tuple[UUID, list[UUID]]:
+    """Seed a fresh vault + 2 pending proposals via raw SQL. Returns (vault_id, [f1, f2])."""
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _seed() -> tuple[UUID, list[UUID]]:
+        conn = await asyncpg.connect(dsn)
+        try:
+            vault_id = uuid4()
+            vault_name = f'F7-int-{vault_id.hex[:8]}'
+            await conn.execute(
+                'INSERT INTO vaults (id, name, created_at) VALUES ($1, $2, NOW())',
+                vault_id,
+                vault_name,
+            )
+            ids: list[UUID] = []
+            for rule in ('rule_review_a', 'rule_review_b'):
+                fid = uuid4()
+                await conn.execute(
+                    'INSERT INTO maintenance_proposals '
+                    '(id, vault_id, lint_type, target_type, target_id, rule_name, evidence, '
+                    'suggested_action, status, source) '
+                    "VALUES ($1, $2, 'quality', 'memory_unit', $3, $4, '{}'::jsonb, "
+                    "'fix it', 'pending', 'rule')",
+                    fid,
+                    vault_id,
+                    str(uuid4()),
+                    rule,
+                )
+                ids.append(fid)
+            return vault_id, ids
+        finally:
+            await conn.close()
+
+    return asyncio.run(_seed())
+
+
+def _read_status_row(postgres_url: str, finding_id: UUID) -> dict[str, object]:
+    """Return ``{status, resolved_by}`` for a given finding (resolved_at is non-deterministic)."""
+    dsn = postgres_url.replace('postgresql+asyncpg://', 'postgresql://')
+
+    async def _read() -> dict[str, object]:
+        conn = await asyncpg.connect(dsn)
+        try:
+            row = await conn.fetchrow(
+                'SELECT status, resolved_by, resolved_at IS NOT NULL AS has_resolved_at '
+                'FROM maintenance_proposals WHERE id = $1',
+                finding_id,
+            )
+            assert row is not None
+            return dict(row)
+        finally:
+            await conn.close()
+
+    return asyncio.run(_read())
+
+
+@pytest.mark.integration
+def test_review_apply_resolves_accepted_and_leaves_skipped(postgres_container, postgres_url):
+    """``a\\ns\\n`` with ``--apply`` flips one finding to resolved and leaves the other pending.
+
+    The CLI surfaces findings in ``created_at DESC`` order; rather than guessing which
+    rule lands first, we just assert exactly one row is resolved and the other still pending.
+    """
+    _setup_env(postgres_container)
+    vault_id, [f1, f2] = _seed_two_pending_findings(postgres_url)
+
+    with patch('memex_cli.lint.get_api_context', _mock_api_context):
+        result = runner.invoke(
+            app,
+            [
+                *_CLI_OVERRIDES,
+                'lint',
+                'review',
+                '--vault',
+                str(vault_id),
+                '--apply',
+            ],
+            input='a\ns\n',
+        )
+
+    assert result.exit_code == 0, f'CLI failed: {result.stdout}'
+
+    rows = [_read_status_row(postgres_url, fid) for fid in (f1, f2)]
+    statuses = sorted(str(r['status']).rsplit('.', 1)[-1] for r in rows)
+    assert statuses == ['pending', 'resolved'], (
+        f'expected one pending + one resolved, got {statuses}. stdout: {result.stdout}'
+    )
+    resolved_rows = [r for r in rows if str(r['status']).endswith('resolved')]
+    pending_rows = [r for r in rows if str(r['status']).endswith('pending')]
+    assert resolved_rows[0]['has_resolved_at'] is True
+    assert pending_rows[0]['has_resolved_at'] is False
+
+
+@pytest.mark.integration
+def test_review_apply_audit_log_invariant_matches_direct_resolve(postgres_container, postgres_url):
+    """A finding resolved via ``lint resolve <id>`` and one resolved via ``lint review --apply``
+    must end up with the same shape on the audit-log-relevant columns.
+
+    Concretely: both rows must have ``status=resolved``, ``resolved_at IS NOT NULL``,
+    and the same ``resolved_by`` value (NULL in both cases — the route does not
+    pass ``actor`` through to ``LintService.set_status``).
+    """
+    _setup_env(postgres_container)
+    vault_id, [direct_id, review_id] = _seed_two_pending_findings(postgres_url)
+
+    with patch('memex_cli.lint.get_api_context', _mock_api_context):
+        direct_result = runner.invoke(
+            app,
+            [*_CLI_OVERRIDES, 'lint', 'resolve', str(direct_id)],
+        )
+        assert direct_result.exit_code == 0, f'direct resolve failed: {direct_result.stdout}'
+
+        review_result = runner.invoke(
+            app,
+            [
+                *_CLI_OVERRIDES,
+                'lint',
+                'review',
+                '--vault',
+                str(vault_id),
+                '--apply',
+            ],
+            input='a\nq\n',
+        )
+        assert review_result.exit_code == 0, f'review --apply failed: {review_result.stdout}'
+
+    direct_row = _read_status_row(postgres_url, direct_id)
+    review_row = _read_status_row(postgres_url, review_id)
+
+    assert str(direct_row['status']).endswith('resolved')
+    assert str(review_row['status']).endswith('resolved')
+    assert direct_row['has_resolved_at'] is True
+    assert review_row['has_resolved_at'] is True
+    assert direct_row['resolved_by'] == review_row['resolved_by']
+
+
+@pytest.mark.integration
+def test_review_dry_run_does_not_mutate(postgres_container, postgres_url):
+    """``a\\na\\n`` WITHOUT ``--apply`` collects verdicts but leaves both rows pending."""
+    _setup_env(postgres_container)
+    vault_id, [f1, f2] = _seed_two_pending_findings(postgres_url)
+
+    with patch('memex_cli.lint.get_api_context', _mock_api_context):
+        result = runner.invoke(
+            app,
+            [
+                *_CLI_OVERRIDES,
+                'lint',
+                'review',
+                '--vault',
+                str(vault_id),
+            ],
+            input='a\na\n',
+        )
+
+    assert result.exit_code == 0, f'CLI failed: {result.stdout}'
+
+    after_f1 = _read_status_row(postgres_url, f1)
+    after_f2 = _read_status_row(postgres_url, f2)
+    assert str(after_f1['status']).endswith('pending'), after_f1
+    assert str(after_f2['status']).endswith('pending'), after_f2
+    assert after_f1['has_resolved_at'] is False
+    assert after_f2['has_resolved_at'] is False


### PR DESCRIPTION
## Summary

`memex lint review` — human-side parity verb for F8's agent-driven lint triage. Walks each pending finding interactively, renders evidence + suggested action, lets the user accept / dismiss / skip via single keypress. Defaults to dry-run; requires `--apply` to write.

## What changed

- `packages/cli/src/memex_cli/lint.py` — new `@app.command('review')` subcommand.
- `packages/cli/src/memex_cli/lint_review.py` — new module: per-finding render + prompt loop.
- Tests: unit (11 cases) + integration (3 cases) with audit-log-invariant check.
- §4 F7 marked as shipped in research report.
- BACKLOG.md: F7 ticked.

## Out of scope

- No MCP / Hermes / Claude Code parity (F7 is human-only by design — F8 is the agent counterpart).
- No new lint check types.
- No destructive default.

## Test plan

- [ ] Unit + integration tests pass (audit-log invariant verified).
- [ ] Manual smoke: `memex lint review --vault X` → renders findings, accepts single keypress, `--apply` writes; without `--apply` no DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)