### PR TITLE
docs: V7 note lifecycle review (post-FSFM)

### DIFF
--- a/docs/design/lifecycle-review.md
+++ b/docs/design/lifecycle-review.md
@@ -1,0 +1,154 @@
+# Note lifecycle review — post-FSFM
+
+**Status:** review (decision record). Sprint ticket V7.
+**Branch:** `release/tier-a-cognitive-memory`.
+**Date:** 2026-05-11.
+
+> **Note on `DESIGN_DOCUMENT.md` references in this document.**
+> The canonical design document lives at the repo root as `DESIGN_DOCUMENT.md`. It is **`.gitignore`d** (`.gitignore:205`) and intentionally not under version control; it exists locally in the primary checkout. Section references in this review (e.g. "§2.4.4", "§3.3", "P6 in §1.2") point at that local artifact. Anchor verification therefore runs against the on-disk file, not the git tree.
+
+## TL;DR — 30-second read
+
+Lifecycle (`Note.status`) and FSFM (`MemoryUnit.is_deprioritized`) operate at different granularities, with different recovery paths and different retrieval-time filters. They do **not** collapse into each other.
+
+Two of the four lifecycle states earn less of their keep post-FSFM: `archived` duplicates the supersede cascade and could become an FSFM-driven path; `appended` is a chronology marker, not a suppression state, and belongs on a FK relation rather than the status enum. Two behaviors need small patches: MW counters on supersession (undocumented retention, not a bug), and orphan inbound `contradicts` links to stale targets (hygiene gap, surface via lint).
+
+| Question | Recommendation | Follow-up ticket |
+|---|---|---|
+| Q1 — `active` vs `is_deprioritized=true` | **Keep** | — |
+| Q2 — MW counters on supersession | **Patch** | V13 (proposed) |
+| Q3 — `archived` destructive cascade | **Consolidate** | V14 (proposed) |
+| Q4 — `appended` as a status value | **Consolidate** | V15 (proposed) |
+| Q5 — Hard overrides in FSFM | **Keep** | — |
+| Q6 — Orphan `contradicts` links | **Patch** | V16 (proposed) |
+
+---
+
+## Q1. `active` vs `is_deprioritized=true` — are these overlapping?
+
+**Recommendation: Keep.**
+
+The two flags live at different granularities, carry different semantics, and have non-overlapping recovery paths.
+
+- **Granularity.** `Note.status` (`packages/core/src/memex_core/memory/sql_models.py:269-278`) is a per-note string enum with CHECK constraint `status IN ('active','superseded','appended','archived')` at `packages/core/src/memex_core/memory/sql_models.py:312-315`. `MemoryUnit.is_deprioritized` (`packages/core/src/memex_core/memory/sql_models.py:596-600`) is a per-unit boolean. A note can be `active` while individual extracted units are `is_deprioritized=true`; the inverse holds too (note `superseded` → all units cascade to `status='stale'`).
+- **Retrieval semantics.** `SearchService.search` exposes three independent filter flags — `include_stale`, `include_superseded`, `include_deprioritized` — at `packages/core/src/memex_core/services/search.py:65-67`. They are not aliased. A deprioritized active unit is filtered by `include_deprioritized=False` (default); a stale unit (from a superseded or archived note) is filtered by `include_stale=False`. Both default to hidden; the agent sees neither without an explicit opt-in.
+- **Recovery.** A deprioritized unit recovers through the FSFM auto-band (composite score falls below the band threshold) or through the `memex_memory_restore` MCP tool; the `cooldown_days` knob gates the post-restore re-deprioritization window, not the band threshold itself. A stale unit recovers only through an explicit `Notes.set_note_status(...)` back to `active`, which cascades `unit.status = 'active'` for every unit on the note (`packages/core/src/memex_core/services/notes.py:248-258`).
+- **FSFM short-circuit reinforces the distinction.** The stale short-circuit at `packages/core/src/memex_core/services/deprioritize_score.py:208-209` returns score 0 for stale units before running the composite — this is defense-in-depth (the retrieval-time filter is the primary gate), and explicitly relies on `status != 'stale'` being the precondition for FSFM to operate.
+
+**Boundary to document in `DESIGN_DOCUMENT.md` §2.4.4:** lifecycle states are about *human intent* over notes; `is_deprioritized` is about *observed signal* over units. They cohabit one retrieval pipeline because both can suppress visibility, but they are not redundant.
+
+---
+
+## Q2. Superseded notes — do MW counters port to the superseder?
+
+**Recommendation: Patch.**
+
+Today, when a note is superseded, `Notes.set_note_status` enters the `superseded` branch at `packages/core/src/memex_core/services/notes.py:241-243` (writes `doc.superseded_by = linked_note_id`, then calls `_deactivate_note_units`); the cascade itself lives at `packages/core/src/memex_core/services/notes.py:279-299` and sets `unit.status = 'stale'` on every memory unit attached to the note (write at `:297`). The unit's `success_co_count` / `failure_co_count` columns are **not touched** and remain on the now-stale row. FSFM's `status == 'stale'` short-circuit at `packages/core/src/memex_core/services/deprioritize_score.py:208-209` means those counters are never read by the scorer — they are operationally inert.
+
+There are two questions here:
+
+1. **Should counters port to the superseder?** *No.* The superseder is, by Memex's append-only model, a new note with new units (`packages/core/src/memex_core/memory/sql_models.py:280-284`). Outcome attribution at the time the counters were incremented was against the old unit's text; porting would conflate contexts. The Beta-Bernoulli prior (`success+1, failure+1`) lets the superseder's new units start fresh at neutral.
+2. **Are the inert counters a bug?** *Almost no, with one patch needed.* The audit trail is valuable — historical lineage is a stated invariant (P6 in §1.2 of `DESIGN_DOCUMENT.md`, gitignored). But re-activating a superseded note today (`Notes.set_note_status(note_id, 'active')`) cascades `unit.status = 'active'` at `packages/core/src/memex_core/services/notes.py:258` (inside the `elif status == 'active'` branch starting at `:248`) and *re-activates the original counters along with the unit*. That is correct (audit trail preserved) but currently undocumented; a reader expecting reset-on-reactivation will be surprised.
+
+**Follow-up V13 (proposed):** Document the supersession→stale→counter retention behavior in `DESIGN_DOCUMENT.md` §2.4.4 and add an audit-event note. Optionally add a unit test under `packages/core/tests/unit/services/test_notes.py` asserting (a) counters are unchanged across supersede+reactivate, (b) FSFM does not read counters of stale units.
+
+---
+
+## Q3. `archived` — is the destructive cascade still differentiated from supersede?
+
+**Recommendation: Consolidate.**
+
+Operationally, `superseded` and `archived` are now indistinguishable in code: the `superseded` branch at `packages/core/src/memex_core/services/notes.py:241-243` and the `archived` branch at `packages/core/src/memex_core/services/notes.py:244-245` both call `_deactivate_note_units`, and the cascade body at `packages/core/src/memex_core/services/notes.py:279-299` is identical for both. The only branch difference is at `:242`: `superseded` writes `doc.superseded_by = linked_note_id`; `archived` skips the FK write. Wave 0 §3's framing of archive as a *destructive* cascade is misleading — neither transition actually destroys rows. Both leave the units as `status='stale'`, fully retained in `memory_units`, surfaced through the partial HNSW for stale units (`packages/core/src/memex_core/memory/sql_models.py:763-769`), and readable via `include_stale=True`.
+
+The intent split is real: *superseded* says "this is replaced by note X"; *archived* says "I'm done with this." But the operational cost of carrying two states for one cascade is non-zero — `NoteNotAppendableError` (raised at `packages/core/src/memex_core/services/ingestion.py:743-747`; docstring at `:561` enumerates archived/superseded as the two non-appendable parent states) gates both equally, retrieval flags treat both via `include_superseded` / `include_stale`, and the agent surface (`memex_set_note_status`) exposes both verbs with effectively identical downstream behavior.
+
+Post-FSFM, the better factoring is:
+- `archived` = `is_deprioritized=true` cascade across the note's units + a `note.archived_at` timestamp on `Note` (intent retained).
+- Loses the dedicated status value; gains FSFM-uniform suppression semantics (score-aware, auto-band-recoverable instead of requiring an explicit `set_note_status('active')`).
+
+**Follow-up V14 (proposed):** Migrate `archived` semantics into FSFM. Drop `archived` from `Note.status` CHECK enum. Add `Note.archived_at: datetime | None`. On archive, cascade `MemoryUnit.is_deprioritized = true` rather than `status = 'stale'`. Migration: backfill `archived_at = updated_at` for existing rows with `status='archived'`; flip `status` to `active`; flip units to `is_deprioritized = true`. Agent-surface impact: `memex_set_note_status('archived')` keeps the same name and intent, dispatches to the new path. Eval coverage: internal-regression scenario verifying archive → suppression visible at retrieval AND restore via `memex_memory_restore` works on archived-source units.
+
+---
+
+## Q4. `appended` — status value or relation-only concern?
+
+**Recommendation: Consolidate.**
+
+`appended` is the only one of the four states that is not a *lifecycle* status in the usual sense. The `Notes.set_note_status` path at `packages/core/src/memex_core/services/notes.py:246-247` writes `doc.appended_to = linked_note_id` but does **not** call `_deactivate_note_units` — the note keeps its `MemoryUnit` rows in `status='active'`, fully indexed, fully retrievable. The only structural effect is the `Note.appended_to` FK at `packages/core/src/memex_core/memory/sql_models.py:286-290`.
+
+In the post-FSFM landscape, the status enum's four values divide cleanly:
+- `active` — default visibility.
+- `superseded` — stale-cascade + replacement FK.
+- `archived` — stale-cascade (today) or FSFM suppression (per Q3).
+- `appended` — *not* a suppression state; a chronology marker.
+
+`appended` belongs alongside `superseded_by` as a structural FK relation, not on the status enum. The benefit is symmetry: the enum becomes a suppression-state enum (`active` / `superseded` / `archived`), the FK columns (`superseded_by`, `appended_to`) carry the relational chronology. Today's `Notes.set_note_status('appended', linked_note_id=X)` becomes `Ingestion.append_to_note(parent_note_id=X, ...)` semantically (the actual ingestion path at `packages/core/src/memex_core/services/ingestion.py:534` already does this through `NoteAppend`; the `status='appended'` value is the legacy duplicate).
+
+**Follow-up V15 (proposed):** Drop `'appended'` from `Note.status` CHECK enum. The `Note.appended_to` FK and the `NoteAppend` chronology table stay. Migration: backfill `status='active'` for existing rows with `status='appended'` (their unit-level state was already active). Agent-surface impact: `memex_set_note_status` rejects `'appended'` with a `ValueError` pointing the caller to the append flow; `memex_append_note` (or its CLI equivalent) is the supported path. Eval coverage: regression scenario asserting appended-parent notes remain retrievable at `status='active'` and the FK chain is queryable via `memex_get_lineage`.
+
+---
+
+## Q5. Hard overrides in FSFM — is the lifecycle layer redundant?
+
+**Recommendation: Keep.**
+
+FSFM hard overrides at `packages/core/src/memex_core/services/deprioritize_score.py:205-213` short-circuit the composite scorer for four conditions:
+
+1. `is_deprioritized=true` (check at `:206`) → score 0 (already deprioritized; idempotency).
+2. `status == 'stale'` (check at `:208`) → score 0 (lifecycle layer already filtered).
+3. `risk_class in {'sensitive','private','safety'}` (`PROTECTED_RISK_CLASSES` declared at `packages/core/src/memex_core/services/deprioritize_score.py:66`; check at `:210`) → score 0 (PII / safety floors).
+4. `intent_class == 'permanent'` (check at `:212`) → score 0 (write-time importance assertion).
+
+Each override addresses a non-overlapping concern. The lifecycle short-circuit (#2) is **not** redundant with the retrieval-time `include_stale=False` filter at `packages/core/src/memex_core/services/search.py:65-67`. They are layered:
+
+- The retrieval filter prevents stale units from being *served*.
+- The FSFM short-circuit prevents stale units from being *scored* (and thus from being mis-deprioritized further, or from polluting the score histogram).
+
+Without the FSFM short-circuit, a future code path that surfaces stale units in some bespoke flow (export, audit, debugging) could leak deprioritization scoring against rows whose `success_co_count` / `failure_co_count` are intentionally inert (per Q2). Defense-in-depth.
+
+The risk and intent overrides are orthogonal to lifecycle. A `risk_class='sensitive'` unit must be protected from auto-deprioritization regardless of its note's status; a `intent_class='permanent'` unit must never decay regardless of how its note has aged.
+
+**Boundary to document in `DESIGN_DOCUMENT.md` §2.4.4:** lifecycle state and risk/intent class are independent axes that both inform FSFM's hard overrides. Removing the lifecycle layer (Q3) does not change this layering; the override on `status=='stale'` continues to apply (or, post-Q3-merge, the override becomes `is_deprioritized=true` — same effect, narrower enum).
+
+---
+
+## Q6. State transitions and orphan `contradicts` links
+
+**Recommendation: Patch.**
+
+`MemoryLink` carries ten typed relations including `contradicts` (CHECK at `packages/core/src/memex_core/memory/sql_models.py:1344`). When a note is superseded or archived, `_deactivate_note_units` (`packages/core/src/memex_core/services/notes.py:279-299`, with the `unit.status = 'stale'` write at `:297`) sets every memory unit attached to the note to stale but leaves all inbound and outbound `MemoryLink` rows untouched. Specifically:
+
+- If unit U on note N is contradicted by unit V on note M (`MemoryLink(from_unit_id=V, to_unit_id=U, link_type='contradicts')`), and note N is archived, the link row survives. Unit U is now stale; unit V still surfaces.
+- At retrieval time, V's confidence may already have been lowered at extraction time by the contradiction-detection pass against U (the contradiction event runs at ingestion, not at scoring; the scoring path reads `unit.confidence` via the `confidence_alpha` reranker term — so V keeps carrying a lowered-confidence signal even though U is no longer reachable).
+
+This is **not** a correctness bug — FSFM's `status=='stale'` short-circuit (Q5) and the retrieval-time `include_stale` filter (Q1) ensure stale units don't surface in default flows. But it is a hygiene issue: the `MemoryLink` table accumulates rows pointing at stale targets indefinitely; the lint dashboard (`packages/core/src/memex_core/services/lint.py`) has no rule to surface this.
+
+Two options:
+
+- **Reap on transition.** On supersede/archive, delete inbound `contradicts` links where the target is now stale. Loses audit history (the contradiction *did* exist and may have influenced past retrievals).
+- **Surface via lint.** Add a lint rule `orphan_contradicts_links_post_stale` that proposes (does not auto-apply) reaping when accumulation exceeds a threshold. Keeps audit history; gives the operator the choice.
+
+The second option aligns with the non-destructive-curation invariant (P1).
+
+**Follow-up V16 (proposed):** Add lint rule `orphan_contradicts_links_post_stale` to `packages/core/src/memex_core/services/lint.py`. Rule predicate: `MemoryLink.link_type='contradicts'` where the `to_unit_id` references a unit with `status='stale'` or `is_deprioritized=true`. Emits a `MaintenanceProposal` (`packages/core/src/memex_core/memory/sql_models.py:1721`) with `lint_type='quality'` (per the CHECK at `:1797`: one of `structural` / `quality` / `governance` / `schema` — `quality` fits because the FK is intact and the orphan link is a data-hygiene concern, not a graph-integrity violation) and `source='rule'`. Surfaces via `memex_get_lint_flags`. Observability: counter `memex_orphan_contradicts_links_total{vault_id}`. Migration: none (read-only lint rule). Eval coverage: integration scenario seeds a contradiction edge, archives the source, verifies the lint rule proposes the link for triage without auto-applying.
+
+---
+
+## Summary table — proposed follow-ups
+
+| ID | Title | Scope | Migration | Agent-surface | Eval |
+|---|---|---|---|---|---|
+| V13 | Document supersession→stale→counter retention | Doc + unit test | N/A | N/A | unit test only |
+| V14 | Migrate `archived` into FSFM (`is_deprioritized` cascade) | Schema + service | Drop `archived` from `Note.status` enum; add `Note.archived_at`; backfill units | `memex_set_note_status('archived')` dispatch change | internal-regression scenario |
+| V15 | Drop `appended` from `Note.status` enum | Schema + service | Backfill `status='active'` for existing `appended` rows | `memex_set_note_status` rejects `'appended'` | regression scenario |
+| V16 | Lint rule for orphan `contradicts` links to stale targets | Service + lint | N/A | new `MaintenanceProposal` shape via `memex_get_lint_flags` | integration scenario |
+
+Each follow-up file declares its own full DoD, anchors, parity, and eval coverage when it's authored via `memex-feature-plan`.
+
+---
+
+## What this review does *not* do
+
+- No code change, no migration, no agent-surface change, no test change, no eval change land in this PR. The review is a decision document.
+- `DESIGN_DOCUMENT.md` §2.4.4 (Curate) and §3.3 (Note row) are not edited here — the boundary documentation called out under Q1 and Q5 lands alongside whichever follow-up implements behavior change (or as its own small doc-only PR).
+- The four follow-up IDs (V13–V16) are *proposed*; the BACKLOG entries are appended in this PR but the implementations are separate tickets.

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,16 @@ Understanding-oriented articles that explain how Memex works and why it is desig
 
 ---
 
+## Design notes
+
+Decision records and design reviews for ongoing or recently-shipped subsystems.
+
+| Note | Description |
+|:-----|:------------|
+| [Note lifecycle review (post-FSFM)](design/lifecycle-review.md) | Re-evaluates the four `Note.status` lifecycle states (`active` / `superseded` / `appended` / `archived`) against the FSFM-driven `is_deprioritized` path shipped in PR #156. Per-state Keep / Consolidate / Patch recommendation (no Remove) + follow-up tickets V13–V16. |
+
+---
+
 ## Package READMEs
 
 Each package in the monorepo has its own README with package-specific details.


### PR DESCRIPTION
## Summary

V7 is a review-only ticket: re-evaluate the four \`Note.status\` lifecycle states against the FSFM-driven \`is_deprioritized\` path shipped in PR #156. Produces \`docs/design/lifecycle-review.md\`, indexes it via \`docs/index.md\`, and drafts four follow-up tickets V13–V16 for the non-\`Keep\` recommendations.

No code, schema, agent-surface, test, or eval change lands in this PR. Behavior changes are deferred to whichever V13–V16 follow-up implements them.

## Verdict per question (full rationale in the doc)

| Q | Topic | Recommendation | Follow-up |
|---|---|---|---|
| Q1 | \`active\` vs \`is_deprioritized\` | Keep | — |
| Q2 | MW counters on supersession | Patch | V13 |
| Q3 | \`archived\` destructive cascade | Consolidate | V14 |
| Q4 | \`appended\` as status value | Consolidate | V15 |
| Q5 | FSFM hard overrides | Keep | — |
| Q6 | Orphan \`contradicts\` links | Patch | V16 |

## Changes

- New file: \`docs/design/lifecycle-review.md\` (164-line review with verified \`file:line\` citations for every claim).
- New directory: \`docs/design/\`.
- Updated: \`docs/index.md\` — new "Design notes" section + table row pointing at the review.
- \`BACKLOG.md\` (gitignored, not in this diff) — V13–V16 follow-up tickets drafted with full intent / scope / dependencies / agent-surface / tests / eval shape.

## Review history

6 adversarial-review rounds (each spawning a fresh reviewer; no cycle cap per the augmented \`implement-backlog-item\` skill):

1. Round 1: 3 CRIT / 4 HIGH / 2 MED / 2 LOW — all citation anchors in \`notes.py\` were wrong (lines pointed inside \`_deactivate_note_units\` instead of the \`set_note_status\` branches), one \`deprioritize_score.py\` line off-by-2, one \`sql_models.py\` btree vs HNSW miscitation, reviewer misread \`DESIGN_DOCUMENT.md\` as a missing file (it's gitignored — preamble added).
2. Round 2: 1 HIGH / 1 MED / 1 LOW — V14 BACKLOG anchor was the same anchor-class error in BACKLOG; TL;DR was too dense.
3. Round 3: 2 MED — method name \`Notes.set_status\` doesn't exist (real method is \`set_note_status\`); \`Notes.append_note\` also fabricated (real is \`Ingestion.append_to_note\`).
4. Round 4: 1 HIGH / 2 MED / 2 LOW — V16 fabricated an MCP tool (\`memex_apply_lint_proposal\` doesn't exist); V15 BACKLOG missed one \`set_status\` site; \`NoteNotAppendableError\` anchor pointed at docstring not raise site; \`cooldown_days\` and \`confidence_alpha\` framings were loose.
5. Round 5: 1 MED — fabricated \`severity\` field on \`MaintenanceProposal\` (schema uses \`lint_type\` enum: \`structural | quality | governance | schema\`).
6. Round 6: 0 CRIT / 0 HIGH / 0 MED / 1 LOW — cosmetic mismatch in \`docs/index.md\` row (mentioned "Remove" verdict that the review never used). Patched.

Self-assessment: **99%**.

## Test plan

- [x] \`prek run --files docs/design/lifecycle-review.md docs/index.md\` clean.
- [x] Every \`path:line\` anchor in the review doc + V13–V16 BACKLOG entries verified against the worktree by an adversarial reviewer (round 6).
- [ ] Human spot-check on Q3 and Q4 recommendations (Consolidate verdicts — V14 + V15 follow-up scopes need product agreement before implementation kicks off).

## After merge

- Tick the V7 checkbox in SPRINT.md.
- Consider scheduling V13 first (smallest scope, pure documentation + one unit test).
- V14 and V15 are schema migrations — coordinate with any in-flight migration work to avoid revision-id collisions.