### PR TITLE
feat(eval): port LongMemEval as complementary external benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-4,900%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-4,998%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -120,6 +120,29 @@ The benchmark runs in three decoupled phases, each resumable:
 - **Image-dependent questions**: Some LoCoMo questions reference images shared in conversations (book covers, photos of signs, pottery). The Memex pipeline extracts text from conversations but does not process shared images, so questions whose answers depend solely on image content cannot be answered from stored memories alone.
 - **Adversarial scoring**: Adversarial questions deliberately swap subjects (e.g., asking about Melanie's instruments when they are Caroline's). The judge must recognize that correcting the false premise is a correct response, not an error.
 
+### External benchmarks (LongMemEval)
+
+[LongMemEval](https://arxiv.org/abs/2502.19373) evaluates long-term memory across five question categories with a focus on abstention (knowing when the memory does not contain the answer). It runs as a complementary benchmark alongside LoCoMo.
+
+```bash
+# End-to-end (ingest -> answer -> judge -> report)
+memex-eval longmemeval run --dataset-path ./data/longmemeval/ --run-id baseline
+
+# Individual phases
+memex-eval longmemeval ingest --dataset-path ./data/longmemeval/ --variant s --run-id baseline
+memex-eval longmemeval answer --dataset-path ./data/longmemeval/ --variant s --run-id baseline
+memex-eval longmemeval judge --dataset-path ./data/longmemeval/ --variant s --hypotheses hypotheses.jsonl
+memex-eval longmemeval report --judgments judgments.jsonl
+
+# Compare modes (agent vs note-only vs memory-only)
+memex-eval longmemeval compare --mode-run agent:./run-agent --mode-run note-only:./run-note
+
+# Parse trace files
+memex-eval longmemeval parse-trace traces/ --dataset-path ./data/longmemeval/
+```
+
+**Dataset variants**: `s` (default, matches agentmemory baseline), `oracle`, `m`. The dataset SHA-256 is pinned; use `--allow-unpinned-checksum` to bypass during development.
+
 ## Results
 
 > Single run on LoCoMo conversation 0. Scores include manual review corrections where the automated judge was inconsistent.
@@ -163,6 +186,15 @@ memex_eval/
     locomo_judge.py       # Phase 3: grade answers + produce report
     locomo_efficiency.py  # Efficiency analysis: latency, tokens, tool usage
     locomo_report.py      # Phase 4: generate Markdown report with plots
+    longmemeval_common.py       # Shared types, dataset loaders, SHA-256 pin, abstention helpers
+    longmemeval_ingest.py       # Phase 0: ingest LongMemEval sessions
+    longmemeval_answer.py       # Phase 2: answer via Claude Code subagent (agent/note-only/memory-only modes)
+    longmemeval_answer_direct.py # Direct retrieval-only answer modes
+    longmemeval_judge.py        # Phase 3: graded correctness + abstention precision
+    longmemeval_report.py       # Phase 4: three-axis evaluation + plots
+    longmemeval_compare.py      # A/B comparison across modes
+    longmemeval_trace_parser.py # Claude Code session trace parsing
+    longmemeval_efficiency.py  # Efficiency analysis: latency, tokens, retrieval cost
 ```
 
 ## Adding scenarios (internal)

--- a/packages/eval/src/memex_eval/cli.py
+++ b/packages/eval/src/memex_eval/cli.py
@@ -1,9 +1,10 @@
-"""Typer CLI for memex-eval: `memex-eval run`, `memex-eval locomo-*`, etc."""
+"""Typer CLI for memex-eval: `memex-eval run`, `memex-eval locomo-*`, `memex-eval longmemeval-*`."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from uuid import uuid4
 
 import typer
 from rich.console import Console
@@ -210,6 +211,423 @@ def locomo_efficiency_cmd(
         answers_path=answers,
         output_path=output,
         traces_dir=traces_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# LongMemEval subcommands
+# ---------------------------------------------------------------------------
+
+longmemeval_app = typer.Typer(
+    name='longmemeval',
+    help='Run the LongMemEval external benchmark (xiaowu0162/longmemeval).',
+    no_args_is_help=True,
+)
+app.add_typer(longmemeval_app, name='longmemeval')
+
+
+@longmemeval_app.command('ingest')
+def longmemeval_ingest_cmd(
+    dataset_path: str = typer.Option(
+        ..., '--dataset-path', '-d', help='Path to the LongMemEval dataset directory or file.'
+    ),
+    variant: str = typer.Option(
+        's',
+        '--variant',
+        help=('Dataset variant: "s" (default, matches agentmemory baseline), "oracle", or "m".'),
+    ),
+    run_id: str = typer.Option(
+        ..., '--run-id', help='Identifier for this run (used in the per-run vault name).'
+    ),
+    server: str = typer.Option(DEFAULT_SERVER, '--server', '-s', help='Memex API server URL.'),
+    question_limit: int | None = typer.Option(
+        None, '--questions', '-n', help='Limit ingest to the first N questions.'
+    ),
+    clean: bool = typer.Option(False, '--clean', help='Delete existing notes and re-ingest.'),
+    allow_unpinned_checksum: bool = typer.Option(
+        False,
+        '--allow-unpinned-checksum',
+        help='Bypass the dataset SHA-256 pin requirement (dev only). Logs the computed hash.',
+    ),
+    verbose: bool = typer.Option(False, '--verbose', '-v', help='Enable verbose logging.'),
+) -> None:
+    """Phase 0: Ingest LongMemEval sessions into a dedicated vault."""
+    _setup_logging(verbose)
+
+    from memex_eval.external.longmemeval_ingest import ingest_longmemeval
+
+    asyncio.run(
+        ingest_longmemeval(
+            server_url=server,
+            dataset_path=dataset_path,
+            variant=variant,
+            run_id=run_id,
+            question_limit=question_limit,
+            clean=clean,
+            allow_unpinned_checksum=allow_unpinned_checksum,
+        )
+    )
+
+
+@longmemeval_app.command('answer')
+def longmemeval_answer_cmd(
+    dataset_path: str = typer.Option(..., '--dataset-path', '-d'),
+    variant: str = typer.Option('s', '--variant'),
+    run_id: str = typer.Option(..., '--run-id'),
+    output: str = typer.Option('hypotheses.jsonl', '--output', '-o'),
+    server: str = typer.Option(DEFAULT_SERVER, '--server', '-s'),
+    method: str = typer.Option(
+        'claude-code',
+        '--method',
+        help='Answer-module driver. One of "claude-code" or "gemini-cli".',
+    ),
+    mode: str = typer.Option(
+        'agent',
+        '--mode',
+        help=(
+            'Retrieval configuration: "agent" (default, full Claude Code subagent), '
+            '"note-only" (direct memex_note_search + LLM synthesis), or '
+            '"memory-only" (direct memex_memory_search + LLM synthesis). '
+            'Non-agent modes retry once with expand_query=true on abstention.'
+        ),
+    ),
+    plugin_dir: str | None = typer.Option(
+        None,
+        '--plugin-dir',
+        help=(
+            'Path to the memex Claude Code plugin directory. Defaults to '
+            'packages/claude-code-plugin/ in this repo, or $MEMEX_CLAUDE_PLUGIN_DIR.'
+        ),
+    ),
+    question_limit: int | None = typer.Option(None, '--questions', '-n'),
+    subagent_timeout_s: float = typer.Option(
+        300.0,
+        '--subagent-timeout-s',
+        help='Per-question timeout for the Claude Code subagent (seconds).',
+    ),
+    allow_unpinned_checksum: bool = typer.Option(
+        False,
+        '--allow-unpinned-checksum',
+        help='Bypass the dataset SHA-256 pin requirement (dev only). Logs the computed hash.',
+    ),
+    verbose: bool = typer.Option(False, '--verbose', '-v'),
+) -> None:
+    """Phase 2: Answer questions and emit hypotheses JSONL."""
+    _setup_logging(verbose)
+
+    from memex_eval.external.longmemeval_answer import AnswerMethod, AnswerMode, answer_questions
+
+    asyncio.run(
+        answer_questions(
+            server_url=server,
+            dataset_path=dataset_path,
+            variant=variant,
+            run_id=run_id,
+            output_path=output,
+            method=AnswerMethod(method),
+            mode=AnswerMode(mode),
+            plugin_dir=plugin_dir,
+            question_limit=question_limit,
+            subagent_timeout_s=subagent_timeout_s,
+            allow_unpinned_checksum=allow_unpinned_checksum,
+        )
+    )
+
+
+@longmemeval_app.command('judge')
+def longmemeval_judge_cmd(
+    dataset_path: str = typer.Option(..., '--dataset-path', '-d'),
+    variant: str = typer.Option('s', '--variant'),
+    hypotheses: str = typer.Option('hypotheses.jsonl', '--hypotheses'),
+    output: str = typer.Option('judgments.jsonl', '--output', '-o'),
+    judge_model: str | None = typer.Option(None, '--judge-model'),
+    cache: str | None = typer.Option(
+        None, '--cache', help='JSON file with cached judge responses (for offline runs).'
+    ),
+    traces_dir: str | None = typer.Option(
+        None,
+        '--traces-dir',
+        help='Directory with per-question trace JSONL files for retrieval containment judging.',
+    ),
+    allow_unpinned_checksum: bool = typer.Option(
+        False,
+        '--allow-unpinned-checksum',
+        help='Bypass the dataset SHA-256 pin requirement (dev only). Logs the computed hash.',
+    ),
+    verbose: bool = typer.Option(False, '--verbose', '-v'),
+) -> None:
+    """Phase 3: Judge hypotheses against ground-truth answers."""
+    _setup_logging(verbose)
+
+    from pathlib import Path
+
+    from memex_eval.external.longmemeval_judge import judge_hypotheses
+
+    resolved_traces = traces_dir or str(Path(hypotheses).parent / 'traces')
+
+    asyncio.run(
+        judge_hypotheses(
+            dataset_path=dataset_path,
+            variant=variant,
+            hypotheses_path=hypotheses,
+            output_path=output,
+            judge_model=judge_model,
+            cache_path=cache,
+            allow_unpinned_checksum=allow_unpinned_checksum,
+            traces_dir=resolved_traces,
+        )
+    )
+
+
+@longmemeval_app.command('report')
+def longmemeval_report_cmd(
+    judgments: str = typer.Option('judgments.jsonl', '--judgments'),
+    output_dir: str = typer.Option('report', '--output-dir', '-o'),
+    run_id: str | None = typer.Option(None, '--run-id'),
+    variant: str = typer.Option('s', '--variant'),
+    dataset_path: str | None = typer.Option(
+        None, '--dataset-path', '-d', help='Optional, used to embed dataset SHA-256 in report.'
+    ),
+    hypotheses_path: str | None = typer.Option(
+        None, '--hypotheses', help='Path to hypotheses.jsonl (auto-detected if omitted).'
+    ),
+    traces_dir: str | None = typer.Option(
+        None, '--traces-dir', help='Directory with per-question trace JSONL files.'
+    ),
+    allow_unpinned_checksum: bool = typer.Option(
+        False,
+        '--allow-unpinned-checksum',
+        help='Bypass the dataset SHA-256 pin requirement (dev only).',
+    ),
+    verbose: bool = typer.Option(False, '--verbose', '-v'),
+) -> None:
+    """Phase 4: Aggregate judgments into a report with efficiency analysis."""
+    _setup_logging(verbose)
+
+    from pathlib import Path
+
+    from memex_eval.external.longmemeval_report import generate_report
+
+    resolved_hypotheses = hypotheses_path or judgments.replace(
+        'judgments.jsonl', 'hypotheses.jsonl'
+    )
+    resolved_traces = traces_dir or str(Path(judgments).parent / 'traces')
+
+    generate_report(
+        judgments_path=judgments,
+        output_dir=output_dir,
+        run_id=run_id,
+        variant=variant,
+        dataset_path=dataset_path,
+        hypotheses_path=resolved_hypotheses,
+        traces_dir=resolved_traces,
+        allow_unpinned_checksum=allow_unpinned_checksum,
+    )
+
+
+@longmemeval_app.command('compare')
+def longmemeval_compare_cmd(
+    mode_run: list[str] = typer.Option(
+        ...,
+        '--mode-run',
+        help=(
+            'Labelled mode run, repeatable. Format: "<label>:<run-dir>". '
+            'Example: --mode-run agent:./run-agent --mode-run note-only:./run-note. '
+            'Each run dir must contain judgments.jsonl and hypotheses.jsonl.'
+        ),
+    ),
+    output_dir: str = typer.Option('compare-report', '--output-dir', '-o'),
+    verbose: bool = typer.Option(False, '--verbose', '-v'),
+) -> None:
+    """Compare multiple mode runs (agent vs note-only vs memory-only)."""
+    _setup_logging(verbose)
+
+    from pathlib import Path
+
+    from memex_eval.external.longmemeval_compare import generate_comparison_report
+
+    parsed: list[tuple[str, Path]] = []
+    for spec in mode_run:
+        if ':' not in spec:
+            raise typer.BadParameter(
+                f'Invalid --mode-run spec {spec!r}. Expected "<label>:<run-dir>".'
+            )
+        label, run_dir = spec.split(':', 1)
+        rd = Path(run_dir)
+        if not rd.is_dir():
+            raise typer.BadParameter(f'Run dir does not exist: {rd}')
+        parsed.append((label, rd))
+
+    summary = generate_comparison_report(parsed, Path(output_dir))
+    console.print('[bold green]Comparison report written to[/bold green]', output_dir)
+    console.print_json(data=summary)
+
+
+@longmemeval_app.command('parse-trace')
+def longmemeval_parse_trace_cmd(
+    traces_path: str = typer.Argument(
+        help='Path to a trace JSONL file or directory of trace files.'
+    ),
+    dataset_path: str | None = typer.Option(
+        None,
+        '--dataset-path',
+        '-d',
+        help='Dataset file to compute recall against gold session IDs.',
+    ),
+    variant: str = typer.Option('s', '--variant'),
+    allow_unpinned_checksum: bool = typer.Option(
+        False,
+        '--allow-unpinned-checksum',
+        help='Bypass the dataset SHA-256 pin requirement (dev only).',
+    ),
+    verbose: bool = typer.Option(False, '--verbose', '-v'),
+) -> None:
+    """Parse trace files and show per-question retrieval breakdown."""
+    _setup_logging(verbose)
+
+    from pathlib import Path
+
+    from memex_eval.external.longmemeval_trace_parser import (
+        compute_recall,
+        format_question_breakdown,
+        parse_trace,
+        parse_traces_dir,
+    )
+
+    p = Path(traces_path)
+
+    gold_map: dict[str, list[str]] = {}
+    category_map: dict[str, str] = {}
+    if dataset_path:
+        from memex_eval.external.longmemeval_common import _load_variant
+
+        questions = _load_variant(
+            Path(dataset_path), variant, allow_unpinned=allow_unpinned_checksum
+        )
+        gold_map = {q.question_id: q.answer_session_ids for q in questions}
+        category_map = {q.question_id: q.category.value for q in questions}
+
+    if p.is_dir():
+        traces = parse_traces_dir(p)
+    elif p.is_file():
+        traces = [parse_trace(p)]
+    else:
+        console.print(f'[red]Not found: {traces_path}[/red]')
+        raise typer.Exit(code=1)
+
+    if not traces:
+        console.print('[dim]No trace files found.[/dim]')
+        raise typer.Exit(code=0)
+
+    total_gold = 0
+    total_found = 0
+
+    for trace in traces:
+        gold = gold_map.get(trace.question_id, [])
+        cat = category_map.get(trace.question_id, '')
+        metrics = compute_recall(trace, gold, category=cat) if gold else None
+        print(format_question_breakdown(trace, metrics))
+        print()
+
+        if metrics:
+            total_gold += len(metrics.gold_session_ids)
+            total_found += len(metrics.found_session_ids)
+
+    if total_gold > 0:
+        overall_recall = total_found / total_gold
+        console.print(
+            f'[bold]Overall Recall@3: {total_found}/{total_gold} ({overall_recall:.3f})[/bold]'
+        )
+    else:
+        console.print('[dim]No gold session IDs available for recall computation.[/dim]')
+
+
+@longmemeval_app.command('run')
+def longmemeval_run_cmd(
+    dataset_path: str = typer.Option(..., '--dataset-path', '-d'),
+    variant: str = typer.Option('s', '--variant'),
+    run_id: str | None = typer.Option(
+        None, '--run-id', help='Identifier for this run (auto-generated if omitted).'
+    ),
+    server: str = typer.Option(DEFAULT_SERVER, '--server', '-s'),
+    output_dir: str = typer.Option('./longmemeval-run', '--output-dir', '-o'),
+    method: str = typer.Option(
+        'claude-code', '--method', help='Answer driver: "claude-code" | "gemini-cli".'
+    ),
+    plugin_dir: str | None = typer.Option(
+        None,
+        '--plugin-dir',
+        help='Path to the memex Claude Code plugin. Defaults to packages/claude-code-plugin/.',
+    ),
+    judge_model: str | None = typer.Option(None, '--judge-model'),
+    cache: str | None = typer.Option(None, '--cache'),
+    question_limit: int | None = typer.Option(None, '--questions', '-n'),
+    subagent_timeout_s: float = typer.Option(300.0, '--subagent-timeout-s'),
+    allow_unpinned_checksum: bool = typer.Option(
+        False,
+        '--allow-unpinned-checksum',
+        help='Bypass the dataset SHA-256 pin requirement (dev only). Logs the computed hash.',
+    ),
+    verbose: bool = typer.Option(False, '--verbose', '-v'),
+) -> None:
+    """End-to-end: ingest -> answer -> judge -> report."""
+    _setup_logging(verbose)
+
+    from pathlib import Path
+
+    from memex_eval.external.longmemeval_answer import AnswerMethod, answer_questions
+    from memex_eval.external.longmemeval_ingest import ingest_longmemeval
+    from memex_eval.external.longmemeval_judge import judge_hypotheses
+    from memex_eval.external.longmemeval_report import generate_report
+
+    rid = run_id or uuid4().hex[:8]
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    hypotheses = out / 'hypotheses.jsonl'
+    judgments = out / 'judgments.jsonl'
+
+    async def _pipeline() -> None:
+        await ingest_longmemeval(
+            server_url=server,
+            dataset_path=dataset_path,
+            variant=variant,
+            run_id=rid,
+            question_limit=question_limit,
+            allow_unpinned_checksum=allow_unpinned_checksum,
+        )
+        await answer_questions(
+            server_url=server,
+            dataset_path=dataset_path,
+            variant=variant,
+            run_id=rid,
+            output_path=str(hypotheses),
+            method=AnswerMethod(method),
+            plugin_dir=plugin_dir,
+            question_limit=question_limit,
+            subagent_timeout_s=subagent_timeout_s,
+            allow_unpinned_checksum=allow_unpinned_checksum,
+        )
+        await judge_hypotheses(
+            dataset_path=dataset_path,
+            variant=variant,
+            hypotheses_path=str(hypotheses),
+            output_path=str(judgments),
+            judge_model=judge_model,
+            cache_path=cache,
+            allow_unpinned_checksum=allow_unpinned_checksum,
+            traces_dir=str(out / 'traces'),
+        )
+
+    asyncio.run(_pipeline())
+    generate_report(
+        judgments_path=str(judgments),
+        output_dir=str(out),
+        run_id=rid,
+        variant=variant,
+        dataset_path=dataset_path,
+        hypotheses_path=str(hypotheses),
+        traces_dir=str(out / 'traces'),
+        allow_unpinned_checksum=allow_unpinned_checksum,
     )
 
 

--- a/packages/eval/src/memex_eval/external/longmemeval_answer.py
+++ b/packages/eval/src/memex_eval/external/longmemeval_answer.py
@@ -1,0 +1,691 @@
+"""LongMemEval Phase 2: Answer questions using a Claude Code subagent.
+
+One subprocess per question. Each question gets a fresh temporary
+workspace prepared with:
+
+- ``.mcp.json`` — stdio MCP server pointing at the running Memex REST
+  server so the subagent can use the memex MCP tools.
+- ``.memex.yaml`` — pins the per-run vault so all MCP calls are scoped
+  to the benchmark's data.
+- ``CLAUDE.md`` — retrieval-playbook system prompt (routing,
+  citations, prohibitions). Mirrors the LoCoMo pattern this module
+  replaced.
+- ``.claude/settings.local.json`` — permissions allow-list for the
+  memex MCP tools so ``--dangerously-skip-permissions`` stays off for
+  anything else.
+
+On top of that, the **memex Claude Code plugin** (``packages/
+claude-code-plugin/``) is wired in via the ``--plugin-dir`` flag so
+the subagent has the plugin's skills (``/remember``, ``/recall``,
+``/retro``) and hooks in addition to the raw MCP tools.
+
+Falls back to nothing else — ``AnswerMethod.GEMINI_CLI`` is reserved
+for future work and currently raises ``NotImplementedError``.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+from memex_eval.external.longmemeval_common import (
+    LongMemEvalHypothesis,
+    _load_variant,
+    append_jsonl,
+    read_completed_ids,
+    vault_name_for,
+)
+
+logger = logging.getLogger('memex_eval.longmemeval_answer')
+console = Console()
+
+
+# Pinned prompt-template version — bumped whenever the system prompt
+# materially changes so hypothesis fingerprints stay traceable.
+ANSWER_PROMPT_TEMPLATE_VERSION = '2026-04-15.v2'
+
+
+# Repo root: packages/eval/src/memex_eval/external/longmemeval_answer.py
+# -> parents[5] is the repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_PLUGIN_DIR = _REPO_ROOT / 'packages' / 'claude-code-plugin'
+
+
+class AnswerMethod(str, enum.Enum):
+    """Curated agent CLIs that can answer LongMemEval questions."""
+
+    CLAUDE_CODE = 'claude-code'
+    GEMINI_CLI = 'gemini-cli'
+
+
+class AnswerMode(str, enum.Enum):
+    """Retrieval configuration for answer generation.
+
+    - ``agent``: Full Claude Code subagent with all Memex MCP tools.
+    - ``note-only``: Direct ``memex_note_search`` call (limit=10) + LLM
+      synthesis. Retries once with ``expand_query=true`` on abstention.
+    - ``memory-only``: Direct ``memex_memory_search`` call (limit=10) +
+      LLM synthesis. Same retry policy as note-only.
+    """
+
+    AGENT = 'agent'
+    NOTE_ONLY = 'note-only'
+    MEMORY_ONLY = 'memory-only'
+
+
+_MCP_JSON_TEMPLATE = """\
+{{
+  "mcpServers": {{
+    "memex": {{
+      "type": "stdio",
+      "command": "uv",
+      "args": ["--directory", "{workspace}", "run", "memex", "mcp", "run"],
+      "env": {{
+        "MEMEX_SERVER_URL": "{server_url_base}",
+        "MEMEX_SERVER__DEFAULT_ACTIVE_VAULT": "{vault}",
+        "MEMEX_SERVER__DEFAULT_READER_VAULT": "{vault}"
+      }}
+    }}
+  }}
+}}
+"""
+
+
+_MEMEX_YAML_TEMPLATE = """\
+server_url: {server_url_base}
+vault:
+  active: "{vault}"
+server:
+  default_active_vault: "{vault}"
+  default_reader_vault: "{vault}"
+"""
+
+
+_CLAUDE_MD = """\
+# LongMemEval — Memex Retrieval
+
+You are answering a question about a long-running multi-session
+conversation. A Memex vault has been pre-populated with one note per
+session (timestamped via ``publish_date`` frontmatter) and every fact
+extracted into a ``MemoryUnit``. Use the Memex MCP tools to find the
+answer.
+
+Retrieval routing, search query formulation, and tool usage rules are
+provided by the memex plugin (loaded automatically). Follow them.
+
+## First action
+
+Fetch all Memex MCP tool schemas in a single call:
+
+```
+ToolSearch(query="select:mcp__memex__memex_memory_search,mcp__memex__memex_note_search,\
+mcp__memex__memex_list_entities,mcp__memex__memex_get_entity_mentions,\
+mcp__memex__memex_get_entity_cooccurrences,mcp__memex__memex_get_notes_metadata,\
+mcp__memex__memex_get_page_indices,mcp__memex__memex_get_nodes,\
+mcp__memex__memex_read_note", max_results=9)
+```
+
+## Abstention
+
+If the memory contains no evidence to answer the question, reply
+exactly:
+
+    I do not know based on the available memory.
+
+Do NOT hedge; do NOT invent. Abstention is scored as correct on
+``*_abs`` questions.
+
+## Answer format
+
+Answer concisely in plain text. Do NOT wrap in code fences. The final
+message you send is the hypothesis — everything else is scaffolding.
+"""
+
+
+def _normalise_server_url(server_url: str) -> str:
+    """Strip trailing ``/api/v1`` / slash so MCP + config take the base URL."""
+    base = server_url.rstrip('/')
+    if base.endswith('/api/v1'):
+        base = base[: -len('/api/v1')]
+    return base
+
+
+def _setup_subagent_workspace(server_url: str, vault_name: str) -> str:
+    """Create a temp workspace with MCP config, memex YAML, and CLAUDE.md.
+
+    The memex Claude Code plugin is wired in separately via the
+    ``--plugin-dir`` flag on the ``claude`` invocation; nothing is
+    copied into the workspace itself. This keeps the plugin
+    installation idempotent across runs and matches the plugin
+    README's "local development" install path.
+    """
+    tmpdir = tempfile.mkdtemp(prefix='longmemeval-claude-')
+    base_url = _normalise_server_url(server_url)
+
+    (Path(tmpdir) / '.mcp.json').write_text(
+        _MCP_JSON_TEMPLATE.format(
+            workspace=str(_REPO_ROOT), server_url_base=base_url, vault=vault_name
+        )
+    )
+    (Path(tmpdir) / '.memex.yaml').write_text(
+        _MEMEX_YAML_TEMPLATE.format(server_url_base=base_url, vault=vault_name)
+    )
+    (Path(tmpdir) / 'CLAUDE.md').write_text(_CLAUDE_MD)
+
+    claude_dir = Path(tmpdir) / '.claude'
+    claude_dir.mkdir()
+    (claude_dir / 'settings.local.json').write_text(
+        json.dumps(
+            {
+                'permissions': {
+                    'allow': [
+                        'mcp__memex__memex_memory_search',
+                        'mcp__memex__memex_note_search',
+                        'mcp__memex__memex_list_entities',
+                        'mcp__memex__memex_get_entities',
+                        'mcp__memex__memex_get_entity_mentions',
+                        'mcp__memex__memex_get_entity_cooccurrences',
+                        'mcp__memex__memex_get_notes_metadata',
+                        'mcp__memex__memex_get_page_indices',
+                        'mcp__memex__memex_get_nodes',
+                        'mcp__memex__memex_read_note',
+                        'mcp__memex__memex_list_vaults',
+                    ]
+                }
+            },
+            indent=2,
+        )
+    )
+
+    # Silence ``claude`` warnings about running in a non-git workdir.
+    subprocess.run(['git', 'init'], cwd=tmpdir, capture_output=True, check=False)
+
+    return tmpdir
+
+
+def _resolve_plugin_dir(override: str | None = None) -> Path:
+    """Locate the memex Claude Code plugin directory.
+
+    Resolution order:
+      1. Explicit ``override`` argument.
+      2. ``MEMEX_CLAUDE_PLUGIN_DIR`` env var.
+      3. Repo-local ``packages/claude-code-plugin/`` (the monorepo default).
+    """
+    if override is not None:
+        return Path(override)
+    env_override = os.environ.get('MEMEX_CLAUDE_PLUGIN_DIR')
+    if env_override:
+        return Path(env_override)
+    return _PLUGIN_DIR
+
+
+def _verify_plugin_installed(plugin_dir: Path) -> None:
+    """Raise if the plugin directory is missing required files.
+
+    Catches configuration mistakes (e.g. wrong ``--plugin-dir`` path)
+    before we spawn 500 subagents against a broken install.
+    """
+    if not plugin_dir.exists():
+        raise FileNotFoundError(
+            f'memex Claude Code plugin not found at {plugin_dir}. '
+            f'Set MEMEX_CLAUDE_PLUGIN_DIR or pass --plugin-dir.'
+        )
+    manifest = plugin_dir / '.claude-plugin' / 'plugin.json'
+    if not manifest.exists():
+        raise FileNotFoundError(
+            f'memex Claude Code plugin at {plugin_dir} is missing '
+            f'{manifest.relative_to(plugin_dir)}. Is this the right directory?'
+        )
+    skills_dir = plugin_dir / 'skills'
+    if not skills_dir.is_dir():
+        logger.warning(
+            "memex Claude Code plugin at %s has no 'skills/' directory — "
+            'subagents will have MCP tools but no plugin skills.',
+            plugin_dir,
+        )
+    else:
+        skill_names = sorted(p.name for p in skills_dir.iterdir() if p.is_dir())
+        logger.info(
+            'memex Claude Code plugin at %s exposes skills: %s',
+            plugin_dir,
+            ', '.join(skill_names) or '(none)',
+        )
+
+
+# ---------------------------------------------------------------------------
+# Session trace capture
+# ---------------------------------------------------------------------------
+
+
+def _collect_session_trace(
+    workdir: str, output_dir: str, question_id: str
+) -> dict[str, str | None]:
+    """Copy the Claude Code session trace file for a question.
+
+    Finds the most recently modified ``.jsonl`` in the Claude Code project
+    directory for the workdir, then copies it into
+    ``<output_dir>/traces/<question_id>.jsonl``.
+
+    Returns dict with ``session_id`` and ``trace_file`` (both may be None on failure).
+    """
+    result: dict[str, str | None] = {'session_id': None, 'trace_file': None}
+
+    try:
+        # Claude Code stores project data under ~/.claude/projects/<slug>/
+        # where slug = absolute path with / replaced by - (leading - kept).
+        # Claude Code may also replace underscores with dashes in the slug.
+        projects_root = Path.home() / '.claude' / 'projects'
+        slug = workdir.replace('/', '-')
+        project_dir = projects_root / slug
+
+        if not project_dir.exists():
+            # Fallback: try with underscores also replaced by dashes
+            slug_alt = slug.replace('_', '-')
+            project_dir_alt = projects_root / slug_alt
+            if project_dir_alt.exists():
+                project_dir = project_dir_alt
+            else:
+                logger.warning('Project dir not found at %s (or %s)', project_dir, project_dir_alt)
+                return result
+
+        # Find the most recently modified .jsonl (the trace for the last -p call)
+        traces = sorted(
+            project_dir.glob('*.jsonl'),
+            key=lambda f: f.stat().st_mtime,
+            reverse=True,
+        )
+        if not traces:
+            logger.warning('No session traces in %s', project_dir)
+            return result
+
+        trace_src = traces[0]
+        session_id = trace_src.stem
+        result['session_id'] = session_id
+
+        # Copy to output traces dir
+        traces_dir = Path(output_dir) / 'traces'
+        traces_dir.mkdir(parents=True, exist_ok=True)
+        trace_dst = traces_dir / f'{question_id}.jsonl'
+        shutil.copy2(str(trace_src), str(trace_dst))
+        result['trace_file'] = str(trace_dst)
+        logger.info('Captured session trace -> %s', trace_dst)
+
+    except Exception:
+        logger.warning('Failed to collect session trace', exc_info=True)
+
+    return result
+
+
+def _extract_tool_calls_from_trace(trace_path: str) -> list[dict[str, Any]]:
+    """Extract tool_use blocks from a Claude Code session trace file."""
+    tool_calls: list[dict[str, Any]] = []
+    try:
+        for line in Path(trace_path).read_text().strip().splitlines():
+            if not line.strip():
+                continue
+            obj = json.loads(line)
+            if obj.get('type') != 'assistant':
+                continue
+            for block in obj.get('message', {}).get('content', []):
+                if isinstance(block, dict) and block.get('type') == 'tool_use':
+                    tool_calls.append(
+                        {
+                            'name': block.get('name', ''),
+                            'input': block.get('input', {}),
+                        }
+                    )
+    except Exception:
+        logger.warning('Failed to extract tool calls from trace', exc_info=True)
+    return tool_calls
+
+
+def _run_claude_subagent(
+    question_text: str,
+    workdir: str,
+    *,
+    plugin_dir: Path,
+    timeout_s: float = 300.0,
+) -> dict[str, Any]:
+    """Invoke ``claude -p ... --output-format json`` for one question.
+
+    Returns a dict with ``answer``, ``tool_calls``, ``tokens``,
+    ``num_turns``, ``cost_usd``, ``duration_s``, ``model``, ``error``.
+    """
+    prompt = f'Answer the following LongMemEval question: {question_text}'
+    env = {k: v for k, v in os.environ.items() if k != 'CLAUDECODE'}
+
+    cmd = [
+        'claude',
+        '--model',
+        'claude-sonnet-4-6',
+        '--plugin-dir',
+        str(plugin_dir),
+        '-p',
+        prompt,
+        '--output-format',
+        'json',
+        '--dangerously-skip-permissions',
+    ]
+
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=workdir,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            'answer': '',
+            'tool_calls': [],
+            'tokens': {'input': 0, 'output': 0},
+            'num_turns': 0,
+            'cost_usd': 0.0,
+            'duration_s': round(time.time() - t0, 2),
+            'model': None,
+            'error': 'timeout',
+        }
+
+    duration = time.time() - t0
+
+    if proc.returncode != 0:
+        return {
+            'answer': '',
+            'tool_calls': [],
+            'tokens': {'input': 0, 'output': 0},
+            'num_turns': 0,
+            'cost_usd': 0.0,
+            'duration_s': round(duration, 2),
+            'model': None,
+            'error': f'claude exit code {proc.returncode}: {proc.stderr[:500]}',
+        }
+
+    return _parse_claude_json_output(proc.stdout, duration)
+
+
+def _parse_claude_json_output(stdout: str, duration: float) -> dict[str, Any]:
+    """Parse the JSONL / JSON emitted by ``claude --output-format json``.
+
+    Conversation messages come first as JSONL; the final line is the
+    ``result`` summary. Some versions emit a single JSON object. Both
+    shapes are supported.
+    """
+    lines = [line for line in stdout.strip().splitlines() if line.strip()]
+    tool_calls: list[dict[str, Any]] = []
+    result_data: dict[str, Any] = {}
+
+    for line in lines:
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if obj.get('type') == 'assistant':
+            for block in obj.get('message', {}).get('content', []) or []:
+                if isinstance(block, dict) and block.get('type') == 'tool_use':
+                    tool_calls.append(
+                        {
+                            'name': block.get('name', ''),
+                            'input': block.get('input', {}),
+                        }
+                    )
+        if obj.get('type') == 'result' or 'result' in obj:
+            result_data = obj
+
+    answer = result_data.get('result', '')
+    if not isinstance(answer, str):
+        answer = str(answer)
+
+    usage = result_data.get('usage', {}) or {}
+    input_tokens = (
+        usage.get('input_tokens', 0)
+        + usage.get('cache_creation_input_tokens', 0)
+        + usage.get('cache_read_input_tokens', 0)
+    )
+    output_tokens = usage.get('output_tokens', 0)
+    num_turns = result_data.get('num_turns', 0)
+    cost_usd = result_data.get('total_cost_usd', 0.0) or 0.0
+    model = result_data.get('model') or None
+
+    return {
+        'answer': answer,
+        'tool_calls': tool_calls,
+        'tokens': {'input': input_tokens, 'output': output_tokens},
+        'num_turns': num_turns,
+        'cost_usd': round(float(cost_usd), 6),
+        'duration_s': round(duration, 2),
+        'model': model,
+        'error': None,
+    }
+
+
+def _fingerprint(
+    model: str | None,
+    method: AnswerMethod,
+    mode: 'AnswerMode | None' = None,
+) -> str:
+    model_part = model or 'claude-sonnet-4-6'
+    mode_part = f'{mode.value}:' if mode and mode is not AnswerMode.AGENT else ''
+    return f'{mode_part}{method.value}:{model_part}@{ANSWER_PROMPT_TEMPLATE_VERSION}'
+
+
+def _resolve_answer_method(method: AnswerMethod | None) -> AnswerMethod:
+    """Resolve the answer method. Defaults to CLAUDE_CODE when no flag is set."""
+    return method if method is not None else AnswerMethod.CLAUDE_CODE
+
+
+async def _answer_questions_direct(
+    *,
+    server_url: str,
+    output_path: str,
+    pending: list[Any],
+    total: int,
+    vault_name: str,
+    method: AnswerMethod,
+    mode: 'AnswerMode',
+) -> int:
+    """Answer loop for non-agent modes (note-only / memory-only).
+
+    Calls the retrieval tool directly with ``limit=10`` and uses an
+    LLM to synthesize the answer. Retries once with ``expand_query=True``
+    on abstention before declaring final abstention.
+    """
+    import dspy
+
+    from memex_eval.external.longmemeval_answer_direct import (
+        DEFAULT_ANSWER_MODEL,
+        DirectMode,
+        answer_direct,
+    )
+
+    direct_mode = DirectMode(mode.value)
+    # Allow override via env var (MEMEX_EVAL_ANSWER_MODEL) for environments
+    # without Anthropic API access; defaults to Sonnet per the benchmark spec.
+    model_name = os.environ.get('MEMEX_EVAL_ANSWER_MODEL', DEFAULT_ANSWER_MODEL)
+    answer_lm = dspy.LM(model_name)
+    logger.info('Direct-mode answer model: %s', model_name)
+    answered = 0
+
+    for i, question in enumerate(pending):
+        result = await answer_direct(
+            question=question,
+            mode=direct_mode,
+            vault_name=vault_name,
+            server_url=server_url,
+            answer_lm=answer_lm,
+        )
+
+        from memex_eval.external.longmemeval_common import LongMemEvalToolCall
+
+        tool_call_records = [
+            LongMemEvalToolCall(name=call.get('name', ''), input=call.get('input', {}))
+            for call in result['tool_calls']
+        ]
+        hypothesis = LongMemEvalHypothesis(
+            question_id=question.question_id,
+            hypothesis=(result['answer'] or '').strip(),
+            retrieved_unit_ids=result.get('retrieved_ids', []) or [],
+            answer_model_fingerprint=_fingerprint(result.get('model'), method, mode),
+            latency_ms=round(result['duration_s'] * 1000.0, 2),
+            cost_usd=result.get('cost_usd', 0.0),
+            input_tokens=result['tokens']['input'],
+            output_tokens=result['tokens']['output'],
+            num_turns=result['num_turns'],
+            tool_calls=tool_call_records,
+            session_id=None,
+            trace_file=None,
+        )
+        append_jsonl(output_path, hypothesis.model_dump())
+        answered += 1
+        logger.info(
+            '[%d/%d] (%s) %s -> %s',
+            i + 1,
+            len(pending),
+            mode.value,
+            question.question_id,
+            (result['answer'] or '').strip()[:80],
+        )
+
+    console.print(f'\n[bold green]Answered {answered} questions -> {output_path}[/bold green]')
+    return answered
+
+
+async def answer_questions(
+    server_url: str,
+    dataset_path: str,
+    variant: str,
+    run_id: str,
+    output_path: str,
+    *,
+    method: AnswerMethod | None = None,
+    mode: 'AnswerMode | None' = None,
+    answer_model: str | None = None,  # noqa: ARG001 — reserved for future (e.g. --model passthrough)
+    answer_api_key: str | None = None,  # noqa: ARG001 — reserved for future
+    retrieval_limit: int = 20,  # noqa: ARG001 — retrieval is subagent-driven now
+    question_limit: int | None = None,
+    allow_unpinned_checksum: bool = False,
+    plugin_dir: str | None = None,
+    subagent_timeout_s: float = 300.0,
+) -> int:
+    """Answer LongMemEval questions via Claude Code subagents.
+
+    Returns the number of hypotheses produced in this run. Resumes
+    safely: questions already present in ``output_path`` are skipped.
+    """
+    resolved_method = _resolve_answer_method(method)
+    if resolved_method is not AnswerMethod.CLAUDE_CODE:
+        raise NotImplementedError(f'{resolved_method.value} is not yet implemented.')
+
+    resolved_mode = mode if mode is not None else AnswerMode.AGENT
+
+    questions = _load_variant(Path(dataset_path), variant, allow_unpinned=allow_unpinned_checksum)
+    if question_limit is not None:
+        questions = questions[:question_limit]
+    completed = read_completed_ids(output_path)
+    pending = [q for q in questions if q.question_id not in completed]
+
+    if not pending:
+        console.print('[dim]All questions already answered. Nothing to do.[/dim]')
+        return 0
+
+    console.print(
+        f'[bold]{len(pending)} questions to answer[/bold] '
+        f'({len(completed)} already done, {len(questions)} total) '
+        f'mode={resolved_mode.value}'
+    )
+
+    vault_name = vault_name_for(variant, run_id)
+
+    # Direct modes skip the subagent workspace + plugin setup entirely.
+    if resolved_mode is not AnswerMode.AGENT:
+        return await _answer_questions_direct(
+            server_url=server_url,
+            output_path=output_path,
+            pending=pending,
+            total=len(questions),
+            vault_name=vault_name,
+            method=resolved_method,
+            mode=resolved_mode,
+        )
+
+    resolved_plugin_dir = _resolve_plugin_dir(plugin_dir)
+    _verify_plugin_installed(resolved_plugin_dir)
+
+    workdir = _setup_subagent_workspace(server_url, vault_name)
+    logger.info('Subagent workspace: %s (plugin-dir: %s)', workdir, resolved_plugin_dir)
+
+    output_dir = str(Path(output_path).parent)
+    answered = 0
+    try:
+        for i, question in enumerate(pending):
+            result = _run_claude_subagent(
+                question.question_text,
+                workdir=workdir,
+                plugin_dir=resolved_plugin_dir,
+                timeout_s=subagent_timeout_s,
+            )
+
+            # Capture session trace and extract tool calls from it
+            trace_info = _collect_session_trace(workdir, output_dir, question.question_id)
+
+            # If stdout parsing missed tool calls, extract from the trace file
+            trace_file = trace_info.get('trace_file')
+            if not result['tool_calls'] and trace_file:
+                result['tool_calls'] = _extract_tool_calls_from_trace(trace_file)
+
+            from memex_eval.external.longmemeval_common import LongMemEvalToolCall
+
+            tool_call_records = [
+                LongMemEvalToolCall(
+                    name=call.get('name', ''),
+                    input=call.get('input', {}),
+                )
+                for call in result['tool_calls']
+            ]
+            hypothesis = LongMemEvalHypothesis(
+                question_id=question.question_id,
+                hypothesis=(result['answer'] or '').strip(),
+                retrieved_unit_ids=[
+                    tc.input.get('unit_id', '') or ''
+                    for tc in tool_call_records
+                    if isinstance(tc.input, dict)
+                ],
+                answer_model_fingerprint=_fingerprint(result.get('model'), resolved_method),
+                latency_ms=round(result['duration_s'] * 1000.0, 2),
+                cost_usd=result['cost_usd'],
+                input_tokens=result['tokens']['input'],
+                output_tokens=result['tokens']['output'],
+                num_turns=result['num_turns'],
+                tool_calls=tool_call_records,
+                session_id=trace_info.get('session_id'),
+                trace_file=trace_info.get('trace_file'),
+            )
+            append_jsonl(output_path, hypothesis.model_dump())
+            answered += 1
+            logger.info(
+                '[%d/%d] %s -> %s',
+                i + 1,
+                len(pending),
+                question.question_id,
+                (result['answer'] or '').strip()[:80],
+            )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    console.print(f'\n[bold green]Answered {answered} questions -> {output_path}[/bold green]')
+    return answered

--- a/packages/eval/src/memex_eval/external/longmemeval_answer_direct.py
+++ b/packages/eval/src/memex_eval/external/longmemeval_answer_direct.py
@@ -1,0 +1,293 @@
+"""LongMemEval direct-retrieval answer modes.
+
+Provides ``note-only`` and ``memory-only`` modes that bypass the
+Claude Code subagent entirely. A single tool call (``note_search`` or
+``memory_search``) is made with ``limit=10``, then an LLM synthesizes
+an answer from the top-10 results. If the LLM abstains, we retry once
+with ``expand_query=true`` before declaring final abstention.
+
+These modes isolate retrieval quality from agent-orchestration quality,
+so accuracy/efficiency can be compared head-to-head against the full
+agent mode.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import time
+from typing import Any
+
+import dspy
+import httpx
+import tiktoken
+
+from memex_common.client import RemoteMemexAPI
+from memex_common.schemas import MemoryUnitDTO, NoteSearchResult
+
+from memex_eval.external.longmemeval_common import LongMemEvalQuestion
+
+logger = logging.getLogger('memex_eval.longmemeval_answer_direct')
+
+
+ABSTENTION_MARKER = 'I do not know based on the available memory.'
+DEFAULT_ANSWER_MODEL = 'claude-sonnet-4-6'
+DEFAULT_LIMIT = 10
+
+
+class DirectMode(str, enum.Enum):
+    """Non-agent answer modes that call a single retrieval tool directly."""
+
+    NOTE_ONLY = 'note-only'
+    MEMORY_ONLY = 'memory-only'
+
+
+class DirectAnswerSignature(dspy.Signature):
+    """Answer the question using ONLY the provided memory context.
+
+    If the context does NOT contain the answer, reply with exactly the
+    abstention marker. Do NOT invent, hedge, or guess.
+    """
+
+    question: str = dspy.InputField(desc='The user question to answer.')
+    context: str = dspy.InputField(desc='Retrieved memory context (numbered).')
+    abstention_marker: str = dspy.InputField(
+        desc='The EXACT string to reply when context does not contain the answer.'
+    )
+    answer: str = dspy.OutputField(
+        desc='Concise plain-text answer, or the abstention marker verbatim.'
+    )
+
+
+def _format_memory_results(units: list[MemoryUnitDTO]) -> str:
+    """Render MemoryUnits as a numbered context block for the LLM."""
+    lines: list[str] = []
+    for i, u in enumerate(units, start=1):
+        src = getattr(u, 'note_title', None) or getattr(u, 'note_id', '?')
+        lines.append(f'[{i}] ({src}) {u.text}')
+    return '\n'.join(lines)
+
+
+def _format_note_results(notes: list[NoteSearchResult]) -> str:
+    """Render note search results as a numbered context block for the LLM."""
+    lines: list[str] = []
+    for i, n in enumerate(notes, start=1):
+        title = getattr(n, 'title', None) or str(getattr(n, 'note_id', '?'))
+        desc = getattr(n, 'description', '') or ''
+        # Prefer summaries when available for richer context
+        summaries = getattr(n, 'summaries', None) or []
+        body_parts: list[str] = []
+        if desc:
+            body_parts.append(desc.strip())
+        for s in summaries:
+            if isinstance(s, str) and s.strip():
+                body_parts.append(s.strip())
+            elif isinstance(s, dict):
+                txt = s.get('summary') or s.get('text') or ''
+                if txt.strip():
+                    body_parts.append(txt.strip())
+        body = '\n  '.join(body_parts) or '(no description)'
+        lines.append(f'[{i}] ({title})\n  {body}')
+    return '\n'.join(lines)
+
+
+async def _retrieve(
+    mode: DirectMode,
+    api: RemoteMemexAPI,
+    query: str,
+    vault_ids: list[str],
+    *,
+    limit: int,
+    expand_query: bool,
+    reference_date: Any = None,
+) -> tuple[list[Any], str, list[str]]:
+    """Call the single retrieval tool for this mode.
+
+    Returns (raw_results, formatted_context, retrieved_ids).
+    """
+    if mode is DirectMode.MEMORY_ONLY:
+        units = await api.search(
+            query=query,
+            limit=limit,
+            vault_ids=list(vault_ids),
+            expand_query=expand_query,
+            reference_date=reference_date,
+        )
+        return units, _format_memory_results(units), [str(u.id) for u in units]
+
+    # DirectMode.NOTE_ONLY
+    notes = await api.search_notes(
+        query=query,
+        limit=limit,
+        vault_ids=list(vault_ids),
+        expand_query=expand_query,
+        reference_date=reference_date,
+    )
+    return notes, _format_note_results(notes), [str(n.note_id) for n in notes]
+
+
+async def _synthesize(
+    question: str,
+    context: str,
+    lm: dspy.LM,
+) -> tuple[str, int, int]:
+    """Call the answer LLM and return (answer, input_tokens, output_tokens)."""
+    predictor = dspy.Predict(DirectAnswerSignature)
+    lm_call = lm.copy()
+
+    with dspy.context(lm=lm_call):
+        if hasattr(predictor, 'acall'):
+            result = await predictor.acall(
+                question=question,
+                context=context,
+                abstention_marker=ABSTENTION_MARKER,
+            )
+        else:
+            import asyncio as _asyncio
+
+            result = await _asyncio.to_thread(
+                predictor,
+                question=question,
+                context=context,
+                abstention_marker=ABSTENTION_MARKER,
+            )
+
+    answer = (result.answer if hasattr(result, 'answer') else '').strip()
+
+    input_tokens = 0
+    output_tokens = 0
+    history = getattr(lm_call, 'history', None) or []
+    for entry in history:
+        usage = (entry or {}).get('usage', {}) or {}
+        input_tokens += int(usage.get('prompt_tokens') or usage.get('input_tokens') or 0)
+        output_tokens += int(usage.get('completion_tokens') or usage.get('output_tokens') or 0)
+
+    if hasattr(lm_call, 'history'):
+        try:
+            lm_call.history.clear()
+        except Exception:
+            pass
+
+    return answer, input_tokens, output_tokens
+
+
+def _is_abstention(answer: str) -> bool:
+    """Check whether an LLM answer should be treated as abstention."""
+    a = (answer or '').strip().lower()
+    if not a:
+        return True
+    return (
+        ABSTENTION_MARKER.lower() in a
+        or a.startswith('i do not know')
+        or a.startswith("i don't know")
+    )
+
+
+async def answer_direct(
+    question: LongMemEvalQuestion,
+    mode: DirectMode,
+    vault_name: str,
+    server_url: str,
+    answer_lm: dspy.LM,
+    *,
+    limit: int = DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    """Answer a single question by direct tool call + LLM synthesis.
+
+    Implements the two-try retry policy:
+      1. First attempt: tool call with ``expand_query=False``.
+      2. If the LLM abstains, retry once with ``expand_query=True``.
+      3. If still abstaining, return the abstention marker as final.
+
+    Returns a dict with the same shape ``_run_claude_subagent`` uses,
+    so the outer loop can serialize without branching.
+    """
+    t0 = time.time()
+    tool_name = 'memex_memory_search' if mode is DirectMode.MEMORY_ONLY else 'memex_note_search'
+    enc = tiktoken.get_encoding('cl100k_base')
+
+    total_input_tokens = 0
+    total_output_tokens = 0
+    tool_calls: list[dict[str, Any]] = []
+    retrieval_tokens = 0
+    retrieved_ids: list[str] = []
+    final_answer = ''
+
+    attempts: list[bool] = [False]  # first attempt without expansion
+    # Thread the question's reference date through so temporal expressions resolve
+    reference_date = question.question_date
+
+    async with httpx.AsyncClient(base_url=server_url, timeout=120.0) as client:
+        api = RemoteMemexAPI(client)
+        try:
+            vault_id = await api.resolve_vault_identifier(vault_name)
+            vault_ids = [str(vault_id)]
+        except Exception:
+            # Let the server resolve by name; should not happen in practice
+            vault_ids = [vault_name]
+
+        for attempt_idx, expand_query in enumerate(attempts + [True]):
+            # Stop if we already have a non-abstention answer
+            if final_answer and not _is_abstention(final_answer):
+                break
+
+            try:
+                _raw, context, ids = await _retrieve(
+                    mode=mode,
+                    api=api,
+                    query=question.question_text,
+                    vault_ids=vault_ids,
+                    limit=limit,
+                    expand_query=expand_query,
+                    reference_date=reference_date,
+                )
+            except (httpx.HTTPError, OSError) as e:
+                logger.warning('%s retrieval failed (expand=%s): %s', tool_name, expand_query, e)
+                context, ids = '', []
+
+            retrieval_tokens += len(enc.encode(context))
+            retrieved_ids = ids  # keep the most recent attempt's IDs
+            tool_calls.append(
+                {
+                    'name': tool_name,
+                    'input': {
+                        'query': question.question_text,
+                        'limit': limit,
+                        'expand_query': expand_query,
+                    },
+                }
+            )
+
+            if not context.strip():
+                final_answer = ABSTENTION_MARKER
+                continue
+
+            try:
+                answer, in_tok, out_tok = await _synthesize(
+                    question.question_text, context, answer_lm
+                )
+            except (RuntimeError, ValueError, OSError) as e:
+                logger.warning('Answer synthesis failed (attempt %d): %s', attempt_idx + 1, e)
+                answer, in_tok, out_tok = ABSTENTION_MARKER, 0, 0
+
+            total_input_tokens += in_tok
+            total_output_tokens += out_tok
+            final_answer = answer
+
+    duration = time.time() - t0
+
+    return {
+        'answer': final_answer or ABSTENTION_MARKER,
+        'tool_calls': tool_calls,
+        'tokens': {
+            'input': total_input_tokens + retrieval_tokens,
+            'output': total_output_tokens,
+        },
+        'num_turns': len(tool_calls),
+        'cost_usd': 0.0,
+        'duration_s': round(duration, 2),
+        'model': DEFAULT_ANSWER_MODEL,
+        'error': None,
+        'retrieved_ids': retrieved_ids,
+        'retrieval_tokens': retrieval_tokens,
+    }

--- a/packages/eval/src/memex_eval/external/longmemeval_common.py
+++ b/packages/eval/src/memex_eval/external/longmemeval_common.py
@@ -1,0 +1,505 @@
+"""Shared utilities for the LongMemEval benchmark.
+
+Types, dataset loaders, and JSONL helpers used across the
+`longmemeval_*.py` module family.
+
+Upstream dataset: https://github.com/xiaowu0162/longmemeval (v1 release,
+500 evaluation questions across six cognitive-ability categories + `_abs`
+abstention variants). The loaders do not redistribute dataset files —
+callers pass a local path.
+
+Checksum policy: ``DATASET_SHA256`` pins per-variant SHA-256 digests.
+Loading a variant whose pin is ``None`` raises
+``DatasetChecksumUnpinnedError`` by default. Operators who explicitly
+pass ``allow_unpinned=True`` (CLI flag ``--allow-unpinned-checksum``)
+bypass the check with a loud warning. A mismatched pin always raises
+``DatasetChecksumMismatchError`` — there is no override for that.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger('memex_eval.longmemeval_common')
+
+VAULT_NAME_PREFIX = 'longmemeval'
+
+# ---------------------------------------------------------------------------
+# Dataset checksums (v1 release). Pinned to catch silent upstream drift.
+# ---------------------------------------------------------------------------
+
+# Per-variant SHA-256 pins. ``None`` means "not yet pinned" — the loader
+# REFUSES to proceed in that state unless ``allow_unpinned=True`` is
+# explicitly passed. On first run against the upstream release, operators
+# should pass the override once, copy the hash the loader logs, then paste
+# it here; subsequent runs will fail loudly if upstream silently re-releases.
+#
+# The ``'s'`` pin is the canonical one — LongMemEval-S is the default variant
+# because it matches agentmemory's baseline (same 500 questions, ~40 sessions
+# each, ~115k tokens/question). ``'oracle'`` and ``'m'`` remain available
+# for ablation studies.
+DATASET_SHA256: dict[str, str | None] = {
+    'oracle': None,
+    's': None,
+    'm': None,
+}
+
+
+class DatasetChecksumError(RuntimeError):
+    """Base class for dataset-checksum failures."""
+
+
+class DatasetChecksumUnpinnedError(DatasetChecksumError):
+    """Raised when a variant's SHA-256 pin is None and no override was passed."""
+
+
+class DatasetChecksumMismatchError(DatasetChecksumError):
+    """Raised when the computed SHA-256 does not match the pinned value."""
+
+
+# Canonical filenames as distributed by upstream (see upstream release page).
+DATASET_FILENAMES: dict[str, str] = {
+    'oracle': 'longmemeval_oracle.json',
+    's': 'longmemeval_s.json',
+    'm': 'longmemeval_m.json',
+}
+
+
+# ---------------------------------------------------------------------------
+# Categories
+# ---------------------------------------------------------------------------
+
+
+class LongMemEvalCategory(StrEnum):
+    """The six cognitive-ability categories in LongMemEval v1."""
+
+    SINGLE_SESSION_USER = 'single-session-user'
+    SINGLE_SESSION_ASSISTANT = 'single-session-assistant'
+    SINGLE_SESSION_PREFERENCE = 'single-session-preference'
+    TEMPORAL_REASONING = 'temporal-reasoning'
+    KNOWLEDGE_UPDATE = 'knowledge-update'
+    MULTI_SESSION = 'multi-session'
+
+
+CATEGORY_NAMES: dict[LongMemEvalCategory, str] = {
+    LongMemEvalCategory.SINGLE_SESSION_USER: 'Single-Session (User)',
+    LongMemEvalCategory.SINGLE_SESSION_ASSISTANT: 'Single-Session (Assistant)',
+    LongMemEvalCategory.SINGLE_SESSION_PREFERENCE: 'Single-Session (Preference)',
+    LongMemEvalCategory.TEMPORAL_REASONING: 'Temporal Reasoning',
+    LongMemEvalCategory.KNOWLEDGE_UPDATE: 'Knowledge Update',
+    LongMemEvalCategory.MULTI_SESSION: 'Multi-Session',
+}
+
+
+# ---------------------------------------------------------------------------
+# Pydantic types
+# ---------------------------------------------------------------------------
+
+
+class LongMemEvalTurn(BaseModel):
+    """A single chat turn within a LongMemEval session."""
+
+    role: str = Field(description='"user" or "assistant".')
+    content: str
+    timestamp: datetime = Field(description='Turn timestamp, timezone-aware when possible.')
+
+
+class LongMemEvalSession(BaseModel):
+    """A conversation session (list of turns) with a session-level date."""
+
+    session_id: str
+    session_date: datetime
+    turns: list[LongMemEvalTurn] = Field(default_factory=list)
+
+
+class LongMemEvalQuestion(BaseModel):
+    """A LongMemEval evaluation question plus its evidence sessions."""
+
+    question_id: str
+    category: LongMemEvalCategory
+    is_abstention: bool = Field(
+        description='True if question_id ends with "_abs" — correct answer is "I do not know".',
+    )
+    question_text: str
+    answer: str | None = Field(
+        default=None,
+        description='Ground-truth answer. May be None for abstention questions.',
+    )
+    answer_session_ids: list[str] = Field(
+        default_factory=list,
+        description='Session IDs containing the evidence needed to answer this question.',
+    )
+    question_date: datetime | None = Field(
+        default=None,
+        description='When the question was asked. Used as reference_date for temporal queries.',
+    )
+    sessions: list[LongMemEvalSession] = Field(default_factory=list)
+
+
+class LongMemEvalToolCall(BaseModel):
+    """A single MCP tool invocation recorded from the subagent."""
+
+    name: str
+    input: dict[str, Any] = Field(default_factory=dict)
+
+
+class LongMemEvalHypothesis(BaseModel):
+    """A single answering-LM output for one question."""
+
+    question_id: str
+    hypothesis: str
+    retrieved_unit_ids: list[str] = Field(default_factory=list)
+    answer_model_fingerprint: str
+    latency_ms: float = 0.0
+    cost_usd: float | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    num_turns: int = 0
+    tool_calls: list[LongMemEvalToolCall] = Field(default_factory=list)
+    session_id: str | None = None
+    trace_file: str | None = None
+
+
+class LongMemEvalJudgment(BaseModel):
+    """A single judge output for one hypothesis."""
+
+    question_id: str
+    category: LongMemEvalCategory
+    is_abstention: bool
+    hypothesis: str
+    expected: str | None
+    correct: bool
+    judge_reasoning: str
+    judge_model_fingerprint: str
+    is_abstention_hypothesis: bool = Field(
+        default=False,
+        description=(
+            'True when the LM judge classified this hypothesis as an abstention. '
+            'Populated for every question — not just ground-truth abstention ones — '
+            'so abstention precision can be computed without re-using the judge '
+            'correctness signal as its own denominator.'
+        ),
+    )
+    retrieval_contains_answer: bool = Field(
+        default=True,
+        description='Whether the memex retrieval output contained sufficient evidence to answer.',
+    )
+    retrieval_containment_reasoning: str = Field(
+        default='',
+        description='LLM judge reasoning for retrieval containment.',
+    )
+    interpretation: str = Field(
+        default='correct',
+        description=(
+            'Error analysis label derived from the 2x2 matrix of retrieval containment '
+            'and answer correctness. One of: correct, model_error, correct_abstention, '
+            'hallucination, lucky_guess.'
+        ),
+    )
+
+
+class LongMemEvalCategoryResult(BaseModel):
+    """Aggregate accuracy for a single question category."""
+
+    category: LongMemEvalCategory
+    n_questions: int
+    n_correct: int
+    accuracy: float
+
+
+class LongMemEvalReport(BaseModel):
+    """Full aggregated report for one LongMemEval run."""
+
+    run_id: str
+    variant: str  # 's' | 'm' | 'oracle'
+    total_questions: int
+    overall_accuracy: float
+    per_category: list[LongMemEvalCategoryResult] = Field(default_factory=list)
+    abstention_precision: float = 0.0
+    abstention_recall: float = 0.0
+    answer_model_fingerprint: str = ''
+    judge_model_fingerprint: str = ''
+    total_cost_usd: float | None = None
+    dataset_sha256: str = ''
+
+
+# ---------------------------------------------------------------------------
+# JSONL helpers.
+# ---------------------------------------------------------------------------
+
+
+def read_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    """Read all records from a JSONL file. Returns [] if the file is missing."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if line:
+            records.append(json.loads(line))
+    return records
+
+
+def append_jsonl(path: str | Path, record: dict[str, Any]) -> None:
+    """Append a single JSON record to a JSONL file (creating it if needed)."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, 'a') as f:
+        f.write(json.dumps(record, default=str) + '\n')
+
+
+def read_completed_ids(path: str | Path) -> set[str]:
+    """Read the set of already-answered question IDs from a JSONL file."""
+    records = read_jsonl(path)
+    return {r['question_id'] for r in records if 'question_id' in r}
+
+
+# ---------------------------------------------------------------------------
+# Dataset loading
+# ---------------------------------------------------------------------------
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _verify_checksum(path: Path, variant: str, *, allow_unpinned: bool = False) -> str:
+    """Compute and verify the SHA-256 of ``path`` against the pinned value.
+
+    Returns the actual hash (for embedding in reports). Raises
+    ``DatasetChecksumUnpinnedError`` when the pin is ``None`` and
+    ``allow_unpinned`` is False. Raises ``DatasetChecksumMismatchError``
+    when the pin is set and does not match.
+    """
+    actual = _sha256_file(path)
+    pinned = DATASET_SHA256.get(variant)
+    if pinned is None:
+        if not allow_unpinned:
+            raise DatasetChecksumUnpinnedError(
+                f'Dataset checksum not pinned for longmemeval variant {variant!r}; '
+                f'refusing to proceed. Run once against the upstream release with '
+                f'--allow-unpinned-checksum, capture the hash from the log '
+                f'(actual={actual}), then pin it in '
+                f'memex_eval.external.longmemeval_common.DATASET_SHA256.'
+            )
+        logger.warning(
+            'UNPINNED checksum for longmemeval variant %r. Computed hash: %s. '
+            'Running with --allow-unpinned-checksum — pin this value in '
+            'DATASET_SHA256 for reproducible runs.',
+            variant,
+            actual,
+        )
+        return actual
+    if actual != pinned:
+        raise DatasetChecksumMismatchError(
+            f'Dataset checksum mismatch for {path} (variant={variant!r}): '
+            f'expected {pinned}, got {actual}. Upstream may have re-released '
+            f'without a version bump.'
+        )
+    return actual
+
+
+def _parse_turn(raw: dict[str, Any], *, fallback_date: datetime | None = None) -> LongMemEvalTurn:
+    """Normalise an upstream turn record.
+
+    ``fallback_date`` should be the session-level date so that turns
+    without per-turn timestamps inherit the session date instead of
+    falling back to epoch (which causes ``power(2, -687)`` underflow
+    in the graph strategy's temporal decay).
+    """
+    ts = raw.get('timestamp') or raw.get('time') or raw.get('date')
+    if ts is None:
+        ts_parsed = fallback_date or datetime.now()
+    elif isinstance(ts, datetime):
+        ts_parsed = ts
+    else:
+        ts_parsed = datetime.fromisoformat(str(ts).replace('Z', '+00:00'))
+    return LongMemEvalTurn(
+        role=raw.get('role', 'user'),
+        content=raw.get('content', ''),
+        timestamp=ts_parsed,
+    )
+
+
+_UPSTREAM_DATE_FORMATS = (
+    '%Y/%m/%d (%a) %H:%M',  # canonical LongMemEval upstream format, e.g. '2023/05/20 (Sat) 02:21'
+    '%Y/%m/%d %H:%M',
+    '%Y-%m-%d %H:%M:%S',
+)
+
+
+def _parse_upstream_date(value: Any) -> datetime:
+    """Parse a session/turn timestamp in any of the shapes upstream uses."""
+    if value is None:
+        return datetime.now()
+    if isinstance(value, datetime):
+        return value
+    s = str(value)
+    try:
+        return datetime.fromisoformat(s.replace('Z', '+00:00'))
+    except ValueError:
+        pass
+    for fmt in _UPSTREAM_DATE_FORMATS:
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    raise ValueError(f'Unrecognised LongMemEval date format: {s!r}')
+
+
+def _parse_session(
+    raw: dict[str, Any] | list[dict[str, Any]],
+    fallback_idx: int = 0,
+    *,
+    session_id: str | None = None,
+    session_date: Any = None,
+) -> LongMemEvalSession:
+    """Normalise an upstream session record.
+
+    Upstream LongMemEval ships sessions as a parallel-array layout: each
+    question carries `haystack_session_ids[i]`, `haystack_dates[i]`, and
+    `haystack_sessions[i]` (a list of turn dicts). The caller passes the
+    three pieces explicitly via `session_id` / `session_date` / `raw=turns`.
+
+    For backwards compatibility with self-contained fixture rows (and any
+    legacy upstream variant), `raw` may also be a dict with `session_id`,
+    `session_date`, and `turns` keys — in that case the `session_id` and
+    `session_date` kwargs are ignored.
+    """
+    if isinstance(raw, dict):
+        sid = str(raw.get('session_id') or raw.get('id') or f'session-{fallback_idx}')
+        date_value = raw.get('session_date') or raw.get('date') or raw.get('timestamp')
+        turns_raw = raw.get('turns') or raw.get('messages') or []
+    else:
+        sid = str(session_id or f'session-{fallback_idx}')
+        date_value = session_date
+        turns_raw = raw
+    parsed_date = _parse_upstream_date(date_value)
+    return LongMemEvalSession(
+        session_id=sid,
+        session_date=parsed_date,
+        turns=[_parse_turn(t, fallback_date=parsed_date) for t in turns_raw],
+    )
+
+
+def _parse_question(raw: dict[str, Any]) -> LongMemEvalQuestion:
+    """Normalise an upstream question record."""
+    qid = str(raw.get('question_id') or raw.get('id'))
+    category_raw = raw.get('question_type') or raw.get('category')
+    if category_raw is None:
+        raise ValueError(f'Question {qid!r} is missing a category/question_type field.')
+    # Strip a trailing "_abs" suffix when mapping to the enum — upstream
+    # encodes abstention as a category suffix on both the ID and the type.
+    is_abstention = qid.endswith('_abs') or str(category_raw).endswith('_abs')
+    category_clean = str(category_raw).removesuffix('_abs')
+    try:
+        category = LongMemEvalCategory(category_clean)
+    except ValueError as exc:
+        raise ValueError(
+            f'Unknown LongMemEval category {category_clean!r} for question {qid!r}'
+        ) from exc
+
+    sessions_raw = raw.get('haystack_sessions') or raw.get('sessions') or []
+    session_ids = raw.get('haystack_session_ids') or []
+    session_dates = raw.get('haystack_dates') or []
+    sessions = [
+        _parse_session(
+            s,
+            i,
+            session_id=session_ids[i] if i < len(session_ids) else None,
+            session_date=session_dates[i] if i < len(session_dates) else None,
+        )
+        for i, s in enumerate(sessions_raw)
+    ]
+
+    answer_raw = raw.get('answer')
+    answer = None if answer_raw is None else str(answer_raw)
+    answer_session_ids = raw.get('answer_session_ids', [])
+    if not isinstance(answer_session_ids, list):
+        answer_session_ids = []
+    # Parse question_date — upstream format is '2023/05/30 (Tue) 23:40'
+    question_date_raw = raw.get('question_date')
+    question_date = None
+    if question_date_raw:
+        try:
+            question_date = _parse_upstream_date(question_date_raw)
+        except (ValueError, TypeError):
+            pass
+
+    return LongMemEvalQuestion(
+        question_id=qid,
+        category=category,
+        is_abstention=is_abstention,
+        question_text=raw.get('question') or raw.get('question_text') or '',
+        answer=answer,
+        answer_session_ids=[str(sid) for sid in answer_session_ids],
+        question_date=question_date,
+        sessions=sessions,
+    )
+
+
+def _load_variant(
+    path: str | Path, variant: str, *, allow_unpinned: bool = False
+) -> list[LongMemEvalQuestion]:
+    """Load one LongMemEval variant. Verifies the dataset checksum on read."""
+    p = Path(path)
+    if p.is_dir():
+        p = p / DATASET_FILENAMES[variant]
+    if not p.exists():
+        raise FileNotFoundError(
+            f'LongMemEval {variant!r} dataset not found at {p}. '
+            f'Download from https://github.com/xiaowu0162/longmemeval and pass '
+            f'the containing directory or JSON file as --dataset-path.'
+        )
+    _verify_checksum(p, variant, allow_unpinned=allow_unpinned)
+    raw_data = json.loads(p.read_text())
+    if not isinstance(raw_data, list):
+        raise ValueError(f'Expected a top-level list in {p}, got {type(raw_data).__name__}.')
+    return [_parse_question(r) for r in raw_data]
+
+
+def load_longmemeval_oracle(
+    path: str | Path, *, allow_unpinned: bool = False
+) -> list[LongMemEvalQuestion]:
+    """Load the LongMemEval_Oracle variant (ground-truth evidence only)."""
+    return _load_variant(path, 'oracle', allow_unpinned=allow_unpinned)
+
+
+def load_longmemeval_s(
+    path: str | Path, *, allow_unpinned: bool = False
+) -> list[LongMemEvalQuestion]:
+    """Load the LongMemEval_S variant (~40 sessions / ~115k tokens per q)."""
+    return _load_variant(path, 's', allow_unpinned=allow_unpinned)
+
+
+def load_longmemeval_m(
+    path: str | Path, *, allow_unpinned: bool = False
+) -> list[LongMemEvalQuestion]:
+    """Load the LongMemEval_M variant (~500 sessions per question)."""
+    return _load_variant(path, 'm', allow_unpinned=allow_unpinned)
+
+
+def dataset_sha256(path: str | Path, variant: str) -> str:
+    """Compute the SHA-256 hash of a dataset file (for report provenance)."""
+    p = Path(path)
+    if p.is_dir():
+        p = p / DATASET_FILENAMES[variant]
+    return _sha256_file(p)
+
+
+def vault_name_for(variant: str, run_id: str) -> str:
+    """Build a dedicated vault name for a LongMemEval run."""
+    return f'{VAULT_NAME_PREFIX}_{variant}_{run_id}'

--- a/packages/eval/src/memex_eval/external/longmemeval_compare.py
+++ b/packages/eval/src/memex_eval/external/longmemeval_compare.py
@@ -1,0 +1,221 @@
+"""Compare multiple LongMemEval runs side-by-side (agent vs note-only vs memory-only).
+
+Takes N labelled run directories (each containing ``judgments.jsonl`` and
+``hypotheses.jsonl``) and produces a comparison markdown report covering:
+
+- Accuracy + interpretation breakdown per mode
+- Retrieval recall@K against gold session IDs
+- Token/cost/latency efficiency
+- Per-question disagreement table (which modes got each question right)
+
+Intended to isolate retrieval quality from agent quality by running the
+same questions through three retrieval configurations.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger('memex_eval.longmemeval_compare')
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _dedupe_by_qid(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Keep the first record per question_id."""
+    out: dict[str, dict[str, Any]] = {}
+    for r in records:
+        qid = r.get('question_id')
+        if qid and qid not in out:
+            out[qid] = r
+    return out
+
+
+def _summarize_run(
+    label: str,
+    run_dir: Path,
+) -> dict[str, Any]:
+    """Compute summary stats for a single mode run."""
+    judgments = _dedupe_by_qid(_load_jsonl(run_dir / 'judgments.jsonl'))
+    hypotheses = _dedupe_by_qid(_load_jsonl(run_dir / 'hypotheses.jsonl'))
+
+    if not judgments:
+        logger.warning('No judgments found at %s', run_dir / 'judgments.jsonl')
+
+    n = len(judgments)
+    correct = sum(1 for j in judgments.values() if j.get('correct'))
+
+    interpretations: Counter[str] = Counter()
+    for j in judgments.values():
+        interpretations[j.get('interpretation') or 'unknown'] += 1
+
+    retrieval_found = sum(1 for j in judgments.values() if j.get('retrieval_contains_answer'))
+
+    # Efficiency aggregates
+    latencies = [float(h.get('latency_ms') or 0) / 1000.0 for h in hypotheses.values()]
+    total_tokens = [
+        int(h.get('input_tokens') or 0) + int(h.get('output_tokens') or 0)
+        for h in hypotheses.values()
+    ]
+    costs = [float(h.get('cost_usd') or 0.0) for h in hypotheses.values()]
+
+    return {
+        'label': label,
+        'run_dir': str(run_dir),
+        'n_questions': n,
+        'accuracy': correct / n if n else 0.0,
+        'correct': correct,
+        'retrieval_recall': retrieval_found / n if n else 0.0,
+        'retrieval_found': retrieval_found,
+        'interpretations': dict(interpretations),
+        'avg_latency_s': statistics.mean(latencies) if latencies else 0.0,
+        'median_latency_s': statistics.median(latencies) if latencies else 0.0,
+        'avg_total_tokens': statistics.mean(total_tokens) if total_tokens else 0.0,
+        'total_cost_usd': sum(costs),
+        'avg_cost_usd': statistics.mean(costs) if costs else 0.0,
+        'judgments': judgments,
+        'hypotheses': hypotheses,
+    }
+
+
+def generate_comparison_report(
+    mode_runs: list[tuple[str, Path]],
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Generate a comparison markdown report across mode runs.
+
+    Args:
+        mode_runs: list of ``(label, run_dir)`` tuples. ``run_dir`` must
+            contain ``judgments.jsonl`` and ``hypotheses.jsonl``.
+        output_dir: where to write the report.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    summaries = [_summarize_run(label, rd) for label, rd in mode_runs]
+
+    # Collect all qids seen across runs, and compute per-question correctness
+    all_qids: set[str] = set()
+    for s in summaries:
+        all_qids.update(s['judgments'].keys())
+    qids_sorted = sorted(all_qids)
+
+    # Build report
+    lines: list[str] = []
+    lines.append('# LongMemEval Mode Comparison\n')
+    lines.append(f'Comparing {len(summaries)} modes across {len(qids_sorted)} questions.\n')
+
+    # --- Accuracy table ---
+    lines.append('## Accuracy\n')
+    lines.append('| Mode | N | Correct | Accuracy | Retrieval recall |')
+    lines.append('|---|---:|---:|---:|---:|')
+    for s in summaries:
+        lines.append(
+            f'| {s["label"]} | {s["n_questions"]} | {s["correct"]} | '
+            f'{s["accuracy"]:.1%} | {s["retrieval_recall"]:.1%} |'
+        )
+    lines.append('')
+
+    # --- Interpretation breakdown ---
+    lines.append('## Interpretation breakdown\n')
+    all_interps = sorted({k for s in summaries for k in s['interpretations'].keys()})
+    header = '| Mode | ' + ' | '.join(all_interps) + ' |'
+    sep = '|---|' + '|'.join(['---:'] * len(all_interps)) + '|'
+    lines.append(header)
+    lines.append(sep)
+    for s in summaries:
+        row = [s['label']] + [str(s['interpretations'].get(k, 0)) for k in all_interps]
+        lines.append('| ' + ' | '.join(row) + ' |')
+    lines.append('')
+
+    # --- Efficiency ---
+    lines.append('## Efficiency\n')
+    lines.append(
+        '| Mode | Avg latency (s) | Median latency (s) | Avg total tokens | Avg cost (USD) | Total cost (USD) |'
+    )
+    lines.append('|---|---:|---:|---:|---:|---:|')
+    for s in summaries:
+        lines.append(
+            f'| {s["label"]} | {s["avg_latency_s"]:.1f} | {s["median_latency_s"]:.1f} '
+            f'| {s["avg_total_tokens"]:,.0f} | ${s["avg_cost_usd"]:.4f} '
+            f'| ${s["total_cost_usd"]:.2f} |'
+        )
+    lines.append('')
+
+    # --- Per-question disagreement ---
+    lines.append('## Per-question correctness\n')
+    header_cells = ['QID'] + [s['label'] for s in summaries]
+    lines.append('| ' + ' | '.join(header_cells) + ' |')
+    lines.append('|' + '|'.join(['---'] * len(header_cells)) + '|')
+    for qid in qids_sorted:
+        row = [qid]
+        for s in summaries:
+            j = s['judgments'].get(qid)
+            if j is None:
+                row.append('—')
+            elif j.get('correct'):
+                row.append('✓')
+            elif j.get('retrieval_contains_answer'):
+                row.append('model-fail')
+            else:
+                row.append('retr-fail')
+        lines.append('| ' + ' | '.join(row) + ' |')
+    lines.append('')
+
+    # --- Disagreement summary ---
+    lines.append('## Where modes disagree\n')
+    disagree_all_wrong: list[str] = []
+    disagree_mixed: list[tuple[str, list[str]]] = []
+    agree_correct: list[str] = []
+
+    for qid in qids_sorted:
+        results = []
+        for s in summaries:
+            j = s['judgments'].get(qid)
+            results.append(bool(j and j.get('correct')))
+        if all(results):
+            agree_correct.append(qid)
+        elif not any(results):
+            disagree_all_wrong.append(qid)
+        else:
+            modes_correct = [s['label'] for s, r in zip(summaries, results) if r]
+            disagree_mixed.append((qid, modes_correct))
+
+    lines.append(f'- All modes correct: **{len(agree_correct)}** questions')
+    lines.append(f'- All modes wrong: **{len(disagree_all_wrong)}** questions')
+    lines.append(f'- Modes disagree: **{len(disagree_mixed)}** questions\n')
+
+    if disagree_mixed:
+        lines.append('### Questions where only some modes got it right')
+        for qid, modes in disagree_mixed[:50]:
+            lines.append(f'- `{qid}` — correct in: {", ".join(modes)}')
+        if len(disagree_mixed) > 50:
+            lines.append(f'- (... and {len(disagree_mixed) - 50} more)')
+        lines.append('')
+
+    report_path = output_dir / 'comparison_report.md'
+    report_path.write_text('\n'.join(lines))
+
+    # JSON summary for programmatic consumption
+    json_summary = {
+        'modes': [
+            {k: v for k, v in s.items() if k not in ('judgments', 'hypotheses')} for s in summaries
+        ],
+        'n_questions_total': len(qids_sorted),
+        'agreement': {
+            'all_correct': len(agree_correct),
+            'all_wrong': len(disagree_all_wrong),
+            'mixed': len(disagree_mixed),
+        },
+    }
+    (output_dir / 'comparison.json').write_text(json.dumps(json_summary, indent=2))
+
+    return json_summary

--- a/packages/eval/src/memex_eval/external/longmemeval_efficiency.py
+++ b/packages/eval/src/memex_eval/external/longmemeval_efficiency.py
@@ -1,0 +1,294 @@
+"""LongMemEval efficiency analysis: latency, token cost, tool usage patterns.
+
+Ported from locomo_efficiency.py — analyzes answer records and session trace
+files to produce distribution metrics for duration, tokens, turns, tool calls,
+and retrieval token cost.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import tiktoken
+from rich.console import Console
+from rich.table import Table
+
+from memex_eval.external.longmemeval_common import read_jsonl
+
+logger = logging.getLogger('memex_eval.longmemeval_efficiency')
+console = Console()
+
+_MEMEX_TOOL_PREFIX = 'mcp__memex__'
+
+
+def _distribution(values: list[float]) -> dict[str, float]:
+    """Compute distribution stats for a list of numeric values."""
+    if not values:
+        return {
+            'mean': 0.0,
+            'median': 0.0,
+            'p25': 0.0,
+            'p75': 0.0,
+            'min': 0.0,
+            'max': 0.0,
+            'std': 0.0,
+        }
+    q = statistics.quantiles(values, n=4) if len(values) >= 2 else [values[0]] * 3
+    return {
+        'mean': round(statistics.mean(values), 2),
+        'median': round(statistics.median(values), 2),
+        'p25': round(q[0], 2),
+        'p75': round(q[2], 2),
+        'min': round(min(values), 2),
+        'max': round(max(values), 2),
+        'std': round(statistics.stdev(values), 2) if len(values) >= 2 else 0.0,
+    }
+
+
+def _count_retrieval_tokens_from_trace(trace_path: Path, enc: tiktoken.Encoding) -> dict[str, Any]:
+    """Parse a session trace JSONL and count tokens in Memex tool results.
+
+    Returns a dict with total retrieval tokens and per-tool-type breakdown.
+    """
+    per_tool: Counter[str] = Counter()
+    total = 0
+
+    try:
+        lines = trace_path.read_text().strip().splitlines()
+    except Exception:
+        logger.warning('Failed to read trace %s', trace_path)
+        return {'total': 0, 'per_tool': {}}
+
+    # Build a map of tool_use_id -> tool_name from assistant messages
+    tool_id_to_name: dict[str, str] = {}
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+
+        msg_type = obj.get('type')
+
+        # Collect tool_use blocks from assistant messages
+        if msg_type == 'assistant':
+            for block in obj.get('message', {}).get('content', []):
+                if isinstance(block, dict) and block.get('type') == 'tool_use':
+                    tool_name = block.get('name', '')
+                    tool_id = block.get('id', '')
+                    if tool_id and tool_name.startswith(_MEMEX_TOOL_PREFIX):
+                        tool_id_to_name[tool_id] = tool_name
+
+        # Count tokens in tool results that match Memex tools
+        if msg_type == 'user':
+            for block in obj.get('message', {}).get('content', []):
+                if isinstance(block, dict) and block.get('type') == 'tool_result':
+                    tool_use_id = block.get('tool_use_id', '')
+                    tool_name = tool_id_to_name.get(tool_use_id)
+                    if not tool_name:
+                        continue
+
+                    # Extract text content from the result
+                    content = block.get('content', '')
+                    if isinstance(content, list):
+                        text_parts = []
+                        for part in content:
+                            if isinstance(part, dict) and part.get('type') == 'text':
+                                text_parts.append(part.get('text', ''))
+                        content = '\n'.join(text_parts)
+                    elif not isinstance(content, str):
+                        content = str(content)
+
+                    tokens = len(enc.encode(content))
+                    per_tool[tool_name] += tokens
+                    total += tokens
+
+    return {'total': total, 'per_tool': dict(per_tool)}
+
+
+def analyze_efficiency(
+    answers_path: str,
+    output_path: str,
+    traces_dir: str,
+) -> dict[str, Any]:
+    """Analyze efficiency metrics from answers and session traces.
+
+    Args:
+        answers_path: Path to hypotheses.jsonl from Phase 2.
+        output_path: Path to write the efficiency report JSON.
+        traces_dir: Directory containing per-question trace JSONL files.
+
+    Returns:
+        The full efficiency report dict.
+    """
+    answers = read_jsonl(answers_path)
+    if not answers:
+        raise ValueError(f'No answers found in {answers_path}')
+
+    traces_path = Path(traces_dir)
+
+    # Initialize tiktoken encoder
+    enc = tiktoken.get_encoding('cl100k_base')
+
+    # Collect per-question metrics
+    durations: list[float] = []
+    total_tokens_list: list[float] = []
+    num_turns_list: list[float] = []
+    num_tool_calls_list: list[float] = []
+    retrieval_tokens_list: list[float] = []
+    tool_counter: Counter[str] = Counter()
+    tool_per_question: Counter[str] = Counter()
+    retrieval_per_tool: Counter[str] = Counter()
+    n_questions = len(answers)
+    n_with_traces = 0
+
+    for a in answers:
+        qid = a.get('question_id', a.get('id', ''))
+        duration = (
+            a.get('latency_ms', 0.0) / 1000.0 if 'latency_ms' in a else a.get('duration_s', 0.0)
+        )
+        input_tokens = a.get('input_tokens', 0)
+        output_tokens = a.get('output_tokens', 0)
+        tool_calls = a.get('tool_calls', [])
+
+        durations.append(duration)
+        total_tokens_list.append(input_tokens + output_tokens)
+        num_turns_list.append(a.get('num_turns', 0))
+        num_tool_calls_list.append(len(tool_calls))
+
+        # Tool frequency
+        for tc in tool_calls:
+            name = tc.get('name', '')
+            tool_counter[name] += 1
+            tool_per_question[name] += 1
+
+        # Retrieval tokens from trace
+        trace_file = traces_path / f'{qid}.jsonl'
+        if trace_file.exists():
+            n_with_traces += 1
+            rt = _count_retrieval_tokens_from_trace(trace_file, enc)
+            retrieval_tokens_list.append(rt['total'])
+            for tool_name, count in rt['per_tool'].items():
+                retrieval_per_tool[tool_name] += count
+        else:
+            retrieval_tokens_list.append(0)
+
+    # Distribution metrics
+    distributions = {
+        'duration_s': _distribution(durations),
+        'total_tokens': _distribution(total_tokens_list),
+        'num_turns': _distribution(num_turns_list),
+        'num_tool_calls': _distribution(num_tool_calls_list),
+        'retrieval_tokens': _distribution(retrieval_tokens_list),
+    }
+
+    # Tool call analysis
+    tool_frequency = dict(tool_counter.most_common())
+    tool_mean_per_question = {
+        name: round(count / n_questions, 2) for name, count in tool_per_question.most_common()
+    }
+
+    # Retrieval token breakdown
+    total_retrieval = sum(retrieval_tokens_list)
+    total_all_tokens = sum(total_tokens_list)
+    retrieval_breakdown = {
+        'total_retrieval_tokens': total_retrieval,
+        'per_tool': dict(retrieval_per_tool.most_common()),
+        'retrieval_to_total_ratio': (
+            round(total_retrieval / total_all_tokens, 4) if total_all_tokens > 0 else 0.0
+        ),
+        'questions_with_traces': n_with_traces,
+    }
+
+    report: dict[str, Any] = {
+        'benchmark': 'LongMemEval-Efficiency',
+        'answers_file': answers_path,
+        'traces_dir': traces_dir,
+        'n_questions': n_questions,
+        'distributions': distributions,
+        'tool_frequency': tool_frequency,
+        'tool_mean_per_question': tool_mean_per_question,
+        'retrieval_breakdown': retrieval_breakdown,
+    }
+
+    # Write report
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(output_path).write_text(json.dumps(report, indent=2, default=str))
+
+    # Print terminal summary
+    _print_report(report)
+
+    return report
+
+
+def _print_report(report: dict[str, Any]) -> None:
+    """Print a rich terminal summary of the efficiency report."""
+    console.print()
+    console.rule('[bold]LongMemEval Efficiency Report[/bold]')
+    console.print()
+    console.print(f'[dim]{report["n_questions"]} questions analyzed[/dim]')
+    console.print()
+
+    # Distribution table
+    dist_table = Table(show_header=True, header_style='bold cyan', title='Distribution Metrics')
+    dist_table.add_column('Metric', style='white')
+    for stat in ['mean', 'median', 'p25', 'p75', 'min', 'max', 'std']:
+        dist_table.add_column(stat, justify='right')
+
+    dist_labels = {
+        'duration_s': 'Duration (s)',
+        'total_tokens': 'Total Tokens',
+        'num_turns': 'Num Turns',
+        'num_tool_calls': 'Num Tool Calls',
+        'retrieval_tokens': 'Retrieval Tokens',
+    }
+
+    for key, label in dist_labels.items():
+        d = report['distributions'][key]
+        fmt = '.1f' if key == 'duration_s' else ',.0f'
+        dist_table.add_row(
+            label,
+            *[f'{d[s]:{fmt}}' for s in ['mean', 'median', 'p25', 'p75', 'min', 'max', 'std']],
+        )
+
+    console.print(dist_table)
+    console.print()
+
+    # Tool frequency table
+    tool_table = Table(show_header=True, header_style='bold cyan', title='Tool Call Frequency')
+    tool_table.add_column('Tool', style='white')
+    tool_table.add_column('Total Calls', justify='right')
+    tool_table.add_column('Mean/Question', justify='right')
+
+    for tool_name, count in sorted(
+        report['tool_frequency'].items(), key=lambda x: x[1], reverse=True
+    ):
+        mean = report['tool_mean_per_question'].get(tool_name, 0)
+        tool_table.add_row(tool_name, str(count), f'{mean:.2f}')
+
+    console.print(tool_table)
+    console.print()
+
+    # Retrieval breakdown
+    rb = report['retrieval_breakdown']
+    console.print('[bold]Retrieval Token Breakdown[/bold]')
+    console.print(f'  Total retrieval tokens: {rb["total_retrieval_tokens"]:,}')
+    console.print(f'  Retrieval/total ratio:  {rb["retrieval_to_total_ratio"]:.2%}')
+    console.print(f'  Questions with traces:  {rb["questions_with_traces"]}')
+
+    if rb['per_tool']:
+        console.print('  Per tool:')
+        for tool_name, tokens in sorted(rb['per_tool'].items(), key=lambda x: x[1], reverse=True):
+            console.print(f'    {tool_name}: {tokens:,}')
+
+    console.print()

--- a/packages/eval/src/memex_eval/external/longmemeval_ingest.py
+++ b/packages/eval/src/memex_eval/external/longmemeval_ingest.py
@@ -1,0 +1,200 @@
+"""LongMemEval Phase 0: Ingest sessions into Memex.
+
+Loads one variant of the LongMemEval dataset, formats each session's chat
+turns as a Markdown note with YAML frontmatter (so the ingest pipeline
+preserves the session timestamp as ``publish_date``), and ingests one note
+per session through ``RemoteMemexAPI.ingest``.
+
+Each run writes to a dedicated vault named
+``longmemeval_<variant>_<run_id>`` so benchmark data does not pollute the
+user's active vault.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from pathlib import Path
+
+import httpx
+
+from memex_common.client import RemoteMemexAPI
+from memex_common.schemas import CreateVaultRequest, NoteCreateDTO
+
+from memex_eval.external.longmemeval_common import (
+    LongMemEvalQuestion,
+    LongMemEvalSession,
+    _load_variant,
+    vault_name_for,
+)
+from memex_eval.helpers import wait_for_extraction
+
+logger = logging.getLogger('memex_eval.longmemeval_ingest')
+
+POLL_INTERVAL = 3.0
+POLL_TIMEOUT = 600.0
+
+
+def _format_turn(role: str, content: str, timestamp: str) -> str:
+    speaker = 'User' if role == 'user' else 'Assistant'
+    return f'**{speaker}** ({timestamp}): {content}'
+
+
+def _format_session(
+    session: LongMemEvalSession,
+    question_id: str,
+    variant: str,
+) -> str:
+    """Render a session as Markdown with YAML frontmatter.
+
+    The ``publish_date`` key in the frontmatter is parsed by the core
+    ingestion service and propagates to ``MemoryUnit.event_date`` for every
+    extracted fact — critical for the temporal-reasoning subset.
+    """
+    session_iso = session.session_date.isoformat()
+    lines = [
+        '---',
+        f'publish_date: {session_iso}',
+        f'session_id: {session.session_id}',
+        f'question_id: {question_id}',
+        f'variant: {variant}',
+        '---',
+        '',
+        f'# LongMemEval Session {session.session_id}',
+        f'**Date:** {session_iso}',
+        f'**Question:** {question_id}',
+        '',
+        '## Dialogue',
+        '',
+    ]
+    for turn in session.turns:
+        lines.append(_format_turn(turn.role, turn.content, turn.timestamp.isoformat()))
+        lines.append('')
+    return '\n'.join(lines)
+
+
+async def _setup_vault(api: RemoteMemexAPI, name: str, clean: bool = False):
+    """Get or create a vault by name. Only cleans if explicitly requested."""
+    vaults = await api.list_vaults()
+    for vault in vaults:
+        if vault.name == name:
+            if clean:
+                logger.info('Cleaning existing vault "%s"...', name)
+                notes = await api.list_notes(vault_id=vault.id, limit=500)
+                for note in notes:
+                    await api.delete_note(note.id)
+            else:
+                logger.info('Found existing vault "%s" (id=%s)', name, vault.id)
+            return vault.id
+
+    logger.info('Creating vault "%s"...', name)
+    vault = await api.create_vault(
+        CreateVaultRequest(name=name, description=f'LongMemEval benchmark vault ({name}).')
+    )
+    return vault.id
+
+
+async def _wait_for_extraction(api: RemoteMemexAPI, vault_id) -> None:
+    await wait_for_extraction(
+        api,
+        vault_id,
+        poll_interval=POLL_INTERVAL,
+        poll_timeout=POLL_TIMEOUT,
+        stable_ticks_required=3,
+        max_consecutive_errors=0,
+    )
+
+
+def build_note_payloads(
+    question: LongMemEvalQuestion,
+    variant: str,
+    vault_id: str,
+) -> list[NoteCreateDTO]:
+    """Build one ``NoteCreateDTO`` per session for a single question.
+
+    Pure function — exposed for unit testing the session-to-note adapter
+    without requiring a live Memex server.
+    """
+    payloads: list[NoteCreateDTO] = []
+    for session in question.sessions:
+        md = _format_session(session, question.question_id, variant)
+        payload = NoteCreateDTO(
+            name=f'{question.question_id} — {session.session_id}',
+            description=(
+                f'LongMemEval {variant} session {session.session_id} '
+                f'for question {question.question_id} on {session.session_date.isoformat()}.'
+            ),
+            content=base64.b64encode(md.encode('utf-8')),
+            tags=[
+                'longmemeval',
+                f'variant:{variant}',
+                f'question:{question.question_id}',
+                f'category:{question.category.value}',
+            ],
+            vault_id=str(vault_id),
+            note_key=f'longmemeval-{variant}-{question.question_id}-{session.session_id}',
+            author='longmemeval',
+        )
+        payloads.append(payload)
+    return payloads
+
+
+async def ingest_longmemeval(
+    server_url: str,
+    dataset_path: str,
+    variant: str,
+    run_id: str,
+    question_limit: int | None = None,
+    clean: bool = False,
+    allow_unpinned_checksum: bool = False,
+) -> int:
+    """Ingest sessions for a LongMemEval variant into a dedicated Memex vault.
+
+    Returns the number of sessions ingested (across all selected questions).
+    """
+    questions = _load_variant(Path(dataset_path), variant, allow_unpinned=allow_unpinned_checksum)
+    if question_limit is not None:
+        questions = questions[:question_limit]
+
+    vault_name = vault_name_for(variant, run_id)
+    ingested = 0
+
+    async with httpx.AsyncClient(base_url=server_url, timeout=60.0) as client:
+        api = RemoteMemexAPI(client)
+
+        vault_id = await _setup_vault(api, vault_name, clean=clean)
+        logger.info('Using vault "%s" (id=%s)', vault_name, vault_id)
+
+        existing_notes = await api.list_notes(vault_id=vault_id, limit=1)
+        if existing_notes and not clean:
+            logger.info(
+                'Vault "%s" already has notes. Skipping ingestion (use --clean to re-ingest).',
+                vault_name,
+            )
+            return 0
+
+        for i, question in enumerate(questions):
+            payloads = build_note_payloads(question, variant, vault_id)
+            logger.info(
+                '[%d/%d] %s (%s): submitting %d session(s) as background batch',
+                i + 1,
+                len(questions),
+                question.question_id,
+                question.category.value,
+                len(payloads),
+            )
+            job = await api.ingest_batch(payloads, vault_id=str(vault_id))
+            logger.info(
+                '[%d/%d] batch accepted (job_id=%s, status=%s)',
+                i + 1,
+                len(questions),
+                job.job_id,
+                job.status,
+            )
+            ingested += len(payloads)
+
+        logger.info('All %d sessions submitted. Waiting for extraction to complete...', ingested)
+        await _wait_for_extraction(api, vault_id)
+
+    logger.info('Ingested %d sessions into vault "%s".', ingested, vault_name)
+    return ingested

--- a/packages/eval/src/memex_eval/external/longmemeval_judge.py
+++ b/packages/eval/src/memex_eval/external/longmemeval_judge.py
@@ -1,0 +1,352 @@
+"""LongMemEval Phase 3: Judge hypotheses with an LLM-as-judge.
+
+Reads hypotheses + questions, runs a binary-correctness judge per row, and
+writes ``LongMemEvalJudgment`` records to a JSONL file. Reuses
+``memex_eval.judge.Judge`` as the underlying executor.
+
+Additionally performs retrieval containment judging: determines whether
+the memex retrieval output contains sufficient evidence to answer the
+question. Combined with answer correctness, this yields a 2x2 error
+analysis (correct, model_error, correct_abstention, hallucination,
+lucky_guess).
+
+Supports a JSON cache fixture so smoke-tier CI runs do not require live
+judge API calls. The cache shape is ``{question_id: {"correct": bool,
+"reasoning": str, "judge_model_fingerprint": str}}``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import dspy
+from rich.console import Console
+
+
+from memex_eval.external.longmemeval_common import (
+    LongMemEvalJudgment,
+    LongMemEvalQuestion,
+    _load_variant,
+    append_jsonl,
+    read_jsonl,
+)
+from memex_eval.external.longmemeval_trace_parser import extract_retrieval_content
+from memex_eval.judge import Judge
+
+logger = logging.getLogger('memex_eval.longmemeval_judge')
+console = Console()
+
+
+JUDGE_PROMPT_TEMPLATE_VERSION = '2026-04-15.v1'
+
+# The template the underlying dspy.Signature wraps. Documented here so that
+# any prompt drift versus the upstream LongMemEval evaluate_qa.py reference
+# is visible at code-review time.
+JUDGE_PROMPT_GUIDANCE = """\
+You are evaluating whether a hypothesis answer correctly addresses a
+LongMemEval question given the ground-truth answer.
+
+Mark the hypothesis as CORRECT when:
+- It conveys the same information as the ground truth (paraphrasing OK).
+- For abstention questions where the ground truth is missing/null and the
+  hypothesis explicitly admits "I do not know" (or close paraphrase).
+
+Mark the hypothesis as INCORRECT when:
+- It contradicts the ground truth.
+- It hallucinates specifics not supported by the ground truth.
+- It refuses to answer when the ground truth provides a clear answer.
+"""
+
+
+def _load_cache(cache_path: str | Path | None) -> dict[str, dict[str, Any]]:
+    if cache_path is None:
+        return {}
+    p = Path(cache_path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text())
+
+
+def _heuristic_abstention_fallback(hypothesis: str) -> bool:
+    """Heuristic abstention classifier used ONLY as a fallback when the LM
+    judge errors out. The primary path routes all hypotheses through the
+    LM (see ``Judge.classify_abstention``); this exists so a transient LM
+    failure does not zero out the abstention metric.
+    """
+    h = hypothesis.lower()
+    return any(
+        marker in h
+        for marker in (
+            'i do not know',
+            "i don't know",
+            'cannot answer',
+            'not enough information',
+            'no information',
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Retrieval containment judge
+# ---------------------------------------------------------------------------
+
+
+class RetrievalContainment(dspy.Signature):
+    """Judge whether retrieval results contain sufficient evidence to answer a question."""
+
+    question: str = dspy.InputField(desc='The question that was asked.')
+    expected_answer: str = dspy.InputField(desc='The ground truth expected answer.')
+    retrieval_results: str = dspy.InputField(
+        desc='All memex tool result text from the session trace.'
+    )
+    contains_answer: bool = dspy.OutputField(
+        desc='Whether the retrieval output contains the information needed to answer correctly.'
+    )
+    reasoning: str = dspy.OutputField(
+        desc='Brief explanation of what evidence is present or missing.'
+    )
+
+
+async def judge_retrieval_containment(
+    question_text: str,
+    gold_answer: str,
+    retrieval_content: str,
+    judge_model: str | None = None,
+    *,
+    judge_instance: Judge | None = None,
+) -> tuple[bool, str]:
+    """Judge whether retrieval results contain the answer.
+
+    Returns (contains, reasoning).
+    """
+    if not retrieval_content.strip():
+        return False, 'No retrieval content found in trace.'
+
+    if judge_instance is None:
+        judge_instance = Judge(model=judge_model)
+
+    predictor = dspy.ChainOfThought(RetrievalContainment)
+    with dspy.context(lm=judge_instance.lm):
+        result = predictor(
+            question=question_text,
+            expected_answer=gold_answer or 'The question has no known answer (abstention).',
+            retrieval_results=retrieval_content,
+        )
+    return result.contains_answer, result.reasoning
+
+
+def compute_interpretation(
+    retrieval_contains: bool,
+    answer_correct: bool,
+    is_abstention_hypothesis: bool,
+) -> str:
+    """Compute the interpretation label from the 2x2 matrix.
+
+    Returns one of: correct, model_error, correct_abstention,
+    hallucination, lucky_guess.
+    """
+    if retrieval_contains and answer_correct:
+        return 'correct'
+    if retrieval_contains and not answer_correct:
+        return 'model_error'
+    if not retrieval_contains and is_abstention_hypothesis:
+        return 'correct_abstention'
+    if not retrieval_contains and answer_correct:
+        return 'lucky_guess'
+    # not retrieval_contains and not answer_correct and not abstention
+    return 'hallucination'
+
+
+async def judge_hypotheses(
+    dataset_path: str,
+    variant: str,
+    hypotheses_path: str,
+    output_path: str,
+    *,
+    judge_model: str | None = None,
+    cache_path: str | Path | None = None,
+    allow_unpinned_checksum: bool = False,
+    traces_dir: str | Path | None = None,
+) -> int:
+    """Judge hypotheses and write ``LongMemEvalJudgment`` JSONL.
+
+    Returns the number of judgments written. Skips hypotheses that already
+    have a judgment in ``output_path``.
+
+    When ``traces_dir`` is provided, also performs retrieval containment
+    judging: extracts all memex tool results from the session trace and
+    asks an LLM whether they contain the evidence needed to answer.
+    The result populates ``retrieval_contains_answer``,
+    ``retrieval_containment_reasoning``, and ``interpretation`` fields.
+    """
+    questions: dict[str, LongMemEvalQuestion] = {
+        q.question_id: q
+        for q in _load_variant(Path(dataset_path), variant, allow_unpinned=allow_unpinned_checksum)
+    }
+    hypotheses = read_jsonl(hypotheses_path)
+    if not hypotheses:
+        raise ValueError(f'No hypotheses found in {hypotheses_path}')
+
+    already_judged = {r['question_id'] for r in read_jsonl(output_path) if 'question_id' in r}
+    pending = [h for h in hypotheses if h['question_id'] not in already_judged]
+    if not pending:
+        console.print('[dim]All hypotheses already judged.[/dim]')
+        return 0
+
+    cache = _load_cache(cache_path)
+
+    judge: Judge | None = None
+
+    # The LM is needed for any pending row not fully cached. A cache hit must
+    # also provide ``is_abstention_hypothesis`` to skip the classifier call.
+    def _cache_entry_is_complete(entry: dict[str, Any]) -> bool:
+        return 'correct' in entry and 'is_abstention_hypothesis' in entry
+
+    needs_lm = any(
+        h['question_id'] not in cache or not _cache_entry_is_complete(cache[h['question_id']])
+        for h in pending
+    )
+    if needs_lm:
+        judge = Judge(model=judge_model)
+
+    judge_fingerprint = judge_model or 'cached'
+    written = 0
+
+    for i, h in enumerate(pending):
+        qid = h['question_id']
+        question = questions.get(qid)
+        if question is None:
+            logger.warning('Hypothesis %s has no matching question; skipping.', qid)
+            continue
+
+        cache_entry = cache.get(qid)
+        if cache_entry is not None and _cache_entry_is_complete(cache_entry):
+            correct = bool(cache_entry['correct'])
+            reasoning = cache_entry.get('reasoning', '')
+            fingerprint = cache_entry.get('judge_model_fingerprint', 'cached')
+            is_abstention_hypothesis = bool(cache_entry['is_abstention_hypothesis'])
+        else:
+            assert judge is not None
+            # Every hypothesis (abstention question or not) is run through the
+            # classifier so abstention precision has an independent denominator.
+            try:
+                is_abstention_hypothesis, _ = judge.classify_abstention(h['hypothesis'])
+            except Exception as exc:
+                logger.warning(
+                    'Abstention classifier failed for %s: %s — using heuristic fallback.',
+                    qid,
+                    exc,
+                )
+                is_abstention_hypothesis = _heuristic_abstention_fallback(h['hypothesis'])
+
+            if question.is_abstention and not question.answer:
+                # No ground-truth string — ask the LM whether the hypothesis
+                # correctly abstains for this specific question.
+                try:
+                    correct, reasoning = judge.judge_abstention_correctness(
+                        question=question.question_text,
+                        response=h['hypothesis'],
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        'Abstention judge failed for %s: %s — using heuristic fallback.',
+                        qid,
+                        exc,
+                    )
+                    correct = _heuristic_abstention_fallback(h['hypothesis'])
+                    reasoning = (
+                        'Abstention judge LM failed; heuristic fallback '
+                        f'returned correct={correct}.'
+                    )
+            else:
+                correct, reasoning = judge.judge_correctness(
+                    question=question.question_text,
+                    expected=question.answer or '',
+                    response=h['hypothesis'],
+                )
+            fingerprint = (
+                f'{getattr(judge.lm, "model", judge_model or "unknown")}'
+                f'@{JUDGE_PROMPT_TEMPLATE_VERSION}'
+            )
+            judge_fingerprint = fingerprint
+
+        # --- Retrieval containment judging ---
+        retrieval_contains = True
+        containment_reasoning = ''
+        if traces_dir is not None:
+            traces_path = Path(traces_dir)
+            trace_file = traces_path / f'{qid}.jsonl'
+            if trace_file.exists():
+                retrieval_content = extract_retrieval_content(trace_file)
+
+                cache_containment = (cache.get(qid) or {}).get('retrieval_contains_answer')
+                if cache_containment is not None:
+                    retrieval_contains = bool(cache_containment)
+                    containment_reasoning = (cache.get(qid) or {}).get(
+                        'retrieval_containment_reasoning', ''
+                    )
+                elif judge is not None:
+                    try:
+                        (
+                            retrieval_contains,
+                            containment_reasoning,
+                        ) = await judge_retrieval_containment(
+                            question_text=question.question_text,
+                            gold_answer=question.answer or '',
+                            retrieval_content=retrieval_content,
+                            judge_instance=judge,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            'Retrieval containment judge failed for %s: %s',
+                            qid,
+                            exc,
+                        )
+                        retrieval_contains = True
+                        containment_reasoning = f'Retrieval containment judge failed: {exc}'
+            else:
+                logger.debug('No trace file for %s; skipping containment judge.', qid)
+
+        interpretation = compute_interpretation(
+            retrieval_contains=retrieval_contains,
+            answer_correct=correct,
+            is_abstention_hypothesis=is_abstention_hypothesis,
+        )
+
+        judgment = LongMemEvalJudgment(
+            question_id=qid,
+            category=question.category,
+            is_abstention=question.is_abstention,
+            hypothesis=h['hypothesis'],
+            expected=question.answer,
+            correct=correct,
+            judge_reasoning=reasoning,
+            judge_model_fingerprint=fingerprint,
+            is_abstention_hypothesis=is_abstention_hypothesis,
+            retrieval_contains_answer=retrieval_contains,
+            retrieval_containment_reasoning=containment_reasoning,
+            interpretation=interpretation,
+        )
+        append_jsonl(output_path, judgment.model_dump())
+        written += 1
+        logger.info(
+            '[%d/%d] %s (%s, abstention=%s, hyp_abstained=%s) -> '
+            'correct=%s retrieval_contains=%s interpretation=%s',
+            i + 1,
+            len(pending),
+            qid,
+            question.category.value,
+            question.is_abstention,
+            is_abstention_hypothesis,
+            correct,
+            retrieval_contains,
+            interpretation,
+        )
+
+    console.print(f'\n[bold green]Wrote {written} judgments -> {output_path}[/bold green]')
+    # Surface the last judge fingerprint we used for the report layer.
+    logger.debug('Final judge fingerprint: %s', judge_fingerprint)
+    return written

--- a/packages/eval/src/memex_eval/external/longmemeval_report.py
+++ b/packages/eval/src/memex_eval/external/longmemeval_report.py
@@ -1,0 +1,1186 @@
+"""LongMemEval Phase 4: Generate evaluation report with plots.
+
+Ported from locomo_report.py — reads judge results, answers/hypotheses, and
+session traces to produce a reproducible Markdown report with seaborn
+distribution plots and mermaid retrieval diagrams.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+from collections import Counter
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import matplotlib
+import matplotlib.pyplot as plt
+import seaborn as sns
+import tiktoken
+from rich.console import Console
+from rich.table import Table
+
+from memex_eval.external.longmemeval_common import (
+    CATEGORY_NAMES,
+    LongMemEvalCategory,
+    LongMemEvalCategoryResult,
+    LongMemEvalHypothesis,
+    LongMemEvalJudgment,
+    LongMemEvalReport,
+    _load_variant,
+    dataset_sha256,
+    read_jsonl,
+)
+from memex_eval.external.longmemeval_efficiency import _count_retrieval_tokens_from_trace
+from memex_eval.external.longmemeval_trace_parser import (
+    RecallMetrics,
+    compute_batch_recall,
+    parse_traces_dir,
+)
+
+matplotlib.use('Agg')
+
+logger = logging.getLogger('memex_eval.longmemeval_report')
+console = Console()
+
+_MEMEX_TOOL_PREFIX = 'mcp__memex__'
+
+
+def _to_seaborn_data(rows: list[dict[str, Any]]) -> dict[str, list[Any]]:
+    """Convert a list-of-dicts to a dict-of-lists for seaborn.
+
+    Seaborn's ``data`` parameter accepts ``Mapping`` (dict of lists)
+    but not ``list[dict]``.  This helper pivots the row-wise structure
+    into the column-wise structure seaborn expects, without pulling
+    in pandas.
+    """
+    if not rows:
+        return {}
+    columns: dict[str, list[Any]] = {k: [] for k in rows[0]}
+    for row in rows:
+        for k, v in row.items():
+            columns[k].append(v)
+    return columns
+
+
+# Category ordering for tables and plots
+_CATEGORY_ORDER = list(LongMemEvalCategory)
+
+
+# ---------------------------------------------------------------------------
+# Aggregation (preserved from the original module)
+# ---------------------------------------------------------------------------
+
+
+def _aggregate(
+    judgments: list[LongMemEvalJudgment],
+) -> tuple[list[LongMemEvalCategoryResult], float, float, float]:
+    """Compute per-category results plus abstention precision/recall."""
+    by_cat: dict[LongMemEvalCategory, list[LongMemEvalJudgment]] = {}
+    for j in judgments:
+        by_cat.setdefault(j.category, []).append(j)
+
+    per_category: list[LongMemEvalCategoryResult] = []
+    for category, items in by_cat.items():
+        n = len(items)
+        n_correct = sum(1 for j in items if j.correct)
+        per_category.append(
+            LongMemEvalCategoryResult(
+                category=category,
+                n_questions=n,
+                n_correct=n_correct,
+                accuracy=round(n_correct / n, 4) if n else 0.0,
+            )
+        )
+
+    overall_accuracy = (
+        round(sum(1 for j in judgments if j.correct) / len(judgments), 4) if judgments else 0.0
+    )
+
+    abstention_questions = [j for j in judgments if j.is_abstention]
+    abstention_correct = [j for j in abstention_questions if j.correct]
+    abstention_recall = (
+        round(len(abstention_correct) / len(abstention_questions), 4)
+        if abstention_questions
+        else 0.0
+    )
+
+    abstained_hyps = [j for j in judgments if j.is_abstention_hypothesis]
+    abstention_precision = (
+        round(sum(1 for j in abstained_hyps if j.is_abstention) / len(abstained_hyps), 4)
+        if abstained_hyps
+        else 0.0
+    )
+
+    return per_category, overall_accuracy, abstention_precision, abstention_recall
+
+
+# ---------------------------------------------------------------------------
+# Data loading and enrichment
+# ---------------------------------------------------------------------------
+
+
+def _load_data(
+    judgments: list[LongMemEvalJudgment],
+    hypotheses: list[LongMemEvalHypothesis],
+    traces_dir: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Cross-reference judgments, hypotheses, and trace metrics.
+
+    Returns (enriched_details, retrieval_by_tool).
+    """
+    hyp_by_id = {h.question_id: h for h in hypotheses}
+    traces_path = Path(traces_dir)
+    enc = tiktoken.get_encoding('cl100k_base')
+
+    enriched: list[dict[str, Any]] = []
+    retrieval_per_tool: Counter[str] = Counter()
+    total_retrieval = 0
+
+    for j in judgments:
+        qid = j.question_id
+        hyp = hyp_by_id.get(qid)
+
+        # Build base detail record from judgment
+        detail: dict[str, Any] = {
+            'id': qid,
+            'category': j.category.value,
+            'score': 1.0 if j.correct else 0.0,
+            'question': hyp.hypothesis[:120] if hyp else '',
+            'reasoning': j.judge_reasoning[:120] if j.judge_reasoning else '',
+            'is_abstention': j.is_abstention,
+            'retrieval_contains_answer': j.retrieval_contains_answer,
+            'retrieval_containment_reasoning': j.retrieval_containment_reasoning,
+            'interpretation': j.interpretation,
+        }
+
+        if hyp:
+            duration_s = hyp.latency_ms / 1000.0
+            total_tokens = hyp.input_tokens + hyp.output_tokens
+            tool_calls = hyp.tool_calls
+            memex_calls = sum(1 for tc in tool_calls if tc.name.startswith(_MEMEX_TOOL_PREFIX))
+            detail.update(
+                {
+                    'duration_s': round(duration_s, 1),
+                    'tokens': {'input': hyp.input_tokens, 'output': hyp.output_tokens},
+                    'total_tokens': total_tokens,
+                    'num_turns': hyp.num_turns,
+                    'cost_usd': hyp.cost_usd or 0.0,
+                    'memex_calls': memex_calls,
+                    'tool_calls': [{'name': tc.name, 'input': tc.input} for tc in tool_calls],
+                }
+            )
+        else:
+            detail.update(
+                {
+                    'duration_s': 0.0,
+                    'tokens': {'input': 0, 'output': 0},
+                    'total_tokens': 0,
+                    'num_turns': 0,
+                    'cost_usd': 0.0,
+                    'memex_calls': 0,
+                    'tool_calls': [],
+                }
+            )
+
+        # Retrieval tokens from trace
+        retr_tokens = 0
+        trace_file = traces_path / f'{qid}.jsonl'
+        if trace_file.exists():
+            rt = _count_retrieval_tokens_from_trace(trace_file, enc)
+            retr_tokens = rt['total']
+            for tool_name, count in rt['per_tool'].items():
+                retrieval_per_tool[tool_name] += count
+            total_retrieval += retr_tokens
+
+        detail['retrieval_tokens'] = retr_tokens
+        detail['retrieval_pct'] = (
+            round(retr_tokens / detail['total_tokens'] * 100, 1)
+            if detail['total_tokens'] > 0
+            else 0.0
+        )
+
+        enriched.append(detail)
+
+    retrieval_breakdown = {
+        'total': total_retrieval,
+        'per_tool': dict(retrieval_per_tool.most_common()),
+    }
+
+    return enriched, retrieval_breakdown
+
+
+# ---------------------------------------------------------------------------
+# Retrieval path classification
+# ---------------------------------------------------------------------------
+
+_ENTITY_TOOLS = {
+    'mcp__memex__memex_list_entities',
+    'mcp__memex__memex_get_entity_mentions',
+    'mcp__memex__memex_get_entity_cooccurrences',
+    'mcp__memex__memex_get_entities',
+}
+
+_DEEP_TOOLS = {
+    'mcp__memex__memex_get_page_indices',
+    'mcp__memex__memex_get_nodes',
+}
+
+
+def _classify_retrieval_path(detail: dict[str, Any]) -> str:
+    """Classify a question's retrieval path based on its tool call sequence."""
+    tool_calls = detail.get('tool_calls', [])
+    tool_names = [tc.get('name', '') for tc in tool_calls]
+    memex_names = [n for n in tool_names if n.startswith(_MEMEX_TOOL_PREFIX)]
+
+    if not memex_names:
+        return 'simple'
+
+    # Count occurrences of key tools
+    memory_search_count = sum(1 for n in memex_names if n == 'mcp__memex__memex_memory_search')
+    note_search_count = sum(1 for n in memex_names if n == 'mcp__memex__memex_note_search')
+    has_entity = any(n in _ENTITY_TOOLS for n in memex_names)
+    has_deep = any(n in _DEEP_TOOLS for n in memex_names)
+    has_note_search = note_search_count > 0
+
+    # Exhaustive: multiple rounds of memory_search or note_search
+    if memory_search_count > 1 or note_search_count > 1:
+        return 'exhaustive'
+
+    # Deep + entity
+    if has_deep and has_entity:
+        return 'deep_entity'
+
+    # Deep verification
+    if has_deep and has_note_search:
+        return 'deep'
+
+    # Two-stage + entity
+    if has_note_search and has_entity:
+        return 'two_stage_entity'
+
+    # Simple + entity
+    if has_entity and not has_note_search and not has_deep:
+        return 'simple_entity'
+
+    # Two-stage: memory_search + note_search only
+    if has_note_search:
+        return 'two_stage'
+
+    return 'simple'
+
+
+# ---------------------------------------------------------------------------
+# Plot generation
+# ---------------------------------------------------------------------------
+
+
+def _setup_plot_style() -> None:
+    """Configure seaborn/matplotlib for consistent report plots."""
+    sns.set_theme(style='whitegrid', palette='muted', font_scale=1.1)
+    plt.rcParams['figure.figsize'] = (10, 6)
+    plt.rcParams['figure.dpi'] = 150
+
+
+def _generate_plots(
+    details: list[dict[str, Any]],
+    retrieval_breakdown: dict[str, Any],
+    plots_dir: Path,
+) -> list[str]:
+    """Generate all distribution plots. Returns list of generated filenames."""
+    _setup_plot_style()
+    plots_dir.mkdir(parents=True, exist_ok=True)
+    generated: list[str] = []
+
+    # Category order for consistent axis
+    cat_order = [CATEGORY_NAMES.get(c, c.value) for c in _CATEGORY_ORDER]
+
+    def _cat_label(d: dict[str, Any]) -> str:
+        cat_val = d.get('category', '')
+        try:
+            cat = LongMemEvalCategory(cat_val)
+            return CATEGORY_NAMES.get(cat, cat_val)
+        except ValueError:
+            return cat_val
+
+    # 1. Token usage by category
+    fig, ax = plt.subplots()
+    data = [{'Category': _cat_label(d), 'Total Tokens': d['total_tokens']} for d in details]
+    if data:
+        sns.boxplot(
+            data=_to_seaborn_data(data), x='Category', y='Total Tokens', order=cat_order, ax=ax
+        )
+        ax.set_title('Token Usage by Category')
+        ax.set_xlabel('')
+        ax.tick_params(axis='x', rotation=15)
+        fig.tight_layout()
+        fig.savefig(plots_dir / 'tokens_by_category.png')
+        generated.append('tokens_by_category.png')
+    plt.close(fig)
+
+    # 2. Duration by category
+    fig, ax = plt.subplots()
+    data = [{'Category': _cat_label(d), 'Duration (s)': d['duration_s']} for d in details]
+    if data:
+        sns.boxplot(
+            data=_to_seaborn_data(data), x='Category', y='Duration (s)', order=cat_order, ax=ax
+        )
+        ax.set_title('Duration by Category')
+        ax.set_xlabel('')
+        ax.tick_params(axis='x', rotation=15)
+        fig.tight_layout()
+        fig.savefig(plots_dir / 'duration_by_category.png')
+        generated.append('duration_by_category.png')
+    plt.close(fig)
+
+    # 3. Retrieval vs total tokens (scatter)
+    fig, ax = plt.subplots()
+    data = [
+        {
+            'Total Tokens': d['total_tokens'],
+            'Retrieval Tokens': d['retrieval_tokens'],
+            'Category': _cat_label(d),
+        }
+        for d in details
+        if d['retrieval_tokens'] > 0
+    ]
+    if data:
+        sns.scatterplot(
+            data=_to_seaborn_data(data),
+            x='Total Tokens',
+            y='Retrieval Tokens',
+            hue='Category',
+            s=80,
+            alpha=0.7,
+            ax=ax,
+        )
+        ax.set_title('Retrieval Tokens vs Total Tokens')
+        fig.tight_layout()
+        fig.savefig(plots_dir / 'retrieval_vs_total.png')
+        generated.append('retrieval_vs_total.png')
+    plt.close(fig)
+
+    # 4. Duration vs Memex calls (scatter)
+    fig, ax = plt.subplots()
+    data = [
+        {
+            'Memex Calls': d['memex_calls'],
+            'Duration (s)': d['duration_s'],
+            'Category': _cat_label(d),
+        }
+        for d in details
+    ]
+    if data:
+        sns.scatterplot(
+            data=_to_seaborn_data(data),
+            x='Memex Calls',
+            y='Duration (s)',
+            hue='Category',
+            s=80,
+            alpha=0.7,
+            ax=ax,
+        )
+        ax.set_title('Duration vs Memex Tool Calls')
+        fig.tight_layout()
+        fig.savefig(plots_dir / 'duration_vs_memex_calls.png')
+        generated.append('duration_vs_memex_calls.png')
+    plt.close(fig)
+
+    # 5. Turns distribution
+    fig, ax = plt.subplots()
+    turns = [d['num_turns'] for d in details if d.get('num_turns', 0) > 0]
+    if turns:
+        sns.histplot(turns, bins=range(1, max(turns) + 2), discrete=True, ax=ax)
+        ax.set_title('Turns per Question')
+        ax.set_xlabel('Number of Turns')
+        ax.set_ylabel('Count')
+        fig.tight_layout()
+        fig.savefig(plots_dir / 'turns_distribution.png')
+        generated.append('turns_distribution.png')
+    plt.close(fig)
+
+    # 6. Retrieval token breakdown by tool
+    fig, ax = plt.subplots()
+    per_tool = retrieval_breakdown.get('per_tool', {})
+    if per_tool:
+        # Shorten tool names
+        short = {k.replace('mcp__memex__memex_', ''): v for k, v in per_tool.items()}
+        names = list(short.keys())
+        values = list(short.values())
+        colors = sns.color_palette('muted', len(names))
+        ax.barh(names, values, color=colors)
+        ax.set_title('Retrieval Tokens by Memex Tool')
+        ax.set_xlabel('Tokens')
+        fig.tight_layout()
+        fig.savefig(plots_dir / 'retrieval_token_breakdown.png')
+        generated.append('retrieval_token_breakdown.png')
+    plt.close(fig)
+
+    return generated
+
+
+# ---------------------------------------------------------------------------
+# Markdown report generation
+# ---------------------------------------------------------------------------
+
+_RETRIEVAL_PATHS_MERMAID = """\
+### Two-stage path
+
+Memory search and note search provide sufficient context to answer directly.
+
+```mermaid
+graph LR
+    A[memory_search] --> B[note_search] --> C[Answer]
+    style A fill:#4C72B0,color:white
+    style B fill:#8172B2,color:white
+    style C fill:#55A868,color:white
+```
+
+### Two-stage + entity path
+
+Memory and note search augmented with entity exploration.
+
+```mermaid
+graph LR
+    A[memory_search] --> B[note_search] --> C[list_entities] --> D[Answer]
+    style A fill:#4C72B0,color:white
+    style B fill:#8172B2,color:white
+    style C fill:#DD8452,color:white
+    style D fill:#55A868,color:white
+```
+
+### Deep verification path
+
+Full two-speed reading: search, then drill into specific note sections.
+
+```mermaid
+graph TD
+    A[memory_search] --> B[note_search]
+    B --> C[get_page_indices]
+    C --> D[get_nodes]
+    D --> E[Answer]
+    style A fill:#4C72B0,color:white
+    style B fill:#8172B2,color:white
+    style C fill:#CCB974,color:black
+    style D fill:#C44E52,color:white
+    style E fill:#55A868,color:white
+```
+
+### Deep + entity path
+
+Adds entity exploration to deep verification.
+
+```mermaid
+graph TD
+    E1[list_entities] --> E2[get_entity_mentions]
+    E2 --> A[memory_search]
+    A --> B[note_search]
+    B --> C[get_page_indices]
+    C --> D[get_nodes]
+    D --> F[Answer]
+    style E1 fill:#DD8452,color:white
+    style E2 fill:#DD8452,color:white
+    style A fill:#4C72B0,color:white
+    style B fill:#8172B2,color:white
+    style C fill:#CCB974,color:black
+    style D fill:#C44E52,color:white
+    style F fill:#55A868,color:white
+```
+
+### Simple + entity path
+
+A single search round with entity exploration. No deep reading needed.
+
+```mermaid
+graph LR
+    A[memory_search] --> B[list_entities] --> C[Answer]
+    style A fill:#4C72B0,color:white
+    style B fill:#DD8452,color:white
+    style C fill:#55A868,color:white
+```
+
+### Exhaustive path
+
+Multiple rounds of searching and reading across different notes and queries.
+
+```mermaid
+graph TD
+    A[memory_search] --> B[note_search]
+    B --> C[get_page_indices]
+    C --> D[get_nodes]
+    D --> E{Sufficient?}
+    E -- No --> F[Refined memory_search]
+    F --> G[note_search]
+    G --> H[get_page_indices]
+    H --> I[get_nodes]
+    I --> J[Answer]
+    E -- Yes --> J
+    style A fill:#4C72B0,color:white
+    style B fill:#8172B2,color:white
+    style C fill:#CCB974,color:black
+    style D fill:#C44E52,color:white
+    style F fill:#4C72B0,color:white
+    style G fill:#8172B2,color:white
+    style H fill:#CCB974,color:black
+    style I fill:#C44E52,color:white
+    style J fill:#55A868,color:white
+```
+"""
+
+
+def _generate_markdown(
+    report: LongMemEvalReport,
+    details: list[dict[str, Any]],
+    retrieval_breakdown: dict[str, Any],
+    plots_dir_rel: str,
+    plot_files: list[str],
+    recall_metrics: list[RecallMetrics] | None = None,
+) -> str:
+    """Generate the full Markdown report with three evaluation axes."""
+    lines: list[str] = []
+
+    def w(line: str = '') -> None:
+        lines.append(line)
+
+    total_cost = sum(d.get('cost_usd', 0) for d in details)
+    total_duration = sum(d.get('duration_s', 0) for d in details)
+    total_tokens_all = sum(d.get('total_tokens', 0) for d in details)
+    total_retr = retrieval_breakdown['total']
+
+    n_correct = sum(1 for d in details if d['score'] == 1.0)
+    n_wrong = sum(1 for d in details if d['score'] == 0.0)
+    n_scored = len(details)
+
+    # --- Header ---
+    w('# LongMemEval Evaluation Report')
+    w()
+    w(
+        f'> Run: `{report.run_id}` | Variant: `{report.variant}` '
+        f'| Model: `{report.answer_model_fingerprint}` '
+        f'| Judge: `{report.judge_model_fingerprint}`'
+    )
+    w()
+
+    # --- Summary ---
+    w('## Summary')
+    w()
+    w('| Metric | Value |')
+    w('|---|---|')
+    w(f'| Questions (scored) | {n_scored} |')
+    w(f'| Overall Accuracy | **{report.overall_accuracy:.3f}** |')
+    w(f'| Correct answers | {n_correct} ({n_correct / n_scored * 100:.1f}%) |')
+    w(f'| Wrong answers | {n_wrong} ({n_wrong / n_scored * 100:.1f}%) |')
+    w(f'| Abstention precision | {report.abstention_precision:.3f} |')
+    w(f'| Abstention recall | {report.abstention_recall:.3f} |')
+    w(f'| Total cost | ${total_cost:.2f} |')
+    w(f'| Total duration | {total_duration / 60:.1f} min |')
+    if report.dataset_sha256:
+        w(f'| Dataset SHA-256 | `{report.dataset_sha256[:16]}...` |')
+    w()
+
+    # ===================================================================
+    # AXIS 1: Retrieval Recall
+    # ===================================================================
+    w('## 1. Retrieval Recall')
+    w()
+    w('Measures whether memex surfaces the right evidence in the first 3 calls per tool type.')
+    w('Cap: first 3 calls each for memory_search, note_search, survey.')
+    w()
+
+    if recall_metrics:
+        # Filter to questions that have gold session IDs
+        with_gold = [m for m in recall_metrics if m.gold_session_ids]
+
+        if with_gold:
+            total_gold = sum(len(m.gold_session_ids) for m in with_gold)
+            total_found = sum(len(m.found_session_ids) for m in with_gold)
+            overall_recall = total_found / total_gold if total_gold > 0 else 0.0
+
+            w('| Question | Category | Gold Sessions | Found | Recall@3 |')
+            w('|---|---|---|---|---|')
+            for m in sorted(with_gold, key=lambda x: x.question_id):
+                cat_label = m.category or ''
+                w(
+                    f'| {m.question_id} | {cat_label} '
+                    f'| {len(m.gold_session_ids)} '
+                    f'| {len(m.found_session_ids)} '
+                    f'| {m.recall:.3f} |'
+                )
+            w(
+                f'| **Overall** | | **{total_gold}** '
+                f'| **{total_found}** | **{overall_recall:.3f}** |'
+            )
+            w()
+
+            # Per-tool recall
+            tool_stats: dict[str, dict[str, int]] = {}
+            for m in with_gold:
+                for tool_name, info in m.per_tool.items():
+                    if tool_name not in tool_stats:
+                        tool_stats[tool_name] = {
+                            'capped_calls': 0,
+                            'total_results': 0,
+                            'gold_found': 0,
+                        }
+                    tool_stats[tool_name]['capped_calls'] += info['capped_calls']
+                    tool_stats[tool_name]['total_results'] += info['total_results']
+                    tool_stats[tool_name]['gold_found'] += len(info['gold_found'])
+
+            if tool_stats:
+                w('Per-tool recall:')
+                w()
+                w('| Tool | Calls (capped) | Total Results | Gold Found | Recall |')
+                w('|---|---|---|---|---|')
+                for tool_name in sorted(tool_stats.keys()):
+                    s = tool_stats[tool_name]
+                    short = tool_name.replace('mcp__memex__memex_', '')
+                    recall_val = s['gold_found'] / total_gold if total_gold > 0 else 0.0
+                    w(
+                        f'| `{short}` | {s["capped_calls"]} '
+                        f'| {s["total_results"]} '
+                        f'| {s["gold_found"]} | {recall_val:.3f} |'
+                    )
+                w()
+        else:
+            w('No questions with gold session IDs available for recall computation.')
+            w()
+    else:
+        w('No trace data or dataset available for recall computation.')
+        w()
+
+    # ===================================================================
+    # AXIS 2: Answer Quality
+    # ===================================================================
+    w('## 2. Answer Quality')
+    w()
+    w(
+        f'Measures end-to-end answer correctness. '
+        f'Model: `{report.answer_model_fingerprint}`. '
+        f'Judge: `{report.judge_model_fingerprint}`.'
+    )
+    w()
+
+    # Accuracy by category
+    w('### Accuracy by category')
+    w()
+    w('| Category | Count | Correct | Accuracy |')
+    w('|---|---|---|---|')
+
+    for cat in _CATEGORY_ORDER:
+        cat_details = [d for d in details if d.get('category') == cat.value]
+        if not cat_details:
+            continue
+        cat_correct = sum(1 for d in cat_details if d['score'] == 1.0)
+        accuracy = round(cat_correct / len(cat_details), 3) if cat_details else 0.0
+        name = CATEGORY_NAMES.get(cat, cat.value)
+        w(f'| {name} | {len(cat_details)} | {cat_correct} | **{accuracy:.3f}** |')
+
+    w(f'| **Overall** | **{n_scored}** | **{n_correct}** | **{report.overall_accuracy:.3f}** |')
+    w()
+
+    # Per-question detail (now includes retrieval containment)
+    w('### Per-question detail')
+    w()
+    w('| ID | Category | Score | Retrieval Contains | Interpretation | Reasoning |')
+    w('|---|---|---|---|---|---|')
+
+    for d in sorted(details, key=lambda x: x['id']):
+        qid = d['id']
+        cat_val = d.get('category', '')
+        try:
+            cat = LongMemEvalCategory(cat_val)
+            cat_name = CATEGORY_NAMES.get(cat, cat_val)
+        except ValueError:
+            cat_name = cat_val
+        score_str = f'{d["score"]:.1f}'
+        retr_contains = d.get('retrieval_contains_answer', True)
+        retr_str = 'Yes' if retr_contains else 'No'
+        interp = d.get('interpretation', '')
+        reasoning = d.get('reasoning', '')[:120]
+        w(f'| {qid} | {cat_name.lower()} | {score_str} | {retr_str} | {interp} | {reasoning} |')
+    w()
+
+    # Errors
+    errors = [d for d in details if d['score'] == 0.0]
+    if errors:
+        w(f'### Wrong answers ({len(errors)})')
+        w()
+        w('| ID | Category | Issue |')
+        w('|---|---|---|')
+        for d in errors:
+            cat_val = d.get('category', '')
+            try:
+                cat = LongMemEvalCategory(cat_val)
+                cat_name = CATEGORY_NAMES.get(cat, cat_val)
+            except ValueError:
+                cat_name = cat_val
+            reasoning = d.get('reasoning', '')[:120]
+            w(f'| {d["id"]} | {cat_name} | {reasoning} |')
+        w()
+
+    # ===================================================================
+    # Error Analysis (retrieval containment x answer correctness)
+    # ===================================================================
+    w('## Error Analysis')
+    w()
+    w(
+        'Combines retrieval containment (does memex return the evidence?) with '
+        'answer correctness to classify each question into one of five outcomes.'
+    )
+    w()
+
+    # Per-question error analysis table
+    w('| Question | Retrieval Contains | Answer Correct | Interpretation |')
+    w('|---|---|---|---|')
+    for d in sorted(details, key=lambda x: x['id']):
+        retr_contains = d.get('retrieval_contains_answer', True)
+        retr_str = 'Yes' if retr_contains else 'No'
+        correct_str = 'Yes' if d['score'] == 1.0 else 'No'
+        interp = d.get('interpretation', '')
+        w(f'| {d["id"]} | {retr_str} | {correct_str} | {interp} |')
+    w()
+
+    # Summary counts
+    interpretation_counts: Counter[str] = Counter()
+    for d in details:
+        interpretation_counts[d.get('interpretation', 'unknown')] += 1
+
+    interp_order = ['correct', 'model_error', 'correct_abstention', 'hallucination', 'lucky_guess']
+    w('### Summary')
+    w()
+    w('| Interpretation | Count | Share |')
+    w('|---|---|---|')
+    for interp_label in interp_order:
+        cnt = interpretation_counts.get(interp_label, 0)
+        if cnt == 0:
+            continue
+        share = round(cnt / n_scored * 100, 1) if n_scored else 0.0
+        w(f'| {interp_label} | {cnt} | {share}% |')
+    w()
+
+    # ===================================================================
+    # AXIS 3: Token Efficiency
+    # ===================================================================
+    w('## 3. Token Efficiency')
+    w()
+    w('Measures total token spend across the full subagent session (uncapped -- all calls count).')
+    w()
+
+    # Token breakdown
+    w('### Token breakdown')
+    w()
+    w('| Metric | Value |')
+    w('|---|---|')
+    w(f'| Total tokens (all) | {total_tokens_all:,} |')
+    retr_pct = round(total_retr / total_tokens_all * 100, 1) if total_tokens_all > 0 else 0.0
+    w(f'| Retrieval tokens (Memex) | {total_retr:,} (**{retr_pct}%** of total) |')
+    w(f'| Agent overhead tokens | {total_tokens_all - total_retr:,} ({100 - retr_pct:.1f}%) |')
+    retr_values = [d['retrieval_tokens'] for d in details if d['retrieval_tokens'] > 0]
+    if retr_values:
+        w(f'| Retrieval tokens/question (mean) | {round(statistics.mean(retr_values)):,} |')
+        w(f'| Retrieval tokens/question (median) | {round(statistics.median(retr_values)):,} |')
+    w()
+
+    # Retrieval by tool
+    per_tool = retrieval_breakdown.get('per_tool', {})
+    if per_tool:
+        tool_call_counts: Counter[str] = Counter()
+        for d in details:
+            for tc in d.get('tool_calls', []):
+                name = tc.get('name', '')
+                if name.startswith(_MEMEX_TOOL_PREFIX):
+                    tool_call_counts[name] += 1
+
+        w('### Retrieval by tool')
+        w()
+        w('| Tool | Tokens | Share | Calls | Calls/q |')
+        w('|---|---|---|---|---|')
+        for tool_name, tokens in per_tool.items():
+            share = round(tokens / total_retr * 100, 1) if total_retr > 0 else 0.0
+            short = tool_name.replace('mcp__memex__memex_', '')
+            calls = tool_call_counts.get(tool_name, 0)
+            per_q = round(calls / n_scored, 1) if n_scored else 0.0
+            w(f'| `{short}` | {tokens:,} | {share}% | {calls} | {per_q} |')
+        w()
+
+    if 'retrieval_token_breakdown.png' in plot_files:
+        w(f'![Retrieval token breakdown]({plots_dir_rel}/retrieval_token_breakdown.png)')
+        w()
+
+    # Efficiency by category
+    w('### Efficiency by category')
+    w()
+    w('| Category | Duration | Turns | Total Tokens | Retr Tokens | Retr % | Memex Calls |')
+    w('|---|---|---|---|---|---|---|')
+
+    for cat in _CATEGORY_ORDER:
+        cat_d = [d for d in details if d.get('category') == cat.value]
+        if not cat_d:
+            continue
+        name = CATEGORY_NAMES.get(cat, cat.value)
+        avg_dur = round(statistics.mean([d['duration_s'] for d in cat_d]), 1)
+        avg_turns = round(statistics.mean([d['num_turns'] for d in cat_d]), 1)
+        avg_tok = round(statistics.mean([d['total_tokens'] for d in cat_d]))
+        avg_retr = round(statistics.mean([d['retrieval_tokens'] for d in cat_d]))
+        avg_pct = round(statistics.mean([d['retrieval_pct'] for d in cat_d]), 1)
+        avg_memex = round(statistics.mean([d['memex_calls'] for d in cat_d]), 1)
+        w(
+            f'| {name} | {avg_dur}s | {avg_turns} | {avg_tok:,} | '
+            f'{avg_retr:,} | {avg_pct}% | {avg_memex} |'
+        )
+    w()
+
+    # Resource usage
+    w('### Resource usage')
+    w()
+    total_input = sum(d.get('tokens', {}).get('input', 0) for d in details)
+    total_output = sum(d.get('tokens', {}).get('output', 0) for d in details)
+    w('| Metric | Value |')
+    w('|---|---|')
+    w(f'| Total tokens | {total_tokens_all:,} |')
+    w(f'| Input tokens | {total_input:,} |')
+    w(f'| Output tokens | {total_output:,} |')
+    w(f'| Retrieval tokens (Memex) | {total_retr:,} ({retr_pct}%) |')
+    w(f'| Total duration | {total_duration:,.0f}s ({total_duration / 60:.1f} min) |')
+    avg_dur = round(total_duration / len(details), 1) if details else 0.0
+    w(f'| Avg duration/question | {avg_dur}s |')
+    dur_values = [d['duration_s'] for d in details]
+    if dur_values:
+        w(f'| Median duration/question | {round(statistics.median(dur_values), 1)}s |')
+    w(f'| Total cost | ${total_cost:.2f} |')
+    if details:
+        w(f'| Avg cost/question | ${total_cost / len(details):.3f} |')
+    w()
+
+    # Per-question efficiency detail
+    w('### Per-question efficiency')
+    w()
+    w('| ID | Category | Dur | Turns | Total Tok | Retr Tok | Retr % | Memex# | Cost |')
+    w('|---|---|---|---|---|---|---|---|---|')
+
+    for d in sorted(details, key=lambda x: x['id']):
+        qid = d['id']
+        cat_val = d.get('category', '')
+        try:
+            cat = LongMemEvalCategory(cat_val)
+            cat_name = CATEGORY_NAMES.get(cat, cat_val)
+        except ValueError:
+            cat_name = cat_val
+
+        w(
+            f'| {qid} | {cat_name.lower()} | {d["duration_s"]:.1f}s '
+            f'| {d["num_turns"]} | {d["total_tokens"]:,} | {d["retrieval_tokens"]:,} '
+            f'| {d["retrieval_pct"]}% | {d["memex_calls"]} '
+            f'| ${d.get("cost_usd", 0):.2f} |'
+        )
+    w()
+
+    # Tool usage patterns
+    w('### Tool usage patterns')
+    w()
+
+    toolsearch_calls = sum(
+        1 for d in details for tc in d.get('tool_calls', []) if tc.get('name') == 'ToolSearch'
+    )
+    toolsearch_multi = sum(
+        1
+        for d in details
+        if sum(1 for tc in d.get('tool_calls', []) if tc.get('name') == 'ToolSearch') > 1
+    )
+    ts_per_q = round(toolsearch_calls / n_scored, 1) if n_scored else 0.0
+
+    entity_questions = sum(
+        1
+        for d in details
+        if any(tc.get('name', '') in _ENTITY_TOOLS for tc in d.get('tool_calls', []))
+    )
+    entity_pct = round(entity_questions / n_scored * 100) if n_scored else 0
+
+    w('| Metric | Value |')
+    w('|---|---|')
+    w(
+        f'| ToolSearch calls/question | {ts_per_q} '
+        f'({toolsearch_calls} total, {toolsearch_multi} questions with >1) |'
+    )
+    w(f'| Entity exploration | {entity_questions}/{n_scored} questions ({entity_pct}%) |')
+    w()
+
+    memex_tool_counts: Counter[str] = Counter()
+    for d in details:
+        for tc in d.get('tool_calls', []):
+            name = tc.get('name', '')
+            if name.startswith(_MEMEX_TOOL_PREFIX):
+                memex_tool_counts[name] += 1
+
+    if memex_tool_counts:
+        w('### Memex tool call distribution')
+        w()
+        w('| Tool | Total Calls | Calls/q |')
+        w('|---|---|---|')
+        for tool_name, count in memex_tool_counts.most_common():
+            short = tool_name.replace('mcp__memex__memex_', '')
+            per_q = round(count / n_scored, 1) if n_scored else 0.0
+            w(f'| `{short}` | {count} | {per_q} |')
+        w()
+
+    # Distribution plots
+    if plot_files:
+        w('### Distribution plots')
+        w()
+        for pf in plot_files:
+            if pf == 'retrieval_token_breakdown.png':
+                continue
+            label = pf.replace('.png', '').replace('_', ' ').title()
+            w(f'![{label}]({plots_dir_rel}/{pf})')
+            w()
+
+    # Retrieval paths
+    w('### Retrieval paths')
+    w()
+
+    path_counts: Counter[str] = Counter()
+    path_details: dict[str, list[dict[str, Any]]] = {}
+    for d in details:
+        path = _classify_retrieval_path(d)
+        path_counts[path] += 1
+        path_details.setdefault(path, []).append(d)
+
+    path_labels = {
+        'simple': 'Simple',
+        'two_stage': 'Two-stage',
+        'two_stage_entity': 'Two-stage + entity',
+        'deep': 'Deep verification',
+        'deep_entity': 'Deep + entity',
+        'simple_entity': 'Simple + entity',
+        'exhaustive': 'Exhaustive',
+    }
+    path_order = [
+        'two_stage',
+        'two_stage_entity',
+        'deep',
+        'deep_entity',
+        'simple_entity',
+        'exhaustive',
+        'simple',
+    ]
+
+    w('| Pattern | Count | Share | Avg Score | Avg Tools | Avg Duration | Avg Cost |')
+    w('|---|---|---|---|---|---|---|')
+    for key in path_order:
+        cnt = path_counts.get(key, 0)
+        if cnt == 0:
+            continue
+        pct = round(cnt / n_scored * 100) if n_scored > 0 else 0
+        pd_list = path_details.get(key, [])
+        avg_score = round(statistics.mean([d['score'] for d in pd_list]), 2)
+        avg_tools = round(statistics.mean([len(d.get('tool_calls', [])) for d in pd_list]), 1)
+        avg_dur_val = round(statistics.mean([d['duration_s'] for d in pd_list]))
+        avg_cost = round(statistics.mean([d.get('cost_usd', 0) for d in pd_list]), 2)
+        w(
+            f'| {path_labels[key]} | {cnt} | {pct}% | {avg_score} '
+            f'| {avg_tools} | {avg_dur_val}s | ${avg_cost} |'
+        )
+    w()
+    w(_RETRIEVAL_PATHS_MERMAID)
+
+    return '\n'.join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Terminal summary
+# ---------------------------------------------------------------------------
+
+
+def _print_summary(report: LongMemEvalReport) -> None:
+    console.print()
+    console.rule('[bold]LongMemEval Report[/bold]')
+    console.print(
+        f'[dim]run={report.run_id} | variant={report.variant} | '
+        f'questions={report.total_questions}[/dim]'
+    )
+    console.print()
+    table = Table(show_header=True, header_style='bold cyan')
+    table.add_column('Category', style='white')
+    table.add_column('N', justify='right')
+    table.add_column('Correct', justify='right')
+    table.add_column('Accuracy', justify='right')
+    for cat_result in sorted(report.per_category, key=lambda c: c.category.value):
+        acc = cat_result.accuracy
+        style = 'green' if acc >= 0.7 else ('yellow' if acc >= 0.4 else 'red')
+        table.add_row(
+            CATEGORY_NAMES.get(cat_result.category, cat_result.category.value),
+            str(cat_result.n_questions),
+            str(cat_result.n_correct),
+            f'[{style}]{acc:.3f}[/{style}]',
+        )
+    overall_style = (
+        'green'
+        if report.overall_accuracy >= 0.7
+        else ('yellow' if report.overall_accuracy >= 0.4 else 'red')
+    )
+    table.add_row(
+        '[bold]Overall[/bold]',
+        f'[bold]{report.total_questions}[/bold]',
+        f'[bold]{sum(c.n_correct for c in report.per_category)}[/bold]',
+        f'[bold {overall_style}]{report.overall_accuracy:.3f}[/bold {overall_style}]',
+        end_section=True,
+    )
+    console.print(table)
+    console.print(
+        f'Abstention: precision={report.abstention_precision:.3f} '
+        f'| recall={report.abstention_recall:.3f}'
+    )
+    console.print()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_report(
+    judgments_path: str,
+    output_dir: str,
+    *,
+    run_id: str | None = None,
+    variant: str = 's',
+    dataset_path: str | None = None,
+    hypotheses_path: str | None = None,
+    traces_dir: str | None = None,
+    answer_model_fingerprint: str = '',
+    judge_model_fingerprint: str = '',
+    allow_unpinned_checksum: bool = False,
+) -> str:
+    """Generate the full LongMemEval evaluation report with plots.
+
+    Args:
+        judgments_path: Path to judgments.jsonl from Phase 3 (judge).
+        output_dir: Directory for output report and plots.
+        run_id: Run identifier.
+        variant: Dataset variant.
+        dataset_path: Optional, used to embed dataset SHA-256 and compute recall.
+        hypotheses_path: Path to hypotheses.jsonl from Phase 2.
+        traces_dir: Directory containing per-question trace JSONL files.
+        answer_model_fingerprint: Model fingerprint for answers.
+        judge_model_fingerprint: Model fingerprint for judge.
+        allow_unpinned_checksum: Bypass SHA-256 pin requirement for dataset.
+
+    Returns:
+        Path to the generated report Markdown file.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    plots_dir = out / 'plots'
+
+    # Load judgments
+    judgments_raw = read_jsonl(judgments_path)
+    if not judgments_raw:
+        raise ValueError(f'No judgments found in {judgments_path}')
+    judgments = [LongMemEvalJudgment(**r) for r in judgments_raw]
+
+    # Load hypotheses
+    hypotheses: list[LongMemEvalHypothesis] = []
+    if hypotheses_path and Path(hypotheses_path).exists():
+        hypotheses = [LongMemEvalHypothesis(**r) for r in read_jsonl(hypotheses_path)]
+
+    # Infer fingerprints from data if not supplied
+    if not answer_model_fingerprint and hypotheses:
+        fps = [h.answer_model_fingerprint for h in hypotheses if h.answer_model_fingerprint]
+        answer_model_fingerprint = statistics.mode(fps) if fps else ''
+    if not judge_model_fingerprint:
+        fps = [j.judge_model_fingerprint for j in judgments if j.judge_model_fingerprint]
+        judge_model_fingerprint = statistics.mode(fps) if fps else ''
+
+    # Build the structured report
+    per_category, overall, abst_p, abst_r = _aggregate(judgments)
+    sha = dataset_sha256(Path(dataset_path), variant) if dataset_path else ''
+
+    # Compute total cost from hypotheses
+    total_cost_usd = sum(h.cost_usd or 0.0 for h in hypotheses) if hypotheses else None
+
+    report = LongMemEvalReport(
+        run_id=run_id or str(uuid4())[:8],
+        variant=variant,
+        total_questions=len(judgments),
+        overall_accuracy=overall,
+        per_category=per_category,
+        abstention_precision=abst_p,
+        abstention_recall=abst_r,
+        answer_model_fingerprint=answer_model_fingerprint,
+        judge_model_fingerprint=judge_model_fingerprint,
+        total_cost_usd=total_cost_usd,
+        dataset_sha256=sha,
+    )
+
+    # Resolve traces dir
+    resolved_traces_dir = traces_dir or str(out / 'traces')
+
+    # Load and enrich data
+    console.print('[bold]Loading data...[/bold]')
+    details, retrieval_breakdown = _load_data(judgments, hypotheses, resolved_traces_dir)
+
+    # Compute retrieval recall (Axis 1) if dataset + traces available
+    recall_metrics: list[RecallMetrics] | None = None
+    if dataset_path and Path(resolved_traces_dir).is_dir():
+        try:
+            questions = _load_variant(
+                Path(dataset_path), variant, allow_unpinned=allow_unpinned_checksum
+            )
+            gold_map = {q.question_id: q.answer_session_ids for q in questions}
+            category_map = {q.question_id: q.category.value for q in questions}
+            traces = parse_traces_dir(Path(resolved_traces_dir))
+            computed = compute_batch_recall(traces, gold_map, category_map)
+            n_with_gold = sum(1 for m in computed if m.gold_session_ids)
+            console.print(
+                f'  Computed recall@3 for {len(computed)} traces ({n_with_gold} with gold IDs)'
+            )
+            recall_metrics = computed
+        except Exception:
+            logger.warning('Failed to compute retrieval recall', exc_info=True)
+
+    # Generate plots
+    console.print('[bold]Generating plots...[/bold]')
+    plot_files = _generate_plots(details, retrieval_breakdown, plots_dir)
+    console.print(f'  {len(plot_files)} plots -> {plots_dir}')
+
+    # Generate markdown
+    console.print('[bold]Generating report...[/bold]')
+    md = _generate_markdown(
+        report,
+        details,
+        retrieval_breakdown,
+        'plots',
+        plot_files,
+        recall_metrics=recall_metrics,
+    )
+
+    # Write outputs
+    results_path = out / 'results.json'
+    results_data = report.model_dump()
+    results_path.write_text(json.dumps(results_data, indent=2, default=str))
+
+    md_path = out / 'longmemeval_report.md'
+    md_path.write_text(md)
+
+    # Terminal output
+    _print_summary(report)
+    console.print(f'\n[bold green]Report -> {md_path}[/bold green]')
+    return str(md_path)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def aggregate_for_test(judgments: list[LongMemEvalJudgment]) -> dict[str, Any]:
+    """Convenience wrapper used by tests to exercise aggregation directly."""
+    per_category, overall, abst_p, abst_r = _aggregate(judgments)
+    return {
+        'overall_accuracy': overall,
+        'per_category': [c.model_dump() for c in per_category],
+        'abstention_precision': abst_p,
+        'abstention_recall': abst_r,
+    }

--- a/packages/eval/src/memex_eval/external/longmemeval_trace_parser.py
+++ b/packages/eval/src/memex_eval/external/longmemeval_trace_parser.py
@@ -1,0 +1,480 @@
+"""LongMemEval trace parser: extract retrieval recall from Claude Code session traces.
+
+Parses session trace JSONL files to find memex retrieval tool calls, extract
+returned IDs, and compute recall against gold ``answer_session_ids`` from the
+upstream dataset.
+
+The ``recall_any@3`` metric caps each retrieval tool type at the **first 3
+calls** and checks whether any gold session appears among the returned results.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger('memex_eval.longmemeval_trace_parser')
+
+_MEMEX_TOOL_PREFIX = 'mcp__memex__'
+
+# All memex tools whose results we extract content from for retrieval containment.
+_ALL_MEMEX_TOOLS = {
+    'mcp__memex__memex_memory_search',
+    'mcp__memex__memex_note_search',
+    'mcp__memex__memex_survey',
+    'mcp__memex__memex_get_page_indices',
+    'mcp__memex__memex_get_nodes',
+    'mcp__memex__memex_read_note',
+    'mcp__memex__memex_get_notes_metadata',
+    'mcp__memex__memex_get_memory_units',
+    'mcp__memex__memex_list_entities',
+    'mcp__memex__memex_get_entity_mentions',
+    'mcp__memex__memex_get_entity_cooccurrences',
+    'mcp__memex__memex_find_note',
+    'mcp__memex__memex_get_vault_summary',
+}
+
+# Retrieval tools whose results we parse for recall.
+_RETRIEVAL_TOOLS = {
+    'mcp__memex__memex_memory_search',
+    'mcp__memex__memex_note_search',
+    'mcp__memex__memex_survey',
+}
+
+# Cap per tool type for recall@3.
+_RECALL_CAP = 3
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToolCall:
+    """A single retrieval tool call with its results."""
+
+    tool_name: str
+    tool_use_id: str
+    input_params: dict[str, Any] = field(default_factory=dict)
+    result_note_ids: list[str] = field(default_factory=list)
+    result_note_titles: list[str] = field(default_factory=list)
+    result_unit_count: int = 0
+
+
+@dataclass
+class TraceAnalysis:
+    """Parsed trace with per-tool-type call lists."""
+
+    question_id: str
+    calls_by_tool: dict[str, list[ToolCall]] = field(default_factory=dict)
+
+    def capped_calls(self, tool_name: str) -> list[ToolCall]:
+        """Return the first ``_RECALL_CAP`` calls for a tool type."""
+        return self.calls_by_tool.get(tool_name, [])[:_RECALL_CAP]
+
+    def all_capped_note_ids(self) -> set[str]:
+        """All note IDs across capped calls for all retrieval tools."""
+        ids: set[str] = set()
+        for tool_name in _RETRIEVAL_TOOLS:
+            for call in self.capped_calls(tool_name):
+                ids.update(call.result_note_ids)
+        return ids
+
+    def all_capped_note_titles(self) -> set[str]:
+        """All note titles across capped calls for all retrieval tools."""
+        titles: set[str] = set()
+        for tool_name in _RETRIEVAL_TOOLS:
+            for call in self.capped_calls(tool_name):
+                titles.update(call.result_note_titles)
+        return titles
+
+
+@dataclass
+class RecallMetrics:
+    """Recall results for a single question."""
+
+    question_id: str
+    category: str
+    gold_session_ids: list[str]
+    found_session_ids: list[str] = field(default_factory=list)
+    recall: float = 0.0
+    per_tool: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Trace parsing
+# ---------------------------------------------------------------------------
+
+
+def _extract_ids_from_result(content: str | list[Any]) -> tuple[list[str], list[str], int]:
+    """Extract note IDs, note titles, and unit count from a tool result block.
+
+    Returns (note_ids, note_titles, unit_count).
+    """
+    text = ''
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and part.get('type') == 'text':
+                parts.append(part.get('text', ''))
+        text = '\n'.join(parts)
+
+    note_ids: list[str] = []
+    note_titles: list[str] = []
+    unit_count = 0
+
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return note_ids, note_titles, unit_count
+
+    results = data.get('result', data.get('results', []))
+    if not isinstance(results, list):
+        return note_ids, note_titles, unit_count
+
+    seen_note_ids: set[str] = set()
+    seen_note_titles: set[str] = set()
+
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        unit_count += 1
+
+        # note_id can be top-level or nested
+        nid = r.get('note_id') or r.get('id', '')
+        ntitle = r.get('note_title') or r.get('title', '')
+
+        if nid and nid not in seen_note_ids:
+            note_ids.append(str(nid))
+            seen_note_ids.add(nid)
+        if ntitle and ntitle not in seen_note_titles:
+            note_titles.append(str(ntitle))
+            seen_note_titles.add(ntitle)
+
+    return note_ids, note_titles, unit_count
+
+
+def parse_trace(trace_path: Path, question_id: str | None = None) -> TraceAnalysis:
+    """Parse a Claude Code session trace JSONL and extract retrieval tool calls.
+
+    Args:
+        trace_path: Path to a ``.jsonl`` trace file.
+        question_id: Optional question ID (defaults to stem of filename).
+
+    Returns:
+        A ``TraceAnalysis`` with per-tool-type call lists.
+    """
+    qid = question_id or trace_path.stem
+    analysis = TraceAnalysis(question_id=qid)
+
+    try:
+        lines = trace_path.read_text().strip().splitlines()
+    except Exception:
+        logger.warning('Failed to read trace %s', trace_path)
+        return analysis
+
+    # Pass 1: collect tool_use blocks (id -> name, input)
+    tool_use_map: dict[str, tuple[str, dict[str, Any]]] = {}
+    # Maintain ordering by collecting tool_use_ids in order
+    ordered_tool_ids: list[str] = []
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if obj.get('type') == 'assistant':
+            for block in obj.get('message', {}).get('content', []):
+                if isinstance(block, dict) and block.get('type') == 'tool_use':
+                    name = block.get('name', '')
+                    tid = block.get('id', '')
+                    if tid and name in _RETRIEVAL_TOOLS:
+                        tool_use_map[tid] = (name, block.get('input', {}))
+                        ordered_tool_ids.append(tid)
+
+    # Pass 2: match tool_result blocks to tool_use IDs
+    tool_results: dict[str, str | list[Any]] = {}
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if obj.get('type') == 'user':
+            for block in obj.get('message', {}).get('content', []):
+                if isinstance(block, dict) and block.get('type') == 'tool_result':
+                    tid = block.get('tool_use_id', '')
+                    if tid in tool_use_map:
+                        tool_results[tid] = block.get('content', '')
+
+    # Build ToolCall records in order
+    for tid in ordered_tool_ids:
+        name, input_params = tool_use_map[tid]
+        content = tool_results.get(tid, '')
+        note_ids, note_titles, unit_count = _extract_ids_from_result(content)
+        call = ToolCall(
+            tool_name=name,
+            tool_use_id=tid,
+            input_params=input_params,
+            result_note_ids=note_ids,
+            result_note_titles=note_titles,
+            result_unit_count=unit_count,
+        )
+        analysis.calls_by_tool.setdefault(name, []).append(call)
+
+    return analysis
+
+
+# ---------------------------------------------------------------------------
+# Session ID extraction from note titles
+# ---------------------------------------------------------------------------
+
+# Note titles follow the pattern: ``{question_id} — {session_id}``
+# (set by longmemeval_ingest: note_key=f'longmemeval-{variant}-{qid}-{sid}')
+_NOTE_TITLE_RE = re.compile(r'^.+?\s+—\s+(.+)$')
+
+
+def _session_id_from_note_title(title: str) -> str | None:
+    """Extract the session_id from a note title like 'e47becba — answer_280352e9'."""
+    m = _NOTE_TITLE_RE.match(title)
+    return m.group(1) if m else None
+
+
+def _collect_session_ids_from_trace(trace: TraceAnalysis) -> set[str]:
+    """Collect all session IDs from capped retrieval calls via note titles."""
+    session_ids: set[str] = set()
+    for title in trace.all_capped_note_titles():
+        sid = _session_id_from_note_title(title)
+        if sid:
+            session_ids.add(sid)
+    return session_ids
+
+
+# ---------------------------------------------------------------------------
+# Recall computation
+# ---------------------------------------------------------------------------
+
+
+def compute_recall(
+    trace: TraceAnalysis,
+    gold_session_ids: list[str],
+    category: str = '',
+) -> RecallMetrics:
+    """Compute recall@3 for a single question.
+
+    Checks whether gold ``answer_session_ids`` appear among the note titles
+    returned by the first 3 calls per retrieval tool type.
+    """
+    found_sids = _collect_session_ids_from_trace(trace)
+    gold_set = set(gold_session_ids)
+    found_gold = sorted(gold_set & found_sids)
+
+    recall = len(found_gold) / len(gold_set) if gold_set else 1.0
+
+    # Per-tool breakdown
+    per_tool: dict[str, dict[str, Any]] = {}
+    for tool_name in _RETRIEVAL_TOOLS:
+        capped = trace.capped_calls(tool_name)
+        total_calls = len(trace.calls_by_tool.get(tool_name, []))
+        if not capped:
+            continue
+
+        tool_sids: set[str] = set()
+        total_results = 0
+        total_notes = 0
+        for call in capped:
+            total_results += call.result_unit_count
+            total_notes += len(call.result_note_ids)
+            for title in call.result_note_titles:
+                sid = _session_id_from_note_title(title)
+                if sid:
+                    tool_sids.add(sid)
+
+        tool_found = sorted(gold_set & tool_sids)
+        per_tool[tool_name] = {
+            'capped_calls': len(capped),
+            'total_calls': total_calls,
+            'total_results': total_results,
+            'total_notes': total_notes,
+            'gold_found': tool_found,
+            'recall': len(tool_found) / len(gold_set) if gold_set else 1.0,
+        }
+
+    return RecallMetrics(
+        question_id=trace.question_id,
+        category=category,
+        gold_session_ids=gold_session_ids,
+        found_session_ids=found_gold,
+        recall=recall,
+        per_tool=per_tool,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Human-readable formatting
+# ---------------------------------------------------------------------------
+
+
+def format_question_breakdown(trace: TraceAnalysis, metrics: RecallMetrics | None) -> str:
+    """Format a human-readable breakdown for one question."""
+    lines: list[str] = []
+    cat_label = f' ({metrics.category})' if metrics and metrics.category else ''
+    lines.append(f'Question {trace.question_id}{cat_label}:')
+
+    for tool_name in sorted(_RETRIEVAL_TOOLS):
+        all_calls = trace.calls_by_tool.get(tool_name, [])
+        capped = trace.capped_calls(tool_name)
+        if not all_calls:
+            continue
+
+        short = tool_name.replace('mcp__memex__memex_', '')
+        lines.append(f'  {short} ({len(capped)}/{len(all_calls)} calls used for recall):')
+        for i, call in enumerate(capped):
+            note_ids_short = [nid[:8] for nid in call.result_note_ids[:5]]
+            extra = f'... +{len(call.result_note_ids) - 5}' if len(call.result_note_ids) > 5 else ''
+            lines.append(
+                f'    Call {i + 1}: returned {call.result_unit_count} units '
+                f'from notes [{", ".join(note_ids_short)}{extra}]'
+            )
+
+    if metrics:
+        lines.append(f'  Gold session IDs: {metrics.gold_session_ids}')
+        n_gold = len(metrics.gold_session_ids)
+        n_found = len(metrics.found_session_ids)
+        lines.append(f'  Recall@3: {n_found}/{n_gold} gold sessions found ({metrics.recall:.3f})')
+        if metrics.found_session_ids:
+            lines.append(f'  Found: {metrics.found_session_ids}')
+    else:
+        lines.append('  (no gold session IDs available)')
+
+    return '\n'.join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Retrieval content extraction (for containment judging)
+# ---------------------------------------------------------------------------
+
+
+def _extract_text_from_content(content: str | list[Any]) -> str:
+    """Extract plain text from a tool_result content block."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and part.get('type') == 'text':
+                parts.append(part.get('text', ''))
+        return '\n'.join(parts)
+    return ''
+
+
+def extract_retrieval_content(trace_path: Path) -> str:
+    """Extract all memex tool result text from a session trace.
+
+    Parses the JSONL trace, finds all ``tool_result`` blocks whose
+    ``tool_use_id`` maps to a memex tool, extracts the text content,
+    and concatenates. Returns a single string with all retrieval output.
+    """
+    try:
+        lines = trace_path.read_text().strip().splitlines()
+    except Exception:
+        logger.warning('Failed to read trace %s', trace_path)
+        return ''
+
+    # Pass 1: collect all memex tool_use IDs
+    memex_tool_ids: set[str] = set()
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if obj.get('type') == 'assistant':
+            for block in obj.get('message', {}).get('content', []):
+                if isinstance(block, dict) and block.get('type') == 'tool_use':
+                    name = block.get('name', '')
+                    tid = block.get('id', '')
+                    if tid and name in _ALL_MEMEX_TOOLS:
+                        memex_tool_ids.add(tid)
+
+    # Pass 2: collect tool_result content for those IDs
+    result_parts: list[str] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if obj.get('type') == 'user':
+            for block in obj.get('message', {}).get('content', []):
+                if isinstance(block, dict) and block.get('type') == 'tool_result':
+                    tid = block.get('tool_use_id', '')
+                    if tid in memex_tool_ids:
+                        text = _extract_text_from_content(block.get('content', ''))
+                        if text.strip():
+                            result_parts.append(text)
+
+    return '\n\n---\n\n'.join(result_parts)
+
+
+# ---------------------------------------------------------------------------
+# Batch analysis
+# ---------------------------------------------------------------------------
+
+
+def parse_traces_dir(
+    traces_dir: Path,
+) -> list[TraceAnalysis]:
+    """Parse all trace files in a directory."""
+    traces: list[TraceAnalysis] = []
+    for trace_file in sorted(traces_dir.glob('*.jsonl')):
+        traces.append(parse_trace(trace_file))
+    return traces
+
+
+def compute_batch_recall(
+    traces: list[TraceAnalysis],
+    gold_map: dict[str, list[str]],
+    category_map: dict[str, str] | None = None,
+) -> list[RecallMetrics]:
+    """Compute recall for all traces against a gold mapping.
+
+    Args:
+        traces: Parsed trace analyses.
+        gold_map: ``{question_id: [answer_session_ids]}``.
+        category_map: Optional ``{question_id: category}`` mapping.
+
+    Returns:
+        List of ``RecallMetrics``, one per trace.
+    """
+    results: list[RecallMetrics] = []
+    for trace in traces:
+        gold = gold_map.get(trace.question_id, [])
+        cat = (category_map or {}).get(trace.question_id, '')
+        results.append(compute_recall(trace, gold, category=cat))
+    return results

--- a/packages/eval/src/memex_eval/judge.py
+++ b/packages/eval/src/memex_eval/judge.py
@@ -42,6 +42,39 @@ class GradedCorrectness(dspy.Signature):
     reasoning: str = dspy.OutputField(desc='Brief explanation of the judgment.')
 
 
+class AbstentionCorrectness(dspy.Signature):
+    """Judge whether a hypothesis correctly abstains from answering.
+
+    Used for LongMemEval ``*_abs`` questions: the ground-truth answer is
+    missing/null, so correctness is defined as the hypothesis explicitly
+    declining to answer (e.g. "I do not know based on the available
+    memory"). Paraphrase is acceptable; hallucinating any specific answer
+    is INCORRECT.
+    """
+
+    question: str = dspy.InputField(desc='The question that was asked.')
+    model_response: str = dspy.InputField(desc='The model/system response to evaluate.')
+    is_correct_abstention: bool = dspy.OutputField(
+        desc='Whether the response correctly abstains (declines to answer).'
+    )
+    reasoning: str = dspy.OutputField(desc='Brief explanation of the judgment.')
+
+
+class AbstentionClassifier(dspy.Signature):
+    """Classify whether a hypothesis *itself* is an abstention.
+
+    Independent of ground-truth or correctness — this is a pure labelling
+    task over the hypothesis text. Used as the denominator for abstention
+    precision so that metric is not definitionally coupled to correctness.
+    """
+
+    model_response: str = dspy.InputField(desc='The model/system response to classify.')
+    is_abstention: bool = dspy.OutputField(
+        desc='True iff the response declines to answer / says it does not know.'
+    )
+    reasoning: str = dspy.OutputField(desc='Brief explanation.')
+
+
 class Judge:
     """LLM-as-a-judge using dspy with Gemini."""
 
@@ -61,6 +94,8 @@ class Judge:
         self._correctness = dspy.ChainOfThought(BinaryCorrectness)
         self._relevance = dspy.ChainOfThought(RetrievalRelevance)
         self._graded = dspy.ChainOfThought(GradedCorrectness)
+        self._abstention_correctness = dspy.ChainOfThought(AbstentionCorrectness)
+        self._abstention_classifier = dspy.ChainOfThought(AbstentionClassifier)
 
     def judge_correctness(self, question: str, expected: str, response: str) -> tuple[bool, str]:
         """Judge whether a response correctly answers a question.
@@ -106,3 +141,26 @@ class Judge:
                 search_result=search_result,
             )
         return result.is_relevant, result.reasoning
+
+    def judge_abstention_correctness(self, question: str, response: str) -> tuple[bool, str]:
+        """Judge whether a hypothesis correctly abstains.
+
+        Used when the ground-truth answer is missing/null (LongMemEval
+        ``*_abs`` questions). Returns (is_correct, reasoning).
+        """
+        with dspy.context(lm=self.lm):
+            result = self._abstention_correctness(
+                question=question,
+                model_response=response,
+            )
+        return result.is_correct_abstention, result.reasoning
+
+    def classify_abstention(self, response: str) -> tuple[bool, str]:
+        """Classify a hypothesis as abstention vs attempted-answer.
+
+        Returns (is_abstention, reasoning). Pure labelling; does not
+        consult the ground truth.
+        """
+        with dspy.context(lm=self.lm):
+            result = self._abstention_classifier(model_response=response)
+        return result.is_abstention, result.reasoning

--- a/packages/eval/tests/fixtures/longmemeval_smoke_cache.json
+++ b/packages/eval/tests/fixtures/longmemeval_smoke_cache.json
@@ -1,0 +1,47 @@
+{
+  "_meta": {
+    "description": "Cached judge responses for the LongMemEval smoke-tier test. Keys are question_id; values describe the deterministic judge verdict for that hypothesis. ``is_abstention_hypothesis`` reflects what the LM abstention classifier would have returned. ``retrieval_contains_answer`` and ``retrieval_containment_reasoning`` are for retrieval containment judging. Placeholder values — recorded against synthetic fixture questions, not the upstream dataset.",
+    "judge_model_fingerprint": "cached-smoke@2026-04-15.v1",
+    "prompt_template_version": "2026-04-15.v1"
+  },
+  "smoke-q-001": {
+    "correct": true,
+    "reasoning": "Hypothesis matches the ground truth.",
+    "judge_model_fingerprint": "cached-smoke@2026-04-15.v1",
+    "is_abstention_hypothesis": false,
+    "retrieval_contains_answer": true,
+    "retrieval_containment_reasoning": "Retrieval results contain the greeting."
+  },
+  "smoke-q-002": {
+    "correct": true,
+    "reasoning": "Hypothesis matches the ground truth.",
+    "judge_model_fingerprint": "cached-smoke@2026-04-15.v1",
+    "is_abstention_hypothesis": false,
+    "retrieval_contains_answer": true,
+    "retrieval_containment_reasoning": "Retrieval results contain meeting schedule."
+  },
+  "smoke-q-003": {
+    "correct": false,
+    "reasoning": "Hypothesis missed the date constraint.",
+    "judge_model_fingerprint": "cached-smoke@2026-04-15.v1",
+    "is_abstention_hypothesis": false,
+    "retrieval_contains_answer": true,
+    "retrieval_containment_reasoning": "Retrieval results contain time reference."
+  },
+  "smoke-q-004_abs": {
+    "correct": true,
+    "reasoning": "Abstention question; hypothesis correctly abstained.",
+    "judge_model_fingerprint": "cached-smoke@2026-04-15.v1",
+    "is_abstention_hypothesis": true,
+    "retrieval_contains_answer": false,
+    "retrieval_containment_reasoning": "No information about middle name in retrieval results."
+  },
+  "smoke-q-005": {
+    "correct": true,
+    "reasoning": "Hypothesis matches the ground truth.",
+    "judge_model_fingerprint": "cached-smoke@2026-04-15.v1",
+    "is_abstention_hypothesis": false,
+    "retrieval_contains_answer": true,
+    "retrieval_containment_reasoning": "Retrieval results contain preference information."
+  }
+}

--- a/packages/eval/tests/test_longmemeval_abstention.py
+++ b/packages/eval/tests/test_longmemeval_abstention.py
@@ -1,0 +1,146 @@
+"""Tests for the LongMemEval abstention metric decoupling (C3).
+
+Before C3 the report derived abstention precision via the same
+heuristic that gated correctness, so the numerator and denominator
+were tautologically coupled and could not actually detect
+hallucination-on-abstention-question. These tests exercise two
+hypothesis shapes against the same ground-truth set and verify that
+precision and recall diverge — i.e. that the metric discriminates.
+"""
+
+from __future__ import annotations
+
+from memex_eval.external.longmemeval_common import (
+    LongMemEvalCategory,
+    LongMemEvalJudgment,
+)
+from memex_eval.external.longmemeval_report import aggregate_for_test
+
+
+def _mk_judgment(
+    qid: str,
+    *,
+    is_abstention: bool,
+    hypothesis: str,
+    correct: bool,
+    is_abstention_hypothesis: bool,
+) -> LongMemEvalJudgment:
+    return LongMemEvalJudgment(
+        question_id=qid,
+        category=LongMemEvalCategory.KNOWLEDGE_UPDATE,
+        is_abstention=is_abstention,
+        hypothesis=hypothesis,
+        expected=None if is_abstention else 'ground-truth',
+        correct=correct,
+        judge_reasoning='fixture',
+        judge_model_fingerprint='test',
+        is_abstention_hypothesis=is_abstention_hypothesis,
+    )
+
+
+def test_abstention_metrics_distinguish_correct_vs_hallucinated() -> None:
+    """Two fixtures — one correctly abstains, one hallucinates — must
+    produce different precision/recall even though the ground-truth set
+    is identical. This test would fail against the pre-C3
+    implementation where precision was computed via the same heuristic
+    used for correctness.
+    """
+    # Correct-abstention fixture.
+    correct_fixture = [
+        _mk_judgment(
+            'q-abs-001_abs',
+            is_abstention=True,
+            hypothesis='I do not know based on the available memory.',
+            correct=True,
+            is_abstention_hypothesis=True,
+        ),
+        _mk_judgment(
+            'q-nonabs-001',
+            is_abstention=False,
+            hypothesis='Tuesday.',
+            correct=True,
+            is_abstention_hypothesis=False,
+        ),
+    ]
+
+    # Hallucinating fixture: on the abstention question, the hypothesis
+    # confidently makes something up. The judge (correctly) marks it
+    # incorrect, and the LM abstention classifier (correctly) marks it
+    # as NOT an abstention.
+    hallucinating_fixture = [
+        _mk_judgment(
+            'q-abs-001_abs',
+            is_abstention=True,
+            hypothesis='The answer is clearly Wednesday at noon.',
+            correct=False,
+            is_abstention_hypothesis=False,
+        ),
+        _mk_judgment(
+            'q-nonabs-001',
+            is_abstention=False,
+            hypothesis='Tuesday.',
+            correct=True,
+            is_abstention_hypothesis=False,
+        ),
+    ]
+
+    correct_agg = aggregate_for_test(correct_fixture)
+    halluc_agg = aggregate_for_test(hallucinating_fixture)
+
+    # Recall must drop: the ground-truth abstention was not answered correctly.
+    assert correct_agg['abstention_recall'] == 1.0
+    assert halluc_agg['abstention_recall'] == 0.0
+
+    # Precision must also drop — but crucially, the two numbers are
+    # different. Under the pre-C3 coupling both would be identical.
+    assert correct_agg['abstention_precision'] != halluc_agg['abstention_precision']
+
+
+def test_precision_denominator_uses_lm_classified_abstentions() -> None:
+    """A non-abstention question whose hypothesis is phrased as an
+    abstention (e.g. a cautious LM) drags precision down — this is the
+    behaviour we want. The denominator is driven by
+    ``is_abstention_hypothesis``, not by string-matching correctness.
+    """
+    judgments = [
+        # Ground-truth abstention + hypothesis correctly abstains.
+        _mk_judgment(
+            'q-abs-001_abs',
+            is_abstention=True,
+            hypothesis='I do not know.',
+            correct=True,
+            is_abstention_hypothesis=True,
+        ),
+        # Ground-truth has an answer, but hypothesis is cautious —
+        # counted as an abstention hypothesis (wrongly abstained).
+        _mk_judgment(
+            'q-nonabs-001',
+            is_abstention=False,
+            hypothesis='I do not have enough information to say.',
+            correct=False,
+            is_abstention_hypothesis=True,
+        ),
+    ]
+    agg = aggregate_for_test(judgments)
+    # Two abstention hypotheses, one of which maps to a true
+    # abstention question -> precision = 0.5.
+    assert agg['abstention_precision'] == 0.5
+    # Only one ground-truth abstention, correctly answered -> recall = 1.0.
+    assert agg['abstention_recall'] == 1.0
+
+
+def test_judgment_default_is_abstention_hypothesis_is_false() -> None:
+    """The new field is additive; existing callers that omit it still
+    parse, with the safe default that nothing is counted as an
+    abstention hypothesis."""
+    j = LongMemEvalJudgment(
+        question_id='q',
+        category=LongMemEvalCategory.MULTI_SESSION,
+        is_abstention=False,
+        hypothesis='x',
+        expected='x',
+        correct=True,
+        judge_reasoning='',
+        judge_model_fingerprint='t',
+    )
+    assert j.is_abstention_hypothesis is False

--- a/packages/eval/tests/test_longmemeval_answer_direct.py
+++ b/packages/eval/tests/test_longmemeval_answer_direct.py
@@ -1,0 +1,413 @@
+"""Unit tests for longmemeval_answer_direct (note-only / memory-only modes)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from memex_eval.external.longmemeval_answer_direct import (
+    ABSTENTION_MARKER,
+    DirectMode,
+    _format_memory_results,
+    _format_note_results,
+    _is_abstention,
+    answer_direct,
+)
+from memex_eval.external.longmemeval_common import (
+    LongMemEvalCategory,
+    LongMemEvalQuestion,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def question() -> LongMemEvalQuestion:
+    return LongMemEvalQuestion(
+        question_id='q_test',
+        category=LongMemEvalCategory.SINGLE_SESSION_USER,
+        is_abstention=False,
+        question_text='What is the capital of France?',
+        answer='Paris',
+        answer_session_ids=['sess_1'],
+        question_date=dt.datetime(2023, 5, 30, 12, 0, 0, tzinfo=dt.timezone.utc),
+        sessions=[],
+    )
+
+
+@pytest.fixture
+def mock_lm() -> MagicMock:
+    lm = MagicMock()
+    lm.copy = MagicMock(return_value=lm)
+    lm.history = []
+    return lm
+
+
+def _mock_memory_unit(text: str, note_title: str = 'note') -> MagicMock:
+    u = MagicMock()
+    u.id = uuid4()
+    u.text = text
+    u.note_id = str(uuid4())
+    u.note_title = note_title
+    return u
+
+
+def _mock_note_result(title: str, description: str) -> MagicMock:
+    n = MagicMock()
+    n.note_id = uuid4()
+    n.title = title
+    n.description = description
+    n.summaries = []
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def test_format_memory_results_renders_numbered_block() -> None:
+    units = [
+        _mock_memory_unit('First fact', note_title='NoteA'),
+        _mock_memory_unit('Second fact', note_title='NoteB'),
+    ]
+    out = _format_memory_results(units)
+    assert '[1] (NoteA) First fact' in out
+    assert '[2] (NoteB) Second fact' in out
+
+
+def test_format_note_results_includes_description_and_summaries() -> None:
+    n = MagicMock()
+    n.note_id = uuid4()
+    n.title = 'Paris Travel Log'
+    n.description = 'Trip to Paris'
+    n.summaries = ['Visited the Eiffel Tower', {'summary': 'Ate croissants'}]
+    out = _format_note_results([n])
+    assert '[1] (Paris Travel Log)' in out
+    assert 'Trip to Paris' in out
+    assert 'Visited the Eiffel Tower' in out
+    assert 'Ate croissants' in out
+
+
+def test_format_note_results_handles_missing_description() -> None:
+    n = MagicMock()
+    n.note_id = uuid4()
+    n.title = 'Empty'
+    n.description = ''
+    n.summaries = []
+    out = _format_note_results([n])
+    assert '(no description)' in out
+
+
+# ---------------------------------------------------------------------------
+# Abstention detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'answer, expected',
+    [
+        ('', True),
+        ('   ', True),
+        (ABSTENTION_MARKER, True),
+        ('I do not know based on the available memory.', True),
+        ('i do not know', True),
+        ("I don't know for certain", True),
+        ('Paris', False),
+        ('The capital is Paris.', False),
+    ],
+)
+def test_is_abstention_classifies_correctly(answer: str, expected: bool) -> None:
+    assert _is_abstention(answer) is expected
+
+
+# ---------------------------------------------------------------------------
+# answer_direct: memory-only mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_try_success_no_retry_memory_only(question, mock_lm) -> None:
+    """When first attempt returns a confident answer, do not call the tool a second time."""
+    with (
+        patch('memex_eval.external.longmemeval_answer_direct.RemoteMemexAPI') as mock_api_cls,
+        patch(
+            'memex_eval.external.longmemeval_answer_direct._synthesize',
+            new_callable=AsyncMock,
+            return_value=('Paris', 100, 5),
+        ) as mock_synth,
+        patch('memex_eval.external.longmemeval_answer_direct.httpx.AsyncClient') as mock_client_cls,
+    ):
+        mock_api = AsyncMock()
+        mock_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+        mock_api.search = AsyncMock(return_value=[_mock_memory_unit('France capital is Paris')])
+        mock_api_cls.return_value = mock_api
+
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await answer_direct(
+            question=question,
+            mode=DirectMode.MEMORY_ONLY,
+            vault_name='test-vault',
+            server_url='http://test',
+            answer_lm=mock_lm,
+        )
+
+    assert result['answer'] == 'Paris'
+    assert mock_api.search.await_count == 1, 'should NOT retry when first answer is confident'
+    assert mock_synth.await_count == 1
+    assert len(result['tool_calls']) == 1
+    assert result['tool_calls'][0]['input']['expand_query'] is False
+    assert result['tool_calls'][0]['name'] == 'memex_memory_search'
+
+
+@pytest.mark.asyncio
+async def test_abstention_triggers_expand_retry_memory_only(question, mock_lm) -> None:
+    """First abstention → retry with expand_query=True."""
+    with (
+        patch('memex_eval.external.longmemeval_answer_direct.RemoteMemexAPI') as mock_api_cls,
+        patch(
+            'memex_eval.external.longmemeval_answer_direct._synthesize',
+            new_callable=AsyncMock,
+            side_effect=[(ABSTENTION_MARKER, 50, 10), ('Paris', 120, 8)],
+        ) as mock_synth,
+        patch('memex_eval.external.longmemeval_answer_direct.httpx.AsyncClient') as mock_client_cls,
+    ):
+        mock_api = AsyncMock()
+        mock_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+        mock_api.search = AsyncMock(
+            side_effect=[
+                [_mock_memory_unit('irrelevant data')],
+                [_mock_memory_unit('Paris is the capital')],
+            ]
+        )
+        mock_api_cls.return_value = mock_api
+
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await answer_direct(
+            question=question,
+            mode=DirectMode.MEMORY_ONLY,
+            vault_name='test-vault',
+            server_url='http://test',
+            answer_lm=mock_lm,
+        )
+
+    assert result['answer'] == 'Paris'
+    assert mock_api.search.await_count == 2, 'second call should fire on abstention'
+    assert mock_synth.await_count == 2
+    # First call has expand_query=False, second has True
+    assert mock_api.search.await_args_list[0].kwargs['expand_query'] is False
+    assert mock_api.search.await_args_list[1].kwargs['expand_query'] is True
+    assert len(result['tool_calls']) == 2
+
+
+@pytest.mark.asyncio
+async def test_double_abstention_returns_final_abstention(question, mock_lm) -> None:
+    """If both attempts abstain, final answer is the abstention marker."""
+    with (
+        patch('memex_eval.external.longmemeval_answer_direct.RemoteMemexAPI') as mock_api_cls,
+        patch(
+            'memex_eval.external.longmemeval_answer_direct._synthesize',
+            new_callable=AsyncMock,
+            return_value=(ABSTENTION_MARKER, 30, 5),
+        ),
+        patch('memex_eval.external.longmemeval_answer_direct.httpx.AsyncClient') as mock_client_cls,
+    ):
+        mock_api = AsyncMock()
+        mock_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+        mock_api.search = AsyncMock(return_value=[_mock_memory_unit('irrelevant')])
+        mock_api_cls.return_value = mock_api
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await answer_direct(
+            question=question,
+            mode=DirectMode.MEMORY_ONLY,
+            vault_name='test-vault',
+            server_url='http://test',
+            answer_lm=mock_lm,
+        )
+
+    assert result['answer'] == ABSTENTION_MARKER
+    assert mock_api.search.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_token_accumulation_across_retries(question, mock_lm) -> None:
+    """Tokens from both attempts accumulate in the result."""
+    with (
+        patch('memex_eval.external.longmemeval_answer_direct.RemoteMemexAPI') as mock_api_cls,
+        patch(
+            'memex_eval.external.longmemeval_answer_direct._synthesize',
+            new_callable=AsyncMock,
+            side_effect=[(ABSTENTION_MARKER, 50, 10), ('Paris', 120, 8)],
+        ),
+        patch('memex_eval.external.longmemeval_answer_direct.httpx.AsyncClient') as mock_client_cls,
+    ):
+        mock_api = AsyncMock()
+        mock_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+        mock_api.search = AsyncMock(return_value=[_mock_memory_unit('text')])
+        mock_api_cls.return_value = mock_api
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await answer_direct(
+            question=question,
+            mode=DirectMode.MEMORY_ONLY,
+            vault_name='test-vault',
+            server_url='http://test',
+            answer_lm=mock_lm,
+        )
+
+    # Output tokens accumulate across both synthesis calls
+    assert result['tokens']['output'] == 10 + 8
+    # Input tokens = synthesis input + retrieval content tokens (both attempts)
+    assert result['tokens']['input'] >= 50 + 120  # at least synthesis inputs
+
+
+# ---------------------------------------------------------------------------
+# answer_direct: note-only mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_note_only_calls_search_notes(question, mock_lm) -> None:
+    """note-only mode should call api.search_notes, NOT api.search."""
+    with (
+        patch('memex_eval.external.longmemeval_answer_direct.RemoteMemexAPI') as mock_api_cls,
+        patch(
+            'memex_eval.external.longmemeval_answer_direct._synthesize',
+            new_callable=AsyncMock,
+            return_value=('Paris', 80, 5),
+        ),
+        patch('memex_eval.external.longmemeval_answer_direct.httpx.AsyncClient') as mock_client_cls,
+    ):
+        mock_api = AsyncMock()
+        mock_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+        mock_api.search = AsyncMock(return_value=[])
+        mock_api.search_notes = AsyncMock(
+            return_value=[_mock_note_result('France', 'Paris is the capital of France')]
+        )
+        mock_api_cls.return_value = mock_api
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await answer_direct(
+            question=question,
+            mode=DirectMode.NOTE_ONLY,
+            vault_name='test-vault',
+            server_url='http://test',
+            answer_lm=mock_lm,
+        )
+
+    assert mock_api.search_notes.await_count == 1
+    assert mock_api.search.await_count == 0
+    assert result['tool_calls'][0]['name'] == 'memex_note_search'
+    assert result['answer'] == 'Paris'
+
+
+@pytest.mark.asyncio
+async def test_limit_passed_through(question, mock_lm) -> None:
+    """Default limit of 10 is passed to the tool."""
+    with (
+        patch('memex_eval.external.longmemeval_answer_direct.RemoteMemexAPI') as mock_api_cls,
+        patch(
+            'memex_eval.external.longmemeval_answer_direct._synthesize',
+            new_callable=AsyncMock,
+            return_value=('Paris', 80, 5),
+        ),
+        patch('memex_eval.external.longmemeval_answer_direct.httpx.AsyncClient') as mock_client_cls,
+    ):
+        mock_api = AsyncMock()
+        mock_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+        mock_api.search = AsyncMock(return_value=[_mock_memory_unit('x')])
+        mock_api_cls.return_value = mock_api
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        await answer_direct(
+            question=question,
+            mode=DirectMode.MEMORY_ONLY,
+            vault_name='test-vault',
+            server_url='http://test',
+            answer_lm=mock_lm,
+        )
+
+    call = mock_api.search.await_args
+    assert call is not None
+    assert call.kwargs['limit'] == 10
+
+
+@pytest.mark.asyncio
+async def test_reference_date_passed_through(question, mock_lm) -> None:
+    """question.question_date is passed as reference_date for temporal resolution."""
+    with (
+        patch('memex_eval.external.longmemeval_answer_direct.RemoteMemexAPI') as mock_api_cls,
+        patch(
+            'memex_eval.external.longmemeval_answer_direct._synthesize',
+            new_callable=AsyncMock,
+            return_value=('Paris', 80, 5),
+        ),
+        patch('memex_eval.external.longmemeval_answer_direct.httpx.AsyncClient') as mock_client_cls,
+    ):
+        mock_api = AsyncMock()
+        mock_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+        mock_api.search = AsyncMock(return_value=[_mock_memory_unit('x')])
+        mock_api_cls.return_value = mock_api
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        await answer_direct(
+            question=question,
+            mode=DirectMode.MEMORY_ONLY,
+            vault_name='test-vault',
+            server_url='http://test',
+            answer_lm=mock_lm,
+        )
+
+    call = mock_api.search.await_args
+    assert call is not None
+    assert call.kwargs['reference_date'] == question.question_date
+
+
+@pytest.mark.asyncio
+async def test_empty_results_produce_abstention(question, mock_lm) -> None:
+    """If retrieval returns zero results, we abstain without calling the LLM for that attempt."""
+    with (
+        patch('memex_eval.external.longmemeval_answer_direct.RemoteMemexAPI') as mock_api_cls,
+        patch(
+            'memex_eval.external.longmemeval_answer_direct._synthesize',
+            new_callable=AsyncMock,
+            return_value=(ABSTENTION_MARKER, 0, 0),
+        ) as mock_synth,
+        patch('memex_eval.external.longmemeval_answer_direct.httpx.AsyncClient') as mock_client_cls,
+    ):
+        mock_api = AsyncMock()
+        mock_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
+        mock_api.search = AsyncMock(return_value=[])
+        mock_api_cls.return_value = mock_api
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__.return_value = mock_client
+
+        result = await answer_direct(
+            question=question,
+            mode=DirectMode.MEMORY_ONLY,
+            vault_name='test-vault',
+            server_url='http://test',
+            answer_lm=mock_lm,
+        )
+
+    # Synthesis should NOT be called when there is no context at all
+    assert mock_synth.await_count == 0
+    assert result['answer'] == ABSTENTION_MARKER
+    # But retrieval IS called twice (retry on empty)
+    assert mock_api.search.await_count == 2

--- a/packages/eval/tests/test_longmemeval_answer_dto.py
+++ b/packages/eval/tests/test_longmemeval_answer_dto.py
@@ -1,0 +1,60 @@
+"""Tests for the LongMemEval answer module's shape (M5 + M6).
+
+The answer module no longer renders prompts in-process — it shells
+out to a Claude Code subagent (M6). What remains DTO-contract-worthy
+on the Python side is the ``MemoryUnitDTO`` import surface (the
+subagent uses the MCP tools which return DTOs through the client).
+These tests assert:
+
+- ``MemoryUnitDTO`` exposes the fields the subagent's retrieval
+  playbook relies on: ``text``, ``fact_type``, ``occurred_start``,
+  ``mentioned_at``. If any are renamed upstream, the test fails loudly
+  instead of the subagent silently seeing empty strings.
+- ``FactTypes`` serialises via ``.value`` so the MCP surface carries
+  the string "event"/"world"/"observation" rather than ``FactTypes.EVENT``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from memex_common.schemas import MemoryUnitDTO
+from memex_common.types import FactTypes
+
+
+def test_memory_unit_dto_exposes_expected_fields() -> None:
+    dt = datetime(2024, 5, 1, 9, 30, tzinfo=timezone.utc)
+    unit = MemoryUnitDTO(
+        id=uuid4(),
+        text='Project kickoff.',
+        fact_type=FactTypes.EVENT,
+        occurred_start=dt,
+        mentioned_at=dt,
+    )
+    # Names the MCP path and the subagent's retrieval playbook rely on.
+    assert unit.text == 'Project kickoff.'
+    assert unit.fact_type is FactTypes.EVENT
+    assert unit.occurred_start == dt
+    assert unit.mentioned_at == dt
+
+
+def test_fact_type_value_is_string_not_enum_repr() -> None:
+    """The MCP surface and any downstream JSON serialiser must render
+    ``FactTypes`` via its ``.value`` so clients see ``"event"``, not
+    ``"FactTypes.EVENT"``."""
+    assert FactTypes.EVENT.value == 'event'
+    assert FactTypes.WORLD.value == 'world'
+    assert FactTypes.OBSERVATION.value == 'observation'
+
+
+def test_memory_unit_dto_does_not_have_event_date_attribute() -> None:
+    """Pre-M5 code used ``getattr(u, 'event_date', None)``. This test
+    pins the reality: ``event_date`` is NOT on the DTO — operators
+    must go through ``occurred_start`` / ``mentioned_at``."""
+    unit = MemoryUnitDTO(
+        id=uuid4(),
+        text='x',
+        fact_type=FactTypes.WORLD,
+    )
+    assert not hasattr(unit, 'event_date')

--- a/packages/eval/tests/test_longmemeval_answer_subagent.py
+++ b/packages/eval/tests/test_longmemeval_answer_subagent.py
@@ -1,0 +1,345 @@
+"""Tests for the Claude Code subagent answer module (M6 + M7).
+
+These unit tests do NOT spawn a real ``claude`` process. They assert:
+
+- Workspace setup writes the expected ``.mcp.json``, ``.memex.yaml``,
+  and ``CLAUDE.md`` files with correct contents.
+- Plugin resolution honours the override arg, then the env var, then
+  the repo-default path.
+- ``_run_claude_subagent`` assembles the right CLI (including
+  ``--plugin-dir``) and parses JSONL output into the expected shape.
+- ``answer_questions`` rejects unimplemented methods.
+- ``answer_questions`` writes hypotheses via ``append_jsonl`` when the
+  subagent subprocess is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from memex_eval.external.longmemeval_answer import (
+    _PLUGIN_DIR,
+    AnswerMethod,
+    _normalise_server_url,
+    _parse_claude_json_output,
+    _resolve_plugin_dir,
+    _run_claude_subagent,
+    _setup_subagent_workspace,
+    answer_questions,
+)
+from memex_eval.external.longmemeval_common import DATASET_FILENAMES, append_jsonl
+
+
+def test_normalise_server_url_strips_api_v1_and_trailing_slash() -> None:
+    assert _normalise_server_url('http://localhost:8001/api/v1/') == 'http://localhost:8001'
+    assert _normalise_server_url('http://localhost:8001/api/v1') == 'http://localhost:8001'
+    assert _normalise_server_url('http://localhost:8001/') == 'http://localhost:8001'
+    assert _normalise_server_url('http://localhost:8001') == 'http://localhost:8001'
+
+
+def test_setup_subagent_workspace_writes_expected_files(tmp_path: Path) -> None:
+    workdir = _setup_subagent_workspace(
+        server_url='http://localhost:8001/api/v1/',
+        vault_name='longmemeval_s_run-1',
+    )
+    try:
+        w = Path(workdir)
+        assert (w / '.mcp.json').exists()
+        mcp = json.loads((w / '.mcp.json').read_text())
+        assert 'memex' in mcp['mcpServers']
+        assert mcp['mcpServers']['memex']['env']['MEMEX_SERVER_URL'] == 'http://localhost:8001'
+
+        memex_yaml = (w / '.memex.yaml').read_text()
+        assert 'longmemeval_s_run-1' in memex_yaml
+        assert 'http://localhost:8001' in memex_yaml
+
+        claude_md = (w / 'CLAUDE.md').read_text()
+        assert 'LongMemEval' in claude_md
+        assert 'I do not know based on the available memory.' in claude_md
+
+        settings = json.loads((w / '.claude' / 'settings.local.json').read_text())
+        assert 'mcp__memex__memex_memory_search' in settings['permissions']['allow']
+    finally:
+        import shutil
+
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def test_resolve_plugin_dir_override_wins(tmp_path: Path) -> None:
+    assert _resolve_plugin_dir(str(tmp_path)) == tmp_path
+
+
+def test_resolve_plugin_dir_env_var_wins(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv('MEMEX_CLAUDE_PLUGIN_DIR', str(tmp_path))
+    assert _resolve_plugin_dir(None) == tmp_path
+
+
+def test_resolve_plugin_dir_defaults_to_repo_packages_path(monkeypatch) -> None:
+    monkeypatch.delenv('MEMEX_CLAUDE_PLUGIN_DIR', raising=False)
+    assert _resolve_plugin_dir(None) == _PLUGIN_DIR
+    # And the repo default actually exists in this worktree — i.e. the
+    # plugin IS installed and ready to be passed via --plugin-dir.
+    assert _PLUGIN_DIR.exists()
+    assert (_PLUGIN_DIR / '.claude-plugin' / 'plugin.json').exists()
+    assert (_PLUGIN_DIR / 'skills').is_dir()
+
+
+def test_parse_claude_json_output_extracts_answer_and_tool_calls() -> None:
+    lines = [
+        json.dumps(
+            {
+                'type': 'assistant',
+                'message': {
+                    'content': [
+                        {
+                            'type': 'tool_use',
+                            'name': 'mcp__memex__memex_memory_search',
+                            'input': {'query': 'foo'},
+                        },
+                    ]
+                },
+            }
+        ),
+        json.dumps(
+            {
+                'type': 'result',
+                'result': 'Tuesday at 3pm.',
+                'usage': {
+                    'input_tokens': 100,
+                    'cache_read_input_tokens': 50,
+                    'output_tokens': 20,
+                },
+                'num_turns': 3,
+                'total_cost_usd': 0.0123,
+                'model': 'claude-sonnet-4-6',
+            }
+        ),
+    ]
+    parsed = _parse_claude_json_output('\n'.join(lines), duration=12.5)
+    assert parsed['answer'] == 'Tuesday at 3pm.'
+    assert parsed['model'] == 'claude-sonnet-4-6'
+    assert parsed['num_turns'] == 3
+    assert parsed['cost_usd'] == 0.0123
+    assert parsed['duration_s'] == 12.5
+    assert parsed['tokens']['input'] == 150
+    assert parsed['tokens']['output'] == 20
+    assert parsed['tool_calls'] == [
+        {'name': 'mcp__memex__memex_memory_search', 'input': {'query': 'foo'}}
+    ]
+
+
+def test_run_claude_subagent_invokes_correct_cli(tmp_path: Path) -> None:
+    """The assembled argv must include ``--plugin-dir`` pointing at the
+    resolved plugin directory — this is the M7 wiring."""
+    captured: dict = {}
+
+    class _FakeProc:
+        returncode = 0
+        stdout = json.dumps({'type': 'result', 'result': 'ok', 'usage': {}, 'model': 'claude-opus'})
+        stderr = ''
+
+    def _fake_run(cmd, **kwargs):
+        captured['cmd'] = cmd
+        captured['kwargs'] = kwargs
+        return _FakeProc()
+
+    with patch('memex_eval.external.longmemeval_answer.subprocess.run', _fake_run):
+        result = _run_claude_subagent(
+            'What did the user say?',
+            workdir=str(tmp_path),
+            plugin_dir=Path('/fake/plugin'),
+            timeout_s=60.0,
+        )
+
+    assert result['answer'] == 'ok'
+    cmd = captured['cmd']
+    assert cmd[0] == 'claude'
+    assert '--plugin-dir' in cmd
+    assert cmd[cmd.index('--plugin-dir') + 1] == '/fake/plugin'
+    assert '-p' in cmd
+    assert '--output-format' in cmd and 'json' in cmd
+
+
+def test_verify_plugin_installed_passes_for_repo_default() -> None:
+    """The repo-default plugin is a valid install — verification passes."""
+    from memex_eval.external.longmemeval_answer import _verify_plugin_installed
+
+    _verify_plugin_installed(_PLUGIN_DIR)  # no raise
+
+
+def test_verify_plugin_installed_raises_on_missing_dir(tmp_path: Path) -> None:
+    from memex_eval.external.longmemeval_answer import _verify_plugin_installed
+
+    with pytest.raises(FileNotFoundError, match='plugin'):
+        _verify_plugin_installed(tmp_path / 'does-not-exist')
+
+
+def test_verify_plugin_installed_raises_on_missing_manifest(tmp_path: Path) -> None:
+    """A directory without ``.claude-plugin/plugin.json`` is rejected —
+    this catches ``--plugin-dir`` pointing at the wrong folder."""
+    from memex_eval.external.longmemeval_answer import _verify_plugin_installed
+
+    (tmp_path / 'skills').mkdir()  # skills without a manifest
+    with pytest.raises(FileNotFoundError, match='plugin.json'):
+        _verify_plugin_installed(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_answer_questions_rejects_gemini_cli(tmp_path: Path) -> None:
+    dataset = tmp_path / DATASET_FILENAMES['oracle']
+    dataset.write_text(json.dumps([]))
+    output = tmp_path / 'hypotheses.jsonl'
+
+    with pytest.raises(NotImplementedError):
+        await answer_questions(
+            server_url='http://localhost:8001',
+            dataset_path=str(dataset),
+            variant='oracle',
+            run_id='r1',
+            output_path=str(output),
+            method=AnswerMethod.GEMINI_CLI,
+            allow_unpinned_checksum=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_answer_questions_writes_hypotheses_via_mock_subagent(tmp_path: Path) -> None:
+    """Full answer pipeline with subprocess mocked out — asserts the
+    hypothesis JSONL carries the subagent's answer + model fingerprint."""
+    dataset = tmp_path / DATASET_FILENAMES['oracle']
+    dataset.write_text(
+        json.dumps(
+            [
+                {
+                    'question_id': 'q-001',
+                    'question_type': 'single-session-user',
+                    'question': 'What did the user say first?',
+                    'answer': 'Hello.',
+                    'haystack_sessions': [],
+                }
+            ]
+        )
+    )
+    output = tmp_path / 'hypotheses.jsonl'
+
+    def _fake_run(cmd, **kwargs):
+        class _P:
+            returncode = 0
+            stdout = json.dumps(
+                {
+                    'type': 'result',
+                    'result': 'Hello.',
+                    'usage': {'input_tokens': 1, 'output_tokens': 2},
+                    'total_cost_usd': 0.001,
+                    'model': 'claude-sonnet-4-6',
+                }
+            )
+            stderr = ''
+
+        return _P()
+
+    plugin_dir = tmp_path / 'plugin'
+    (plugin_dir / '.claude-plugin').mkdir(parents=True)
+    (plugin_dir / '.claude-plugin' / 'plugin.json').write_text('{}')
+
+    with (
+        patch('memex_eval.external.longmemeval_answer.subprocess.run', _fake_run),
+    ):
+        answered = await answer_questions(
+            server_url='http://localhost:8001',
+            dataset_path=str(dataset),
+            variant='oracle',
+            run_id='r1',
+            output_path=str(output),
+            method=AnswerMethod.CLAUDE_CODE,
+            plugin_dir=str(plugin_dir),
+            allow_unpinned_checksum=True,
+        )
+
+    assert answered == 1
+    rows = [json.loads(line) for line in output.read_text().splitlines() if line]
+    assert len(rows) == 1
+    assert rows[0]['hypothesis'] == 'Hello.'
+    assert 'claude-code' in rows[0]['answer_model_fingerprint']
+    assert 'claude-sonnet-4-6' in rows[0]['answer_model_fingerprint']
+
+
+@pytest.mark.asyncio
+async def test_answer_questions_raises_when_plugin_dir_missing(tmp_path: Path) -> None:
+    dataset = tmp_path / DATASET_FILENAMES['oracle']
+    dataset.write_text(
+        json.dumps(
+            [
+                {
+                    'question_id': 'q-001',
+                    'question_type': 'single-session-user',
+                    'question': '?',
+                    'answer': 'x',
+                    'haystack_sessions': [],
+                }
+            ]
+        )
+    )
+    output = tmp_path / 'hypotheses.jsonl'
+
+    with pytest.raises(FileNotFoundError, match='plugin'):
+        await answer_questions(
+            server_url='http://localhost:8001',
+            dataset_path=str(dataset),
+            variant='oracle',
+            run_id='r1',
+            output_path=str(output),
+            method=AnswerMethod.CLAUDE_CODE,
+            plugin_dir=str(tmp_path / 'does-not-exist'),
+            allow_unpinned_checksum=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_answer_questions_resume_skips_completed(tmp_path: Path) -> None:
+    dataset = tmp_path / DATASET_FILENAMES['oracle']
+    dataset.write_text(
+        json.dumps(
+            [
+                {
+                    'question_id': 'q-001',
+                    'question_type': 'single-session-user',
+                    'question': '?',
+                    'answer': 'x',
+                    'haystack_sessions': [],
+                }
+            ]
+        )
+    )
+    output = tmp_path / 'hypotheses.jsonl'
+    append_jsonl(
+        output,
+        {
+            'question_id': 'q-001',
+            'hypothesis': 'prev',
+            'retrieved_unit_ids': [],
+            'answer_model_fingerprint': 'x',
+        },
+    )
+
+    # With the only question already in output, nothing runs — the
+    # subprocess is never invoked, so if it IS invoked the test would
+    # fail against a missing ``claude`` binary.
+    plugin_dir = tmp_path / 'plugin'
+    (plugin_dir / '.claude-plugin').mkdir(parents=True)
+
+    answered = await answer_questions(
+        server_url='http://localhost:8001',
+        dataset_path=str(dataset),
+        variant='oracle',
+        run_id='r1',
+        output_path=str(output),
+        method=AnswerMethod.CLAUDE_CODE,
+        plugin_dir=str(plugin_dir),
+        allow_unpinned_checksum=True,
+    )
+    assert answered == 0

--- a/packages/eval/tests/test_longmemeval_checksum.py
+++ b/packages/eval/tests/test_longmemeval_checksum.py
@@ -1,0 +1,75 @@
+"""Tests for the LongMemEval dataset-checksum pin enforcement (C2).
+
+The loader must refuse to proceed when a variant has no pinned
+SHA-256 unless ``allow_unpinned=True`` is explicitly set. A pinned
+value that matches the file hash must pass silently; a mismatched
+pin must raise — with no override available.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from memex_eval.external import longmemeval_common as lmc_mod
+from memex_eval.external.longmemeval_common import (
+    DATASET_FILENAMES,
+    DatasetChecksumMismatchError,
+    DatasetChecksumUnpinnedError,
+    _sha256_file,
+    load_longmemeval_oracle,
+)
+
+
+def _write_min_dataset(tmp_path: Path) -> Path:
+    out = tmp_path / DATASET_FILENAMES['oracle']
+    out.write_text(
+        json.dumps(
+            [
+                {
+                    'question_id': 'q-001',
+                    'question_type': 'single-session-user',
+                    'question': 'Why?',
+                    'answer': 'Because.',
+                    'haystack_sessions': [],
+                }
+            ]
+        )
+    )
+    return out
+
+
+def test_unpinned_checksum_raises_without_override(tmp_path: Path) -> None:
+    path = _write_min_dataset(tmp_path)
+    # Ensure oracle pin is None for this test.
+    with patch.dict(lmc_mod.DATASET_SHA256, {'oracle': None}, clear=False):
+        with pytest.raises(DatasetChecksumUnpinnedError):
+            load_longmemeval_oracle(path)
+
+
+def test_unpinned_checksum_with_override_loads(tmp_path: Path) -> None:
+    path = _write_min_dataset(tmp_path)
+    with patch.dict(lmc_mod.DATASET_SHA256, {'oracle': None}, clear=False):
+        questions = load_longmemeval_oracle(path, allow_unpinned=True)
+    assert len(questions) == 1
+
+
+def test_matching_pin_loads_without_override(tmp_path: Path) -> None:
+    path = _write_min_dataset(tmp_path)
+    actual = _sha256_file(path)
+    with patch.dict(lmc_mod.DATASET_SHA256, {'oracle': actual}, clear=False):
+        questions = load_longmemeval_oracle(path)
+    assert len(questions) == 1
+
+
+def test_mismatched_pin_raises(tmp_path: Path) -> None:
+    path = _write_min_dataset(tmp_path)
+    with patch.dict(lmc_mod.DATASET_SHA256, {'oracle': 'deadbeef' * 8}, clear=False):
+        with pytest.raises(DatasetChecksumMismatchError):
+            load_longmemeval_oracle(path)
+        # Override does not help for a mismatch — integrity takes priority.
+        with pytest.raises(DatasetChecksumMismatchError):
+            load_longmemeval_oracle(path, allow_unpinned=True)

--- a/packages/eval/tests/test_longmemeval_cli_variant_default.py
+++ b/packages/eval/tests/test_longmemeval_cli_variant_default.py
@@ -1,0 +1,49 @@
+"""Tests for the LongMemEval CLI variant default (M8).
+
+The canonical variant is ``s`` (LongMemEval-S) — 500 questions, ~40
+sessions / ~115k tokens per question — matching agentmemory's
+baseline so scores are directly comparable. These tests pin that
+default on every subcommand that takes ``--variant``.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from memex_eval.cli import app
+
+
+def test_longmemeval_ingest_help_defaults_to_s() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ['longmemeval', 'ingest', '--help'])
+    assert result.exit_code == 0
+    # Typer renders ``--variant`` default as ``[default: s]``.
+    assert 'default: s' in result.stdout.replace('\n', ' ').lower()
+
+
+def test_longmemeval_answer_help_defaults_to_s() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ['longmemeval', 'answer', '--help'])
+    assert result.exit_code == 0
+    assert 'default: s' in result.stdout.replace('\n', ' ').lower()
+
+
+def test_longmemeval_judge_help_defaults_to_s() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ['longmemeval', 'judge', '--help'])
+    assert result.exit_code == 0
+    assert 'default: s' in result.stdout.replace('\n', ' ').lower()
+
+
+def test_longmemeval_report_help_defaults_to_s() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ['longmemeval', 'report', '--help'])
+    assert result.exit_code == 0
+    assert 'default: s' in result.stdout.replace('\n', ' ').lower()
+
+
+def test_longmemeval_run_help_defaults_to_s() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ['longmemeval', 'run', '--help'])
+    assert result.exit_code == 0
+    assert 'default: s' in result.stdout.replace('\n', ' ').lower()

--- a/packages/eval/tests/test_longmemeval_compare.py
+++ b/packages/eval/tests/test_longmemeval_compare.py
@@ -1,0 +1,198 @@
+"""Unit tests for longmemeval_compare multi-mode comparison report."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from memex_eval.external.longmemeval_compare import (
+    _dedupe_by_qid,
+    _summarize_run,
+    generate_comparison_report,
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('\n'.join(json.dumps(r) for r in records) + '\n')
+
+
+def _judgment(qid: str, correct: bool, retrieval: bool, interp: str) -> dict:
+    return {
+        'question_id': qid,
+        'correct': correct,
+        'retrieval_contains_answer': retrieval,
+        'interpretation': interp,
+    }
+
+
+def _hypothesis(
+    qid: str, latency_ms: float = 30_000, tokens: int = 80_000, cost: float = 0.10
+) -> dict:
+    return {
+        'question_id': qid,
+        'hypothesis': 'test',
+        'latency_ms': latency_ms,
+        'input_tokens': tokens // 2,
+        'output_tokens': tokens - (tokens // 2),
+        'cost_usd': cost,
+    }
+
+
+def test_dedupe_by_qid_keeps_first() -> None:
+    records = [
+        {'question_id': 'a', 'x': 1},
+        {'question_id': 'b', 'x': 2},
+        {'question_id': 'a', 'x': 99},  # duplicate — should be ignored
+    ]
+    out = _dedupe_by_qid(records)
+    assert out['a']['x'] == 1
+    assert out['b']['x'] == 2
+    assert len(out) == 2
+
+
+def test_dedupe_ignores_missing_qid() -> None:
+    out = _dedupe_by_qid([{'no_id': 1}, {'question_id': 'a', 'x': 1}])
+    assert list(out.keys()) == ['a']
+
+
+def test_summarize_run_computes_stats(tmp_path: Path) -> None:
+    run = tmp_path / 'run-agent'
+    _write_jsonl(
+        run / 'judgments.jsonl',
+        [
+            _judgment('q1', True, True, 'correct'),
+            _judgment('q2', False, True, 'model_error'),
+            _judgment('q3', False, False, 'retr_fail'),
+        ],
+    )
+    _write_jsonl(
+        run / 'hypotheses.jsonl',
+        [
+            _hypothesis('q1', latency_ms=10_000, tokens=50_000, cost=0.05),
+            _hypothesis('q2', latency_ms=20_000, tokens=70_000, cost=0.10),
+            _hypothesis('q3', latency_ms=30_000, tokens=90_000, cost=0.15),
+        ],
+    )
+
+    summary = _summarize_run('agent', run)
+
+    assert summary['n_questions'] == 3
+    assert summary['correct'] == 1
+    assert summary['accuracy'] == pytest.approx(1 / 3)
+    assert summary['retrieval_found'] == 2
+    assert summary['retrieval_recall'] == pytest.approx(2 / 3)
+    assert summary['interpretations'] == {'correct': 1, 'model_error': 1, 'retr_fail': 1}
+    assert summary['avg_latency_s'] == pytest.approx(20.0)
+    assert summary['median_latency_s'] == pytest.approx(20.0)
+    assert summary['avg_total_tokens'] == pytest.approx(70_000)
+    assert summary['total_cost_usd'] == pytest.approx(0.30)
+    assert summary['avg_cost_usd'] == pytest.approx(0.10)
+
+
+def test_summarize_run_handles_missing_files(tmp_path: Path) -> None:
+    summary = _summarize_run('empty', tmp_path / 'nope')
+    assert summary['n_questions'] == 0
+    assert summary['accuracy'] == 0.0
+    assert summary['total_cost_usd'] == 0.0
+
+
+def test_generate_comparison_report_produces_markdown(tmp_path: Path) -> None:
+    # Two runs with partially overlapping results
+    agent_run = tmp_path / 'agent'
+    _write_jsonl(
+        agent_run / 'judgments.jsonl',
+        [
+            _judgment('q1', True, True, 'correct'),
+            _judgment('q2', False, True, 'model_error'),
+            _judgment('q3', True, True, 'correct'),
+        ],
+    )
+    _write_jsonl(
+        agent_run / 'hypotheses.jsonl',
+        [_hypothesis('q1'), _hypothesis('q2'), _hypothesis('q3')],
+    )
+
+    note_run = tmp_path / 'note-only'
+    _write_jsonl(
+        note_run / 'judgments.jsonl',
+        [
+            _judgment('q1', True, True, 'correct'),
+            _judgment('q2', False, False, 'retr_fail'),
+            _judgment('q3', False, False, 'retr_fail'),
+        ],
+    )
+    _write_jsonl(
+        note_run / 'hypotheses.jsonl',
+        [_hypothesis('q1', cost=0.01), _hypothesis('q2', cost=0.01), _hypothesis('q3', cost=0.01)],
+    )
+
+    out = tmp_path / 'report'
+    summary = generate_comparison_report(
+        [('agent', agent_run), ('note-only', note_run)],
+        out,
+    )
+
+    # Report files exist
+    assert (out / 'comparison_report.md').exists()
+    assert (out / 'comparison.json').exists()
+
+    # Summary structure
+    assert len(summary['modes']) == 2
+    assert summary['n_questions_total'] == 3
+    assert summary['agreement']['all_correct'] == 1  # q1: both correct
+    assert summary['agreement']['all_wrong'] == 1  # q2: both wrong
+    assert summary['agreement']['mixed'] == 1  # q3: agent correct, note wrong
+
+    # Markdown content sanity
+    md = (out / 'comparison_report.md').read_text()
+    assert '# LongMemEval Mode Comparison' in md
+    assert '| agent |' in md
+    assert '| note-only |' in md
+    assert 'q1' in md
+    assert 'model-fail' in md or 'retr-fail' in md
+
+
+def test_comparison_marks_all_wrong_correctly(tmp_path: Path) -> None:
+    """When every mode gets a question wrong, it's classified as all_wrong."""
+    run_a = tmp_path / 'a'
+    _write_jsonl(
+        run_a / 'judgments.jsonl',
+        [_judgment('q1', False, False, 'retr_fail')],
+    )
+    _write_jsonl(run_a / 'hypotheses.jsonl', [_hypothesis('q1')])
+
+    run_b = tmp_path / 'b'
+    _write_jsonl(
+        run_b / 'judgments.jsonl',
+        [_judgment('q1', False, True, 'model_error')],
+    )
+    _write_jsonl(run_b / 'hypotheses.jsonl', [_hypothesis('q1')])
+
+    summary = generate_comparison_report([('a', run_a), ('b', run_b)], tmp_path / 'report')
+    assert summary['agreement']['all_wrong'] == 1
+    assert summary['agreement']['all_correct'] == 0
+    assert summary['agreement']['mixed'] == 0
+
+
+def test_comparison_missing_question_renders_dash(tmp_path: Path) -> None:
+    """A question present in one run but not another gets a dash in the table."""
+    run_a = tmp_path / 'a'
+    _write_jsonl(
+        run_a / 'judgments.jsonl',
+        [_judgment('q1', True, True, 'correct'), _judgment('q2', True, True, 'correct')],
+    )
+    _write_jsonl(run_a / 'hypotheses.jsonl', [_hypothesis('q1'), _hypothesis('q2')])
+
+    run_b = tmp_path / 'b'
+    _write_jsonl(run_b / 'judgments.jsonl', [_judgment('q1', False, False, 'retr_fail')])
+    _write_jsonl(run_b / 'hypotheses.jsonl', [_hypothesis('q1')])
+
+    out = tmp_path / 'report'
+    generate_comparison_report([('a', run_a), ('b', run_b)], out)
+
+    md = (out / 'comparison_report.md').read_text()
+    # q2 exists in a but not b — b column should show "—"
+    assert '| q2 | ✓ | — |' in md or 'q2' in md and '—' in md

--- a/packages/eval/tests/test_longmemeval_ingest_clean.py
+++ b/packages/eval/tests/test_longmemeval_ingest_clean.py
@@ -1,0 +1,71 @@
+"""Tests for the ``--clean`` path of the LongMemEval ingest adapter.
+
+These assert the concrete ``RemoteMemexAPI`` contract that
+``_setup_vault(..., clean=True)`` relies on: it must look up existing notes
+via ``list_notes`` and delete each by id via ``delete_note``. If either
+method is renamed upstream (or the adapter is changed to call a name that
+does not exist), these tests fail loudly instead of at runtime against a
+live server.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from memex_common.client import RemoteMemexAPI
+from memex_eval.external.longmemeval_ingest import _setup_vault
+
+
+def test_remote_memex_api_exposes_delete_note() -> None:
+    """Guard against the adapter calling a nonexistent client method."""
+    assert hasattr(RemoteMemexAPI, 'delete_note')
+    assert hasattr(RemoteMemexAPI, 'list_notes')
+    assert hasattr(RemoteMemexAPI, 'list_vaults')
+
+
+@pytest.mark.asyncio
+async def test_setup_vault_clean_deletes_existing_notes_by_id() -> None:
+    """With clean=True, existing notes in a matched vault must be deleted
+    via ``delete_note(note.id)`` — not via a delete-by-title or any other
+    method name.
+    """
+    vault_id = uuid4()
+    note_a_id = uuid4()
+    note_b_id = uuid4()
+
+    vault = SimpleNamespace(id=vault_id, name='longmemeval_oracle_test-run')
+    note_a = SimpleNamespace(id=note_a_id)
+    note_b = SimpleNamespace(id=note_b_id)
+
+    api = AsyncMock(spec=RemoteMemexAPI)
+    api.list_vaults.return_value = [vault]
+    api.list_notes.return_value = [note_a, note_b]
+    api.delete_note.return_value = True
+
+    result = await _setup_vault(api, 'longmemeval_oracle_test-run', clean=True)
+
+    assert result == vault_id
+    api.list_notes.assert_awaited_once()
+    # Each existing note must be deleted, by id.
+    assert api.delete_note.await_count == 2
+    called_ids = {call.args[0] for call in api.delete_note.await_args_list}
+    assert called_ids == {note_a_id, note_b_id}
+
+
+@pytest.mark.asyncio
+async def test_setup_vault_no_clean_does_not_delete() -> None:
+    vault_id = uuid4()
+    vault = SimpleNamespace(id=vault_id, name='longmemeval_oracle_test-run')
+
+    api = AsyncMock(spec=RemoteMemexAPI)
+    api.list_vaults.return_value = [vault]
+
+    result = await _setup_vault(api, 'longmemeval_oracle_test-run', clean=False)
+
+    assert result == vault_id
+    api.delete_note.assert_not_awaited()
+    api.list_notes.assert_not_awaited()

--- a/packages/eval/tests/test_longmemeval_ingest_roundtrip.py
+++ b/packages/eval/tests/test_longmemeval_ingest_roundtrip.py
@@ -1,0 +1,135 @@
+"""Tests for the LongMemEval session-to-note adapter.
+
+The pure ``build_note_payloads`` function is exercised with a unit test that
+asserts every turn timestamp + session date round-trip through the
+frontmatter the ingest pipeline reads. The full server-roundtrip test is
+marked ``integration`` and deferred to an environment with Docker/Postgres.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from memex_eval.external.longmemeval_common import (
+    LongMemEvalCategory,
+    LongMemEvalQuestion,
+    LongMemEvalSession,
+    LongMemEvalTurn,
+)
+from memex_eval.external.longmemeval_ingest import build_note_payloads
+
+
+def _sample_question() -> LongMemEvalQuestion:
+    turns = [
+        LongMemEvalTurn(
+            role='user',
+            content='When did we last talk about soccer?',
+            timestamp=datetime(2024, 1, 1, 8, 0, 0, tzinfo=timezone.utc),
+        ),
+        LongMemEvalTurn(
+            role='assistant',
+            content='Two weeks ago on Tuesday.',
+            timestamp=datetime(2024, 1, 1, 8, 0, 5, tzinfo=timezone.utc),
+        ),
+    ]
+    session = LongMemEvalSession(
+        session_id='s1',
+        session_date=datetime(2024, 1, 1, 8, 0, 0, tzinfo=timezone.utc),
+        turns=turns,
+    )
+    return LongMemEvalQuestion(
+        question_id='q-temporal-001',
+        category=LongMemEvalCategory.TEMPORAL_REASONING,
+        is_abstention=False,
+        question_text='When did the user last mention soccer?',
+        answer='Two weeks ago.',
+        sessions=[session],
+    )
+
+
+def test_build_note_payloads_one_per_session() -> None:
+    q = _sample_question()
+    vault_id = str(uuid4())
+    payloads = build_note_payloads(q, variant='oracle', vault_id=vault_id)
+    assert len(payloads) == 1
+    p = payloads[0]
+    assert p.vault_id == vault_id
+    assert 'longmemeval' in p.tags
+    assert 'variant:oracle' in p.tags
+    assert 'question:q-temporal-001' in p.tags
+    assert 'category:temporal-reasoning' in p.tags
+    assert p.note_key == 'longmemeval-oracle-q-temporal-001-s1'
+
+
+def test_build_note_payloads_preserves_timestamps_in_frontmatter() -> None:
+    q = _sample_question()
+    payloads = build_note_payloads(q, variant='oracle', vault_id=str(uuid4()))
+    markdown = base64.b64decode(payloads[0].content).decode('utf-8')
+
+    # The session timestamp must appear as publish_date in YAML frontmatter so
+    # the core ingest pipeline propagates it to MemoryUnit.event_date.
+    assert markdown.startswith('---\n')
+    assert 'publish_date: 2024-01-01T08:00:00+00:00' in markdown
+    # Every per-turn timestamp also appears verbatim in the dialogue body.
+    assert '2024-01-01T08:00:00+00:00' in markdown
+    assert '2024-01-01T08:00:05+00:00' in markdown
+    # Turn content is preserved unchanged.
+    assert 'When did we last talk about soccer?' in markdown
+    assert 'Two weeks ago on Tuesday.' in markdown
+
+
+@pytest.mark.integration
+def test_ingest_roundtrip_event_date() -> None:
+    """Full roundtrip: ingest one question's sessions and assert every
+    session-turn timestamp matches the persisted ``MemoryUnit.mentioned_at``
+    (or ``occurred_start`` for event-typed units).
+
+    Gated behind ``integration`` so it runs under ``uv run pytest -m
+    integration``, not by default.
+
+    Blocker — explicit, not a silent skip: the full assertion requires
+    the ``postgres_container`` / ``ensure_db_env_vars`` / ``async_client``
+    fixtures defined in the repository-root ``tests/conftest.py``. Those
+    fixtures import ``memex_core.server`` directly; ``packages/eval``
+    does not depend on ``memex_core`` (only ``memex_common``) and adding
+    that dependency is a scope change outside POC #13 (core is
+    off-limits for this worktree).
+
+    Options to unblock, in priority order:
+      1. Relocate this test to ``tests/`` in the repo root, next to
+         ``test_e2e_frontmatter_pipeline.py``, where the fixtures are
+         already wired. ``build_note_payloads`` stays in
+         ``packages/eval`` and is imported by the relocated test.
+      2. Add ``memex-core`` as a dev-only dependency on ``packages/eval``
+         and copy the relevant fixture block into
+         ``packages/eval/tests/conftest.py``. Avoided here because it
+         expands the eval package's runtime surface.
+
+    We use ``importorskip`` so ``-m integration`` runs against the
+    eval package surface a skip with a reason pointing at the blocker,
+    while non-integration runs do not collect this test body at all
+    (it is still collected by marker filtering but the importorskip
+    call returns immediately when ``memex_core`` is missing).
+    """
+    pytest.importorskip(
+        'memex_core',
+        reason=(
+            'Roundtrip assertion needs repo-root tests/conftest.py fixtures '
+            '(postgres_container + async_client). Relocate this test to '
+            'tests/ or add memex-core as a dev dep to packages/eval to unblock.'
+        ),
+    )
+    # If memex_core IS importable (i.e. run from a full dev install),
+    # we still need the repo-root fixtures to drive a real server. Those
+    # are not currently discoverable from packages/eval/tests, so until
+    # option (1) or (2) above is done, we surface a clear xfail rather
+    # than pretending this covers the contract.
+    pytest.xfail(
+        'Integration fixtures (postgres_container, async_client) are not '
+        'discoverable from packages/eval/tests — relocate this test to '
+        'repo-root tests/ to fully exercise the roundtrip.'
+    )

--- a/packages/eval/tests/test_longmemeval_interpretation.py
+++ b/packages/eval/tests/test_longmemeval_interpretation.py
@@ -1,0 +1,78 @@
+"""Tests for the retrieval containment interpretation matrix."""
+
+from __future__ import annotations
+
+from memex_eval.external.longmemeval_judge import compute_interpretation
+
+
+class TestInterpretationMatrix:
+    """All 5 outcomes of the 2x2 matrix (retrieval_contains x answer_correct)."""
+
+    def test_correct(self) -> None:
+        """Retrieval contains answer AND hypothesis correct -> correct."""
+        assert (
+            compute_interpretation(
+                retrieval_contains=True,
+                answer_correct=True,
+                is_abstention_hypothesis=False,
+            )
+            == 'correct'
+        )
+
+    def test_model_error(self) -> None:
+        """Retrieval contains answer AND hypothesis wrong -> model_error."""
+        assert (
+            compute_interpretation(
+                retrieval_contains=True,
+                answer_correct=False,
+                is_abstention_hypothesis=False,
+            )
+            == 'model_error'
+        )
+
+    def test_correct_abstention(self) -> None:
+        """Retrieval does NOT contain answer AND agent abstained -> correct_abstention."""
+        assert (
+            compute_interpretation(
+                retrieval_contains=False,
+                answer_correct=False,
+                is_abstention_hypothesis=True,
+            )
+            == 'correct_abstention'
+        )
+
+    def test_hallucination(self) -> None:
+        """Retrieval does NOT contain answer AND agent answered wrong -> hallucination."""
+        assert (
+            compute_interpretation(
+                retrieval_contains=False,
+                answer_correct=False,
+                is_abstention_hypothesis=False,
+            )
+            == 'hallucination'
+        )
+
+    def test_lucky_guess(self) -> None:
+        """Retrieval does NOT contain answer AND agent answered correctly -> lucky_guess."""
+        assert (
+            compute_interpretation(
+                retrieval_contains=False,
+                answer_correct=True,
+                is_abstention_hypothesis=False,
+            )
+            == 'lucky_guess'
+        )
+
+    def test_correct_abstention_when_also_correct(self) -> None:
+        """Edge case: retrieval missing, answer marked correct, AND abstention.
+
+        This occurs for abstention questions where the agent correctly
+        abstained and retrieval didn't contain the answer. The abstention
+        check fires first: correct_abstention.
+        """
+        result = compute_interpretation(
+            retrieval_contains=False,
+            answer_correct=True,
+            is_abstention_hypothesis=True,
+        )
+        assert result == 'correct_abstention'

--- a/packages/eval/tests/test_longmemeval_loader.py
+++ b/packages/eval/tests/test_longmemeval_loader.py
@@ -1,0 +1,121 @@
+"""Unit tests for the LongMemEval dataset loaders.
+
+These exercise the pure-Python parsing path only — no network, no database,
+no LLM calls. A synthetic fixture mimicking the upstream JSON shape is
+written to a tmp path and loaded through the public loader API.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from memex_eval.external.longmemeval_common import (
+    DATASET_FILENAMES,
+    LongMemEvalCategory,
+    LongMemEvalQuestion,
+    dataset_sha256,
+    load_longmemeval_oracle,
+    load_longmemeval_s,
+)
+
+
+def _make_turn(role: str, content: str, ts: str) -> dict:
+    return {'role': role, 'content': content, 'timestamp': ts}
+
+
+def _make_question(
+    qid: str,
+    category: str,
+    answer: str | None = 'ground-truth',
+) -> dict:
+    return {
+        'question_id': qid,
+        'question_type': category,
+        'question': f'What about {qid}?',
+        'answer': answer,
+        'haystack_sessions': [
+            {
+                'session_id': f'{qid}-s1',
+                'session_date': '2024-01-01T08:00:00+00:00',
+                'turns': [
+                    _make_turn('user', 'Hi.', '2024-01-01T08:00:00+00:00'),
+                    _make_turn('assistant', 'Hello!', '2024-01-01T08:00:10+00:00'),
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture()
+def oracle_fixture_path(tmp_path: Path) -> Path:
+    """Write a synthetic oracle JSON with one question per category + one _abs."""
+    categories = [c.value for c in LongMemEvalCategory]
+    records = [_make_question(f'q-{i:03d}', cat) for i, cat in enumerate(categories)]
+    # Abstention variant
+    records.append(_make_question('q-abs-001_abs', 'temporal-reasoning', answer=None))
+    out = tmp_path / DATASET_FILENAMES['oracle']
+    out.write_text(json.dumps(records))
+    return out
+
+
+def test_load_oracle_returns_questions(oracle_fixture_path: Path) -> None:
+    questions = load_longmemeval_oracle(oracle_fixture_path, allow_unpinned=True)
+    assert len(questions) == 7
+    assert all(isinstance(q, LongMemEvalQuestion) for q in questions)
+    categories = {q.category for q in questions}
+    assert categories == {
+        LongMemEvalCategory.SINGLE_SESSION_USER,
+        LongMemEvalCategory.SINGLE_SESSION_ASSISTANT,
+        LongMemEvalCategory.SINGLE_SESSION_PREFERENCE,
+        LongMemEvalCategory.TEMPORAL_REASONING,
+        LongMemEvalCategory.KNOWLEDGE_UPDATE,
+        LongMemEvalCategory.MULTI_SESSION,
+    }
+
+
+def test_load_oracle_detects_abstention_suffix(oracle_fixture_path: Path) -> None:
+    questions = load_longmemeval_oracle(oracle_fixture_path, allow_unpinned=True)
+    abs_qs = [q for q in questions if q.is_abstention]
+    assert len(abs_qs) == 1
+    assert abs_qs[0].question_id.endswith('_abs')
+    assert abs_qs[0].answer is None
+
+
+def test_load_oracle_parses_turn_timestamps(oracle_fixture_path: Path) -> None:
+    questions = load_longmemeval_oracle(oracle_fixture_path, allow_unpinned=True)
+    q = questions[0]
+    assert q.sessions, 'expected at least one session'
+    turns = q.sessions[0].turns
+    assert len(turns) == 2
+    assert turns[0].timestamp == datetime(2024, 1, 1, 8, 0, 0, tzinfo=timezone.utc)
+    assert turns[1].timestamp == datetime(2024, 1, 1, 8, 0, 10, tzinfo=timezone.utc)
+
+
+def test_load_from_directory_path(tmp_path: Path, oracle_fixture_path: Path) -> None:
+    # Passing the containing directory should locate the canonical filename.
+    questions = load_longmemeval_oracle(oracle_fixture_path.parent, allow_unpinned=True)
+    assert len(questions) == 7
+
+
+def test_load_s_variant_missing_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_longmemeval_s(tmp_path)
+
+
+def test_dataset_sha256_is_stable(oracle_fixture_path: Path) -> None:
+    h1 = dataset_sha256(oracle_fixture_path, 'oracle')
+    h2 = dataset_sha256(oracle_fixture_path.parent, 'oracle')
+    assert h1 == h2
+    assert len(h1) == 64
+
+
+def test_unknown_category_raises(tmp_path: Path) -> None:
+    bad = [{'question_id': 'q-bad', 'question_type': 'nonsense', 'question': 'x'}]
+    path = tmp_path / DATASET_FILENAMES['oracle']
+    path.write_text(json.dumps(bad))
+    with pytest.raises(ValueError, match='Unknown LongMemEval category'):
+        load_longmemeval_oracle(path, allow_unpinned=True)

--- a/packages/eval/tests/test_longmemeval_smoke.py
+++ b/packages/eval/tests/test_longmemeval_smoke.py
@@ -1,0 +1,344 @@
+"""Smoke test for the LongMemEval pipeline.
+
+Exercises judge + report end-to-end against a synthetic dataset using the
+cached-judge fixture so the test runs offline. Validates pipeline shape
+(file layout, JSON schema), not answer quality.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from unittest.mock import patch
+
+from memex_eval.external.longmemeval_common import (
+    DATASET_FILENAMES,
+    LongMemEvalCategory,
+    LongMemEvalJudgment,
+    LongMemEvalReport,
+    append_jsonl,
+)
+from memex_eval.external.longmemeval_judge import judge_hypotheses
+from memex_eval.external.longmemeval_report import aggregate_for_test, generate_report
+
+FIXTURE_CACHE = Path(__file__).parent / 'fixtures' / 'longmemeval_smoke_cache.json'
+
+
+def _write_synthetic_dataset(tmp_path: Path) -> Path:
+    """Write a synthetic dataset matching the smoke cache question_ids."""
+    records = [
+        {
+            'question_id': 'smoke-q-001',
+            'question_type': 'single-session-user',
+            'question': 'What did the user say first?',
+            'answer': 'Hello.',
+            'haystack_sessions': [],
+        },
+        {
+            'question_id': 'smoke-q-002',
+            'question_type': 'multi-session',
+            'question': 'When was the meeting scheduled?',
+            'answer': 'Tuesday at 3pm.',
+            'haystack_sessions': [],
+        },
+        {
+            'question_id': 'smoke-q-003',
+            'question_type': 'temporal-reasoning',
+            'question': 'How long ago was that?',
+            'answer': 'Two weeks ago.',
+            'haystack_sessions': [],
+        },
+        {
+            'question_id': 'smoke-q-004_abs',
+            'question_type': 'knowledge-update',
+            'question': "What is the user's middle name?",
+            'answer': None,
+            'haystack_sessions': [],
+        },
+        {
+            'question_id': 'smoke-q-005',
+            'question_type': 'single-session-preference',
+            'question': 'What does the user prefer?',
+            'answer': 'Tea over coffee.',
+            'haystack_sessions': [],
+        },
+    ]
+    p = tmp_path / DATASET_FILENAMES['oracle']
+    p.write_text(json.dumps(records))
+    return p
+
+
+def _write_hypotheses(path: Path) -> None:
+    rows = [
+        {'question_id': 'smoke-q-001', 'hypothesis': 'Hello.'},
+        {'question_id': 'smoke-q-002', 'hypothesis': 'Tuesday at 3pm.'},
+        {'question_id': 'smoke-q-003', 'hypothesis': 'A while back.'},
+        {
+            'question_id': 'smoke-q-004_abs',
+            'hypothesis': 'I do not know based on the available memory.',
+        },
+        {'question_id': 'smoke-q-005', 'hypothesis': 'Tea over coffee.'},
+    ]
+    for r in rows:
+        append_jsonl(path, r)
+
+
+@pytest.mark.asyncio
+async def test_smoke_judge_then_report(tmp_path: Path) -> None:
+    dataset = _write_synthetic_dataset(tmp_path)
+    hypotheses = tmp_path / 'hypotheses.jsonl'
+    judgments = tmp_path / 'judgments.jsonl'
+    _write_hypotheses(hypotheses)
+
+    written = await judge_hypotheses(
+        dataset_path=str(dataset),
+        variant='oracle',
+        hypotheses_path=str(hypotheses),
+        output_path=str(judgments),
+        cache_path=str(FIXTURE_CACHE),
+        allow_unpinned_checksum=True,
+    )
+    assert written == 5
+
+    # Validate the JSONL shape.
+    records = [json.loads(line) for line in judgments.read_text().splitlines() if line]
+    assert len(records) == 5
+    parsed = [LongMemEvalJudgment(**r) for r in records]
+    assert sum(1 for p in parsed if p.correct) == 4
+
+    # Generate and validate the report.
+    out_dir = tmp_path / 'report'
+    md_path = generate_report(
+        judgments_path=str(judgments),
+        output_dir=str(out_dir),
+        run_id='smoke',
+        variant='oracle',
+        dataset_path=str(dataset),
+    )
+    assert Path(md_path).exists()
+    results = json.loads((out_dir / 'results.json').read_text())
+    report = LongMemEvalReport(**results)
+    assert report.total_questions == 5
+    assert 0.0 <= report.overall_accuracy <= 1.0
+    assert report.overall_accuracy == 0.8
+    assert report.dataset_sha256 != ''
+
+
+def _write_dataset_with_live_session(tmp_path: Path) -> Path:
+    """Synthetic dataset where smoke-q-002 carries a real session so the
+    ingest/answer formatting paths are exercised end-to-end, not just the
+    report glue."""
+    records = [
+        {
+            'question_id': 'smoke-q-002',
+            'question_type': 'multi-session',
+            'question': 'When was the meeting scheduled?',
+            'answer': 'Tuesday at 3pm.',
+            'haystack_sessions': [
+                {
+                    'session_id': 'sess-1',
+                    'session_date': '2024-02-01T10:00:00+00:00',
+                    'turns': [
+                        {
+                            'role': 'user',
+                            'content': 'Schedule the meeting for Tuesday at 3pm.',
+                            'timestamp': '2024-02-01T10:00:00+00:00',
+                        },
+                        {
+                            'role': 'assistant',
+                            'content': 'Meeting scheduled for Tuesday 3pm.',
+                            'timestamp': '2024-02-01T10:00:05+00:00',
+                        },
+                    ],
+                }
+            ],
+        },
+    ]
+    p = tmp_path / DATASET_FILENAMES['oracle']
+    p.write_text(json.dumps(records))
+    return p
+
+
+class _FlipJudge:
+    """Test double for ``Judge`` that returns a verdict driven by the
+    hypothesis content — NOT the question_id — so the discriminator test
+    observes different metrics when a hypothesis changes.
+    """
+
+    class _LM:
+        model = 'flipjudge-lm'
+
+    def __init__(self, model: str | None = None) -> None:
+        self.lm = self._LM()
+
+    def judge_correctness(self, question: str, expected: str, response: str) -> tuple[bool, str]:
+        # Trivial content-sensitive rule: mark correct iff the expected
+        # answer appears verbatim in the response (case-insensitive).
+        ok = expected.lower().strip('.') in response.lower()
+        return ok, f'flipjudge: expected-in-response={ok}'
+
+    def judge_abstention_correctness(self, question: str, response: str) -> tuple[bool, str]:
+        # Correct iff response explicitly abstains.
+        ok = 'do not know' in response.lower() or "don't know" in response.lower()
+        return ok, f'flipjudge abstention: {ok}'
+
+    def classify_abstention(self, response: str) -> tuple[bool, str]:
+        ok = 'do not know' in response.lower() or "don't know" in response.lower()
+        return ok, 'flipjudge classifier'
+
+
+@pytest.mark.asyncio
+async def test_smoke_discriminator_flipping_hypothesis_changes_metrics(tmp_path: Path) -> None:
+    """Drive the judge against a ``_FlipJudge`` LM (NOT the cache) and
+    verify that flipping one hypothesis flips the overall accuracy. The
+    pre-existing smoke test could not catch this because the fixture
+    cache keyed on question_id, not hypothesis content.
+    """
+    dataset = _write_synthetic_dataset(tmp_path)
+
+    # Round 1: hypotheses all match expected answers verbatim.
+    hypotheses_a = tmp_path / 'hypotheses-a.jsonl'
+    judgments_a = tmp_path / 'judgments-a.jsonl'
+    for row in [
+        {'question_id': 'smoke-q-001', 'hypothesis': 'Hello.'},
+        {'question_id': 'smoke-q-002', 'hypothesis': 'Tuesday at 3pm.'},
+        {'question_id': 'smoke-q-003', 'hypothesis': 'Two weeks ago.'},
+        {
+            'question_id': 'smoke-q-004_abs',
+            'hypothesis': 'I do not know based on the available memory.',
+        },
+        {'question_id': 'smoke-q-005', 'hypothesis': 'Tea over coffee.'},
+    ]:
+        append_jsonl(hypotheses_a, row)
+
+    # Round 2: hypothesis for smoke-q-003 is flipped to something wrong.
+    hypotheses_b = tmp_path / 'hypotheses-b.jsonl'
+    judgments_b = tmp_path / 'judgments-b.jsonl'
+    for row in [
+        {'question_id': 'smoke-q-001', 'hypothesis': 'Hello.'},
+        {'question_id': 'smoke-q-002', 'hypothesis': 'Tuesday at 3pm.'},
+        {'question_id': 'smoke-q-003', 'hypothesis': 'Fish on Fridays.'},
+        {
+            'question_id': 'smoke-q-004_abs',
+            'hypothesis': 'I do not know based on the available memory.',
+        },
+        {'question_id': 'smoke-q-005', 'hypothesis': 'Tea over coffee.'},
+    ]:
+        append_jsonl(hypotheses_b, row)
+
+    # Patch the Judge class used inside longmemeval_judge (not the cache).
+    with patch('memex_eval.external.longmemeval_judge.Judge', _FlipJudge):
+        await judge_hypotheses(
+            dataset_path=str(dataset),
+            variant='oracle',
+            hypotheses_path=str(hypotheses_a),
+            output_path=str(judgments_a),
+            cache_path=None,  # force LM path
+            allow_unpinned_checksum=True,
+        )
+        await judge_hypotheses(
+            dataset_path=str(dataset),
+            variant='oracle',
+            hypotheses_path=str(hypotheses_b),
+            output_path=str(judgments_b),
+            cache_path=None,
+            allow_unpinned_checksum=True,
+        )
+
+    rows_a = [
+        LongMemEvalJudgment(**json.loads(line))
+        for line in judgments_a.read_text().splitlines()
+        if line
+    ]
+    rows_b = [
+        LongMemEvalJudgment(**json.loads(line))
+        for line in judgments_b.read_text().splitlines()
+        if line
+    ]
+
+    # Every judgment has ``is_abstention_hypothesis`` populated.
+    assert all(hasattr(r, 'is_abstention_hypothesis') for r in rows_a + rows_b)
+
+    correct_a = sum(1 for r in rows_a if r.correct)
+    correct_b = sum(1 for r in rows_b if r.correct)
+    assert correct_a == 5  # all match
+    assert correct_b == 4  # smoke-q-003 fails under the flip
+    assert correct_a != correct_b  # the discriminator actually discriminates
+
+    # And the abstention classifier ran for every hypothesis — including
+    # non-abstention ones — so the field is populated for both classes.
+    non_abs = [r for r in rows_a if not r.is_abstention]
+    abs_ = [r for r in rows_a if r.is_abstention]
+    assert any(r.is_abstention_hypothesis for r in abs_)
+    assert all(not r.is_abstention_hypothesis for r in non_abs)
+
+
+def test_smoke_dataset_with_live_session_parses(tmp_path: Path) -> None:
+    """A non-empty session round-trips through the dataset loader with
+    turns and timestamps intact, and through ``build_note_payloads`` so
+    the ingest formatter path is exercised end-to-end."""
+    import base64
+
+    from memex_eval.external.longmemeval_common import load_longmemeval_oracle
+    from memex_eval.external.longmemeval_ingest import build_note_payloads
+
+    path = _write_dataset_with_live_session(tmp_path)
+    questions = load_longmemeval_oracle(path, allow_unpinned=True)
+    assert len(questions) == 1
+    q = questions[0]
+    assert len(q.sessions) == 1
+    assert len(q.sessions[0].turns) == 2
+    assert q.sessions[0].turns[0].content.startswith('Schedule')
+
+    # Drive the ingest note-builder against the live session — this is
+    # the authored code path the smoke test previously failed to
+    # exercise (pre-M6 it used an in-process answer formatter; post-M6
+    # the subagent does formatting, so ingest is the real check).
+    payloads = build_note_payloads(q, variant='oracle', vault_id='v-1')
+    assert len(payloads) == 1
+    md = base64.b64decode(payloads[0].content).decode('utf-8')
+    assert 'Schedule the meeting for Tuesday at 3pm.' in md
+    assert 'publish_date: 2024-02-01T10:00:00+00:00' in md
+
+
+def test_aggregate_per_category() -> None:
+    judgments = [
+        LongMemEvalJudgment(
+            question_id='a',
+            category=LongMemEvalCategory.MULTI_SESSION,
+            is_abstention=False,
+            hypothesis='x',
+            expected='x',
+            correct=True,
+            judge_reasoning='ok',
+            judge_model_fingerprint='test',
+        ),
+        LongMemEvalJudgment(
+            question_id='b',
+            category=LongMemEvalCategory.MULTI_SESSION,
+            is_abstention=False,
+            hypothesis='x',
+            expected='y',
+            correct=False,
+            judge_reasoning='ok',
+            judge_model_fingerprint='test',
+        ),
+        LongMemEvalJudgment(
+            question_id='c_abs',
+            category=LongMemEvalCategory.KNOWLEDGE_UPDATE,
+            is_abstention=True,
+            hypothesis='I do not know based on the available memory.',
+            expected=None,
+            correct=True,
+            judge_reasoning='ok',
+            judge_model_fingerprint='test',
+            is_abstention_hypothesis=True,
+        ),
+    ]
+    agg = aggregate_for_test(judgments)
+    assert agg['overall_accuracy'] == round(2 / 3, 4)
+    assert agg['abstention_recall'] == 1.0
+    assert agg['abstention_precision'] == 1.0

--- a/packages/eval/tests/test_longmemeval_trace_parser.py
+++ b/packages/eval/tests/test_longmemeval_trace_parser.py
@@ -1,0 +1,560 @@
+"""Tests for LongMemEval trace parser and retrieval recall computation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+from memex_eval.external.longmemeval_trace_parser import (
+    RecallMetrics,
+    TraceAnalysis,
+    ToolCall,
+    _session_id_from_note_title,
+    compute_batch_recall,
+    compute_recall,
+    extract_retrieval_content,
+    format_question_breakdown,
+    parse_trace,
+    parse_traces_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_trace_jsonl(
+    tool_calls: list[dict],
+    tool_results: dict[str, str],
+) -> str:
+    """Build a minimal Claude Code session trace JSONL string.
+
+    Args:
+        tool_calls: List of {name, id, input} dicts for assistant tool_use blocks.
+        tool_results: Mapping of tool_use_id -> result content string.
+    """
+    lines: list[str] = []
+
+    # Assistant message with tool_use blocks
+    assistant_msg = {
+        'type': 'assistant',
+        'message': {
+            'content': [
+                {
+                    'type': 'tool_use',
+                    'name': tc['name'],
+                    'id': tc['id'],
+                    'input': tc.get('input', {}),
+                }
+                for tc in tool_calls
+            ]
+        },
+    }
+    lines.append(json.dumps(assistant_msg))
+
+    # User message with tool_result blocks
+    user_msg = {
+        'type': 'user',
+        'message': {
+            'content': [
+                {
+                    'type': 'tool_result',
+                    'tool_use_id': tid,
+                    'content': content,
+                }
+                for tid, content in tool_results.items()
+            ]
+        },
+    }
+    lines.append(json.dumps(user_msg))
+
+    return '\n'.join(lines)
+
+
+def _make_memory_search_result(note_ids_titles: list[tuple[str, str]]) -> str:
+    """Build a memory_search result JSON string."""
+    results = []
+    for nid, ntitle in note_ids_titles:
+        results.append(
+            {
+                'id': f'unit-{nid[:8]}',
+                'text': 'Some fact.',
+                'note_id': nid,
+                'note_title': ntitle,
+            }
+        )
+    return json.dumps({'result': results})
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: session ID extraction
+# ---------------------------------------------------------------------------
+
+
+def test_session_id_from_note_title_standard() -> None:
+    assert _session_id_from_note_title('e47becba \u2014 answer_280352e9') == 'answer_280352e9'
+
+
+def test_session_id_from_note_title_complex() -> None:
+    assert _session_id_from_note_title('abc123 \u2014 sharegpt_yywfIrx_0') == 'sharegpt_yywfIrx_0'
+
+
+def test_session_id_from_note_title_no_match() -> None:
+    assert _session_id_from_note_title('just a plain title') is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: trace parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_trace_empty_file(tmp_path: Path) -> None:
+    trace_file = tmp_path / 'empty.jsonl'
+    trace_file.write_text('')
+    result = parse_trace(trace_file)
+    assert result.question_id == 'empty'
+    assert result.calls_by_tool == {}
+
+
+def test_parse_trace_single_memory_search(tmp_path: Path) -> None:
+    content = _make_trace_jsonl(
+        tool_calls=[
+            {
+                'name': 'mcp__memex__memex_memory_search',
+                'id': 'call-1',
+                'input': {'query': 'test'},
+            },
+        ],
+        tool_results={
+            'call-1': _make_memory_search_result(
+                [
+                    ('note-aaa', 'q1 \u2014 session_a'),
+                    ('note-bbb', 'q1 \u2014 session_b'),
+                ]
+            ),
+        },
+    )
+    trace_file = tmp_path / 'q1.jsonl'
+    trace_file.write_text(content)
+
+    result = parse_trace(trace_file)
+    assert result.question_id == 'q1'
+    calls = result.calls_by_tool.get('mcp__memex__memex_memory_search', [])
+    assert len(calls) == 1
+    assert len(calls[0].result_note_ids) == 2
+    assert 'note-aaa' in calls[0].result_note_ids
+    assert calls[0].result_unit_count == 2
+
+
+def test_parse_trace_caps_at_3(tmp_path: Path) -> None:
+    """Verify that capped_calls returns at most 3."""
+    call_specs: list[tuple[str, str]] = []
+    tool_results: dict[str, str] = {}
+    for i in range(5):
+        tid = f'call-{i}'
+        call_specs.append((tid, f'q{i}'))
+        tool_results[tid] = _make_memory_search_result(
+            [
+                (f'note-{i}', f'q1 \u2014 session_{i}'),
+            ]
+        )
+
+    # Build trace with multiple assistant messages
+    lines: list[str] = []
+    for tid, query in call_specs:
+        lines.append(
+            json.dumps(
+                {
+                    'type': 'assistant',
+                    'message': {
+                        'content': [
+                            {
+                                'type': 'tool_use',
+                                'name': 'mcp__memex__memex_memory_search',
+                                'id': tid,
+                                'input': {'query': query},
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+        lines.append(
+            json.dumps(
+                {
+                    'type': 'user',
+                    'message': {
+                        'content': [
+                            {
+                                'type': 'tool_result',
+                                'tool_use_id': tid,
+                                'content': tool_results[tid],
+                            }
+                        ],
+                    },
+                }
+            )
+        )
+
+    trace_file = tmp_path / 'q1.jsonl'
+    trace_file.write_text('\n'.join(lines))
+
+    result = parse_trace(trace_file)
+    all_calls = result.calls_by_tool['mcp__memex__memex_memory_search']
+    assert len(all_calls) == 5
+    capped = result.capped_calls('mcp__memex__memex_memory_search')
+    assert len(capped) == 3
+
+
+def test_parse_trace_ignores_non_retrieval_tools(tmp_path: Path) -> None:
+    content = _make_trace_jsonl(
+        tool_calls=[
+            {
+                'name': 'mcp__memex__memex_get_page_indices',
+                'id': 'call-1',
+                'input': {},
+            },
+        ],
+        tool_results={
+            'call-1': json.dumps({'result': []}),
+        },
+    )
+    trace_file = tmp_path / 'q1.jsonl'
+    trace_file.write_text(content)
+
+    result = parse_trace(trace_file)
+    assert result.calls_by_tool == {}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: recall computation
+# ---------------------------------------------------------------------------
+
+
+def test_compute_recall_full_hit() -> None:
+    trace = TraceAnalysis(
+        question_id='q1',
+        calls_by_tool={
+            'mcp__memex__memex_memory_search': [
+                ToolCall(
+                    tool_name='mcp__memex__memex_memory_search',
+                    tool_use_id='c1',
+                    result_note_ids=['n1'],
+                    result_note_titles=['q1 \u2014 answer_abc'],
+                    result_unit_count=1,
+                ),
+            ],
+        },
+    )
+    metrics = compute_recall(trace, ['answer_abc'], category='single-session-user')
+    assert metrics.recall == 1.0
+    assert metrics.found_session_ids == ['answer_abc']
+
+
+def test_compute_recall_partial_hit() -> None:
+    trace = TraceAnalysis(
+        question_id='q2',
+        calls_by_tool={
+            'mcp__memex__memex_memory_search': [
+                ToolCall(
+                    tool_name='mcp__memex__memex_memory_search',
+                    tool_use_id='c1',
+                    result_note_ids=['n1'],
+                    result_note_titles=['q2 \u2014 session_a'],
+                    result_unit_count=1,
+                ),
+            ],
+        },
+    )
+    metrics = compute_recall(trace, ['session_a', 'session_b'])
+    assert metrics.recall == 0.5
+    assert 'session_a' in metrics.found_session_ids
+    assert 'session_b' not in metrics.found_session_ids
+
+
+def test_compute_recall_no_gold() -> None:
+    trace = TraceAnalysis(question_id='q3', calls_by_tool={})
+    metrics = compute_recall(trace, [])
+    assert metrics.recall == 1.0
+
+
+def test_compute_recall_miss() -> None:
+    trace = TraceAnalysis(
+        question_id='q4',
+        calls_by_tool={
+            'mcp__memex__memex_memory_search': [
+                ToolCall(
+                    tool_name='mcp__memex__memex_memory_search',
+                    tool_use_id='c1',
+                    result_note_ids=['n1'],
+                    result_note_titles=['q4 \u2014 wrong_session'],
+                    result_unit_count=1,
+                ),
+            ],
+        },
+    )
+    metrics = compute_recall(trace, ['correct_session'])
+    assert metrics.recall == 0.0
+    assert metrics.found_session_ids == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: batch recall
+# ---------------------------------------------------------------------------
+
+
+def test_compute_batch_recall() -> None:
+    traces = [
+        TraceAnalysis(
+            question_id='q1',
+            calls_by_tool={
+                'mcp__memex__memex_memory_search': [
+                    ToolCall(
+                        tool_name='mcp__memex__memex_memory_search',
+                        tool_use_id='c1',
+                        result_note_ids=['n1'],
+                        result_note_titles=['q1 \u2014 s1'],
+                        result_unit_count=1,
+                    ),
+                ],
+            },
+        ),
+        TraceAnalysis(
+            question_id='q2',
+            calls_by_tool={},
+        ),
+    ]
+    gold_map = {'q1': ['s1'], 'q2': ['s2']}
+    results = compute_batch_recall(traces, gold_map)
+    assert len(results) == 2
+    assert results[0].recall == 1.0
+    assert results[1].recall == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_question_breakdown_with_metrics() -> None:
+    trace = TraceAnalysis(
+        question_id='q1',
+        calls_by_tool={
+            'mcp__memex__memex_memory_search': [
+                ToolCall(
+                    tool_name='mcp__memex__memex_memory_search',
+                    tool_use_id='c1',
+                    result_note_ids=['note-aaa'],
+                    result_note_titles=['q1 \u2014 s1'],
+                    result_unit_count=3,
+                ),
+            ],
+        },
+    )
+    metrics = RecallMetrics(
+        question_id='q1',
+        category='single-session-user',
+        gold_session_ids=['s1'],
+        found_session_ids=['s1'],
+        recall=1.0,
+    )
+    output = format_question_breakdown(trace, metrics)
+    assert 'Question q1 (single-session-user)' in output
+    assert 'memory_search (1/1 calls used for recall)' in output
+    assert 'Recall@3: 1/1 gold sessions found (1.000)' in output
+
+
+def test_format_question_breakdown_no_metrics() -> None:
+    trace = TraceAnalysis(question_id='q2', calls_by_tool={})
+    output = format_question_breakdown(trace, None)
+    assert 'Question q2' in output
+    assert 'no gold session IDs' in output
+
+
+# ---------------------------------------------------------------------------
+# Integration: parse_traces_dir
+# ---------------------------------------------------------------------------
+
+
+def test_parse_traces_dir(tmp_path: Path) -> None:
+    # Create two trace files
+    for qid in ('q1', 'q2'):
+        content = _make_trace_jsonl(
+            tool_calls=[
+                {
+                    'name': 'mcp__memex__memex_memory_search',
+                    'id': f'call-{qid}',
+                    'input': {'query': 'test'},
+                },
+            ],
+            tool_results={
+                f'call-{qid}': _make_memory_search_result(
+                    [
+                        (f'note-{qid}', f'{qid} \u2014 sid_{qid}'),
+                    ]
+                ),
+            },
+        )
+        (tmp_path / f'{qid}.jsonl').write_text(content)
+
+    traces = parse_traces_dir(tmp_path)
+    assert len(traces) == 2
+    assert traces[0].question_id == 'q1'
+    assert traces[1].question_id == 'q2'
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: extract_retrieval_content
+# ---------------------------------------------------------------------------
+
+
+def test_extract_retrieval_content_basic(tmp_path: Path) -> None:
+    """Extracts text from memex tool results in a trace."""
+    content = _make_trace_jsonl(
+        tool_calls=[
+            {
+                'name': 'mcp__memex__memex_memory_search',
+                'id': 'call-1',
+                'input': {'query': 'test'},
+            },
+        ],
+        tool_results={
+            'call-1': _make_memory_search_result(
+                [
+                    ('note-aaa', 'q1 — session_a'),
+                ]
+            ),
+        },
+    )
+    trace_file = tmp_path / 'q1.jsonl'
+    trace_file.write_text(content)
+
+    result = extract_retrieval_content(trace_file)
+    assert 'note-aaa' in result or 'Some fact.' in result
+    assert result.strip() != ''
+
+
+def test_extract_retrieval_content_multiple_tools(tmp_path: Path) -> None:
+    """Extracts content from multiple memex tool results."""
+    lines: list[str] = []
+
+    # First tool call: memory_search
+    lines.append(
+        json.dumps(
+            {
+                'type': 'assistant',
+                'message': {
+                    'content': [
+                        {
+                            'type': 'tool_use',
+                            'name': 'mcp__memex__memex_memory_search',
+                            'id': 'call-1',
+                            'input': {'query': 'test'},
+                        }
+                    ]
+                },
+            }
+        )
+    )
+    lines.append(
+        json.dumps(
+            {
+                'type': 'user',
+                'message': {
+                    'content': [
+                        {
+                            'type': 'tool_result',
+                            'tool_use_id': 'call-1',
+                            'content': json.dumps(
+                                {'result': [{'text': 'First fact.', 'note_id': 'n1'}]}
+                            ),
+                        }
+                    ]
+                },
+            }
+        )
+    )
+
+    # Second tool call: note_search
+    lines.append(
+        json.dumps(
+            {
+                'type': 'assistant',
+                'message': {
+                    'content': [
+                        {
+                            'type': 'tool_use',
+                            'name': 'mcp__memex__memex_note_search',
+                            'id': 'call-2',
+                            'input': {'query': 'another'},
+                        }
+                    ]
+                },
+            }
+        )
+    )
+    lines.append(
+        json.dumps(
+            {
+                'type': 'user',
+                'message': {
+                    'content': [
+                        {
+                            'type': 'tool_result',
+                            'tool_use_id': 'call-2',
+                            'content': json.dumps(
+                                {'result': [{'text': 'Second fact.', 'note_id': 'n2'}]}
+                            ),
+                        }
+                    ]
+                },
+            }
+        )
+    )
+
+    trace_file = tmp_path / 'q1.jsonl'
+    trace_file.write_text('\n'.join(lines))
+
+    result = extract_retrieval_content(trace_file)
+    assert 'First fact.' in result
+    assert 'Second fact.' in result
+    # Separator between tool results
+    assert '---' in result
+
+
+def test_extract_retrieval_content_ignores_non_memex(tmp_path: Path) -> None:
+    """Non-memex tool results are not included."""
+    content = _make_trace_jsonl(
+        tool_calls=[
+            {
+                'name': 'some_other_tool',
+                'id': 'call-1',
+                'input': {},
+            },
+        ],
+        tool_results={
+            'call-1': 'Some non-memex result',
+        },
+    )
+    trace_file = tmp_path / 'q1.jsonl'
+    trace_file.write_text(content)
+
+    result = extract_retrieval_content(trace_file)
+    assert result == ''
+
+
+def test_extract_retrieval_content_empty_trace(tmp_path: Path) -> None:
+    """Empty trace file returns empty string."""
+    trace_file = tmp_path / 'empty.jsonl'
+    trace_file.write_text('')
+
+    result = extract_retrieval_content(trace_file)
+    assert result == ''
+
+
+def test_extract_retrieval_content_missing_file(tmp_path: Path) -> None:
+    """Missing trace file returns empty string."""
+    result = extract_retrieval_content(tmp_path / 'missing.jsonl')
+    assert result == ''


### PR DESCRIPTION
## Summary

- Ports LongMemEval as a **complementary** external benchmark alongside the existing LoCoMo benchmark (not replacing it)
- Extracts 8 source modules + 13 test files + fixture from the `feat/links-endpoint-and-filtering` branch
- Adds 7 new CLI subcommands under `memex-eval longmemeval` (ingest, answer, judge, report, compare, parse-trace, run)
- Adds 2 new dspy judge signatures (AbstentionCorrectness, AbstentionClassifier) + methods for LongMemEval abstention metrics
- Removes pandas dependency — seaborn plots use a dict-of-lists helper (`_to_seaborn_data`) instead of `pd.DataFrame`
- All 166 tests passing (69 original + 97 new)

## Test plan

- [x] `uv run pytest packages/eval -v` — 166 passed, 1 xfailed
- [x] `grep -ri locomo packages/eval/` — 0 removals, 3 additions (port attribution comments only)
- [x] `memex-eval --help` shows both `locomo-*` and `longmemeval` command groups
- [x] `ruff check` + `ruff format` clean
- [x] Pre-commit hooks (mypy, ruff, ruff-format, test count badge) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)