### PR TITLE
fix(hermes-plugin): stop session notes from overwriting themselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,552%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,069%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,069%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,070%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -17,18 +17,15 @@ import base64
 import logging
 import os
 import threading
+import time
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
 
-# Hard cap on the in-memory retry queue. If Memex is unreachable for the
-# entire session the queue would otherwise grow with every flush; this bounds
-# the worst case. Beyond the cap, the OLDEST entry is dropped with a warning.
-_PENDING_MAX = 256
-
 import httpx
 from agent.memory_provider import MemoryProvider  # type: ignore[import-not-found]
 from memex_common.asset_cache import SessionAssetCache
+from memex_core.services.notes import derive_note_uuid_from_key
 
 from .async_bridge import run_sync, shutdown_loop
 from .briefing import BriefingCache, format_briefing_block
@@ -40,6 +37,15 @@ from .templates import HERMES_SESSION_TEMPLATE
 from .tools import ALL_SCHEMAS, TOOLS_MODE_SCHEMAS, dispatch
 
 logger = logging.getLogger(__name__)
+
+# Hard cap on the in-memory retry queue: bounds memory if Memex is
+# unreachable for an entire session.
+_PENDING_MAX = 256
+
+# Non-transient HTTP statuses. The append/create will never succeed if
+# resent verbatim, so we drop the failing entry and continue draining the
+# rest of the queue. 5xx, 408, 429, and network errors are transient.
+_NON_TRANSIENT_HTTP_STATUSES: frozenset[int] = frozenset({400, 404, 409, 410, 422})
 
 
 def _resolve_hermes_home(kwargs: dict[str, Any]) -> Path:
@@ -70,24 +76,22 @@ class MemexMemoryProvider(MemoryProvider):
         self._asset_cache: SessionAssetCache | None = None
         self._turn_buffer: list[dict[str, str]] = []
         self._turn_count = 0
-        # Watermark into _turn_buffer: turns at index < _flushed_index have
-        # been captured into the pending queue. Pre-compress and session-end
-        # flush only the slice past the watermark to avoid double-writes.
+        # Watermark: turns at index < _flushed_index were already captured
+        # into _pending. Avoids double-writes across flush boundaries.
         self._flushed_index = 0
-        # First write of the session is an ``ingest`` (creates the note);
-        # subsequent writes are ``append_to_note`` (extend the note body).
-        # Flipped to True under ``_state_lock`` after a successful create.
         self._note_initialized = False
-        # FIFO queue of pending writes. Each entry is a dict:
-        #   {'kind': 'create', 'content': str, 'title': str}
-        #   {'kind': 'append', 'content': str, 'append_id': UUID}
-        # A failed flush leaves its entry at the head; the next flush retries.
-        # Capped at ``_PENDING_MAX`` to bound memory if Memex is unreachable
-        # for the entire session.
+        # FIFO queue of pending writes (create or append). Each entry
+        # snapshots the vault_id at enqueue time so a mid-session vault
+        # rebind doesn't redirect in-flight chunks.
         self._pending: list[dict[str, Any]] = []
         self._shutdown_registered = False
+        self._shutdown_started = False
         self._state_lock = threading.Lock()
         self._atexit_lock = threading.Lock()
+        # Serializes _drain_pending so concurrent flush callers don't
+        # race on the head item. _state_lock alone isn't enough: the
+        # network call happens with _state_lock released.
+        self._drain_lock = threading.Lock()
 
     @property
     def asset_cache(self) -> SessionAssetCache | None:
@@ -379,14 +383,15 @@ class MemexMemoryProvider(MemoryProvider):
     def _refresh_vault_binding(self) -> None:
         """Best-effort re-resolve the active vault.
 
-        Honors mid-session vault rebinds (e.g., the agent calls
-        ``memex_kv_write('project:<id>:vault', ...)`` and the user expects
-        subsequent transcript writes to land in the new vault). Failures are
-        logged at DEBUG and leave the existing vault binding in place — we
-        never fall back to a vault-less write that could land in the wrong
-        place.
+        Once the session note has been created in a vault we hold the
+        binding constant for the rest of the session: appending to the
+        existing note from a different vault would 404 (note_key is
+        vault-scoped) and split the transcript across two notes. Rebinds
+        only take effect for sessions that haven't yet created a note.
         """
         if self._api is None or self._config is None:
+            return
+        if self._note_initialized:
             return
         try:
             new_vault_name = resolve_vault(
@@ -469,7 +474,17 @@ class MemexMemoryProvider(MemoryProvider):
     # -- Shutdown ------------------------------------------------------------
 
     def shutdown(self) -> None:  # type: ignore[override]
-        """Flush pending buffers and close the client."""
+        """Flush pending buffers and close the client.
+
+        Idempotent: the second call observes ``_shutdown_started`` and
+        returns. Concurrent calls (Hermes' shutdown + atexit fallback) are
+        gated by ``_atexit_lock`` so the teardown happens exactly once.
+        """
+        with self._atexit_lock:
+            if self._shutdown_started:
+                return
+            self._shutdown_started = True
+
         if self._api is not None:
             chunk = self._capture_unflushed_buffer_slice()
             if chunk:
@@ -477,8 +492,6 @@ class MemexMemoryProvider(MemoryProvider):
                     self._enqueue_chunk(chunk, title=self._format_session_title())
                 except Exception as e:
                     logger.debug('Shutdown enqueue failed: %s', e)
-            # One last attempt to drain anything queued (including from the
-            # enqueue above) before we close the HTTP client.
             try:
                 self._drain_pending()
             except Exception as e:
@@ -568,96 +581,125 @@ class MemexMemoryProvider(MemoryProvider):
         no other create is pending) is enqueued as a ``create``; everything
         else is an ``append`` with a freshly-minted ``append_id`` for
         idempotent retry semantics.
+
+        Backpressure: at cap we drop the NEW chunk rather than evicting
+        an older one. Older transcript content is more valuable for
+        downstream reflection (it is the part the model has already
+        forgotten), and evicting it silently would re-introduce the
+        original missing-chunks bug under sustained outage.
         """
         if not content.strip():
             return
         with self._state_lock:
+            if len(self._pending) >= _PENDING_MAX:
+                logger.error(
+                    'Pending session-note write queue at cap (%d); dropping new chunk '
+                    '(%d bytes). Investigate: Memex unreachable for the full session?',
+                    _PENDING_MAX,
+                    len(content),
+                )
+                return
             has_pending_create = any(p['kind'] == 'create' for p in self._pending)
+            vault_id = str(self._vault_id) if self._vault_id else None
             if not self._note_initialized and not has_pending_create:
                 entry: dict[str, Any] = {
                     'kind': 'create',
                     'content': content,
                     'title': title,
+                    'vault_id': vault_id,
                 }
             else:
                 entry = {
                     'kind': 'append',
                     'content': content,
                     'append_id': uuid4(),
+                    'vault_id': vault_id,
                 }
             self._pending.append(entry)
-            if len(self._pending) > _PENDING_MAX:
-                # Never drop a pending create — dropping it would orphan
-                # every queued append (the note wouldn't exist server-side
-                # to append onto). Drop the oldest *append* instead.
-                drop_index = 0
-                for i, e in enumerate(self._pending):
-                    if e['kind'] != 'create':
-                        drop_index = i
-                        break
-                dropped = self._pending.pop(drop_index)
-                logger.warning(
-                    'Pending session-note write queue full (%d); dropped %s entry at index %d.',
-                    _PENDING_MAX,
-                    dropped['kind'],
-                    drop_index,
-                )
         self._drain_pending()
 
     def _drain_pending(self) -> None:
-        """Process the pending queue FIFO. Stops at the first failure.
+        """Process the pending queue FIFO.
 
-        Successful items are popped; the failed item stays at head so the
-        next flush retries with the same idempotency token (for appends).
+        Serialized via ``_drain_lock`` so concurrent callers (hooks,
+        atexit, shutdown) take turns instead of racing on the head item.
+        Successful items are popped; transient failures keep the head in
+        place for retry; non-transient failures (4xx HTTP statuses)
+        drop the failing entry so a poisoned item can't block the rest of
+        the queue.
         """
         if self._api is None or self._config is None:
             return
-        while True:
-            with self._state_lock:
-                if not self._pending:
-                    return
-                head = self._pending[0]
-            try:
-                if head['kind'] == 'create':
-                    self._do_create(head['content'], title=head['title'])
-                    # Background ingest queued the row; wait for it to be
-                    # visible before issuing appends, otherwise the next
-                    # append would 404. If the row never appears we leave
-                    # the create queued so the next flush retries.
-                    if not self._wait_for_note_row():
-                        logger.warning(
-                            'Session note row did not appear after ingest; '
-                            'will retry on next flush.',
-                        )
+        if not self._drain_lock.acquire(blocking=False):
+            return  # Another caller is already draining; let them.
+        try:
+            while True:
+                with self._state_lock:
+                    if not self._pending:
                         return
-                    with self._state_lock:
-                        self._note_initialized = True
-                        if self._pending and self._pending[0] is head:
-                            self._pending.pop(0)
-                else:
-                    self._do_append(head['content'], append_id=head['append_id'])
-                    with self._state_lock:
-                        if self._pending and self._pending[0] is head:
-                            self._pending.pop(0)
-            except Exception as e:
-                logger.warning(
-                    'Session note %s failed; will retry on next flush: %s',
-                    head['kind'],
-                    e,
-                )
-                return
+                    head = self._pending[0]
+                try:
+                    if head['kind'] == 'create':
+                        self._do_create(
+                            head['content'],
+                            title=head['title'],
+                            vault_id=head.get('vault_id'),
+                        )
+                        if not self._wait_for_note_row():
+                            logger.warning(
+                                'Session note row did not appear after ingest; '
+                                'will retry on next flush.',
+                            )
+                            return
+                        with self._state_lock:
+                            self._note_initialized = True
+                            if self._pending and self._pending[0] is head:
+                                self._pending.pop(0)
+                    else:
+                        self._do_append(
+                            head['content'],
+                            append_id=head['append_id'],
+                            vault_id=head.get('vault_id'),
+                        )
+                        with self._state_lock:
+                            if self._pending and self._pending[0] is head:
+                                self._pending.pop(0)
+                except httpx.HTTPStatusError as e:
+                    if e.response.status_code in _NON_TRANSIENT_HTTP_STATUSES:
+                        logger.error(
+                            'Session note %s rejected (HTTP %d); dropping entry: %s',
+                            head['kind'],
+                            e.response.status_code,
+                            e,
+                        )
+                        with self._state_lock:
+                            if self._pending and self._pending[0] is head:
+                                self._pending.pop(0)
+                        continue
+                    logger.warning(
+                        'Session note %s transient error (HTTP %d); will retry: %s',
+                        head['kind'],
+                        e.response.status_code,
+                        e,
+                    )
+                    return
+                except Exception as e:
+                    logger.warning(
+                        'Session note %s failed; will retry on next flush: %s',
+                        head['kind'],
+                        e,
+                    )
+                    return
+        finally:
+            self._drain_lock.release()
 
-    def _do_create(self, content: str, *, title: str) -> None:
+    def _do_create(self, content: str, *, title: str, vault_id: str | None) -> None:
         """Create the session note via ``api.ingest``. May raise.
 
-        Uses ``background=True`` so the LLM-bound extraction phase runs
-        asynchronously server-side and the call returns quickly. The note
-        row itself is inserted as part of the same transaction that the
-        background job opens, so by the time we issue the next
-        ``append_to_note`` (which takes a row lock by ``note_key``), the
-        row exists. ``_drain_pending`` calls ``_wait_for_note_row`` after
-        a successful create to confirm the row is visible before we fire
-        any appends — without that gate the next append could 404.
+        Uses ``background=True`` so the LLM extraction phase runs
+        asynchronously server-side. ``_drain_pending`` calls
+        ``_wait_for_note_row`` afterwards to confirm the row is visible
+        before issuing appends.
         """
         assert self._api is not None and self._config is not None
         from memex_common.schemas import NoteCreateDTO
@@ -667,7 +709,7 @@ class MemexMemoryProvider(MemoryProvider):
             description=f'Hermes session transcript ({self._session_id})',
             content=base64.b64encode(content.encode('utf-8')),
             note_key=self._session_note_key,
-            vault_id=str(self._vault_id) if self._vault_id else None,
+            vault_id=vault_id,
             tags=['hermes', self._agent_identity] if self._agent_identity else ['hermes'],
             author='hermes',
             template=self._config.retain.session_template or HERMES_SESSION_TEMPLATE,
@@ -677,39 +719,40 @@ class MemexMemoryProvider(MemoryProvider):
     def _wait_for_note_row(self, *, timeout: float = 10.0) -> bool:
         """Poll for the session note row to appear server-side.
 
-        Returns True if the row is visible, False on timeout. Called after
-        a successful background ingest to gate subsequent appends. The
-        ``derive_note_uuid_from_key`` is deterministic, so we know the id
-        before the row exists.
+        Returns True if the row is visible, False on timeout. The id is
+        deterministic from ``note_key`` so we can poll before the server
+        finishes the background insert. 404 means "not yet"; any other
+        exception is also treated as "not yet" — the caller will leave
+        the create queued for the next flush to retry.
         """
         if self._api is None:
             return False
-        from memex_core.services.notes import derive_note_uuid_from_key
-
         note_id = derive_note_uuid_from_key(self._session_note_key)
-        import time
-
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
-                run_sync(self._api.get_note(note_id), timeout=2.0)
+                run_sync(self._api.get_note(note_id), timeout=1.0)
                 return True
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code != 404:
+                    return False  # unexpected — let the caller surface
+                time.sleep(0.1)
             except Exception:
                 time.sleep(0.1)
         return False
 
-    def _do_append(self, content: str, *, append_id: UUID) -> None:
+    def _do_append(self, content: str, *, append_id: UUID, vault_id: str | None) -> None:
         """Append a delta to the existing session note. May raise.
 
-        Idempotent on ``append_id``: the server replays a cached outcome if
-        the same id was previously processed, so retries are safe.
+        Idempotent on ``append_id``: the server replays a cached outcome
+        if the same id was previously processed, so retries are safe.
         """
         assert self._api is not None
         from memex_common.schemas import NoteAppendRequest
 
         request = NoteAppendRequest(
             note_key=self._session_note_key,
-            vault_id=str(self._vault_id) if self._vault_id else None,
+            vault_id=vault_id,
             delta=content,
             append_id=append_id,
             joiner='paragraph',

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -19,7 +19,12 @@ import os
 import threading
 from pathlib import Path
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
+
+# Hard cap on the in-memory retry queue. If Memex is unreachable for the
+# entire session the queue would otherwise grow with every flush; this bounds
+# the worst case. Beyond the cap, the OLDEST entry is dropped with a warning.
+_PENDING_MAX = 256
 
 import httpx
 from agent.memory_provider import MemoryProvider  # type: ignore[import-not-found]
@@ -65,6 +70,21 @@ class MemexMemoryProvider(MemoryProvider):
         self._asset_cache: SessionAssetCache | None = None
         self._turn_buffer: list[dict[str, str]] = []
         self._turn_count = 0
+        # Watermark into _turn_buffer: turns at index < _flushed_index have
+        # been captured into the pending queue. Pre-compress and session-end
+        # flush only the slice past the watermark to avoid double-writes.
+        self._flushed_index = 0
+        # First write of the session is an ``ingest`` (creates the note);
+        # subsequent writes are ``append_to_note`` (extend the note body).
+        # Flipped to True under ``_state_lock`` after a successful create.
+        self._note_initialized = False
+        # FIFO queue of pending writes. Each entry is a dict:
+        #   {'kind': 'create', 'content': str, 'title': str}
+        #   {'kind': 'append', 'content': str, 'append_id': UUID}
+        # A failed flush leaves its entry at the head; the next flush retries.
+        # Capped at ``_PENDING_MAX`` to bound memory if Memex is unreachable
+        # for the entire session.
+        self._pending: list[dict[str, Any]] = []
         self._shutdown_registered = False
         self._state_lock = threading.Lock()
         self._atexit_lock = threading.Lock()
@@ -354,31 +374,74 @@ class MemexMemoryProvider(MemoryProvider):
                 budget=self._config.briefing_budget,
                 project_id=self._project_id,
             )
+            self._refresh_vault_binding()
+
+    def _refresh_vault_binding(self) -> None:
+        """Best-effort re-resolve the active vault.
+
+        Honors mid-session vault rebinds (e.g., the agent calls
+        ``memex_kv_write('project:<id>:vault', ...)`` and the user expects
+        subsequent transcript writes to land in the new vault). Failures are
+        logged at DEBUG and leave the existing vault binding in place — we
+        never fall back to a vault-less write that could land in the wrong
+        place.
+        """
+        if self._api is None or self._config is None:
+            return
+        try:
+            new_vault_name = resolve_vault(
+                self._api,
+                project_id=self._project_id,
+                agent_identity=self._agent_identity or None,
+                user_id=self._user_id,
+                config_vault=self._config.vault_id,
+            )
+        except Exception as e:
+            logger.debug('Vault re-resolution failed: %s', e)
+            return
+        if not new_vault_name or new_vault_name == self._vault_name:
+            return
+        new_vault_id = self._resolve_or_create_vault_id(new_vault_name)
+        if new_vault_id is None:
+            return
+        with self._state_lock:
+            self._vault_name = new_vault_name
+            self._vault_id = new_vault_id
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = '') -> None:  # type: ignore[override]
-        """Buffer the turn; we ingest the full transcript in ``on_session_end``."""
+        """Buffer the turn locally. Flushes happen at chunk boundaries
+        (``on_pre_compress`` / ``on_session_end`` / ``shutdown``)."""
         with self._state_lock:
             self._turn_buffer.append({'user': user_content, 'assistant': assistant_content})
 
     def on_session_end(self, messages: list[dict[str, Any]]) -> None:  # type: ignore[override]
         if self._api is None or self._config is None:
             return
-        transcript = _format_transcript(messages or self._turn_buffer)
-        if not transcript.strip():
-            return
-        self._ingest_session_note(transcript, title=self._format_session_title())
+        chunk = self._capture_unflushed_buffer_slice()
+        if not chunk and messages:
+            # Degenerate case: ``sync_turn`` was never called this session
+            # (some Hermes deployments only fire on_session_end). Trust
+            # Hermes' history as the fallback source.
+            chunk = _format_transcript(messages)
+        if chunk:
+            self._enqueue_chunk(chunk, title=self._format_session_title())
+        with self._state_lock:
+            self._turn_buffer = []
+            self._flushed_index = 0
 
     def on_pre_compress(self, messages: list[dict[str, Any]]) -> str:  # type: ignore[override]
-        """Append soon-to-be-compressed messages to the session note so nothing is lost.
+        """Flush the unflushed buffer slice so soon-to-be-evicted turns are
+        persisted before Hermes compacts them.
 
         Returns a short summary that Hermes includes in the compression prompt.
+        We trust the local buffer as the verbatim source of truth — Hermes'
+        ``messages`` parameter is used only to size the summary string.
         """
-        if self._api is None or self._config is None or not messages:
+        if self._api is None or self._config is None:
             return ''
-        chunk = _format_transcript(messages)
-        if chunk.strip():
-            title = f'{self._format_session_title()} (pre-compress fragment)'
-            self._ingest_session_note(chunk, title=title)
+        chunk = self._capture_unflushed_buffer_slice()
+        if chunk:
+            self._enqueue_chunk(chunk, title=self._format_session_title())
         return (
             f'Memex captured {len(messages)} pre-compression messages into '
             f'session note `{self._session_note_key}`.'
@@ -407,13 +470,19 @@ class MemexMemoryProvider(MemoryProvider):
 
     def shutdown(self) -> None:  # type: ignore[override]
         """Flush pending buffers and close the client."""
-        if self._api is not None and self._turn_buffer:
-            transcript = _format_transcript(self._turn_buffer)
-            if transcript.strip():
+        if self._api is not None:
+            chunk = self._capture_unflushed_buffer_slice()
+            if chunk:
                 try:
-                    self._ingest_session_note(transcript, title=self._format_session_title())
+                    self._enqueue_chunk(chunk, title=self._format_session_title())
                 except Exception as e:
-                    logger.debug('Shutdown ingest failed: %s', e)
+                    logger.debug('Shutdown enqueue failed: %s', e)
+            # One last attempt to drain anything queued (including from the
+            # enqueue above) before we close the HTTP client.
+            try:
+                self._drain_pending()
+            except Exception as e:
+                logger.debug('Shutdown drain failed: %s', e)
         client = self._client
         self._client = None
         self._api = None
@@ -473,9 +542,124 @@ class MemexMemoryProvider(MemoryProvider):
             )
             return f'Hermes session — {substitutions["date"]}'
 
-    def _ingest_session_note(self, content: str, *, title: str) -> None:
-        assert self._api is not None and self._config is not None
+    def _capture_unflushed_buffer_slice(self) -> str:
+        """Atomically read and watermark the unflushed slice of the buffer.
 
+        Returns the formatted-transcript string for ``buffer[flushed_index:]``
+        and advances ``_flushed_index`` to the current buffer length. The
+        watermark moves on capture, not on successful flush — the pending
+        queue handles retries via stable ``append_id``s, so we never need to
+        reread the same buffer slice twice.
+        """
+        with self._state_lock:
+            unflushed = self._turn_buffer[self._flushed_index :]
+            if not unflushed:
+                return ''
+            formatted = _format_transcript(unflushed)
+            if not formatted.strip():
+                return ''
+            self._flushed_index = len(self._turn_buffer)
+        return formatted
+
+    def _enqueue_chunk(self, content: str, *, title: str) -> None:
+        """Enqueue a transcript chunk and try to drain the pending queue.
+
+        First chunk of the session (when ``_note_initialized`` is False AND
+        no other create is pending) is enqueued as a ``create``; everything
+        else is an ``append`` with a freshly-minted ``append_id`` for
+        idempotent retry semantics.
+        """
+        if not content.strip():
+            return
+        with self._state_lock:
+            has_pending_create = any(p['kind'] == 'create' for p in self._pending)
+            if not self._note_initialized and not has_pending_create:
+                entry: dict[str, Any] = {
+                    'kind': 'create',
+                    'content': content,
+                    'title': title,
+                }
+            else:
+                entry = {
+                    'kind': 'append',
+                    'content': content,
+                    'append_id': uuid4(),
+                }
+            self._pending.append(entry)
+            if len(self._pending) > _PENDING_MAX:
+                # Never drop a pending create — dropping it would orphan
+                # every queued append (the note wouldn't exist server-side
+                # to append onto). Drop the oldest *append* instead.
+                drop_index = 0
+                for i, e in enumerate(self._pending):
+                    if e['kind'] != 'create':
+                        drop_index = i
+                        break
+                dropped = self._pending.pop(drop_index)
+                logger.warning(
+                    'Pending session-note write queue full (%d); dropped %s entry at index %d.',
+                    _PENDING_MAX,
+                    dropped['kind'],
+                    drop_index,
+                )
+        self._drain_pending()
+
+    def _drain_pending(self) -> None:
+        """Process the pending queue FIFO. Stops at the first failure.
+
+        Successful items are popped; the failed item stays at head so the
+        next flush retries with the same idempotency token (for appends).
+        """
+        if self._api is None or self._config is None:
+            return
+        while True:
+            with self._state_lock:
+                if not self._pending:
+                    return
+                head = self._pending[0]
+            try:
+                if head['kind'] == 'create':
+                    self._do_create(head['content'], title=head['title'])
+                    # Background ingest queued the row; wait for it to be
+                    # visible before issuing appends, otherwise the next
+                    # append would 404. If the row never appears we leave
+                    # the create queued so the next flush retries.
+                    if not self._wait_for_note_row():
+                        logger.warning(
+                            'Session note row did not appear after ingest; '
+                            'will retry on next flush.',
+                        )
+                        return
+                    with self._state_lock:
+                        self._note_initialized = True
+                        if self._pending and self._pending[0] is head:
+                            self._pending.pop(0)
+                else:
+                    self._do_append(head['content'], append_id=head['append_id'])
+                    with self._state_lock:
+                        if self._pending and self._pending[0] is head:
+                            self._pending.pop(0)
+            except Exception as e:
+                logger.warning(
+                    'Session note %s failed; will retry on next flush: %s',
+                    head['kind'],
+                    e,
+                )
+                return
+
+    def _do_create(self, content: str, *, title: str) -> None:
+        """Create the session note via ``api.ingest``. May raise.
+
+        Uses ``background=True`` so the LLM-bound extraction phase runs
+        asynchronously server-side and the call returns quickly. The note
+        row itself is inserted as part of the same transaction that the
+        background job opens, so by the time we issue the next
+        ``append_to_note`` (which takes a row lock by ``note_key``), the
+        row exists. ``_drain_pending`` calls ``_wait_for_note_row`` after
+        a successful create to confirm the row is visible before we fire
+        any appends — without that gate the next append could 404.
+        """
+        assert self._api is not None and self._config is not None
         from memex_common.schemas import NoteCreateDTO
 
         dto = NoteCreateDTO(
@@ -488,12 +672,49 @@ class MemexMemoryProvider(MemoryProvider):
             author='hermes',
             template=self._config.retain.session_template or HERMES_SESSION_TEMPLATE,
         )
-        try:
-            run_sync(self._api.ingest(dto, background=True), timeout=30.0)
-            with self._state_lock:
-                self._turn_buffer = []
-        except Exception as e:
-            logger.warning('Session note ingest failed: %s', e)
+        run_sync(self._api.ingest(dto, background=True), timeout=30.0)
+
+    def _wait_for_note_row(self, *, timeout: float = 10.0) -> bool:
+        """Poll for the session note row to appear server-side.
+
+        Returns True if the row is visible, False on timeout. Called after
+        a successful background ingest to gate subsequent appends. The
+        ``derive_note_uuid_from_key`` is deterministic, so we know the id
+        before the row exists.
+        """
+        if self._api is None:
+            return False
+        from memex_core.services.notes import derive_note_uuid_from_key
+
+        note_id = derive_note_uuid_from_key(self._session_note_key)
+        import time
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                run_sync(self._api.get_note(note_id), timeout=2.0)
+                return True
+            except Exception:
+                time.sleep(0.1)
+        return False
+
+    def _do_append(self, content: str, *, append_id: UUID) -> None:
+        """Append a delta to the existing session note. May raise.
+
+        Idempotent on ``append_id``: the server replays a cached outcome if
+        the same id was previously processed, so retries are safe.
+        """
+        assert self._api is not None
+        from memex_common.schemas import NoteAppendRequest
+
+        request = NoteAppendRequest(
+            note_key=self._session_note_key,
+            vault_id=str(self._vault_id) if self._vault_id else None,
+            delta=content,
+            append_id=append_id,
+            joiner='paragraph',
+        )
+        run_sync(self._api.append_to_note(request), timeout=30.0)
 
 
 def _format_transcript(messages: list[dict[str, Any]]) -> str:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -383,15 +383,20 @@ class MemexMemoryProvider(MemoryProvider):
     def _refresh_vault_binding(self) -> None:
         """Best-effort re-resolve the active vault.
 
-        Once the session note has been created in a vault we hold the
-        binding constant for the rest of the session: appending to the
-        existing note from a different vault would 404 (note_key is
-        vault-scoped) and split the transcript across two notes. Rebinds
-        only take effect for sessions that haven't yet created a note.
+        Once the session has committed to a vault — either because the
+        create landed (``_note_initialized``) OR because a create is
+        already queued with a snapshotted ``vault_id`` — we hold the
+        binding constant. Letting the active vault drift after the queued
+        create would land the create in vault A but every subsequent
+        snapshotted-against-B append in vault B, splitting the transcript.
         """
         if self._api is None or self._config is None:
             return
         if self._note_initialized:
+            return
+        with self._state_lock:
+            has_pending_create = any(p['kind'] == 'create' for p in self._pending)
+        if has_pending_create:
             return
         try:
             new_vault_name = resolve_vault(
@@ -721,9 +726,15 @@ class MemexMemoryProvider(MemoryProvider):
 
         Returns True if the row is visible, False on timeout. The id is
         deterministic from ``note_key`` so we can poll before the server
-        finishes the background insert. 404 means "not yet"; any other
-        exception is also treated as "not yet" — the caller will leave
-        the create queued for the next flush to retry.
+        finishes the background insert. 404 and transient errors (5xx,
+        408, 429, network errors) keep polling within the deadline; only
+        a definitive non-transient HTTP error (4xx) bails early — those
+        won't resolve by waiting and signal a real misconfiguration.
+
+        Bailing on a transient blip would otherwise cause the caller to
+        leave the create queued and re-issue another ingest on the next
+        flush, racing the original background job and creating a redundant
+        note version.
         """
         if self._api is None:
             return False
@@ -734,8 +745,9 @@ class MemexMemoryProvider(MemoryProvider):
                 run_sync(self._api.get_note(note_id), timeout=1.0)
                 return True
             except httpx.HTTPStatusError as e:
-                if e.response.status_code != 404:
-                    return False  # unexpected — let the caller surface
+                code = e.response.status_code
+                if code != 404 and code in _NON_TRANSIENT_HTTP_STATUSES:
+                    return False
                 time.sleep(0.1)
             except Exception:
                 time.sleep(0.1)

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -389,14 +389,15 @@ class MemexMemoryProvider(MemoryProvider):
         binding constant. Letting the active vault drift after the queued
         create would land the create in vault A but every subsequent
         snapshotted-against-B append in vault B, splitting the transcript.
+
+        The gate is checked twice: once as a fast-path before the network
+        calls, and once again under the lock at the point of mutation. The
+        second check closes the TOCTOU window where a queued create could
+        appear (or land) while the network calls were in flight.
         """
         if self._api is None or self._config is None:
             return
-        if self._note_initialized:
-            return
-        with self._state_lock:
-            has_pending_create = any(p['kind'] == 'create' for p in self._pending)
-        if has_pending_create:
+        if self._committed_to_vault():
             return
         try:
             new_vault_name = resolve_vault(
@@ -415,8 +416,27 @@ class MemexMemoryProvider(MemoryProvider):
         if new_vault_id is None:
             return
         with self._state_lock:
+            # Re-validate under the lock at the point of mutation: a create
+            # may have been enqueued or initialized while the network calls
+            # above were in flight. Mutating the binding now would split
+            # the transcript across vaults.
+            if self._note_initialized or any(p['kind'] == 'create' for p in self._pending):
+                return
             self._vault_name = new_vault_name
             self._vault_id = new_vault_id
+
+    def _committed_to_vault(self) -> bool:
+        """True if the session has effectively bound a vault.
+
+        Either the create has succeeded (``_note_initialized``) or a
+        create is queued with a snapshotted ``vault_id``. Reads of
+        ``_pending`` are protected by ``_state_lock``; ``_note_initialized``
+        is sampled cheaply outside the lock as a fast-path.
+        """
+        if self._note_initialized:
+            return True
+        with self._state_lock:
+            return any(p['kind'] == 'create' for p in self._pending)
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = '') -> None:  # type: ignore[override]
         """Buffer the turn locally. Flushes happen at chunk boundaries
@@ -726,15 +746,15 @@ class MemexMemoryProvider(MemoryProvider):
 
         Returns True if the row is visible, False on timeout. The id is
         deterministic from ``note_key`` so we can poll before the server
-        finishes the background insert. 404 and transient errors (5xx,
-        408, 429, network errors) keep polling within the deadline; only
-        a definitive non-transient HTTP error (4xx) bails early — those
-        won't resolve by waiting and signal a real misconfiguration.
+        finishes the background insert.
 
-        Bailing on a transient blip would otherwise cause the caller to
-        leave the create queued and re-issue another ingest on the next
-        flush, racing the original background job and creating a redundant
-        note version.
+        Status semantics here differ from the append site:
+        - **404** means "not yet visible" — keep polling. (At the append
+          site, 404 means "note doesn't exist" and is hard-fail.)
+        - **400 / 409 / 410 / 422** are non-transient — bail early; waiting
+          won't change the outcome.
+        - Everything else (5xx, 408, 429, network errors) is transient —
+          retry within the deadline.
         """
         if self._api is None:
             return False
@@ -746,9 +766,12 @@ class MemexMemoryProvider(MemoryProvider):
                 return True
             except httpx.HTTPStatusError as e:
                 code = e.response.status_code
-                if code != 404 and code in _NON_TRANSIENT_HTTP_STATUSES:
+                if code == 404:
+                    time.sleep(0.1)
+                    continue
+                if code in _NON_TRANSIENT_HTTP_STATUSES:
                     return False
-                time.sleep(0.1)
+                time.sleep(0.1)  # transient
             except Exception:
                 time.sleep(0.1)
         return False

--- a/packages/hermes-plugin/tests/integration/test_session_note_persistence.py
+++ b/packages/hermes-plugin/tests/integration/test_session_note_persistence.py
@@ -1,0 +1,299 @@
+"""Integration tests for the Hermes session-transcript persistence pipeline.
+
+These tests run the real provider against a live Memex FastAPI server backed
+by testcontainers Postgres. They pin the durability contract that the unit
+tests cover with mocks: every turn synced into the buffer must end up in the
+final note body verbatim, regardless of how many compression boundaries fire
+in between.
+
+Background: the prior implementation called ``api.ingest`` against a shared
+``note_key`` for both pre-compress fragments and the final session-end write.
+Each ``ingest`` created a new note version that REPLACED the prior content,
+so multi-compression sessions ended up surfacing only the last fragment. The
+unit tests assert the new ingest→append routing in isolation; these tests
+prove it survives the full plugin <-> server <-> Postgres round-trip.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+pytestmark = pytest.mark.hermes_integration
+
+
+# Background batch jobs persist the note asynchronously when ``ingest`` is
+# called with ``background=True`` (the plugin's default for transcript
+# writes). Polling avoids a sleep-based race.
+_PERSIST_POLL_TIMEOUT = 15.0
+_PERSIST_POLL_INTERVAL = 0.25
+
+
+def _derive(note_key: str) -> UUID:
+    from memex_core.services.notes import derive_note_uuid_from_key
+
+    return derive_note_uuid_from_key(note_key)
+
+
+async def _wait_for_note(live_api: Any, note_key: str) -> Any:
+    """Poll until the note exists, then return its DTO."""
+    note_id = _derive(note_key)
+    deadline = asyncio.get_event_loop().time() + _PERSIST_POLL_TIMEOUT
+    last_error: Exception | None = None
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            return await live_api.get_note(note_id)
+        except Exception as e:
+            last_error = e
+            await asyncio.sleep(_PERSIST_POLL_INTERVAL)
+    raise AssertionError(
+        f'Note {note_id} (key={note_key}) did not appear within '
+        f'{_PERSIST_POLL_TIMEOUT}s. Last error: {last_error!r}'
+    )
+
+
+async def _wait_until_body_contains(live_api: Any, note_key: str, *tokens: str) -> str:
+    """Poll until the persisted body contains every token. Returns body."""
+    note_id = _derive(note_key)
+    deadline = asyncio.get_event_loop().time() + _PERSIST_POLL_TIMEOUT
+    last_body = ''
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            note = await live_api.get_note(note_id)
+            body = note.original_text or ''
+            if all(t in body for t in tokens):
+                return body
+            last_body = body
+        except Exception:
+            pass
+        await asyncio.sleep(_PERSIST_POLL_INTERVAL)
+    missing = [t for t in tokens if t not in last_body]
+    raise AssertionError(
+        f'Tokens {missing!r} not found in note body within '
+        f'{_PERSIST_POLL_TIMEOUT}s. Last body length: {len(last_body)}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_lifecycle_persists_every_turn_verbatim(
+    initialized_provider, live_api, live_vault: UUID
+):
+    """End-to-end: sync 5 turns, fire two pre-compresses, end the session.
+
+    The persisted note body must be a verbatim superset of every synced turn.
+    This is the regression test for the original "missing chunks" symptom.
+    """
+    p = initialized_provider
+
+    p.sync_turn('user-q1', 'assistant-a1')
+    p.sync_turn('user-q2', 'assistant-a2')
+    p.on_pre_compress([{'role': 'user', 'content': 'user-q1'}])
+
+    p.sync_turn('user-q3', 'assistant-a3')
+    p.on_pre_compress([{'role': 'user', 'content': 'user-q3'}])
+
+    p.sync_turn('user-q4', 'assistant-a4')
+    p.sync_turn('user-q5', 'assistant-a5')
+    p.on_session_end([])
+
+    body = await _wait_until_body_contains(
+        live_api,
+        p._session_note_key,
+        'user-q1',
+        'assistant-a1',
+        'user-q2',
+        'assistant-a2',
+        'user-q3',
+        'assistant-a3',
+        'user-q4',
+        'assistant-a4',
+        'user-q5',
+        'assistant-a5',
+    )
+    # Order preservation across compressions.
+    assert body.index('user-q1') < body.index('user-q3') < body.index('user-q5')
+
+    note = await _wait_for_note(live_api, p._session_note_key)
+    assert note.vault_id == live_vault
+
+
+@pytest.mark.asyncio
+async def test_session_end_only_path_creates_note(initialized_provider, live_api, live_vault: UUID):
+    """Sessions without compression: single ingest, full body present."""
+    p = initialized_provider
+
+    p.sync_turn('hello', 'world')
+    p.sync_turn('how', 'are you')
+    p.on_session_end([])
+
+    body = await _wait_until_body_contains(
+        live_api, p._session_note_key, 'hello', 'world', 'how', 'are you'
+    )
+    assert body  # sanity
+    note = await _wait_for_note(live_api, p._session_note_key)
+    assert note.vault_id == live_vault
+
+
+@pytest.mark.asyncio
+async def test_append_id_replay_is_idempotent(initialized_provider, live_api, live_vault: UUID):
+    """Replaying the same append_id must NOT double-write the body.
+
+    Server-side idempotency is the safety net behind our retry list. Confirm
+    it actually holds end-to-end.
+    """
+    from uuid import uuid4
+
+    from memex_common.schemas import NoteAppendRequest
+
+    p = initialized_provider
+    p.sync_turn('first', 'turn')
+    p.on_session_end([])
+    # Wait for the create to land before issuing the manual appends.
+    await _wait_for_note(live_api, p._session_note_key)
+
+    append_id = uuid4()
+    delta = '\n\nMANUAL_APPEND_MARKER\n'
+    request = NoteAppendRequest(
+        note_key=p._session_note_key,
+        vault_id=str(live_vault),
+        delta=delta,
+        append_id=append_id,
+        joiner='paragraph',
+    )
+
+    first = await live_api.append_to_note(request)
+    second = await live_api.append_to_note(request)
+
+    assert first.status == 'success'
+    assert second.status == 'replayed'
+
+    note = await _wait_for_note(live_api, p._session_note_key)
+    body = note.original_text or ''
+    assert body.count('MANUAL_APPEND_MARKER') == 1
+
+
+@pytest.mark.asyncio
+async def test_full_provider_lifecycle_end_to_end(initialized_provider, live_api, live_vault: UUID):
+    """Drive every Hermes hook the plugin reacts to, in production order.
+
+    Sequence: initialize (via fixture) → on_turn_start → sync_turn × N
+    → on_pre_compress (twice) → on_session_end → shutdown.
+
+    Asserts the persisted body is the verbatim ordered concatenation of
+    every chunk that should have been flushed, with NO duplication and NO
+    missing turns. This is the contract a session needs to honour for
+    downstream retrieval / reflection to be trustworthy.
+    """
+    p = initialized_provider
+
+    p.on_turn_start(turn_number=1, message='hi')
+    p.sync_turn('what is the answer', '42')
+    p.sync_turn('and the question', 'six times nine')
+    p.on_turn_start(turn_number=2, message='compress now')
+
+    p.on_pre_compress(
+        [
+            {'role': 'user', 'content': 'what is the answer'},
+            {'role': 'assistant', 'content': '42'},
+        ]
+    )
+
+    p.on_turn_start(turn_number=3, message='more')
+    p.sync_turn('side question', 'tangent')
+    p.on_pre_compress(
+        [{'role': 'user', 'content': 'side question'}, {'role': 'assistant', 'content': 'tangent'}]
+    )
+
+    p.on_turn_start(turn_number=4, message='wrap up')
+    p.sync_turn('final', 'goodbye')
+    p.on_session_end([])
+
+    body = await _wait_until_body_contains(
+        live_api,
+        p._session_note_key,
+        'what is the answer',
+        '42',
+        'and the question',
+        'six times nine',
+        'side question',
+        'tangent',
+        'final',
+        'goodbye',
+    )
+    # Exact-order check: the post-flush body must lay down chunks in the
+    # order they were captured. Order matters for downstream LLM consumers.
+    assert body.index('what is the answer') < body.index('side question') < body.index('final')
+    # No duplication of any user-message phrase.
+    for token in ('what is the answer', 'side question', 'final'):
+        assert body.count(token) == 1, (
+            f'token {token!r} appears {body.count(token)} times — expected 1'
+        )
+    # Note belongs to the right vault.
+    note = await _wait_for_note(live_api, p._session_note_key)
+    assert note.vault_id == live_vault
+
+    # shutdown after session_end must be a no-op (buffer cleared).
+    p.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_pending_queue_drains_on_shutdown_after_recovery(
+    loaded_provider, live_api, live_vault: UUID, hermes_home, vault_name: str, monkeypatch
+):
+    """If transient errors stack the pending queue, a clean shutdown drains it.
+
+    We force initial attempts to fail by pointing the provider at a dead URL,
+    populate the queue, then re-point at the live server and call shutdown.
+    The body must contain every queued chunk.
+    """
+    monkeypatch.setenv('MEMEX_VAULT', vault_name)
+    p = loaded_provider
+    p.initialize(
+        'integration-recovery-session',
+        hermes_home=str(hermes_home),
+        platform='cli',
+        agent_identity='integration',
+    )
+
+    live_client = p._client
+    live_api_real = p._api
+
+    import httpx
+
+    from memex_common.client import RemoteMemexAPI
+
+    dead_client = httpx.AsyncClient(base_url='http://127.0.0.1:1/', timeout=0.5)
+    p._client = dead_client
+    p._api = RemoteMemexAPI(dead_client)
+
+    p.sync_turn('q-a', 'r-a')
+    p.on_pre_compress([])
+    p.sync_turn('q-b', 'r-b')
+    p.on_pre_compress([])
+    p.sync_turn('q-c', 'r-c')
+    p.on_pre_compress([])
+
+    assert len(p._pending) == 3
+    assert p._pending[0]['kind'] == 'create'
+
+    await dead_client.aclose()
+    p._client = live_client
+    p._api = live_api_real
+
+    # shutdown drains everything; live_api_real is restored so calls succeed.
+    p.shutdown()
+
+    body = await _wait_until_body_contains(
+        live_api,
+        p._session_note_key,
+        'q-a',
+        'r-a',
+        'q-b',
+        'r-b',
+        'q-c',
+        'r-c',
+    )
+    assert body

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -792,6 +792,105 @@ def test_vault_rebind_after_note_initialized_is_ignored(
                 provider.shutdown()
 
 
+def test_wait_for_note_row_retries_on_transient_5xx(provider_with_append_api):
+    """A 5xx during the post-create poll must NOT abort the wait — that
+    would cause _drain_pending to leave the create queued and re-issue
+    another ingest on the next flush, racing the original background job.
+    Regression for round-2 FINDING-2.
+    """
+    import httpx
+
+    provider, api, _ = provider_with_append_api
+    note_id = uuid4()
+
+    fake_503 = httpx.Response(status_code=503, text='busy')
+    fake_503._request = httpx.Request('GET', 'http://test/notes/x')
+    transient = httpx.HTTPStatusError('503', request=fake_503._request, response=fake_503)
+
+    api.get_note = AsyncMock(side_effect=[transient, transient, SimpleNamespace(id=note_id)])
+    provider._api.get_note = api.get_note
+
+    assert provider._wait_for_note_row(timeout=5.0) is True
+    assert api.get_note.await_count == 3
+
+
+def test_wait_for_note_row_bails_on_definitive_4xx(provider_with_append_api):
+    """A non-404 4xx (e.g. 400/422) signals real misconfiguration — bail
+    immediately so the caller can surface the failure rather than burning
+    the full timeout polling a never-going-to-exist note.
+    """
+    import httpx
+
+    provider, api, _ = provider_with_append_api
+
+    fake_400 = httpx.Response(status_code=400, text='bad request')
+    fake_400._request = httpx.Request('GET', 'http://test/notes/x')
+    bad = httpx.HTTPStatusError('400', request=fake_400._request, response=fake_400)
+
+    api.get_note = AsyncMock(side_effect=bad)
+    provider._api.get_note = api.get_note
+
+    assert provider._wait_for_note_row(timeout=10.0) is False
+    # Bailed early — only one call, not the full poll-loop count.
+    assert api.get_note.await_count == 1
+
+
+def test_vault_rebind_with_pending_create_is_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A queued create with a snapshotted vault_id has effectively
+    committed the session to that vault. If we let _vault_id drift to a
+    new vault before the create lands, the create writes to vault A but
+    every post-snapshot append targets vault B — note_key is vault-scoped,
+    so vault-B appends 404, and the rebound transcript is silently lost.
+
+    Regression for round-2 FINDING-1.
+    """
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
+    monkeypatch.setenv('MEMEX_VAULT', 'vault-A')
+
+    import json
+
+    cfg_dir = tmp_path / 'memex'
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / 'config.json').write_text(json.dumps({'briefing_refresh_cadence': 1}))
+
+    fake_api = Mock()
+    vault_a = uuid4()
+    vault_b = uuid4()
+    fake_api.kv_get = AsyncMock(return_value=None)
+    fake_api.resolve_vault_identifier = AsyncMock(side_effect=[vault_a, vault_b])
+    fake_api.get_session_briefing = AsyncMock(return_value='')
+    # Force the create to fail so it stays queued.
+    fake_api.ingest = AsyncMock(side_effect=RuntimeError('down'))
+    fake_api.get_note = AsyncMock(return_value=SimpleNamespace(id=uuid4()))
+
+    with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
+        with patch(
+            'memex_hermes_plugin.memex.provider.resolve_vault',
+            side_effect=['vault-A', 'vault-B'],
+        ):
+            provider = MemexMemoryProvider()
+            provider.initialize('s', hermes_home=str(tmp_path), platform='cli')
+            try:
+                # Queue a create against vault A (will fail).
+                provider.sync_turn('q', 'a')
+                provider.on_session_end([])
+                assert len(provider._pending) == 1
+                assert provider._pending[0]['kind'] == 'create'
+                assert provider._pending[0]['vault_id'] == str(vault_a)
+
+                # Trigger rebind cadence; must be IGNORED because a create is queued.
+                provider.on_turn_start(1, 'msg')
+                assert provider._vault_id == vault_a
+                assert provider._vault_name == 'vault-A'
+                # And the queued create still targets vault A.
+                assert provider._pending[0]['vault_id'] == str(vault_a)
+            finally:
+                provider.shutdown()
+
+
 def test_shutdown_is_idempotent_under_concurrent_calls(provider_with_append_api):
     """Concurrent shutdown calls (Hermes' explicit shutdown + atexit
     fallback) must tear down exactly once. No double-close, no double-flush."""

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -596,7 +596,8 @@ def test_create_failure_does_not_flip_initialized(provider_with_append_api):
 
 def test_pending_queue_capped_to_protect_memory(provider_with_append_api):
     """If Memex is unreachable for a long session, the queue must not grow
-    without bound. Past the cap, the OLDEST entry is dropped."""
+    without bound. Backpressure refuses NEW chunks at the cap so older
+    content (more valuable for downstream reflection) is preserved."""
     provider, api, _ = provider_with_append_api
     api.ingest = AsyncMock(side_effect=RuntimeError('down'))
     api.append_to_note = AsyncMock(side_effect=RuntimeError('down'))
@@ -610,10 +611,21 @@ def test_pending_queue_capped_to_protect_memory(provider_with_append_api):
         provider.on_pre_compress([])
 
     assert len(provider._pending) == _PENDING_MAX
-    # Critical: the head 'create' must be preserved across drops, otherwise
-    # all queued appends would orphan onto a non-existent note when Memex
-    # comes back.
+    # The head must be the 'create' — appends would orphan onto a
+    # non-existent note when Memex comes back.
     assert provider._pending[0]['kind'] == 'create'
+    # Tail must be appends, in the order they were captured.
+    assert all(p['kind'] == 'append' for p in provider._pending[1:])
+    # First append is from turn 1; the last surviving append is from turn
+    # (_PENDING_MAX - 1). Anything past that was refused at the boundary.
+    assert 'q1' in provider._pending[1]['content']
+    assert f'q{_PENDING_MAX - 1}' in provider._pending[-1]['content']
+    # Verify the refused chunks were dropped, not silently inserted.
+    for refused_idx in (_PENDING_MAX, _PENDING_MAX + 4):
+        for entry in provider._pending:
+            assert f'q{refused_idx}' not in entry.get('content', ''), (
+                f'turn {refused_idx} should have been refused but is in queue'
+            )
 
 
 def test_recovery_after_outage_drains_queue(provider_with_append_api):
@@ -659,6 +671,172 @@ def test_recovery_after_outage_drains_queue(provider_with_append_api):
     api.ingest.assert_awaited_once()
     assert api.append_to_note.await_count == 3
     assert provider._pending == []
+
+
+def test_non_transient_4xx_drops_failing_entry(provider_with_append_api):
+    """A 409 / 422 / 400 / 404 cannot succeed on retry; drop the entry so
+    the queue can keep draining. Otherwise one bad chunk poisons the rest.
+    """
+    import httpx
+
+    provider, api, _ = provider_with_append_api
+
+    # First flush succeeds (create).
+    provider.sync_turn('q1', 'a1')
+    provider.on_pre_compress([])
+    api.ingest.assert_awaited_once()
+
+    # Next append: server returns 422 (delta validation failure).
+    fake_response = httpx.Response(status_code=422, text='delta empty')
+    fake_response._request = httpx.Request('POST', 'http://test/notes/append')
+    bad_error = httpx.HTTPStatusError('422', request=fake_response._request, response=fake_response)
+    api.append_to_note = AsyncMock(side_effect=bad_error)
+    provider._api.append_to_note = api.append_to_note
+
+    provider.sync_turn('q2', 'a2')
+    provider.on_pre_compress([])
+
+    # Bad entry is dropped; queue is empty.
+    assert provider._pending == []
+
+    # Subsequent appends still work (queue is unblocked).
+    api.append_to_note = AsyncMock(
+        return_value=SimpleNamespace(
+            status='success',
+            note_id=uuid4(),
+            append_id=uuid4(),
+            content_hash='x',
+            delta_bytes=1,
+            new_unit_ids=[],
+        )
+    )
+    provider._api.append_to_note = api.append_to_note
+    provider.sync_turn('q3', 'a3')
+    provider.on_pre_compress([])
+    api.append_to_note.assert_awaited_once()
+    assert provider._pending == []
+
+
+def test_transient_5xx_keeps_entry_for_retry(provider_with_append_api):
+    """5xx and network errors are treated as transient; the entry stays
+    queued for the next flush to retry with the same append_id.
+    """
+    import httpx
+
+    provider, api, _ = provider_with_append_api
+
+    provider.sync_turn('q1', 'a1')
+    provider.on_pre_compress([])
+
+    fake_response = httpx.Response(status_code=503, text='busy')
+    fake_response._request = httpx.Request('POST', 'http://test/notes/append')
+    transient = httpx.HTTPStatusError('503', request=fake_response._request, response=fake_response)
+    api.append_to_note = AsyncMock(side_effect=transient)
+    provider._api.append_to_note = api.append_to_note
+
+    provider.sync_turn('q2', 'a2')
+    provider.on_pre_compress([])
+
+    # 503 is transient — entry stays at head.
+    assert len(provider._pending) == 1
+    assert provider._pending[0]['kind'] == 'append'
+
+
+def test_vault_rebind_after_note_initialized_is_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Once we've created the session note in vault A, rebinding to vault B
+    mid-session must NOT redirect subsequent appends — that would 404
+    against vault B (note_key is vault-scoped) and silently split the
+    transcript across two notes.
+    """
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
+    monkeypatch.setenv('MEMEX_VAULT', 'vault-A')
+
+    import json
+
+    cfg_dir = tmp_path / 'memex'
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / 'config.json').write_text(json.dumps({'briefing_refresh_cadence': 1}))
+
+    fake_api = Mock()
+    vault_a = uuid4()
+    vault_b = uuid4()
+    note_uuid = uuid4()
+    fake_api.kv_get = AsyncMock(return_value=None)
+    fake_api.resolve_vault_identifier = AsyncMock(side_effect=[vault_a, vault_b])
+    fake_api.get_session_briefing = AsyncMock(return_value='')
+    fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(note_uuid)))
+    fake_api.get_note = AsyncMock(return_value=SimpleNamespace(id=note_uuid))
+
+    with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
+        with patch(
+            'memex_hermes_plugin.memex.provider.resolve_vault',
+            side_effect=['vault-A', 'vault-B'],
+        ):
+            provider = MemexMemoryProvider()
+            provider.initialize('s', hermes_home=str(tmp_path), platform='cli')
+            try:
+                # Land the create in vault A.
+                provider.sync_turn('q', 'a')
+                provider.on_session_end([])
+                assert provider._note_initialized is True
+                assert provider._vault_id == vault_a
+
+                # Trigger the rebind cadence; must be ignored since note is created.
+                provider.on_turn_start(1, 'msg')
+                assert provider._vault_id == vault_a
+                assert provider._vault_name == 'vault-A'
+            finally:
+                provider.shutdown()
+
+
+def test_shutdown_is_idempotent_under_concurrent_calls(provider_with_append_api):
+    """Concurrent shutdown calls (Hermes' explicit shutdown + atexit
+    fallback) must tear down exactly once. No double-close, no double-flush."""
+    import threading
+
+    provider, api, _ = provider_with_append_api
+    provider.sync_turn('q', 'a')
+
+    barrier = threading.Barrier(2)
+
+    def call_shutdown():
+        barrier.wait()
+        provider.shutdown()
+
+    t1 = threading.Thread(target=call_shutdown)
+    t2 = threading.Thread(target=call_shutdown)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not t1.is_alive() and not t2.is_alive()
+    # ingest fired exactly once even under racing shutdowns.
+    assert api.ingest.await_count == 1
+
+
+def test_pending_survives_session_end_buffer_clear(provider_with_append_api):
+    """on_session_end clears the buffer + watermark, but pending entries
+    must survive — the queue is the durable client-side record once the
+    chunk has been captured (not the buffer)."""
+    provider, api, _ = provider_with_append_api
+
+    # Make ingest fail so the entry stays queued.
+    api.ingest = AsyncMock(side_effect=RuntimeError('down'))
+    provider._api.ingest = api.ingest
+
+    provider.sync_turn('q', 'a')
+    provider.on_session_end([])
+
+    # Buffer cleared, but pending entry preserved.
+    assert provider._turn_buffer == []
+    assert provider._flushed_index == 0
+    assert len(provider._pending) == 1
+    assert provider._pending[0]['kind'] == 'create'
+    assert 'q' in provider._pending[0]['content']
 
 
 def test_vault_rebind_reresolves_on_cadence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -20,10 +20,12 @@ def provider_with_stubbed_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     fake_api = Mock()
     vault_uuid = uuid4()
+    note_uuid = uuid4()
     fake_api.kv_get = AsyncMock(return_value=None)
     fake_api.resolve_vault_identifier = AsyncMock(return_value=vault_uuid)
     fake_api.get_session_briefing = AsyncMock(return_value='# Briefing')
-    fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(uuid4())))
+    fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(note_uuid)))
+    fake_api.get_note = AsyncMock(return_value=SimpleNamespace(id=note_uuid))
     fake_api.kv_put = AsyncMock()
 
     with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
@@ -321,6 +323,385 @@ def test_on_session_end_ingests_transcript(provider_with_stubbed_api):
     assert 'pong' in body
 
 
+# ---------------------------------------------------------------------------
+# Transcript persistence — ingest→append split (Part A)
+# ---------------------------------------------------------------------------
+#
+# Background: the prior implementation called ``api.ingest`` against a shared
+# ``note_key`` for both pre-compress fragments and the final session-end
+# write. ``note_key`` upsert creates a new VERSION per write — only the
+# latest is surfaced — so each flush silently overwrote the prior. The fix:
+# first flush of the session creates the note; every subsequent flush goes
+# through ``api.append_to_note`` with a stable, idempotent ``append_id``.
+# These tests pin the new contract.
+
+
+@pytest.fixture
+def provider_with_append_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Like ``provider_with_stubbed_api`` but also stubs ``append_to_note``."""
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
+    monkeypatch.setenv('MEMEX_VAULT', 'test-vault')
+
+    fake_api = Mock()
+    vault_uuid = uuid4()
+    note_uuid = uuid4()
+    fake_api.kv_get = AsyncMock(return_value=None)
+    fake_api.resolve_vault_identifier = AsyncMock(return_value=vault_uuid)
+    fake_api.get_session_briefing = AsyncMock(return_value='# Briefing')
+    fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(note_uuid)))
+    fake_api.get_note = AsyncMock(return_value=SimpleNamespace(id=note_uuid))
+    fake_api.append_to_note = AsyncMock(
+        return_value=SimpleNamespace(
+            status='success',
+            note_id=note_uuid,
+            append_id=uuid4(),
+            content_hash='abc123',
+            delta_bytes=10,
+            new_unit_ids=[],
+        )
+    )
+    fake_api.kv_put = AsyncMock()
+
+    with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
+        provider = MemexMemoryProvider()
+        provider.initialize('session-abc12345', hermes_home=str(tmp_path), platform='cli')
+        yield provider, fake_api, vault_uuid
+    provider.shutdown()
+
+
+def _decode_ingest_body(api: Mock) -> str:
+    import base64
+
+    dto = api.ingest.call_args.args[0]
+    return base64.b64decode(dto.content).decode('utf-8')
+
+
+def _append_deltas(api: Mock) -> list[str]:
+    return [call.args[0].delta for call in api.append_to_note.await_args_list]
+
+
+def test_first_flush_creates_note_via_ingest(provider_with_append_api):
+    """Single sync_turn → on_session_end ⇒ exactly one ingest, no appends."""
+    provider, api, _ = provider_with_append_api
+    provider.sync_turn('hi', 'hello')
+    provider.sync_turn('ping', 'pong')
+    provider.on_session_end([])
+
+    api.ingest.assert_awaited_once()
+    api.append_to_note.assert_not_awaited()
+    body = _decode_ingest_body(api)
+    assert 'hi' in body and 'hello' in body
+    assert 'ping' in body and 'pong' in body
+
+
+def test_pre_compress_then_session_end_appends(provider_with_append_api):
+    """Pre-compress writes the create; session-end appends the remainder."""
+    provider, api, _ = provider_with_append_api
+    provider.sync_turn('q1', 'a1')
+    provider.sync_turn('q2', 'a2')
+
+    provider.on_pre_compress([{'role': 'user', 'content': 'q1'}])
+    api.ingest.assert_awaited_once()
+    api.append_to_note.assert_not_awaited()
+
+    provider.sync_turn('q3', 'a3')
+    provider.on_session_end([])
+
+    api.ingest.assert_awaited_once()  # still only one create
+    assert api.append_to_note.await_count == 1
+    append_req = api.append_to_note.call_args.args[0]
+    assert append_req.note_key == provider._session_note_key
+    assert append_req.delta  # non-empty
+    assert 'q3' in append_req.delta and 'a3' in append_req.delta
+
+
+def test_pre_compress_does_not_clear_buffer(provider_with_append_api):
+    """The buffer is retained verbatim; only the watermark advances."""
+    provider, _api, _ = provider_with_append_api
+    provider.sync_turn('q1', 'a1')
+    provider.sync_turn('q2', 'a2')
+    provider.sync_turn('q3', 'a3')
+    assert len(provider._turn_buffer) == 3
+
+    provider.on_pre_compress([{'role': 'user', 'content': 'q1'}])
+    # Buffer length is preserved; watermark advanced past all three turns.
+    assert len(provider._turn_buffer) == 3
+    assert provider._flushed_index == 3
+
+
+def test_two_pre_compresses_both_persist(provider_with_append_api):
+    """Regression test for the original missing-chunks symptom.
+
+    The reconstructed body across all writes (one ingest + N appends) must
+    contain every turn verbatim, in order, with no overwrites.
+    """
+    provider, api, _ = provider_with_append_api
+
+    # Compression 1 covers turns 1-2.
+    provider.sync_turn('q1', 'a1')
+    provider.sync_turn('q2', 'a2')
+    provider.on_pre_compress([{'role': 'user', 'content': 'q1'}])
+
+    # Compression 2 covers turns 3-4.
+    provider.sync_turn('q3', 'a3')
+    provider.sync_turn('q4', 'a4')
+    provider.on_pre_compress([{'role': 'user', 'content': 'q3'}])
+
+    # Final tail.
+    provider.sync_turn('q5', 'a5')
+    provider.on_session_end([])
+
+    assert api.ingest.await_count == 1
+    assert api.append_to_note.await_count == 2
+
+    body_parts = [_decode_ingest_body(api), *_append_deltas(api)]
+    full_body = '\n\n'.join(body_parts)
+    for token in ('q1', 'a1', 'q2', 'a2', 'q3', 'a3', 'q4', 'a4', 'q5', 'a5'):
+        assert token in full_body, f'{token} missing from concatenated body'
+    # Order preservation.
+    assert full_body.index('q1') < full_body.index('q3') < full_body.index('q5')
+
+
+def test_append_id_is_stable_for_retry(provider_with_append_api):
+    """A failed append is retried with the SAME append_id on the next flush."""
+    provider, api, _ = provider_with_append_api
+
+    # First flush succeeds (create).
+    provider.sync_turn('q1', 'a1')
+    provider.on_pre_compress([{'role': 'user', 'content': 'q1'}])
+    api.ingest.assert_awaited_once()
+
+    # Force the next append to fail.
+    transient = RuntimeError('connection reset')
+    api.append_to_note = AsyncMock(side_effect=transient)
+    provider._api.append_to_note = api.append_to_note
+
+    provider.sync_turn('q2', 'a2')
+    provider.on_pre_compress([{'role': 'user', 'content': 'q2'}])
+
+    assert api.append_to_note.await_count == 1
+    failed_append_id = api.append_to_note.call_args.args[0].append_id
+    # Item stayed at the head of the queue.
+    assert len(provider._pending) == 1
+    assert provider._pending[0]['append_id'] == failed_append_id
+
+    # Recover. The retry must use the SAME append_id (idempotent replay).
+    api.append_to_note = AsyncMock(
+        return_value=SimpleNamespace(
+            status='replayed',
+            note_id=uuid4(),
+            append_id=failed_append_id,
+            content_hash='x',
+            delta_bytes=1,
+            new_unit_ids=[],
+        )
+    )
+    provider._api.append_to_note = api.append_to_note
+
+    provider.sync_turn('q3', 'a3')
+    provider.on_session_end([])
+
+    sent_append_ids = [c.args[0].append_id for c in api.append_to_note.call_args_list]
+    assert failed_append_id in sent_append_ids
+    assert provider._pending == []
+
+
+def test_session_end_with_empty_messages_falls_back_to_buffer(
+    provider_with_append_api,
+):
+    """Hermes' contract permits ``messages=[]`` at session_end."""
+    provider, api, _ = provider_with_append_api
+    provider.sync_turn('only', 'turn')
+    provider.on_session_end([])
+    api.ingest.assert_awaited_once()
+    body = _decode_ingest_body(api)
+    assert 'only' in body and 'turn' in body
+
+
+def test_session_end_with_empty_buffer_falls_back_to_messages(
+    provider_with_append_api,
+):
+    """Defense in depth: if sync_turn was never called but Hermes hands us
+    a non-empty messages list at session_end, capture it as the create body."""
+    provider, api, _ = provider_with_append_api
+    provider.on_session_end(
+        [
+            {'role': 'user', 'content': 'hello'},
+            {'role': 'assistant', 'content': 'hi back'},
+        ]
+    )
+    api.ingest.assert_awaited_once()
+    body = _decode_ingest_body(api)
+    assert 'hello' in body and 'hi back' in body
+
+
+def test_session_end_with_empty_everything_is_noop(provider_with_append_api):
+    """No turns synced, no messages — no write at all."""
+    provider, api, _ = provider_with_append_api
+    provider.on_session_end([])
+    api.ingest.assert_not_awaited()
+    api.append_to_note.assert_not_awaited()
+
+
+def test_pre_compress_with_empty_buffer_is_noop(provider_with_append_api):
+    """pre_compress trusts the local buffer; an empty buffer means nothing
+    new to persist. Hermes' messages parameter is informational only here."""
+    provider, api, _ = provider_with_append_api
+    summary = provider.on_pre_compress([{'role': 'user', 'content': 'x'}])
+    api.ingest.assert_not_awaited()
+    api.append_to_note.assert_not_awaited()
+    # Summary string is still returned for the compression prompt.
+    assert provider._session_note_key in summary
+
+
+def test_double_session_end_does_not_duplicate(provider_with_append_api):
+    """Calling on_session_end twice in a row must not write twice.
+
+    After the first session_end the buffer is cleared, so the second call
+    finds nothing to flush and is a no-op.
+    """
+    provider, api, _ = provider_with_append_api
+    provider.sync_turn('q', 'a')
+    provider.on_session_end([])
+    provider.on_session_end([])
+    api.ingest.assert_awaited_once()
+    api.append_to_note.assert_not_awaited()
+
+
+def test_create_failure_does_not_flip_initialized(provider_with_append_api):
+    """If the first ingest raises, _note_initialized must stay False so the
+    next flush retries the create — NOT skip ahead to append (which would
+    fail because the note doesn't exist yet)."""
+    provider, api, _ = provider_with_append_api
+    api.ingest = AsyncMock(side_effect=RuntimeError('5xx'))
+    provider._api.ingest = api.ingest
+
+    provider.sync_turn('q', 'a')
+    provider.on_session_end([])
+
+    assert provider._note_initialized is False
+    assert len(provider._pending) == 1
+    assert provider._pending[0]['kind'] == 'create'
+
+    # Recover. Next flush retries the create.
+    api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(uuid4())))
+    provider._api.ingest = api.ingest
+
+    # Re-buffer some content to trigger a flush. Use shutdown's drain path.
+    provider.shutdown()
+    api.ingest.assert_awaited()
+    assert provider._note_initialized is True
+
+
+def test_pending_queue_capped_to_protect_memory(provider_with_append_api):
+    """If Memex is unreachable for a long session, the queue must not grow
+    without bound. Past the cap, the OLDEST entry is dropped."""
+    provider, api, _ = provider_with_append_api
+    api.ingest = AsyncMock(side_effect=RuntimeError('down'))
+    api.append_to_note = AsyncMock(side_effect=RuntimeError('down'))
+    provider._api.ingest = api.ingest
+    provider._api.append_to_note = api.append_to_note
+
+    from memex_hermes_plugin.memex.provider import _PENDING_MAX
+
+    for i in range(_PENDING_MAX + 5):
+        provider.sync_turn(f'q{i}', f'a{i}')
+        provider.on_pre_compress([])
+
+    assert len(provider._pending) == _PENDING_MAX
+    # Critical: the head 'create' must be preserved across drops, otherwise
+    # all queued appends would orphan onto a non-existent note when Memex
+    # comes back.
+    assert provider._pending[0]['kind'] == 'create'
+
+
+def test_recovery_after_outage_drains_queue(provider_with_append_api):
+    """Memex returns after a transient outage; the queue drains in order."""
+    provider, api, _ = provider_with_append_api
+
+    api.ingest = AsyncMock(side_effect=RuntimeError('5xx'))
+    api.append_to_note = AsyncMock(side_effect=RuntimeError('5xx'))
+    provider._api.ingest = api.ingest
+    provider._api.append_to_note = api.append_to_note
+
+    # Build up backlog: 1 create + 3 appends, all failing.
+    provider.sync_turn('q1', 'a1')
+    provider.on_pre_compress([])
+    provider.sync_turn('q2', 'a2')
+    provider.on_pre_compress([])
+    provider.sync_turn('q3', 'a3')
+    provider.on_pre_compress([])
+    provider.sync_turn('q4', 'a4')
+    provider.on_pre_compress([])
+
+    assert len(provider._pending) == 4
+    assert [p['kind'] for p in provider._pending] == ['create', 'append', 'append', 'append']
+
+    # Recovery.
+    api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(uuid4())))
+    api.append_to_note = AsyncMock(
+        return_value=SimpleNamespace(
+            status='success',
+            note_id=uuid4(),
+            append_id=uuid4(),
+            content_hash='x',
+            delta_bytes=1,
+            new_unit_ids=[],
+        )
+    )
+    provider._api.ingest = api.ingest
+    provider._api.append_to_note = api.append_to_note
+
+    # Trigger drain via shutdown.
+    provider.shutdown()
+
+    api.ingest.assert_awaited_once()
+    assert api.append_to_note.await_count == 3
+    assert provider._pending == []
+
+
+def test_vault_rebind_reresolves_on_cadence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Mid-session vault rebinds are honoured at the briefing-refresh cadence."""
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
+    monkeypatch.setenv('MEMEX_VAULT', 'vault-A')
+
+    import json
+
+    cfg_dir = tmp_path / 'memex'
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / 'config.json').write_text(json.dumps({'briefing_refresh_cadence': 2}))
+
+    fake_api = Mock()
+    vault_a = uuid4()
+    vault_b = uuid4()
+    fake_api.kv_get = AsyncMock(return_value=None)
+    # First resolve returns vault-A, subsequent returns vault-B.
+    fake_api.resolve_vault_identifier = AsyncMock(side_effect=[vault_a, vault_b])
+    fake_api.get_session_briefing = AsyncMock(return_value='')
+    fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(uuid4())))
+
+    with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
+        with patch(
+            'memex_hermes_plugin.memex.provider.resolve_vault',
+            side_effect=['vault-A', 'vault-B'],
+        ):
+            provider = MemexMemoryProvider()
+            provider.initialize('s', hermes_home=str(tmp_path), platform='cli')
+            try:
+                assert provider._vault_name == 'vault-A'
+                assert provider._vault_id == vault_a
+
+                provider.on_turn_start(2, 'msg')
+                # On a refresh-cadence boundary, the resolver re-runs and
+                # vault binding follows the new value.
+                assert provider._vault_name == 'vault-B'
+                assert provider._vault_id == vault_b
+            finally:
+                provider.shutdown()
+
+
 def test_on_memory_write_mirrors_to_kv(provider_with_stubbed_api):
     provider, api, _ = provider_with_stubbed_api
     provider.on_memory_write('add', 'user', 'Prefers Rust')
@@ -383,10 +764,14 @@ class TestSessionTitle:
             )
 
         fake_api = Mock()
+        note_uuid = uuid4()
         fake_api.kv_get = AsyncMock(return_value=None)
         fake_api.resolve_vault_identifier = AsyncMock(return_value=uuid4())
         fake_api.get_session_briefing = AsyncMock(return_value='')
-        fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(uuid4())))
+        fake_api.ingest = AsyncMock(
+            return_value=SimpleNamespace(status='ok', note_id=str(note_uuid))
+        )
+        fake_api.get_note = AsyncMock(return_value=SimpleNamespace(id=note_uuid))
         fake_api.kv_put = AsyncMock()
 
         with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
@@ -458,12 +843,22 @@ class TestSessionTitle:
         finally:
             p.shutdown()
 
-    def test_pre_compress_marks_fragment_in_title(self, tmp_path, monkeypatch):
+    def test_pre_compress_uses_session_title_no_fragment_marker(self, tmp_path, monkeypatch):
+        """All writes to the session note share the same title.
+
+        Regression for the original "missing chunks" bug: the prior
+        implementation tagged pre-compress writes "(pre-compress fragment)"
+        as a workaround for fragments overwriting each other. With ingest +
+        idempotent appends, every write extends a single durable note, so
+        the title stays consistent.
+        """
         p, api = self._provider(tmp_path, monkeypatch)
-        p.on_pre_compress([{'role': 'user', 'content': 'bye'}])
         try:
+            p.sync_turn('hi', 'hello')
+            p.on_pre_compress([{'role': 'user', 'content': 'bye'}])
             api.ingest.assert_awaited()
             dto = api.ingest.call_args.args[0]
-            assert 'pre-compress fragment' in dto.name
+            assert 'fragment' not in dto.name
+            assert 'coder' in dto.name and 'cli' in dto.name
         finally:
             p.shutdown()

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
@@ -887,6 +888,71 @@ def test_vault_rebind_with_pending_create_is_ignored(
                 assert provider._vault_name == 'vault-A'
                 # And the queued create still targets vault A.
                 assert provider._pending[0]['vault_id'] == str(vault_a)
+            finally:
+                provider.shutdown()
+
+
+def test_vault_rebind_toctou_reverify_under_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """If a create is enqueued WHILE _refresh_vault_binding's network
+    calls are in flight, the second-pass check under the lock must reject
+    the rebind. Otherwise the binding flips between the fast-path check
+    and the mutation, splitting the transcript across vaults.
+
+    Round-3 regression: simulate the race by patching resolve_vault to
+    enqueue a create as a side effect.
+    """
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
+    monkeypatch.setenv('MEMEX_VAULT', 'vault-A')
+
+    import json
+
+    cfg_dir = tmp_path / 'memex'
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / 'config.json').write_text(json.dumps({'briefing_refresh_cadence': 1}))
+
+    fake_api = Mock()
+    vault_a = uuid4()
+    vault_b = uuid4()
+    fake_api.kv_get = AsyncMock(return_value=None)
+    fake_api.resolve_vault_identifier = AsyncMock(side_effect=[vault_a, vault_b])
+    fake_api.get_session_briefing = AsyncMock(return_value='')
+    fake_api.ingest = AsyncMock(side_effect=RuntimeError('down'))
+
+    provider_holder: dict[str, Any] = {}
+
+    def resolve_vault_side_effect(*args, **kwargs):
+        # First call: returns vault-A (initial init).
+        # Second call: simulate a concurrent flush enqueuing a create
+        # WHILE we're mid-resolution.
+        call_count = resolve_vault_mock.call_count
+        if call_count == 2:
+            p = provider_holder.get('p')
+            if p is not None:
+                p.sync_turn('q', 'a')
+                p.on_session_end([])
+                # A create is now queued (ingest fails, stays in queue).
+        return ['vault-A', 'vault-B'][call_count - 1]
+
+    with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
+        with patch(
+            'memex_hermes_plugin.memex.provider.resolve_vault',
+            side_effect=resolve_vault_side_effect,
+        ) as resolve_vault_mock:
+            provider = MemexMemoryProvider()
+            provider.initialize('s', hermes_home=str(tmp_path), platform='cli')
+            provider_holder['p'] = provider
+            try:
+                # No create queued yet; refresh_vault would normally rotate.
+                # The side-effect injects a create during the network call.
+                provider.on_turn_start(1, 'msg')
+
+                # The create should be queued (from the side-effect).
+                assert any(p['kind'] == 'create' for p in provider._pending)
+                # Vault binding must NOT have rotated to B — the
+                # under-lock re-check rejected the rebind.
+                assert provider._vault_id == vault_a
+                assert provider._vault_name == 'vault-A'
             finally:
                 provider.shutdown()
 


### PR DESCRIPTION
## Summary

- The Hermes transcript path called `api.ingest` with a shared `note_key` for every flush boundary (pre-compress fragment + session-end). `note_key` upsert creates a new VERSION per write, so multi-compression sessions silently lost every fragment except the last — the original "missing chunks" symptom.
- First write of the session now creates the note via `ingest`; every subsequent write extends it via `append_to_note` with stable, idempotent `append_id`s. Pre-compress and session-end flush disjoint slices via a buffer watermark, so there are no double-writes.
- Failed writes stay queued for retry on the next flush; the queue caps at 256 entries (refuses new chunks rather than evicting older ones — older transcript is more valuable for downstream reflection). Non-transient HTTP errors (4xx) drop the failing entry so a poisoned chunk can't block the rest of the queue.
- Vault binding is held constant once the session has committed (`_note_initialized` OR a create is queued); a TOCTOU-safe re-check under `_state_lock` at the mutation point closes the race where a create lands while `_refresh_vault_binding` is mid-resolution.
- Concurrency: `_drain_pending` serializes on a dedicated `_drain_lock`; `shutdown` is idempotent under concurrent calls via `_shutdown_started` + `_atexit_lock`.

## Surface area

- `packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py` — implementation
- `packages/hermes-plugin/tests/test_provider.py` — 49 unit tests (was 20)
- `packages/hermes-plugin/tests/integration/test_session_note_persistence.py` — 5 new integration tests against real Memex+Postgres

## Adversarial review

Iterated 4 rounds of independent adversarial review until clean:

| Round | Findings | Resolution |
|---|---|---|
| 1 | 1 CRITICAL, 4 HIGH, 4 MEDIUM, 3 LOW | All C/H/M patched |
| 2 | 1 HIGH, 2 MEDIUM | All patched |
| 3 | 2 MEDIUM | All patched |
| 4 | none | Loop terminated |

Each round produced a regression test pinning the patched bug.

## Test plan

- [ ] `uv run pytest packages/hermes-plugin/tests/test_provider.py -v` — 49 unit tests green
- [ ] `uv run pytest packages/hermes-plugin/tests/integration/test_session_note_persistence.py -v -m hermes_integration` — 5 integration tests against testcontainers Postgres
- [ ] `uv run pytest packages/hermes-plugin/tests/integration/test_live_hermes.py::test_on_session_end_persists_transcript -m hermes_integration` — existing transcript test still green
- [ ] `just prek` — ruff + ruff-format + mypy clean
- [ ] Manual smoke: drive a real Hermes session against a local Memex server, force `/compact` once, continue ~20 turns, exit. Verify via `memex note read --key hermes:session:<...>` that the body is the verbatim superset of the conversation, not just the post-compression slice.

## Out of scope (deferred to follow-up PRs)

- Part B (prefetch simplification — drop notes layer, hard-cap facts at 5)
- Per-turn appends in `sync_turn` (current cadence is pre-compress + session-end + shutdown)
- `defer_extraction` flag (premise was a misread of `append_note`'s already-incremental extraction)
- On-disk WAL in `HERMES_HOME/memex/wal/`
- Claude Code SessionEnd hook integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)