### PR TITLE
fix(mcp): finish FSRS-5 rip-out; wire residue guard into pre-commit + CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,8 +75,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-      - name: Check no FSRS-5 residue
-        run: bash scripts/ci/check_no_fsrs_residue.sh
       - name: Run pre-commit checks
         uses: JasperHG90/toiminnot/actions/prek@main
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
               - 'pyproject.toml'
               - 'uv.lock'
               - '.pre-commit-config.yaml'
+              - 'scripts/ci/**'
             firefox-extension:
               - 'packages/firefox-extension/**'
             docker:
@@ -73,6 +74,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - uses: actions/checkout@v4
+      - name: Check no FSRS-5 residue
+        run: bash scripts/ci/check_no_fsrs_residue.sh
       - name: Run pre-commit checks
         uses: JasperHG90/toiminnot/actions/prek@main
         with:
@@ -104,6 +108,25 @@ jobs:
           uv_version: ${{ env.UV_VERSION }}
           python_version: ${{ matrix.python-version }}
           markers: "integration and not llm"
+
+  mcp-import-check:
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.python == 'true' || needs.changes.outputs.ci-config == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+      - name: Sync workspace
+        run: uv sync --all-extras --all-packages
+      - name: Collect MCP tests (import-time gate)
+        run: uv run pytest packages/mcp/tests --collect-only -q
 
   firefox-extension-lint-test:
     needs: changes
@@ -204,7 +227,7 @@ jobs:
         run: uv run pytest packages/hermes-plugin/tests/integration/ -v --tb=short -m hermes_integration
 
   build-python:
-    needs: [changes, pre-commit, python-tests]
+    needs: [changes, pre-commit, python-tests, mcp-import-check]
     if: always() && !failure() && !cancelled() && (github.event_name == 'push' || needs.changes.outputs.python == 'true' || needs.changes.outputs.ci-config == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -220,7 +243,7 @@ jobs:
           package: ${{ matrix.package }}
 
   docker-build-memex:
-    needs: [changes, pre-commit, python-tests]
+    needs: [changes, pre-commit, python-tests, mcp-import-check]
     if: >-
       always() && !failure() && !cancelled() &&
       (github.event_name == 'push' ||

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,9 @@ repos:
         language: system
         files: ^(packages/.*/(tests|test)/.*\.py|tests/.*\.py)$
         pass_filenames: false
+      - id: check-no-fsrs-residue
+        name: check no FSRS-5 residue
+        entry: bash scripts/ci/check_no_fsrs_residue.sh
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,470%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,436%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -20,7 +20,6 @@ from fastmcp.exceptions import ToolError
 
 from memex_common.asset_cache import MAX_GET_RESOURCES_PATHS, MAX_RESOURCE_BYTES
 from memex_common.asset_resize import validate_and_resize
-from memex_common.revisit import reject_bool_quality
 from fastmcp.utilities.logging import configure_logging
 import json
 
@@ -4162,129 +4161,6 @@ async def memex_memory_consolidate(
     except Exception as e:
         logger.error(f'memex_memory_consolidate failed: {e}', exc_info=True)
         raise ToolError(f'memex_memory_consolidate failed: {e}')
-
-
-# --- Review / Revisit ---
-
-from memex_mcp._revisit_descriptions import (
-    MEMEX_GET_DUE_FOR_REVIEW_DESCRIPTION,
-    MEMEX_MEMORY_REVIEW_DESCRIPTION,
-)
-
-
-@mcp.tool(
-    name='memex_get_due_for_review',
-    description=MEMEX_GET_DUE_FOR_REVIEW_DESCRIPTION,
-    tags={'read', 'storage'},
-    annotations={'readOnlyHint': True},
-    timeout=30.0,
-)
-async def memex_get_due_for_review(
-    ctx: Context,
-    vault_id: Annotated[
-        str | None,
-        Field(description='Vault UUID or name (defaults to active vault if omitted).'),
-    ] = None,
-    limit: Annotated[
-        int,
-        Field(ge=1, le=200, description='Maximum due units to return (default 20).'),
-    ] = 20,
-) -> list[dict[str, Any]]:
-    """List memory units due for FSRS-5 revisit in a vault."""
-    try:
-        api = get_api(ctx)
-        config = get_config(ctx)
-        if vault_id is None:
-            resolved_vault_id = await api.resolve_vault_identifier(
-                config.server.default_active_vault
-            )
-        else:
-            resolved_vault_id = await _resolve_vault_id(api, vault_id)
-        due = await api.get_due_for_review(resolved_vault_id, limit=limit)
-        return [
-            {
-                'unit_id': str(d.unit_id),
-                'text_preview': d.text_preview,
-                'revisit_due_at': d.revisit_due_at.isoformat(),
-                'intent_class': d.intent_class,
-            }
-            for d in due
-        ]
-    except ToolError:
-        raise
-    except Exception as e:
-        logger.error(f'memex_get_due_for_review failed: {e}', exc_info=True)
-        raise ToolError(f'memex_get_due_for_review failed: {e}')
-
-
-@mcp.tool(
-    name='memex_memory_review',
-    description=MEMEX_MEMORY_REVIEW_DESCRIPTION,
-    tags={'write', 'storage'},
-    annotations={'readOnlyHint': False, 'destructiveHint': False, 'idempotentHint': False},
-    timeout=30.0,
-)
-async def memex_memory_review(
-    ctx: Context,
-    unit_id: Annotated[str, Field(description='Memory unit UUID being reviewed.')],
-    quality: Annotated[
-        int | str,
-        BeforeValidator(reject_bool_quality),
-        Field(
-            description=(
-                'Review rating. Accepts the FSRS-5 IntEnum value (1=again, 2=hard, '
-                "3=good, 4=easy) or the case-insensitive string ('again' / 'hard' / "
-                "'good' / 'easy'). AGAIN/HARD record a failure outcome; GOOD/EASY "
-                'record a success outcome.'
-            ),
-        ),
-    ],
-    vault_id: Annotated[
-        str,
-        Field(
-            description=(
-                'Vault UUID or name the memory unit belongs to. REQUIRED — '
-                'the service rejects cross-vault review (vault-scoping invariant).'
-            ),
-        ),
-    ],
-) -> dict[str, Any]:
-    """Record a review outcome on a memory unit (FSRS-5 advance + outcome + audit)."""
-    try:
-        from memex_core.memory.revisit import Quality
-
-        api = get_api(ctx)
-        try:
-            uuid_obj = UUID(unit_id)
-        except ValueError:
-            raise ToolError(f'Invalid memory unit UUID: {unit_id}')
-
-        if isinstance(quality, int):
-            try:
-                quality_enum = Quality(quality)
-            except ValueError:
-                raise ToolError(
-                    f'Invalid quality {quality!r}; must be 1 (again), 2 (hard), '
-                    '3 (good), or 4 (easy).'
-                )
-        else:
-            quality_lc = quality.strip().lower()
-            try:
-                quality_enum = Quality[quality_lc.upper()]
-            except KeyError:
-                raise ToolError(
-                    f"Invalid quality {quality!r}; must be one of 'again', 'hard', 'good', 'easy'."
-                )
-
-        resolved_vault_id = await _resolve_vault_id(api, vault_id)
-        return await api.review_memory_unit(uuid_obj, quality_enum, vault_id=resolved_vault_id)
-    except ToolError:
-        raise
-    except PermissionError as exc:
-        raise ToolError(str(exc))
-    except Exception as e:
-        logger.error(f'memex_memory_review failed: {e}', exc_info=True)
-        raise ToolError(f'memex_memory_review failed: {e}')
 
 
 # --- Diagnostics ---

--- a/packages/mcp/tests/test_mcp_server_imports.py
+++ b/packages/mcp/tests/test_mcp_server_imports.py
@@ -1,0 +1,12 @@
+"""Backstop: the MCP server module imports cleanly after the FSRS-5 rip-out.
+
+The CI guard `scripts/ci/check_no_fsrs_residue.sh` catches textual residue;
+this test catches the case where a textually-clean import path still fails
+because a transitive module was removed.
+"""
+
+from __future__ import annotations
+
+
+def test_mcp_server_imports_clean() -> None:
+    import memex_mcp.server  # noqa: F401


### PR DESCRIPTION
## Summary

Strict-deletion follow-up to PR #156 (`50961679`, "rip out FSRS-5"). The parent PR removed `memex_common.revisit` and `memex_mcp._revisit_descriptions` modules but missed five lines of residue in `packages/mcp/src/memex_mcp/server.py`, so `import memex_mcp.server` raises `ModuleNotFoundError` on `release/tier-a-cognitive-memory` and silently breaks every Claude-Code consumer of Memex (the plugin's `.mcp.json` spawns `memex mcp run`, which crashes at startup).

This PR finishes that cleanup **and** wires the orphaned guard script into both pre-commit and CI so the regression cannot recur.

## Changes

**Strict deletion:**
- `packages/mcp/src/memex_mcp/server.py:23` — strike broken `from memex_common.revisit import reject_bool_quality` import.
- `packages/mcp/src/memex_mcp/server.py:4167-4287` — strike the entire `# --- Review / Revisit ---` block (second broken import + `memex_get_due_for_review` tool + `memex_memory_review` tool).

**Dual-gate protection (no new logic):**
- `.pre-commit-config.yaml` — second `local` hook `check-no-fsrs-residue` wraps `scripts/ci/check_no_fsrs_residue.sh`. Runs on every commit.
- `.github/workflows/ci.yaml` — three changes:
  1. paths-filter extended to include `scripts/ci/**` so the gate re-runs when the script changes.
  2. New discrete `Check no FSRS-5 residue` step in the existing `pre-commit` job (belt + suspenders: hook is the primary gate, the discrete step is the durable CI gate).
  3. New sibling job `mcp-import-check` running `pytest packages/mcp/tests --collect-only -q` — a sharper gate than the textual scan for import-time regressions. Both `build-python` and `docker-build-memex` now `needs:` this job, so an MCP import regression cannot ship a green artifact.
- `packages/mcp/tests/test_mcp_server_imports.py` — new test backstops the deletion at test-collection time.

**Design doc (gitignored, not in this diff)** — six passages in `DESIGN_DOCUMENT.md` and its `.temp/` lock-step twin were rewritten to drop "rip-out incomplete" / "Cleanup is in flight" / "Currently break MCP-server import" language, accurately describe the new dual-gate protection, and remove the now-stale `revisit()` method reference from the `MemexAPI` facade Mermaid label.

## Test plan

- [x] `bash scripts/ci/check_no_fsrs_residue.sh` exits 0 against the cleaned branch.
- [x] `uv run python -c "import memex_mcp.server"` exits 0.
- [x] `uv run pytest packages/mcp/tests --collect-only -q` exits 0 (403 tests collected).
- [x] `packages/mcp/tests/test_mcp_server_imports.py::test_mcp_server_imports_clean` passes.
- [x] Synthetic re-introduction (`from memex_core.memory.revisit import RevisitConfig` in a throwaway file) fails the pre-commit hook with exit 1 (verified locally; canary reverted).
- [x] `prek run --all-files` clean (commit succeeded with all hooks passing, including the new `check-no-fsrs-residue` hook).
- [ ] CI runs green on this PR — to be observed.
- [ ] Manual: `memex mcp run` spawn from Claude Code plugin no longer crashes (cannot be verified in CI; requires a Claude Code session against this branch).

## Notes for reviewers

- This is a strict deletion + CI-wiring change. No new logic, no new tables, no new tunables.
- The removed tools (`memex_get_due_for_review`, `memex_memory_review`) have been unreachable since PR #156 merged — anyone calling them was already hitting `ModuleNotFoundError`. No deprecation owed.
- `DESIGN_DOCUMENT.md` is gitignored at this repo, so the design-doc updates are not visible in this branch diff. They were applied locally to the canonical and `.temp/` twin in lock-step.
- Parent rip-out: PR #156 (`50961679`).