### PR TITLE
refactor: strip F-code ticket refs from user/agent-facing surfaces (phase 2)

### DIFF
--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -613,7 +613,7 @@ class MemexAPI:
 
     @property
     def lint_llm(self) -> 'LintLLMService':
-        """F10 surprise-gated LLM lint service."""
+        """Surprise-gated LLM lint service."""
         return self._lint_llm
 
     @property
@@ -629,7 +629,7 @@ class MemexAPI:
     ) -> dict[str, Any]:
         """Re-evaluate memories for an entity under a per-entity advisory lock.
 
-        Facade for `LocksService.reconsolidate_entity` (F9).
+        Facade for `LocksService.reconsolidate_entity`.
         """
         return await self._locks.reconsolidate_entity(
             entity_id, vault_id, timeout_seconds=timeout_seconds
@@ -642,7 +642,7 @@ class MemexAPI:
         dry_run: bool = False,
         actor: str | None = None,
     ) -> dict[str, Any]:
-        """Vault-wide low-MW unit consolidation (F9 / RFC-008).
+        """Vault-wide low-MW unit consolidation (RFC-008).
 
         Facade for `LocksService.consolidate_vault`.
         """
@@ -756,7 +756,7 @@ class MemexAPI:
         cleanly on graceful server stop. Idempotent — safe to call multiple
         times. Currently closes:
 
-          * ``LocksService._pool`` — shared asyncpg pool used by F9 entity
+          * ``LocksService._pool`` — shared asyncpg pool used by entity
             locks (CRIT-1 fix).
         """
         try:
@@ -1088,7 +1088,7 @@ class MemexAPI:
         chunk_ids: list[UUID],
         vault_id: UUID,
     ) -> list[Any]:
-        """F46: get memory units belonging to the named chunks (vault-scoped)."""
+        """Get memory units belonging to the named chunks (vault-scoped)."""
         return await self._stats.get_memory_units_by_chunks(chunk_ids, vault_id)
 
     async def delete_memory_unit(self, unit_id: UUID) -> bool:
@@ -1146,7 +1146,7 @@ class MemexAPI:
         max_depth: int = 10,
         vault_id: UUID | None = None,
     ) -> UnitHistoryNodeDTO:
-        """F49: walk the contradiction graph backward from ``unit_id``.
+        """Walk the contradiction graph backward from ``unit_id``.
 
         Returns a ``UnitHistoryNodeDTO`` tree rooted at the queried unit
         (depth=0). v1 walks ``contradicts`` and ``weakens`` links only —
@@ -1165,7 +1165,7 @@ class MemexAPI:
         *,
         limit: int = 20,
     ) -> list[Any]:
-        """F20: list memory units due for revisit in `vault_id`. Delegates to RevisitationService."""
+        """List memory units due for revisit in `vault_id`. Delegates to RevisitationService."""
         return await self._revisit.list_due(vault_id, limit=limit)
 
     async def review_memory_unit(
@@ -1176,7 +1176,7 @@ class MemexAPI:
         vault_id: UUID,
         actor: UUID | None = None,
     ) -> dict[str, Any]:
-        """F20: record a review outcome on a memory unit. Delegates to RevisitationService."""
+        """Record a review outcome on a memory unit. Delegates to RevisitationService."""
         return await self._revisit.review(unit_id, quality, vault_id=vault_id, actor=actor)
 
     async def retrieve(self, request: RetrievalRequest) -> tuple[list[MemoryUnit], Any]:
@@ -1326,7 +1326,7 @@ class MemexAPI:
         scope: str = 'incremental',
         vault_id: UUID | None = None,
     ) -> ReflectionResult:
-        """F5: synchronous on-demand reflection (rate-limited per entity, vault).
+        """Synchronous on-demand reflection (rate-limited per entity, vault).
 
         Delegates to :meth:`ReflectionService.summarize_node`. Surfaces a
         ``RateLimitExceededError`` upward; surface adapters (MCP/Hermes/HTTP)
@@ -1353,7 +1353,7 @@ class MemexAPI:
     ) -> dict[str, Any]:
         """Record an outcome. Delegates to OutcomeService.
 
-        For ``target_type='kv_key'`` (F14), increments the vault-scoped
+        For ``target_type='kv_key'``, increments the vault-scoped
         success/failure counters on ``procedure_outcomes`` for ``kv_key``
         instead of memory units. See
         :meth:`OutcomeService.record_outcome` for the full contract.
@@ -1692,7 +1692,7 @@ class MemexAPI:
         context: str | None = None,
         limit: int = 5,
     ) -> list[dict[str, Any]]:
-        """F14 — Top procedure outcomes for a vault, ranked by MW score."""
+        """Top procedure outcomes for a vault, ranked by MW score."""
         return await self._kv.list_top_procedure_outcomes(
             vault_id=vault_id, context=context, limit=limit
         )

--- a/packages/core/src/memex_core/memory/lint_llm/__init__.py
+++ b/packages/core/src/memex_core/memory/lint_llm/__init__.py
@@ -1,11 +1,11 @@
-"""F10 — Surprise-gated LLM-assisted lint.
+"""Surprise-gated LLM-assisted lint.
 
 Submodules:
 
 - ``surprise``: anisotropy-corrected surprise score for a memory unit.
 - ``signatures``: DSPy signatures for the LLM lint checks.
 - ``checks``: factories that bind a DSPy LM to a runnable ``RunLLMCheck``.
-- ``polarity``: F10b NLI classifier wrapper + per-vault rate limiter.
+- ``polarity``: NLI classifier wrapper + per-vault rate limiter.
 - ``types``: shared dataclasses + the ``PolarityLabel`` enum.
 """
 

--- a/packages/core/src/memex_core/memory/lint_llm/checks.py
+++ b/packages/core/src/memex_core/memory/lint_llm/checks.py
@@ -1,4 +1,4 @@
-"""F10 LLM check factories — build runnable RunLLMCheck callables.
+"""LLM check factories — build runnable RunLLMCheck callables.
 
 Each factory binds a DSPy ``LM`` and signature into a coroutine matching
 :class:`memex_core.services.lint_llm.RunLLMCheck`. The coroutine:
@@ -134,12 +134,12 @@ def make_semantic_contradiction_check(
     unit. Surprise is recomputed inside the check so the evidence payload
     can carry it for downstream filtering / diagnostics.
 
-    F10b: when the orchestrator (:meth:`LintLLMService.maybe_run`) attaches a
+    When the orchestrator (:meth:`LintLLMService.maybe_run`) attaches a
     :class:`CheckContext` carrying a ``PolarityResult`` (because the
     cosine-OR-polarity gate cleared via the polarity branch), the check
     forwards the argmax label to the DSPy signature as ``polarity_hint``
     and adds the probabilities to ``extra_evidence``. With no context, the
-    check is byte-identical to its F10 behaviour.
+    check is byte-identical to its original behaviour.
     """
     predictor = dspy.Predict(CheckSemanticContradiction)
     sk = surprise_k if surprise_k is not None else k
@@ -152,7 +152,7 @@ def make_semantic_contradiction_check(
     ) -> LLMLintFinding | None:
         unit_text = await _load_unit_text(session, unit_id)
         if unit_text is None:
-            logger.warning('F10 semantic-contradiction: unit %s missing — skipping', unit_id)
+            logger.warning('Semantic-contradiction: unit %s missing — skipping', unit_id)
             return None
 
         related = await _load_top_k_related(session, unit_id, vault_id, k=k)
@@ -236,7 +236,7 @@ def make_schema_drift_check(
     ) -> LLMLintFinding | None:
         unit_text = await _load_unit_text(session, unit_id)
         if unit_text is None:
-            logger.warning('F10 schema-drift: unit %s missing — skipping', unit_id)
+            logger.warning('Schema-drift: unit %s missing — skipping', unit_id)
             return None
 
         sample = await _load_random_sample(session, unit_id, vault_id, k=k)

--- a/packages/core/src/memex_core/memory/lint_llm/polarity.py
+++ b/packages/core/src/memex_core/memory/lint_llm/polarity.py
@@ -1,7 +1,7 @@
-"""F10b — polarity-discriminating NLI wrapper.
+"""Polarity-discriminating NLI wrapper.
 
-Augments F10's surprise gate with a three-way NLI signal so polarity-inverting
-unit/peer pairs (POC-002 result.md F3) clear the gate even when MiniLM-L12
+Augments the surprise gate with a three-way NLI signal so polarity-inverting
+unit/peer pairs (POC-002 result.md) clear the gate even when MiniLM-L12
 cosine surprise alone keeps them below the surprise threshold.
 
 The composition is OR'd: a unit/peer pair clears the gate when EITHER
@@ -52,7 +52,7 @@ class PolarityClassifyOutcome:
 class PolarityRateLimiter:
     """Per-vault hourly cap on NLI invocations.
 
-    In-memory sliding window — the F10 lint scheduler is a single-leader process
+    In-memory sliding window — the lint scheduler is a single-leader process
     (Postgres advisory lock) so a process-local counter is sufficient. The cap
     is a soft circuit-breaker; over-cap calls return ``False`` and the gate
     falls back to cosine-only behaviour for that pair.
@@ -113,7 +113,7 @@ class PolarityClassifier:
 
     Uses ``NLIClassifierModel`` for the inference call and ``PolarityRateLimiter``
     for the per-vault hourly cap (None = unlimited). The argmax label and
-    raw probabilities are returned in a :class:`PolarityResult` so the F10 LLM
+    raw probabilities are returned in a :class:`PolarityResult` so the LLM
     check can carry the label through as a hint.
     """
 
@@ -158,7 +158,7 @@ class PolarityClassifier:
         admitted = await self.rate_limiter.admit(vault_id)
         if not admitted:
             logger.warning(
-                'F10b NLI rate-limit exhausted for vault %s — falling back to cosine-only',
+                'NLI rate-limit exhausted for vault %s — falling back to cosine-only',
                 vault_id,
             )
             return PolarityClassifyOutcome(rate_limited=True)
@@ -174,7 +174,7 @@ class PolarityClassifier:
             return PolarityClassifyOutcome(result=result)
         except Exception:
             logger.exception(
-                'F10b NLI classify failed for vault %s — falling back to cosine-only',
+                'NLI classify failed for vault %s — falling back to cosine-only',
                 vault_id,
             )
             await self.rate_limiter.release(vault_id)
@@ -206,7 +206,7 @@ def gate_passes(
     surprise_threshold: float,
     polarity_threshold: float = DEFAULT_POLARITY_THRESHOLD,
 ) -> bool:
-    """OR-combine F10's cosine gate with F10b's polarity gate.
+    """OR-combine the cosine gate with the polarity gate.
 
     The contract is symmetric: the pair clears the gate when EITHER signal
     crosses its respective threshold. The caller is expected to pass

--- a/packages/core/src/memex_core/memory/lint_llm/signatures.py
+++ b/packages/core/src/memex_core/memory/lint_llm/signatures.py
@@ -1,4 +1,4 @@
-"""F10 DSPy signatures for the surprise-gated LLM lint.
+"""DSPy signatures for the surprise-gated LLM lint.
 
 Two checks per RFC-006 §"LLM check types — DSPy signatures":
 
@@ -7,12 +7,12 @@ Two checks per RFC-006 §"LLM check types — DSPy signatures":
 - :class:`CheckSchemaDrift` — does this unit's structure (date format,
   ID style, schema) diverge from the corpus norm?
 
-Both are wrapped in F10's circuit breaker via
+Both are wrapped in the circuit breaker via
 :func:`memex_core.llm.run_dspy_operation` at the factory layer
 (``checks.make_semantic_contradiction_check`` /
 ``make_schema_drift_check``).
 
-Polarity discrimination is bridged by F10b — see
+Polarity discrimination is bridged by the NLI classifier — see
 ``memex_core.memory.lint_llm.polarity`` and the OR'd
 ``surprise.gate_passes`` composition. The NLI label is passed through
 to :class:`CheckSemanticContradiction` via ``polarity_hint`` so the LLM
@@ -51,7 +51,7 @@ class CheckSemanticContradiction(dspy.Signature):
     )
     polarity_hint: PolarityLiteral | None = dspy.InputField(
         desc=(
-            'F10b NLI classifier label (entailment / neutral / contradiction) '
+            'NLI classifier label (entailment / neutral / contradiction) '
             'when the surprise gate cleared via the polarity branch only. '
             'Use as a HINT, not a hard signal — the LLM is still the final '
             'judge. Empty / None when the cosine surprise gate alone fired.'

--- a/packages/core/src/memex_core/memory/lint_llm/surprise.py
+++ b/packages/core/src/memex_core/memory/lint_llm/surprise.py
@@ -1,11 +1,11 @@
-"""F10 surprise score — anisotropy-corrected per-unit surprise.
+"""Surprise score — anisotropy-corrected per-unit surprise.
 
 Mirrors production semantics from ``memory/contradiction/candidates.py`` and
 ``memory/retrieval/engine.py`` (``_compute_pairwise_cosine``)::
 
   surprise(unit, vault) = 1 - mean( normalize( top_k_cosine_sim(unit, vault) ) )
 
-where ``normalize`` is F2's shared :class:`AnisotropyCorrector` (Z-score →
+where ``normalize`` is the shared :class:`AnisotropyCorrector` (Z-score →
 sigmoid) and ``top_k_cosine_sim`` is computed in pgvector with
 ``1 - (a.embedding <=> b.embedding)``.
 
@@ -14,9 +14,9 @@ A unit that is anomalous (figure-skating in a Python-frameworks vault, or a
 contradiction to the corpus consensus) returns low corrected similarities →
 high surprise.
 
-Validated by POC-F10 (`pocs/002-f10-surprise-threshold/result.md`):
+Validated by POC (`pocs/002-f10-surprise-threshold/result.md`):
 - PASS topical-anomaly recall @ 0.7 threshold.
-- Polarity-inversion recall is bridged by F10b: see ``polarity.py`` and
+- Polarity-inversion recall is bridged by the NLI classifier: see ``polarity.py`` and
   :func:`gate_passes` — cosine surprise OR'd with NLI contradiction-probability.
 """
 
@@ -47,7 +47,7 @@ def gate_passes(
     surprise_threshold: float,
     polarity_threshold: float = DEFAULT_POLARITY_THRESHOLD,
 ) -> bool:
-    """F10 + F10b composed gate.
+    """Composed cosine + NLI gate.
 
     Returns ``True`` when the cosine surprise alone clears ``surprise_threshold``
     OR (when cosine is below threshold) the supplied NLI contradiction-probability
@@ -77,7 +77,7 @@ async def compute_unit_surprise(
 
     Returns a value in [0, 1] where 1.0 is maximally surprising. Computes
     top-k cosine similarities to other ACTIVE units in the same vault via
-    pgvector, routes them through F2's anisotropy corrector, then returns
+    pgvector, routes them through the anisotropy corrector, then returns
     ``1 - mean(corrected)``.
 
     A vault with fewer than ``k`` peer units returns 1.0 (no neighborhood to
@@ -125,7 +125,7 @@ async def warm_corrector(
 ) -> int:
     """Warm the shared corrector with random pairwise similarities from a vault.
 
-    F2's corrector is cold-start passthrough until it has ``min_samples``
+    The corrector is cold-start passthrough until it has ``min_samples``
     (default 32) observations in its window; the corrected output only
     diverges from the raw similarity once the window is populated. To make
     the surprise score meaningful on the first call, pre-feed at least

--- a/packages/core/src/memex_core/memory/lint_llm/types.py
+++ b/packages/core/src/memex_core/memory/lint_llm/types.py
@@ -1,4 +1,4 @@
-"""F10 shared types — kept in a leaf module to avoid the circular import
+"""Shared types — kept in a leaf module to avoid the circular import
 between ``memory.lint_llm.checks`` (which produces findings) and
 ``services.lint_llm`` (which persists them).
 """
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class PolarityLabel(str, Enum):
-    """Three-way NLI label produced by F10b's polarity classifier."""
+    """Three-way NLI label produced by the polarity classifier."""
 
     ENTAILMENT = 'entailment'
     NEUTRAL = 'neutral'
@@ -30,7 +30,7 @@ PolarityLiteral = Literal['entailment', 'neutral', 'contradiction']
 
 
 class PolarityResult(BaseModel):
-    """Argmax label + per-class probabilities from F10b's NLI classifier.
+    """Argmax label + per-class probabilities from the NLI classifier.
 
     Probabilities are stored verbatim (no rounding) so the gate can apply its
     threshold to the contradiction-probability without re-deriving it. The
@@ -68,7 +68,7 @@ class PolarityResult(BaseModel):
 
 @dataclass
 class LLMLintFinding:
-    """Output of an F10 LLM check, ready to persist as a MaintenanceProposal.
+    """Output of an LLM check, ready to persist as a MaintenanceProposal.
 
     ``rule_name`` identifies the DSPy signature that produced the finding
     (e.g. ``llm_semantic_contradiction``, ``llm_schema_drift``).
@@ -89,9 +89,9 @@ class LLMLintFinding:
 
 @dataclass
 class CheckContext:
-    """Optional context the F10 service threads into a check invocation.
+    """Optional context the service threads into a check invocation.
 
-    Currently carries the F10b polarity result computed by the orchestrator's
+    Currently carries the polarity result computed by the orchestrator's
     OR'd gate so the check does not re-invoke the NLI model. Forwards the
     argmax label to the DSPy signature as ``polarity_hint`` and the
     probabilities into the finding's ``extra_evidence`` payload.
@@ -102,7 +102,7 @@ class CheckContext:
 
 @runtime_checkable
 class LegacyRunLLMCheck(Protocol):
-    """F10's original 3-positional check signature (kept for backwards compat).
+    """Original 3-positional check signature (kept for backwards compat).
 
     The service uses ``inspect.signature`` to decide whether to call this form
     or :class:`ContextAwareRunLLMCheck`; new checks should accept ``context``.
@@ -118,7 +118,7 @@ class LegacyRunLLMCheck(Protocol):
 
 @runtime_checkable
 class ContextAwareRunLLMCheck(Protocol):
-    """F10b's context-aware check signature.
+    """Context-aware check signature.
 
     Receives a keyword-only :class:`CheckContext` so the orchestrator can plumb
     a precomputed :class:`PolarityResult` through to the DSPy signature without
@@ -135,7 +135,7 @@ class ContextAwareRunLLMCheck(Protocol):
     ) -> 'LLMLintFinding | None': ...
 
 
-# Union of the legacy 3-positional and F10b context-aware check signatures.
+# Union of the legacy 3-positional and context-aware check signatures.
 # Either form is accepted at the service boundary; ``_invoke_check`` routes via
 # ``inspect.signature`` so the right call shape is used at runtime. Using a
 # union (rather than a single Protocol that covers both) keeps positional-arg

--- a/packages/core/src/memex_core/memory/models/backends/onnx_nli.py
+++ b/packages/core/src/memex_core/memory/models/backends/onnx_nli.py
@@ -1,4 +1,4 @@
-"""ONNX-backed NLI classifier (F10b).
+"""ONNX-backed NLI classifier.
 
 Wraps a cross-encoder NLI model (default ``cross-encoder/nli-deberta-v3-small``)
 with the same ``BaseOnnxModel`` substrate that ``FastReranker`` / ``FastEmbedder``
@@ -99,12 +99,12 @@ class OnnxNLIClassifier(BaseOnnxModel):
         ):
             raise ValueError(
                 f'NLI model config.json declares id2label={config_label_order} '
-                f'but the F10b default expects {_LABEL_ORDER}. Pass an explicit '
+                f'but the default expects {_LABEL_ORDER}. Pass an explicit '
                 "label_order=... to opt in to the model's ordering."
             )
         self._label_order = effective
         # ONNX Runtime documents `Run()` as thread-safe on a shared session,
-        # but `_score_pair` is invoked via `asyncio.to_thread` and the F10
+        # but `_score_pair` is invoked via `asyncio.to_thread` and the
         # scheduler can drive multiple vault ticks; serialise inference with
         # a `threading.Lock` so the path is safe under any provider/runtime
         # where that guarantee weakens (e.g. some EP combinations).

--- a/packages/core/src/memex_core/memory/models/nli.py
+++ b/packages/core/src/memex_core/memory/models/nli.py
@@ -1,8 +1,8 @@
-"""F10b NLI classifier factory.
+"""NLI classifier factory.
 
 Mirrors :func:`memex_core.memory.models.reranking.get_reranking_model`: a config
 dispatched factory that returns an object satisfying the
-:class:`NLIClassifierModel` protocol. ONNX-only for v1 (per F10b scope).
+:class:`NLIClassifierModel` protocol. ONNX-only for v1.
 """
 
 from __future__ import annotations
@@ -41,7 +41,7 @@ def _get_init_lock() -> asyncio.Lock:
 
 
 async def get_nli_model(config: NLIModelConfig | None = None) -> NLIClassifierModel | None:
-    """Return an NLI classifier or ``None`` when the F10b gate is disabled.
+    """Return an NLI classifier or ``None`` when the polarity gate is disabled.
 
     Reuses the same cached ONNX session across FastAPI lifespan restarts as
     the embedding/reranker models — the model is ~140 MB, single-instance.

--- a/packages/core/src/memex_core/memory/retrieval/models.py
+++ b/packages/core/src/memex_core/memory/retrieval/models.py
@@ -101,7 +101,7 @@ class RetrievalRequest(SQLModel):
     apply_pre_filter: bool = Field(
         default=True,
         description=(
-            'F40: pre-reranker MW/FSFM filter at hydration. Default ON drops obviously-failed '
+            'Pre-reranker MW/FSFM filter at hydration. Default ON drops obviously-failed '
             'or decayed candidates before the cross-encoder runs. Set False for '
             'historical / audit / lineage queries that need to see contradicted, '
             'behaviorally-failed, or decayed units — every branch is bypassed in one go.'
@@ -147,7 +147,7 @@ class RetrievalRequest(SQLModel):
         ),
     )
 
-    # Intent / risk class filtering (write-time classifier; F25)
+    # Intent / risk class filtering (write-time classifier)
     intent_class: str | None = Field(
         default=None,
         description=(

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -603,7 +603,7 @@ class MemoryUnit(SQLModel, MemoryUnitBase, table=True):  # type: ignore
         default=0,
         sa_column=Column(Integer, nullable=False, server_default='0'),
         description=(
-            'F22: negative-evidence event count — how many times the contradiction '
+            'Negative-evidence event count — how many times the contradiction '
             'engine has weakened or contradicted this unit. Pairs with the closed-form '
             'Beta(1, 1) posterior at memex_core.memory.confidence.mean_and_variance to '
             'derive variance without storing it. Cold-start (count=0) → variance = 1/12.'
@@ -632,7 +632,7 @@ class MemoryUnit(SQLModel, MemoryUnitBase, table=True):  # type: ignore
         default=0,
         sa_column=Column(Integer, nullable=False, server_default='0'),
         description=(
-            'F20: consecutive Again-rating count for the sticky auto-deprioritize gate. '
+            'Consecutive Again-rating count for the sticky auto-deprioritize gate. '
             'Resets to 0 on Hard/Good/Easy.'
         ),
     )
@@ -641,7 +641,7 @@ class MemoryUnit(SQLModel, MemoryUnitBase, table=True):  # type: ignore
         default=None,
         sa_column=Column(TIMESTAMP(timezone=True), nullable=True),
         description=(
-            'F20: wall-clock timestamp of the most recent review. Distinct from '
+            'Wall-clock timestamp of the most recent review. Distinct from '
             'revisit_due_at (next-due); FSRS-5 elapsed-days uses this column.'
         ),
     )
@@ -650,9 +650,9 @@ class MemoryUnit(SQLModel, MemoryUnitBase, table=True):  # type: ignore
         default=None,
         sa_column=Column(Float, nullable=True),
         description=(
-            'F11: importance signal derived from F25 intent_class at write time '
-            '(permanent=1.0, durable=0.7, ephemeral=0.3). NULL for pre-F25 '
-            'unclassified units; the F11 decay boost treats NULL as no signal '
+            'Importance signal derived from intent_class at write time '
+            '(permanent=1.0, durable=0.7, ephemeral=0.3). NULL for '
+            'unclassified units; the decay boost treats NULL as no signal '
             '-> neutral 1.0.'
         ),
     )
@@ -661,8 +661,8 @@ class MemoryUnit(SQLModel, MemoryUnitBase, table=True):  # type: ignore
         default=None,
         sa_column=Column(Float, nullable=True),
         description=(
-            'F11: per-intent-class stability in days (durable=180, ephemeral=14, '
-            'permanent=NULL meaning infinity). The F11 decay boost treats '
+            'Per-intent-class stability in days (durable=180, ephemeral=14, '
+            'permanent=NULL meaning infinity). The decay boost treats '
             'NULL as the stability -> infinity limit (decay term = 1.0).'
         ),
     )
@@ -671,8 +671,8 @@ class MemoryUnit(SQLModel, MemoryUnitBase, table=True):  # type: ignore
         default=None,
         sa_column=Column(TIMESTAMP(timezone=True), nullable=True),
         description=(
-            'F11: wall-clock timestamp of the most recent record_outcome call. '
-            'NULL on units that have never had an outcome recorded; the F11 '
+            'Wall-clock timestamp of the most recent record_outcome call. '
+            'NULL on units that have never had an outcome recorded; the '
             'decay boost treats NULL as no temporal anchor -> neutral 1.0. '
             'Distinct from procedure_outcomes.last_outcome_at (separate table).'
         ),
@@ -1714,7 +1714,7 @@ class ProcedureOutcome(SQLModel, table=True):  # type: ignore
 
 
 # ---------------------------------------------------------------------------
-# F6 — Maintenance ledger (rule-based linter)
+# Maintenance ledger (rule-based linter)
 # ---------------------------------------------------------------------------
 
 
@@ -1737,12 +1737,12 @@ class LintSource(str, Enum):
 
 
 class MaintenanceProposal(SQLModel, table=True):  # type: ignore
-    """Finding ledger row emitted by the F6 LintService.
+    """Finding ledger row emitted by the LintService.
 
-    Read-only from the agent surface (F8). The unique partial index on
+    Read-only from the agent surface. The unique partial index on
     ``(rule_name, target_type, target_id, vault_id) WHERE status = 'pending'``
     makes ``LintService.run_rules`` idempotent on reruns. ``vault_id`` is
-    nullable per AC-F6-1 (NULL = global findings; reserved for Tier B).
+    nullable per acceptance criteria (NULL = global findings; reserved for Tier B).
     """
 
     __tablename__ = 'maintenance_proposals'
@@ -1839,11 +1839,11 @@ class MaintenanceProposal(SQLModel, table=True):  # type: ignore
 
 
 class ConsolidationTick(SQLModel, table=True):  # type: ignore
-    """One row per F38 ``consolidation_tick(vault_id)`` invocation.
+    """One row per ``consolidation_tick(vault_id)`` invocation.
 
-    F38's ``services/consolidation.py`` is a thin orchestrator over
+    ``services/consolidation.py`` is a thin orchestrator over
     reflection + contradiction + prune-stale-only; this row is its sole
-    DB write at the end of each tick (AC-F38-4). ``completed_at IS NULL``
+    DB write at the end of each tick (acceptance criteria). ``completed_at IS NULL``
     signals an in-progress tick; the gap between ``started_at`` and
     ``completed_at`` is wall-clock duration.
     """
@@ -1926,12 +1926,12 @@ class ConsolidationTick(SQLModel, table=True):  # type: ignore
 
 
 # ---------------------------------------------------------------------------
-# F10 — LLM lint quota (rolling-24h cost cap)
+# LLM lint quota (rolling-24h cost cap)
 # ---------------------------------------------------------------------------
 
 
 class LintLLMQuota(SQLModel, table=True):  # type: ignore
-    """Hour-bucket counter for the F10 24h-rolling cost cap.
+    """Hour-bucket counter for the 24h-rolling cost cap.
 
     One row per (vault_id, hour_bucket). The 24h rolling window is computed by
     summing the last 24 hour-buckets via the indexed range scan

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -124,7 +124,7 @@ NOTE_ADD_OVERLAPS_EXISTING_TOTAL = Counter(
 )
 
 # ---------------------------------------------------------------------------
-# Memory Worth (MW) outcome metrics (F1a)
+# Memory Worth (MW) outcome metrics
 # ---------------------------------------------------------------------------
 
 OUTCOME_RECORDED_TOTAL = Counter(
@@ -147,7 +147,7 @@ MW_BOOST_OBSERVED = Histogram(
 )
 
 # ---------------------------------------------------------------------------
-# F40 / F44 / F45 — pre-reranker filter observability
+# Pre-reranker filter observability
 # ---------------------------------------------------------------------------
 # CROSS_ENCODER_INPUT_COUNT_HISTOGRAM and EXPLORATION_INJECTED_TOTAL emit
 # on every retrieval call (regardless of apply_pre_filter) so observability
@@ -189,7 +189,7 @@ EXPLORATION_INJECTED_TOTAL = Counter(
 )
 
 # ---------------------------------------------------------------------------
-# F47: Contradiction-derived confidence reranker composition metrics
+# Contradiction-derived confidence reranker composition metrics
 # ---------------------------------------------------------------------------
 
 CONFIDENCE_SCORE_DISTRIBUTION = Histogram(
@@ -208,7 +208,7 @@ CONFIDENCE_BOOST_OBSERVED = Histogram(
 )
 
 # ---------------------------------------------------------------------------
-# F22: Two-Factor edge confidence — variance over (confidence, evidence_count)
+# Two-Factor edge confidence — variance over (confidence, evidence_count)
 # ---------------------------------------------------------------------------
 
 CONFIDENCE_VARIANCE_OBSERVED = Histogram(
@@ -222,20 +222,20 @@ CONFIDENCE_VARIANCE_OBSERVED = Histogram(
 )
 
 # ---------------------------------------------------------------------------
-# F11: FSFM-lite decay boost reranker composition metric
+# FSFM-lite decay boost reranker composition metric
 # ---------------------------------------------------------------------------
 
 DECAY_BOOST_OBSERVED = Histogram(
     'memex_decay_boost',
-    'F11 decay boost factors applied during reranking. Neutral is 1.0 '
+    'Decay boost factors applied during reranking. Neutral is 1.0 '
     '(NULL importance OR NULL last_outcome_at OR decay_alpha=0).',
     buckets=(0.70, 0.80, 0.85, 0.90, 0.95, 1.0, 1.05, 1.10, 1.15, 1.20, 1.30),
 )
 
 # ---------------------------------------------------------------------------
-# Write-time classifier metrics (F25 / F25b)
+# Write-time classifier metrics
 # ---------------------------------------------------------------------------
-# F25b folded the standalone classifier into the fact-extraction signature, so
+# The standalone classifier was folded into the fact-extraction signature, so
 # the per-call success/error counter (CLASSIFIER_CALLS_TOTAL) was dropped —
 # extraction errors are tracked under the extraction-engine instrumentation.
 # Distribution + blocked counters are still emitted from the engine's
@@ -261,7 +261,7 @@ CLASSIFIER_BLOCKED_TOTAL = Counter(
 )
 
 # ---------------------------------------------------------------------------
-# Diagnostics metrics (F32)
+# Diagnostics metrics
 # ---------------------------------------------------------------------------
 
 DIAGNOSTICS_MANIFOLD_COMPUTE_SECONDS = Histogram(
@@ -284,24 +284,24 @@ DIAGNOSTICS_CACHE_MISSES_TOTAL = Counter(
 )
 
 # ---------------------------------------------------------------------------
-# Lint metrics (F6)
+# Lint metrics
 # ---------------------------------------------------------------------------
 
 LINT_FINDINGS_TOTAL = Counter(
     'memex_lint_findings_total',
-    'Maintenance proposals emitted by F6 lint rules.',
+    'Maintenance proposals emitted by lint rules.',
     ['rule_name', 'lint_type', 'vault_id'],
 )
 
 LINT_RUN_DURATION_SECONDS = Histogram(
     'memex_lint_run_duration_seconds',
-    'Wall-clock duration of a single F6 lint rule execution (seconds).',
+    'Wall-clock duration of a single lint rule execution (seconds).',
     ['rule_name'],
     buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0),
 )
 
 # ---------------------------------------------------------------------------
-# F9 — Per-entity advisory lock + reconsolidate / consolidate metrics
+# Per-entity advisory lock + reconsolidate / consolidate metrics
 # ---------------------------------------------------------------------------
 
 ENTITY_LOCK_ACQUIRES_TOTAL = Counter(
@@ -325,16 +325,16 @@ CONSOLIDATE_TOTAL = Counter(
 )
 
 # ---------------------------------------------------------------------------
-# F41 — Cross-encoder score cache
+# Cross-encoder score cache
 # ---------------------------------------------------------------------------
 
 CROSS_ENCODER_CACHE_HITS_TOTAL = Counter(
     'memex_cross_encoder_cache_hits_total',
-    'Cross-encoder reranker score cache hits (F41). Hit rate = hits / (hits + misses).',
+    'Cross-encoder reranker score cache hits. Hit rate = hits / (hits + misses).',
 )
 
 CROSS_ENCODER_CACHE_MISSES_TOTAL = Counter(
     'memex_cross_encoder_cache_misses_total',
-    'Cross-encoder reranker score cache misses (F41). '
+    'Cross-encoder reranker score cache misses. '
     'A miss triggers a cross-encoder forward pass and a fill.',
 )

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -92,7 +92,7 @@ async def periodic_kv_ttl_cleanup_task(api: 'MemexAPI'):
 
 
 async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
-    """F32: weekly UMAP manifold refresh per vault under leader lock."""
+    """Weekly UMAP manifold refresh per vault under leader lock."""
     async with background_session('bg-sched-diagnostics-refresh'):
         try:
             vaults = await api.list_vaults()
@@ -127,7 +127,7 @@ async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
 
 
 async def periodic_lint_task(api: 'MemexAPI'):
-    """F6: per-vault lint run under existing MEMEX_LEADER_LOCK_ID."""
+    """Per-vault lint run under existing MEMEX_LEADER_LOCK_ID."""
     async with background_session('bg-sched-lint'):
         try:
             vaults = await api.list_vaults()
@@ -136,21 +136,21 @@ async def periodic_lint_task(api: 'MemexAPI'):
                     summary = await api.lint.run_rules(vault.id)
                     if summary.total_findings:
                         logger.info(
-                            'Scheduler: F6 lint emitted %d findings in vault %s',
+                            'Scheduler: Lint emitted %d findings in vault %s',
                             summary.total_findings,
                             vault.name,
                         )
                 except Exception as e:
                     logger.warning(f'Scheduler: Lint run failed for vault {vault.name}: {e}')
         except (OSError, RuntimeError, ValueError) as e:
-            logger.error(f'Scheduler: F6 lint task failed: {e}', exc_info=True)
+            logger.error(f'Scheduler: Lint task failed: {e}', exc_info=True)
 
 
 async def periodic_consolidation_task(api: 'MemexAPI', units_per_tick: int):
-    """F38: per-vault consolidation tick under the single leader lock.
+    """Per-vault consolidation tick under the single leader lock.
 
     Sequential per-vault iteration — per-vault parallelism is intentionally
-    out of scope (Wave 0: only F9 introduces additional advisory locks).
+    out of scope.
     Per-vault failures are warning-logged and never raise — one bad vault
     must not stop other vaults from being consolidated this tick.
     """
@@ -169,7 +169,7 @@ async def periodic_consolidation_task(api: 'MemexAPI', units_per_tick: int):
 
 
 async def periodic_revisit_task(api: 'MemexAPI'):
-    """F20: per-vault revisit-schedule populator under existing MEMEX_LEADER_LOCK_ID.
+    """Per-vault revisit-schedule populator under existing MEMEX_LEADER_LOCK_ID.
 
     Walks every vault and seeds `revisit_due_at` for never-evaluated eligible
     units. Idempotent — already-scheduled units and previously-evaluated-and-
@@ -187,20 +187,20 @@ async def periodic_revisit_task(api: 'MemexAPI'):
                     scheduled = await api.revisit.populate_initial_schedules(vault.id)
                     if scheduled:
                         logger.info(
-                            'Scheduler: F20 revisit scheduled %d unit(s) in vault %s',
+                            'Scheduler: Revisit scheduled %d unit(s) in vault %s',
                             scheduled,
                             vault.name,
                         )
                 except Exception as e:
                     logger.warning(
-                        f'Scheduler: F20 revisit populator failed for vault {vault.name}: {e}'
+                        f'Scheduler: Revisit populator failed for vault {vault.name}: {e}'
                     )
         except (OSError, RuntimeError, ValueError) as e:
-            logger.error(f'Scheduler: F20 revisit task failed: {e}', exc_info=True)
+            logger.error(f'Scheduler: Revisit task failed: {e}', exc_info=True)
 
 
 async def periodic_lint_llm_task(api: 'MemexAPI'):
-    """F10: per-vault surprise-gated LLM lint under MEMEX_LEADER_LOCK_ID.
+    """Per-vault surprise-gated LLM lint under MEMEX_LEADER_LOCK_ID.
 
     Runs the enabled DSPy lint signatures per RFC-006 Option (A): semantic
     contradiction + schema drift. Both share the same 24h cost cap, so the
@@ -234,8 +234,7 @@ async def periodic_lint_llm_task(api: 'MemexAPI'):
                 )
         except Exception as e:
             logger.warning(
-                'Scheduler: F10b NLI classifier load failed (%s); '
-                'falling back to F10 cosine-only gate',
+                'Scheduler: NLI classifier load failed (%s); falling back to cosine-only gate',
                 e,
             )
 
@@ -251,7 +250,7 @@ async def periodic_lint_llm_task(api: 'MemexAPI'):
         checks.append(('schema_drift', make_schema_drift_check(api.lm, k=settings.surprise_k)))
 
     if not checks:
-        logger.info('Scheduler: F10 lint_llm — no checks enabled, skipping tick')
+        logger.info('Scheduler: Lint_llm — no checks enabled, skipping tick')
         return
 
     async with background_session('bg-sched-lint-llm'):
@@ -275,7 +274,7 @@ async def periodic_lint_llm_task(api: 'MemexAPI'):
                             or summary.deferred_processed
                         ):
                             logger.info(
-                                'Scheduler: F10 lint_llm[%s] vault=%s: '
+                                'Scheduler: Lint_llm[%s] vault=%s: '
                                 'evaluated=%d emitted=%d deferred=%d processed_deferred=%d',
                                 check_name,
                                 vault.name,
@@ -286,13 +285,13 @@ async def periodic_lint_llm_task(api: 'MemexAPI'):
                             )
                     except Exception as e:
                         logger.warning(
-                            'Scheduler: F10 lint_llm[%s] failed for vault %s: %s',
+                            'Scheduler: Lint_llm[%s] failed for vault %s: %s',
                             check_name,
                             vault.name,
                             e,
                         )
         except (OSError, RuntimeError, ValueError) as e:
-            logger.error(f'Scheduler: F10 lint_llm task failed: {e}', exc_info=True)
+            logger.error(f'Scheduler: Lint_llm task failed: {e}', exc_info=True)
 
 
 async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI'):
@@ -336,13 +335,13 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
 
     # ============================================================
     # Tier A — Scheduler tasks (under MEMEX_LEADER_LOCK_ID)
-    # F6 lint task:                WS-linter
-    # F20 revisit seed task:       WS-revisit
-    # F32 diagnostics refresh:     WS-diagnostics
-    # F38 consolidation tick:      WS-quick-wins
+    # Lint task:                WS-linter
+    # Revisit seed task:       WS-revisit
+    # Diagnostics refresh:     WS-diagnostics
+    # Consolidation tick:      WS-quick-wins
     # ============================================================
 
-    # --- F6 lint ---       (filled by WS-linter)
+    # --- Lint ---       (filled by WS-linter)
     if config.server.memory.lint.enabled:
         lint_interval = config.server.memory.lint.interval_seconds
 
@@ -350,11 +349,11 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
         async def run_lint_job():
             await periodic_lint_task(api)
 
-    # --- F10 lint_llm ---  (filled by WS-linter)
+    # --- Lint_llm ---  (filled by WS-linter)
     lint_llm_cfg = config.server.memory.lint_llm
     if lint_llm_cfg.enabled and lint_llm_cfg.cost_cap_per_24h > 0:
         logger.info(
-            f'Scheduler: F10 lint_llm enabled. '
+            f'Scheduler: Lint_llm enabled. '
             f'Interval: {lint_llm_cfg.interval_seconds}s. '
             f'Cap: {lint_llm_cfg.cost_cap_per_24h}/24h/vault. '
             f'Threshold: {lint_llm_cfg.surprise_threshold}.'
@@ -364,9 +363,9 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
         async def run_lint_llm_job():
             await periodic_lint_llm_task(api)
     else:
-        logger.info('Scheduler: F10 lint_llm DISABLED (enabled=False or cost_cap_per_24h=0).')
+        logger.info('Scheduler: Lint_llm DISABLED (enabled=False or cost_cap_per_24h=0).')
 
-    # --- F20 revisit ---   (filled by WS-revisit)
+    # --- Revisit ---   (filled by WS-revisit)
     if config.server.memory.revisit.enabled:
         revisit_interval = config.server.memory.revisit.interval_seconds
 
@@ -374,16 +373,16 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
         async def run_revisit_job():
             await periodic_revisit_task(api)
 
-    # --- F32 diagnostics --- (filled by WS-diagnostics)
+    # --- Diagnostics --- (filled by WS-diagnostics)
     @clock.task(trigger=Every(seconds=7 * 86400))
     async def run_diagnostics_refresh():
         await periodic_diagnostics_refresh_task(api)
 
-    # --- F38 consolidation --- (filled by WS-quick-wins)
+    # --- Consolidation --- (filled by WS-quick-wins)
     consolidation_cfg = config.server.memory.consolidation
     if consolidation_cfg.enabled:
         logger.info(
-            f'Scheduler: F38 consolidation enabled. '
+            f'Scheduler: Consolidation enabled. '
             f'Cadence: {consolidation_cfg.cadence_seconds}s. '
             f'Budget: {consolidation_cfg.units_per_tick} units/tick.'
         )
@@ -392,7 +391,7 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
         async def run_consolidation_job():
             await periodic_consolidation_task(api, consolidation_cfg.units_per_tick)
     else:
-        logger.info('Scheduler: F38 consolidation DISABLED via config.')
+        logger.info('Scheduler: Consolidation DISABLED via config.')
 
     # asyncpg requires a plain postgresql:// DSN (no +asyncpg driver suffix)
     sa_url = make_url(config.server.meta_store.instance.connection_string)

--- a/packages/core/src/memex_core/server/consolidation.py
+++ b/packages/core/src/memex_core/server/consolidation.py
@@ -1,7 +1,7 @@
-"""F38 — Consolidation orchestrator endpoints.
+"""Consolidation orchestrator endpoints.
 
-Operator-facing routes for the `memex consolidate` CLI. Per AC-F38-5 there
-is intentionally NO MCP / Hermes / Claude Code tool surface — these are
+Operator-facing routes for the `memex consolidate` CLI. Per acceptance criteria
+there is intentionally NO MCP / Hermes / Claude Code tool surface — these are
 HTTP-only and the CLI is the only first-class client.
 
 Routes:

--- a/packages/core/src/memex_core/server/diagnostics.py
+++ b/packages/core/src/memex_core/server/diagnostics.py
@@ -1,11 +1,11 @@
-"""F32 — Diagnostics endpoints (manifold + retrieval heatmap + summary + lint).
+"""Diagnostics endpoints (manifold + retrieval heatmap + summary + lint).
 
 Routes:
 - GET /diagnostics/manifold/{vault_id}              — 200 (warm) | 202 (cold) | 501 (umap missing)
 - GET /diagnostics/manifold/{vault_id}/status       — 200 (done) | 202 (still computing) | 404
 - GET /diagnostics/retrieval/{vault_id}             — 200 with heatmap JSON
 - GET /diagnostics/summary/{vault_id}               — 200 with full summary
-- GET /diagnostics/lint/{vault_id}                  — 200 with lint pivot dashboard (F26)
+- GET /diagnostics/lint/{vault_id}                  — 200 with lint pivot dashboard
 """
 
 from __future__ import annotations
@@ -133,10 +133,10 @@ async def get_lint_dashboard(
     api: Annotated[MemexAPI, Depends(get_api)],
     auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
 ) -> dict[str, Any]:
-    """F26 — Lint dashboard pivot for one vault.
+    """Lint dashboard pivot for one vault.
 
     Returns the (lint_type, status, source) pivot, the pending_by_type
-    slice, and the top-5 most-recent pending findings. Distinct from F6's
+    slice, and the top-5 most-recent pending findings. Distinct from the
     /lint/status (single count) and /lint/findings (paginated row listing) —
     this is the operator/observability dashboard view per RFC-009 §72.
     """

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -1,14 +1,14 @@
-"""F6 + F8 — Lint endpoints (maintenance ledger).
+"""Lint endpoints (maintenance ledger).
 
 Routes:
 - GET    /api/v1/lint/status                          — pending counts (global + per-vault)
 - GET    /api/v1/lint/findings                        — list findings (CLI surface, offset paged)
-- GET    /api/v1/lint/flags                           — cursor-paginated agent surface (F8)
+- GET    /api/v1/lint/flags                           — cursor-paginated agent surface
 - POST   /api/v1/lint/findings/{finding_id}/dismiss   — flip status to 'dismissed'
 - POST   /api/v1/lint/findings/{finding_id}/resolve   — flip status to 'resolved'
 
 The ``findings`` endpoint backs ``memex lint findings`` (CLI). The
-``flags`` endpoint is the F8 agent surface — shape-stable returns and
+``flags`` endpoint is the agent surface — shape-stable returns and
 opaque cursor pagination, mirrored by ``memex_get_lint_flags`` MCP.
 """
 
@@ -203,13 +203,13 @@ async def lint_flags(
     cursor: str | None = Query(None, description='Opaque cursor from a prior page.'),
     auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
 ) -> dict[str, Any]:
-    """F8 agent surface — shape-stable, cursor-paginated.
+    """Agent surface — shape-stable, cursor-paginated.
 
     Returns ``{findings: [...], next_cursor: str|null}``. The envelope is
     stable across empty / partial / full pages so agents never need to
     handle a missing key.
 
-    AC-F8-5 path: when the maintenance ledger is missing returns 503
+    Acceptance criteria path: when the maintenance ledger is missing returns 503
     with the documented initialization-error envelope.
     """
     if vault_id is not None:

--- a/packages/core/src/memex_core/server/memories.py
+++ b/packages/core/src/memex_core/server/memories.py
@@ -35,7 +35,7 @@ router = APIRouter(prefix='/api/v1')
 
 
 class MemoryUnitsByChunksRequest(BaseModel):
-    """F46: batch lookup of memory units by chunk_id."""
+    """Batch lookup of memory units by chunk_id."""
 
     chunk_ids: list[UUID] = Field(..., description='Chunk UUIDs to expand into memory units.')
     vault_id: UUID = Field(
@@ -57,7 +57,7 @@ async def get_memory_units_by_chunks(
     api: Annotated[MemexAPI, Depends(get_api)],
     auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
 ) -> list[MemoryUnitDTO]:
-    """F46: get all memory units belonging to the named chunks (vault-scoped)."""
+    """Get all memory units belonging to the named chunks (vault-scoped)."""
     await check_vault_access(auth, [request.vault_id], api, permission=Permission.READ)
     try:
         units = await api.get_memory_units_by_chunks(request.chunk_ids, request.vault_id)
@@ -175,12 +175,12 @@ async def restore_memory_unit(
 
 
 # ---------------------------------------------------------------------------
-# F9 — memex_memory_reconsolidate / memex_memory_consolidate
+# Per-entity reconsolidation / vault-wide consolidation
 # ---------------------------------------------------------------------------
 
 
 class ReconsolidateRequest(BaseModel):
-    """F9: per-entity reconsolidation under an advisory lock."""
+    """Per-entity reconsolidation under an advisory lock."""
 
     entity_id: UUID = Field(..., description='Entity UUID to reconsolidate.')
     vault_id: UUID = Field(..., description='Vault UUID — explicit per RFC-005 to scope unit_ids.')
@@ -193,7 +193,7 @@ class ReconsolidateRequest(BaseModel):
 
 
 class ConsolidateRequest(BaseModel):
-    """F9: vault-wide low-MW consolidation."""
+    """Vault-wide low-MW consolidation."""
 
     vault_id: UUID = Field(..., description='Vault UUID to consolidate.')
     dry_run: bool = Field(
@@ -203,7 +203,7 @@ class ConsolidateRequest(BaseModel):
 
 
 class ReconsolidateResponse(BaseModel):
-    """F9: typed response envelope for /memory/reconsolidate.
+    """Typed response envelope for /memory/reconsolidate.
 
     Mirrors `LocksService.reconsolidate_entity` return shape (RFC-005 / RFC-008).
     """
@@ -256,7 +256,7 @@ async def reconsolidate_entity(
     api: Annotated[MemexAPI, Depends(get_api)],
     auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
 ) -> ReconsolidateResponse:
-    """F9: re-evaluate memories for an entity under a per-entity advisory lock.
+    """Re-evaluate memories for an entity under a per-entity advisory lock.
 
     Acquires `acquire_entity_lock(entity_id)` for `timeout_seconds`, then runs
     `ContradictionEngine.detect_contradictions` over linked unit_ids, then
@@ -334,14 +334,14 @@ async def consolidate_vault(
     api: Annotated[MemexAPI, Depends(get_api)],
     auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
 ) -> Any:
-    """F9: vault-wide low-MW unit consolidation. RFC-008.
+    """Vault-wide low-MW unit consolidation. RFC-008.
 
     Predicate: mw_score<0.35 AND outcomes>=5 AND !is_deprioritized AND
     created_at<now()-30d. dry_run=true returns preview without writes.
 
     Rate-limited per vault (RFC-008 line 125; default 1 call per vault per
     hour). Translates ``RateLimitExceededError`` into a 429 envelope with a
-    ``Retry-After`` header. Mirrors the F5 summarize-node 429 contract.
+    ``Retry-After`` header. Mirrors the summarize-node 429 contract.
     """
     await check_vault_access(auth, [request.vault_id], api, permission=Permission.WRITE)
     try:
@@ -428,7 +428,7 @@ async def get_unit_history(
     ),
     auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
 ) -> UnitHistoryNodeDTO:
-    """F49: walk the contradiction graph backward from ``memory_id``.
+    """Walk the contradiction graph backward from ``memory_id``.
 
     Returns the supersession history (negative-evidence path: contradicts /
     weakens links) as an ordered tree rooted at the queried unit (depth=0).

--- a/packages/core/src/memex_core/server/outcomes.py
+++ b/packages/core/src/memex_core/server/outcomes.py
@@ -1,6 +1,6 @@
-"""F29 — Outcome recording endpoint.
+"""Outcome recording endpoint.
 
-HTTP wire surface for ``MemexAPI.record_outcome`` (F14 ADD-2). Required so
+HTTP wire surface for ``MemexAPI.record_outcome`` (ADD-2). Required so
 remote clients (the Hermes plugin via ``RemoteMemexAPI``) can train MW
 scoring on memory units or procedure KV keys. The MCP tool calls
 ``api.record_outcome`` in-process; this route gives non-in-process clients
@@ -64,7 +64,7 @@ class RecordOutcomeRequest(BaseModel):
         default='memory_unit',
         description=(
             "What the outcome scores. 'memory_unit' increments MW counters on "
-            "the memory units in unit_ids. 'kv_key' (F14) increments counters "
+            "the memory units in unit_ids. 'kv_key' increments counters "
             'on the procedure_outcomes row for kv_key.'
         ),
     )
@@ -85,7 +85,7 @@ async def post_record_outcome(
 ) -> dict[str, Any]:
     """Record an outcome for memory units or a procedure key.
 
-    Mirrors :meth:`MemexAPI.record_outcome`; preserves the F14 ADD-2 contract
+    Mirrors :meth:`MemexAPI.record_outcome`; preserves the ADD-2 contract
     (positional ``unit_ids``, ``success`` at the in-process call site).
     Vault is resolved server-side so callers may pass UUID or name.
 

--- a/packages/core/src/memex_core/server/reflection.py
+++ b/packages/core/src/memex_core/server/reflection.py
@@ -33,7 +33,7 @@ router = APIRouter(prefix='/api/v1')
 
 
 class SummarizeNodeRequest(BaseModel):
-    """F5: synchronous summarize-node endpoint body."""
+    """Synchronous summarize-node endpoint body."""
 
     entity_id: UUID = Field(..., description='Entity UUID to reflect on.')
     scope: Literal['incremental', 'full'] = Field(
@@ -101,7 +101,7 @@ async def summarize_node(
 ):
     """F5: synchronously consolidate memories on an entity into its mental model.
 
-    Mirrors §4 F5's synchronous contract — does NOT use BackgroundTasks. Per RFC-002,
+    Mirrors the synchronous contract — does NOT use BackgroundTasks. Per RFC-002,
     rate-limited per (entity_id, vault_id) at the service layer; the endpoint is a
     thin transport that translates ``RateLimitExceededError`` into a 429 envelope
     with a ``Retry-After`` header.

--- a/packages/core/src/memex_core/server/revisit.py
+++ b/packages/core/src/memex_core/server/revisit.py
@@ -1,6 +1,6 @@
-"""F20 — FSRS-5 revisitation HTTP endpoints.
+"""FSRS-5 revisitation HTTP endpoints.
 
-HTTP wire surface for the F20 revisit verbs so non-in-process clients
+HTTP wire surface for the revisit verbs so non-in-process clients
 (the Hermes plugin via ``RemoteMemexAPI``) can call them. The MCP tool
 calls the in-process API directly; this file gives remote callers parity.
 

--- a/packages/core/src/memex_core/services/consolidation.py
+++ b/packages/core/src/memex_core/services/consolidation.py
@@ -1,10 +1,10 @@
-"""F38 ConsolidationService — thin orchestrator over reflection + contradiction + prune.
+"""ConsolidationService — thin orchestrator over reflection + contradiction + prune.
 
 Per RFC-010, this is intentionally a thin module. Its **only** direct DB write
 is the ``consolidation_ticks`` summary row inserted at the end of each tick
-(AC-F38-4 module-write audit). All other writes are delegated.
+(acceptance criteria module-write audit). All other writes are delegated.
 
-Step ordering (B1 adjudication, AC-F38-1):
+Step ordering (B1 adjudication, acceptance criteria):
     1. ``select_diff_units`` — read AuditLog rows with ``action='outcome.record'``
        since the previous tick's ``completed_at``.
     2. ``ContradictionEngine.detect_contradictions`` — runs first so reflection
@@ -12,8 +12,8 @@ Step ordering (B1 adjudication, AC-F38-1):
     3. ``ReflectionService.reflect_batch`` — synthesizes mental models for the
        entities touched by the diff units.
     4. ``prune_stale_evidence`` — invoked **only** on units already at
-       ``ContentStatus.STALE``. F38 does NOT decide staleness — that lives in
-       F25 / contradiction-driven confidence drops / archive cascade.
+       ``ContentStatus.STALE``. Consolidation does NOT decide staleness — that lives in
+       the write-time classifier / contradiction-driven confidence drops / archive cascade.
     5. ``write_tick_summary`` — single ``ConsolidationTick`` row per tick.
 
 The 500-units-per-tick budget (oldest-first by ``mentioned_at`` /
@@ -159,11 +159,11 @@ class ConsolidationService:
         entities_deferred: list[UUID] = []
         error: str | None = None
 
-        # Per-entity loop under F9's per-entity advisory lock so this tick
+        # Per-entity loop under the per-entity advisory lock so this tick
         # cannot race with `memex_memory_reconsolidate` (LocksService) on the
         # same MentalModel/MemoryUnits. Contention policy: skip-and-log-deferred
         # — if another reconsolidation holds the lock, leave the entity for the
-        # next tick rather than block the whole tick. AC-F38-1 step ordering
+        # next tick rather than block the whole tick. Acceptance criteria step ordering
         # (contradiction → reflection → prune) is preserved per entity.
         for eid in entity_ids:
             entity_unit_ids = unit_ids_by_entity[eid]
@@ -404,7 +404,7 @@ class ConsolidationService:
         """Return a {entity_id: [unit_ids]} map for the diff units.
 
         Used by ``tick()`` to drive a per-entity loop under
-        ``acquire_entity_lock`` so F38 cannot race with F9's
+        ``acquire_entity_lock`` so consolidation cannot race with
         ``memex_memory_reconsolidate`` on the same MentalModel. Vault-scoped.
         """
         if not unit_ids:
@@ -432,7 +432,7 @@ class ConsolidationService:
         """Return the subset of ``unit_ids`` whose ``status == STALE``.
 
         This is the AC-F38-2 invariant: F38 invokes ``prune_stale_evidence``
-        ONLY on units already marked stale by some other service. F38 does
+        ONLY on units already marked stale by some other service. Consolidation does
         NOT mutate ``status`` from active to stale.
         """
         if not unit_ids:
@@ -446,7 +446,7 @@ class ConsolidationService:
         return [row for row in result.all() if row is not None]
 
     # ------------------------------------------------------------------
-    # Tick-summary write (the single direct write — AC-F38-4)
+    # Tick-summary write (the single direct write — acceptance criteria)
     # ------------------------------------------------------------------
 
     async def _write_tick_summary(

--- a/packages/core/src/memex_core/services/diagnostics.py
+++ b/packages/core/src/memex_core/services/diagnostics.py
@@ -51,7 +51,7 @@ class DiagnosticsService(BaseService):
         )
 
     async def get_lint_dashboard(self, vault_id: UUID) -> dict[str, Any]:
-        """F26 — Pivot MaintenanceProposal rows by (lint_type, status, source) plus top-5 pending.
+        """Pivot MaintenanceProposal rows by (lint_type, status, source) plus top-5 pending.
 
         Thin wrapper over :func:`memex_core.diagnostics.lint_dashboard.aggregate_lint_findings`.
         """

--- a/packages/core/src/memex_core/services/kv.py
+++ b/packages/core/src/memex_core/services/kv.py
@@ -9,7 +9,7 @@ Keys must start with one of the valid namespace prefixes:
 - ``user:`` — per-user preferences
 - ``project:`` — per-project bindings
 - ``app:`` — per-application configuration
-- ``procedure:`` — procedural observations (F14)
+- ``procedure:`` — procedural observations
 
 The ``procedure:<verb>:<context-tag>`` namespace is special: writes use
 last-writer-wins on the active value with a ``version`` increment, and
@@ -344,7 +344,7 @@ class KVService(BaseService):
         context: str | None = None,
         limit: int = 5,
     ) -> list[dict[str, Any]]:
-        """F14 — Top procedure outcomes for a vault, ranked by Memory Worth.
+        """Top procedure outcomes for a vault, ranked by Memory Worth.
 
         Returns up to ``limit`` rows from ``procedure_outcomes`` joined to
         ``kv_entries`` for the given ``vault_id``, ordered by

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -1,4 +1,4 @@
-"""F6 maintenance ledger — rule-based linter.
+"""Maintenance ledger — rule-based linter.
 
 Implements ``LintService.run_rules(vault_id?)`` which iterates the v1 rule
 registry and emits ``MaintenanceProposal`` rows. Rules are read-only against
@@ -6,11 +6,11 @@ the resources they inspect; the only writes ``run_rules`` performs are
 ``INSERT INTO maintenance_proposals`` (with ``ON CONFLICT DO NOTHING`` against
 the partial unique index ``uq_maintenance_proposals_pending``).
 
-v1 rule set (one per ``LintType`` enum value, per AC-F6-6):
+v1 rule set (one per ``LintType`` enum value):
 
   - ``orphan_mental_model``         (structural)
   - ``cold_low_mw_unit``            (quality)
-  - ``sensitive_unreviewed_unit``   (governance, AC-F6-G1)
+  - ``sensitive_unreviewed_unit``   (governance, governance acceptance criteria)
   - ``dangling_entity_ref_in_unit`` (schema)
 
 The mw_score expression is the inline form of
@@ -54,7 +54,7 @@ logger = logging.getLogger('memex.core.services.lint')
 
 
 # ---------------------------------------------------------------------------
-# F8 — Read-side DTOs, cursor codec, and table-not-found signal
+# Read-side DTOs, cursor codec, and table-not-found signal
 # ---------------------------------------------------------------------------
 
 
@@ -62,7 +62,7 @@ _MAX_LIMIT = 200
 
 
 class LintSubsystemNotInitializedError(RuntimeError):
-    """Signals AC-F8-5: ``maintenance_proposals`` table is missing.
+    """Signals acceptance criteria: ``maintenance_proposals`` table is missing.
 
     The MCP/HTTP layer translates this into the documented error envelope
     so the agent gets a clear, actionable message ("run alembic upgrade").
@@ -70,7 +70,7 @@ class LintSubsystemNotInitializedError(RuntimeError):
 
     def __init__(self) -> None:
         super().__init__(
-            'F6 maintenance_proposals table is missing. '
+            'Maintenance proposals table is missing. '
             'Run `alembic upgrade head` to initialize the lint ledger.'
         )
 
@@ -115,7 +115,7 @@ class LintFindingsPage(BaseModel):
     """Shape-stable page envelope returned by :meth:`LintService.get_findings`.
 
     ``findings`` is always present (possibly empty); ``next_cursor`` is
-    always present (string or None). The agent surface (F8) MUST round-trip
+    always present (string or None). The agent surface MUST round-trip
     these fields verbatim — never collapse to a bare list or null.
     """
 
@@ -134,7 +134,7 @@ def _decode_cursor(cursor: str) -> tuple[datetime, UUID] | None:
 
     Returning None lets ``get_findings`` treat junk cursors as "page 1"
     rather than 500-ing — the cursor is opaque so agents can't reason
-    about its shape, and a stale cursor (e.g. across F8 redeploys)
+    about its shape, and a stale cursor (e.g. across redeploys)
     should degrade gracefully.
     """
     try:
@@ -448,7 +448,7 @@ class LintService(BaseService):
                 ctx.__enter__()
             result = await session.execute(text(spec.select_sql), {'vault_id': str(vault_id)})
             rows = result.mappings().all()
-            # F22 — bulk-fetch (confidence, evidence_count) for every candidate
+            # Bulk-fetch (confidence, evidence_count) for every candidate
             # so the gate predicate runs against an in-memory map rather than
             # firing one SELECT per row (former N+1; Hermes round-1 HIGH).
             confidence_map: dict[str, tuple[float, int]] = {}
@@ -653,8 +653,8 @@ class LintService(BaseService):
         by ``(created_at DESC, id DESC)`` so the cursor is total-order under
         concurrent inserts.
 
-        AC-F8-5 path — when the ``maintenance_proposals`` table is missing
-        (e.g. F8 ran before F6's migration applied) raises
+        Acceptance criteria path — when the ``maintenance_proposals`` table is missing
+        (e.g. the endpoint ran before the migration applied) raises
         :class:`LintSubsystemNotInitializedError`; the MCP/HTTP layer maps
         that to the documented error envelope.
         """

--- a/packages/core/src/memex_core/services/lint_llm.py
+++ b/packages/core/src/memex_core/services/lint_llm.py
@@ -1,4 +1,4 @@
-"""F10 surprise-gated LLM-assisted lint service.
+"""Surprise-gated LLM-assisted lint service.
 
 Implements ``LintLLMService.maybe_run`` which orchestrates:
 

--- a/packages/core/src/memex_core/services/locks.py
+++ b/packages/core/src/memex_core/services/locks.py
@@ -7,8 +7,7 @@ leader lock at ~2^52. See RFC-005.
 Acquire/release pattern uses a dedicated short-lived asyncpg connection per
 context-manager invocation. Lock release is deterministic on context exit; if
 the connection dies mid-hold (process crash, network failure), Postgres
-auto-releases the lock when the backend terminates. Both behaviours validated
-in POC-F9 (commit bba8094, merged at 866ec74).
+auto-releases the lock when the backend terminates.
 
 LocksService orchestrates `memex_memory_reconsolidate` (entity-scoped) and
 `memex_memory_consolidate` (vault-wide). RFC-005 / RFC-008.

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -2,7 +2,7 @@
 
 Exposes `record_outcome()` for incrementing success/failure co-occurrence
 counters on MemoryUnit, UnitEntity, and MentalModel, and `compute_mw_score() /
-compute_mw_boost()` for the Beta-Bernoulli posterior mean used by the F1c
+compute_mw_boost()` for the Beta-Bernoulli posterior mean used by the
 retrieval composition.
 
 The MW formula uses additive-marginal composition (v6.9, §3.4):

--- a/packages/core/src/memex_core/services/rate_limit.py
+++ b/packages/core/src/memex_core/services/rate_limit.py
@@ -1,10 +1,10 @@
-"""In-process token-bucket rate limiter (F5).
+"""In-process token-bucket rate limiter.
 
 Per-key token bucket with monotonic-clock refill. Designed for advisory
 limits, not security gates: multi-worker leakage is accepted in v1
-(F9 introduces distributed locking; F38 will reuse this primitive).
+(distributed locking introduces per-entity locks; consolidation will reuse this primitive).
 
-Reusable across F5, F9, F10, F20 per RFC-002.
+Reusable across surfaces per RFC-002.
 """
 
 from __future__ import annotations
@@ -46,7 +46,7 @@ class TokenBucketRateLimiter:
 
     Mutual exclusion uses ``asyncio.Lock`` to honour the project-wide
     asyncio convention (multi-worker leakage is documented in RFC-002 and
-    acknowledged in the PR body per AC-F5-4). Hold time is microseconds —
+    acknowledged in the PR body per acceptance criteria). Hold time is microseconds —
     dict lookup plus arithmetic — so contention is negligible.
     """
 

--- a/packages/core/src/memex_core/services/revisitation.py
+++ b/packages/core/src/memex_core/services/revisitation.py
@@ -1,4 +1,4 @@
-"""F20 revisitation service — eligibility, scheduling, listing, review.
+"""Revisitation service — eligibility, scheduling, listing, review.
 
 Owns the revisit-policy domain:
 - 5-gate eligibility predicate (Python + SQL forms — single source of truth)

--- a/packages/core/src/memex_core/services/units.py
+++ b/packages/core/src/memex_core/services/units.py
@@ -1,4 +1,4 @@
-"""Memory unit curation service — non-destructive verbs (F4)."""
+"""Memory unit curation service — non-destructive verbs."""
 
 from __future__ import annotations
 
@@ -44,7 +44,7 @@ class UnitsService(BaseService):
         None, no vault check is applied (legacy CLI path).
 
         Does NOT cascade to MentalModels; does NOT call ``prune_stale_evidence``.
-        The retrieval-time filter (F1b) honours the flag — see
+        The retrieval-time filter honours the flag — see
         ``memory/retrieval/strategies.py:93-95``.
         """
         return await self._flip_deprioritized(
@@ -189,7 +189,7 @@ class UnitsService(BaseService):
         vault_id: UUID | None = None,
         link_types: tuple[str, ...] = DEFAULT_HISTORY_LINK_TYPES,
     ) -> UnitHistoryNodeDTO:
-        """F49: walk the contradiction graph backward from ``unit_id``.
+        """Walk the contradiction graph backward from ``unit_id``.
 
         Starts at ``unit_id`` (depth=0) and recursively follows outgoing
         ``contradicts`` / ``weakens`` MemoryLink rows — i.e., links where


### PR DESCRIPTION
## Summary

Phase 2 of stripping F-code ticket IDs from user/agent-facing surfaces. Phase 1 (#143) handled MCP description shim filenames, Prometheus metric names, and CLAUDE.md references. This PR covers the remaining surfaces:

- Prometheus metric descriptions (F1a, F11, F22, F40-F49 refs)
- SQLModel field descriptions (F4, F8, F9, F14 refs)
- API docstrings (F1a, F14, F29 refs)
- Server route docstrings (F4, F8, F9, F20 refs)
- Service docstrings and log messages
- Scheduler log messages
- Lint subsystem strings (F6, F8, F10b, F26, F38 refs)
- ONNX NLI and retrieval model comments
- Rate limit service descriptions

These IDs belong in BACKLOG.md and the design doc, not in runtime-observable surfaces visible to users and agents.

## Test plan

- [ ] CI green (python-tests, hermes-integration, pre-commit)
- [ ] `grep -r "F[0-9][0-9a-z]* " packages/core/src/ packages/mcp/src/ packages/cli/src/ packages/common/src/` should return no user-facing F-code refs (only internal comments that reference design doc sections are OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)