### PR TITLE
feat(cli/sync): V2 — frontmatter vault: override on Obsidian sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,507%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,508%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,503%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,506%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,506%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,507%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,470%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,503%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,508%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,509%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/docs/how-to/override-vault-with-frontmatter.md
+++ b/docs/how-to/override-vault-with-frontmatter.md
@@ -1,0 +1,79 @@
+# How to Override the Target Vault via Frontmatter
+
+Memex sync respects a `vault:` key in a note's YAML frontmatter as an explicit override of the sync's active vault. The override is per-note: it routes the note to a different vault on the same server without re-running sync for the whole folder.
+
+This guide shows the typical flow: adding the override, re-syncing, and verifying the note migrated correctly.
+
+## When to use this
+
+Use a frontmatter override when:
+
+* A single note belongs to a different project than the rest of the vault.
+* You are reorganizing notes across vaults and want sync to migrate them rather than archive-and-recreate manually.
+* You want one Obsidian folder to feed multiple Memex vaults based on per-note classification.
+
+## Add the override
+
+Edit the note's YAML frontmatter and add a `vault:` key. The value is either the vault's name or its UUID:
+
+```markdown
+---
+title: Project Alpha notes
+vault: alpha
+---
+
+# Meeting notes
+...
+```
+
+## Re-sync
+
+Run a normal incremental sync. Memex will detect the override, archive the prior version of the note in its original vault (if any), and re-ingest into the target:
+
+```bash
+memex note sync run ~/my-notes
+```
+
+The sync output reports a `migrated` counter alongside the usual ingest/skip/archive counts:
+
+```
+Synced 1 ingested, 0 skipped, 1 migrated
+```
+
+## Verify
+
+Confirm the note now lives in the target vault:
+
+```bash
+memex note list --vault alpha
+```
+
+The original vault no longer surfaces the note in active retrieval — it was archived as part of the migration.
+
+## Customizing the frontmatter key
+
+By default, the sync engine reads the `vault:` key. Change it in `note-sync.toml` if your existing notes use a different convention:
+
+```toml
+[sync.exclude]
+frontmatter_vault_key = "memex_vault"
+```
+
+## Edge cases
+
+### Unknown vault name
+
+If `vault:` cites a name (or UUID) that the server does not recognize, sync logs a warning and falls back to the active sync vault — the note is **not** orphan-created. Fix the typo or create the vault, then re-sync.
+
+### Removing an override
+
+Removing the `vault:` key from frontmatter is **not** automatically reverted. The note remains in its current target vault. To move it back, set `vault:` to the original vault explicitly, then re-sync.
+
+### Vault name vs. UUID
+
+Both work. Using the UUID is more stable across vault renames but less readable.
+
+## See also
+
+* [Sync Notes](sync-notes.md) — the canonical sync workflow.
+* [Organize with Vaults](organize-with-vaults.md) — how vaults isolate notes and memories.

--- a/docs/how-to/override-vault-with-frontmatter.md
+++ b/docs/how-to/override-vault-with-frontmatter.md
@@ -67,7 +67,11 @@ If `vault:` cites a name (or UUID) that the server does not recognize, sync logs
 
 ### Removing an override
 
-Removing the `vault:` key from frontmatter is **not** automatically reverted. The note remains in its current target vault. To move it back, set `vault:` to the original vault explicitly, then re-sync.
+Removing the `vault:` key from frontmatter is **not** automatically reverted. The note remains in its current target vault, and subsequent edits continue to flow into the same vault — sync remembers the previous routing via per-file state (`SyncedFile.vault_id`). To move it back, set `vault:` to the original vault explicitly, then re-sync.
+
+### Ingest failure during migration
+
+The migration archives the prior version **only after** the new ingest succeeds. If the new ingest fails (network error, validation error, etc.), the original note remains active in its source vault and no `migrated` increment is reported. Retry the sync once the issue is resolved.
 
 ### Vault name vs. UUID
 

--- a/docs/how-to/sync-notes.md
+++ b/docs/how-to/sync-notes.md
@@ -121,6 +121,19 @@ This note will not be synced to Memex.
 
 The frontmatter key and value are configurable in `note-sync.toml` (see below).
 
+## Routing Notes to a Different Vault via Frontmatter
+
+A single note can target a different vault than the active sync vault by adding a `vault:` key to its frontmatter:
+
+```markdown
+---
+title: Project Alpha notes
+vault: alpha
+---
+```
+
+On re-sync, Memex archives the prior version of the note (if any) in its original vault and re-ingests into `alpha`. The sync result includes a `migrated` counter alongside the usual `ingested` / `skipped` counts. See [Override the Target Vault via Frontmatter](override-vault-with-frontmatter.md) for the full workflow, including handling of unknown vault names.
+
 ## Configuration
 
 Edit `note-sync.toml` in your vault folder to customize sync behavior. The full default config:
@@ -144,6 +157,7 @@ extends_exclude = []
 ignore_folders = []
 frontmatter_skip_key = "agents"
 frontmatter_skip_value = "skip"
+frontmatter_vault_key = "vault"
 
 [sync.assets]
 enabled = true

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ Goal-oriented recipes for specific tasks. Assumes you have a working Memex insta
 | [Delete and Archival](how-to/delete-archival.md) | Delete notes, entities, and memory units; manage data lifecycle. |
 | [Note Templates](how-to/note-templates.md) | Create, register, and use note templates for consistent structure. |
 | [Sync Notes](how-to/sync-notes.md) | Sync a folder of Markdown notes to Memex with incremental updates. |
+| [Override Vault with Frontmatter](how-to/override-vault-with-frontmatter.md) | Route individual notes to a different vault using a `vault:` key in YAML frontmatter, with archive-on-migration semantics. |
 | [Firefox Extension](how-to/firefox-extension.md) | Capture articles and PDFs from Firefox directly into Memex. |
 
 ---

--- a/packages/cli/src/memex_cli/sync/config.py
+++ b/packages/cli/src/memex_cli/sync/config.py
@@ -56,6 +56,15 @@ class ExcludeConfig(BaseModel):
         'For example, with key="agents" and value="skip", a note with '
         '"agents: skip" in its frontmatter will not be synced.',
     )
+    frontmatter_vault_key: str = Field(
+        default='vault',
+        description='Frontmatter key checked to route a note to a different vault. '
+        'If the note has this key set to a vault name or vault ID, the note is '
+        'ingested into that vault instead of the active sync vault. Re-syncing '
+        'after the override is added or changed migrates the note: archive in '
+        'the source vault, ingest in the target. Unknown vaults log a warning '
+        'and fall back to the active sync vault.',
+    )
 
     @property
     def all_patterns(self) -> list[str]:

--- a/packages/cli/src/memex_cli/sync/engine.py
+++ b/packages/cli/src/memex_cli/sync/engine.py
@@ -11,10 +11,10 @@ import structlog
 from pydantic import BaseModel, Field
 
 from memex_common.client import RemoteMemexAPI
-from memex_common.schemas import BatchJobStatus, NoteCreateDTO
+from memex_common.schemas import BatchJobStatus, NoteCreateDTO, VaultDTO
 
 from .config import SyncConfig
-from .scanner import VaultNote, scan_vault
+from .scanner import VaultNote, parse_frontmatter, scan_vault
 from .state import SyncStateDB, diff
 
 logger = structlog.get_logger()
@@ -41,6 +41,11 @@ class SyncResult(BaseModel):
         default=0,
         description='Number of previously archived notes reactivated in Memex.',
     )
+    migrated: int = Field(
+        default=0,
+        description='Number of notes migrated to a different vault via frontmatter override. '
+        'Each migrated note is archived in its prior vault and re-ingested in the target.',
+    )
     errors: list[str] = Field(default_factory=list, description='Error messages for failed notes.')
     deleted_detected: list[str] = Field(
         default_factory=list,
@@ -60,10 +65,24 @@ def _build_note_dto(
     vault_id: str | None,
     note_key_prefix: str = 'obsidian',
     tags: list[str] | None = None,
+    override_vault: VaultDTO | None = None,
 ) -> NoteCreateDTO:
-    """Build a NoteCreateDTO from a VaultNote."""
+    """Build a NoteCreateDTO from a VaultNote.
+
+    WHY: note_key embeds vault_name (mutable) rather than vault_id (stable).
+    Renaming a vault folder mid-sync would re-key all of its notes — a known
+    latent limitation. V2 mitigates re-keying for the *frontmatter-override*
+    case via explicit migration in sync_vault; a deeper fix would store
+    vault_id in the key. Filed in BACKLOG.
+    """
     content_bytes = note.path.read_bytes()
-    note_key = f'{note_key_prefix}:{vault_name}:{note.relative_path}'
+    if override_vault is not None:
+        effective_vault_name = override_vault.name
+        effective_vault_id: str | None = str(override_vault.id)
+    else:
+        effective_vault_name = vault_name
+        effective_vault_id = vault_id
+    note_key = f'{note_key_prefix}:{effective_vault_name}:{note.relative_path}'
     name = note.path.stem
 
     files_dict: dict[str, bytes] = {}
@@ -83,9 +102,109 @@ def _build_note_dto(
         files=files_dict,
         tags=tags or [],
         note_key=note_key,
-        vault_id=vault_id,
+        vault_id=effective_vault_id,
         filename=filename,
     )
+
+
+def _post_sync_state(
+    notes: list[VaultNote],
+    overrides: dict[str, VaultDTO],
+    vault_name: str,
+    vault_id: str | None,
+    note_key_prefix: str,
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Compute (note_keys, per_file_vault_ids) maps for state.mark_synced.
+
+    For notes with a resolved frontmatter override, the per-file vault_id is
+    the override's UUID and the note_key embeds the override's vault name.
+    For notes without override, we record the active sync vault_id (when set)
+    and the active vault_name; on a no-op resync this preserves invariants
+    and lets a later override be detected as a migration.
+    """
+    note_keys: dict[str, str] = {}
+    per_file_vault_ids: dict[str, str] = {}
+    for note in notes:
+        ov = overrides.get(note.relative_path)
+        if ov is not None:
+            note_keys[note.relative_path] = f'{note_key_prefix}:{ov.name}:{note.relative_path}'
+            per_file_vault_ids[note.relative_path] = str(ov.id)
+        else:
+            note_keys[note.relative_path] = f'{note_key_prefix}:{vault_name}:{note.relative_path}'
+            if vault_id is not None:
+                per_file_vault_ids[note.relative_path] = vault_id
+    return note_keys, per_file_vault_ids
+
+
+def _read_frontmatter_vault(note: VaultNote, vault_key: str) -> str | None:
+    """Return the raw frontmatter value of ``vault_key`` for ``note``, or None.
+
+    Markdown-only — binary file types in include_extensions have no frontmatter.
+    """
+    if note.path.suffix.lower() != '.md':
+        return None
+    try:
+        content = note.path.read_text(encoding='utf-8', errors='replace')
+    except OSError:
+        return None
+    raw = parse_frontmatter(content).get(vault_key, '').strip()
+    return raw or None
+
+
+async def _resolve_frontmatter_vaults(
+    api: RemoteMemexAPI,
+    notes: list[VaultNote],
+    vault_key: str,
+) -> dict[str, VaultDTO]:
+    """Resolve frontmatter ``vault:`` overrides for the given notes.
+
+    Returns a mapping of ``relative_path → VaultDTO`` for every note whose
+    frontmatter cites a vault that resolves to an existing memex vault.
+    Notes whose frontmatter value does not resolve are skipped here; the
+    caller is expected to surface a warning and fall back to the default
+    vault for those.
+
+    Memoizes via a single ``list_vaults()`` lookup so each unique override
+    name costs zero additional HTTP round-trips after the first call.
+    """
+    requested: dict[str, str] = {}
+    for note in notes:
+        raw = _read_frontmatter_vault(note, vault_key)
+        if raw is not None:
+            requested[note.relative_path] = raw
+
+    if not requested:
+        return {}
+
+    try:
+        all_vaults = await api.list_vaults()
+    except Exception as e:
+        logger.warning(
+            'Failed to list vaults for frontmatter override resolution; '
+            'falling back to default vault for all overrides.',
+            error=str(e),
+        )
+        return {}
+
+    by_name: dict[str, VaultDTO] = {v.name: v for v in all_vaults}
+    by_id: dict[str, VaultDTO] = {str(v.id): v for v in all_vaults}
+
+    resolved: dict[str, VaultDTO] = {}
+    warned: set[str] = set()
+    for rel_path, raw in requested.items():
+        vault = by_name.get(raw) or by_id.get(raw)
+        if vault is not None:
+            resolved[rel_path] = vault
+        elif raw not in warned:
+            logger.warning(
+                'Frontmatter vault override does not match any known vault; '
+                'falling back to default vault.',
+                path=rel_path,
+                requested_vault=raw,
+            )
+            warned.add(raw)
+
+    return resolved
 
 
 async def _poll_job(
@@ -300,6 +419,56 @@ async def sync_vault(
         if dry_run:
             return result
 
+        # Resolve frontmatter vault overrides for changed + returning notes.
+        # Returned mapping covers only the paths whose override resolved to a
+        # known vault; unknown vault names fall back to the default (warned).
+        override_candidates = list(changed) + list(returning)
+        overrides = await _resolve_frontmatter_vaults(
+            api,
+            override_candidates,
+            sync_config.exclude.frontmatter_vault_key,
+        )
+
+        # Detect migrations: a note already tracked in SyncedFile whose
+        # resolved frontmatter override differs from its previously-recorded
+        # vault_id. We archive the old note (by note_id, which is globally
+        # unique) before re-ingesting it into the target vault. This prevents
+        # orphan-create when vault_name is embedded in note_key.
+        migrations: list[tuple[str, str, VaultDTO]] = []  # (rel_path, old_note_id, target)
+        for note in changed:
+            target = overrides.get(note.relative_path)
+            if target is None:
+                continue
+            existing = state.get_file(note.relative_path)
+            if existing is None or existing.note_id is None or existing.vault_id == str(target.id):
+                continue
+            migrations.append((note.relative_path, existing.note_id, target))
+
+        if migrations:
+            if on_progress:
+                on_progress('migrating', 0, len(migrations), 'Migrating notes to new vault...')
+            for i, (rel_path, old_note_id, target) in enumerate(migrations):
+                try:
+                    await api.set_note_status(UUID(old_note_id), 'archived')
+                    result.migrated += 1
+                    logger.info(
+                        'Archived note in prior vault for frontmatter override migration',
+                        path=rel_path,
+                        old_note_id=old_note_id,
+                        target_vault=target.name,
+                        target_vault_id=str(target.id),
+                    )
+                except Exception as e:
+                    result.errors.append(f'{rel_path}: migrate archive failed: {e}')
+                    logger.error(
+                        'Failed to archive prior version during vault migration',
+                        path=rel_path,
+                        old_note_id=old_note_id,
+                        error=str(e),
+                    )
+                if on_progress:
+                    on_progress('migrating', i + 1, len(migrations), rel_path)
+
         # 3. Build DTOs and ingest
         # 3a. Ingest changed notes
         if changed:
@@ -314,6 +483,7 @@ async def sync_vault(
                         vault_id,
                         note_key_prefix=sync_config.note_key_prefix,
                         tags=list(sync_config.default_tags),
+                        override_vault=overrides.get(note.relative_path),
                     )
                     dtos.append(dto)
                 except Exception as e:
@@ -349,10 +519,14 @@ async def sync_vault(
                         result.failed = 1
                         result.errors.append(str(e))
                 else:
+                    # When any DTO carries a frontmatter override, suppress the
+                    # batch-level vault_id so per-note vault_id is respected;
+                    # otherwise server-side batch override would clobber it.
+                    batch_vault_id = None if overrides else vault_id
                     try:
                         job_status = await api.ingest_batch(
                             dtos,
-                            vault_id=vault_id,
+                            vault_id=batch_vault_id,
                             batch_size=sync_config.batch_size,
                         )
 
@@ -408,7 +582,20 @@ async def sync_vault(
 
                 # Update state with note_ids
                 if result.ingested > 0 or result.skipped > 0:
-                    state.mark_synced(changed, vault_id, note_ids=note_ids)
+                    note_keys, per_file_vault_ids = _post_sync_state(
+                        changed,
+                        overrides,
+                        vault_name,
+                        vault_id,
+                        sync_config.note_key_prefix,
+                    )
+                    state.mark_synced(
+                        changed,
+                        vault_id,
+                        note_ids=note_ids,
+                        note_keys=note_keys,
+                        per_file_vault_ids=per_file_vault_ids,
+                    )
 
         # 3b. Handle deleted files
         if deleted and handle_deletes:
@@ -441,17 +628,36 @@ async def sync_vault(
                             vault_id,
                             note_key_prefix=sync_config.note_key_prefix,
                             tags=list(sync_config.default_tags),
+                            override_vault=overrides.get(note.relative_path),
                         )
                         resp = await api.ingest(dto, background=False)
+                        nks, pvids = _post_sync_state(
+                            [note],
+                            overrides,
+                            vault_name,
+                            vault_id,
+                            sync_config.note_key_prefix,
+                        )
                         if resp.status == 'success':
                             result.ingested += 1
                             nids = {}
                             if resp.note_id:
                                 nids[note.relative_path] = resp.note_id
-                            state.mark_synced([note], note_ids=nids)
+                            state.mark_synced(
+                                [note],
+                                vault_id,
+                                note_ids=nids,
+                                note_keys=nks,
+                                per_file_vault_ids=pvids,
+                            )
                         elif resp.status == 'skipped':
                             result.skipped += 1
-                            state.mark_synced([note])
+                            state.mark_synced(
+                                [note],
+                                vault_id,
+                                note_keys=nks,
+                                per_file_vault_ids=pvids,
+                            )
                     except Exception as e:
                         result.errors.append(f'{note.relative_path}: ingest failed: {e}')
                     continue
@@ -473,12 +679,26 @@ async def sync_vault(
                         vault_id,
                         note_key_prefix=sync_config.note_key_prefix,
                         tags=list(sync_config.default_tags),
+                        override_vault=overrides.get(note.relative_path),
                     )
                     resp = await api.ingest(dto, background=False)
                     if resp.status == 'success':
                         result.ingested += 1
                     elif resp.status == 'skipped':
                         result.skipped += 1
+                    nks, pvids = _post_sync_state(
+                        [note],
+                        overrides,
+                        vault_name,
+                        vault_id,
+                        sync_config.note_key_prefix,
+                    )
+                    state.mark_synced(
+                        [note],
+                        vault_id,
+                        note_keys=nks,
+                        per_file_vault_ids=pvids,
+                    )
                 except Exception as e:
                     result.errors.append(f'{note.relative_path}: unarchive failed: {e}')
                     logger.error(

--- a/packages/cli/src/memex_cli/sync/engine.py
+++ b/packages/cli/src/memex_cli/sync/engine.py
@@ -221,6 +221,27 @@ async def _fetch_vaults_by_id(api: RemoteMemexAPI) -> dict[str, VaultDTO]:
     return {str(v.id): v for v in all_vaults}
 
 
+def _resolve_active_vault_id(
+    vault_id: str | None,
+    vaults_by_id: dict[str, VaultDTO],
+) -> str | None:
+    """Return the string UUID of the active sync vault, or None if unknown.
+
+    ``vault_id`` may be a UUID string or a vault name; this resolves either
+    form against the cached vault directory. Used to decide whether a legacy
+    SyncedFile row (vault_id=None) is already in the same vault that a new
+    frontmatter override resolves to — in which case no migration is needed.
+    """
+    if vault_id is None:
+        return None
+    if vault_id in vaults_by_id:
+        return vault_id
+    for vid, vault in vaults_by_id.items():
+        if vault.name == vault_id:
+            return vid
+    return None
+
+
 def _compute_effective_targets(
     notes: list[VaultNote],
     overrides: dict[str, VaultDTO],
@@ -517,13 +538,23 @@ async def sync_vault(
         # relative_path; the post-ingest pass archives the old note ONLY for
         # paths whose new ingest succeeded. Archiving up front would lose the
         # user's note if the new ingest fails.
+        active_vault_uuid = _resolve_active_vault_id(vault_id, vaults_by_id)
         pending_migrations: dict[str, tuple[str, VaultDTO]] = {}
         for note in changed:
             target = overrides.get(note.relative_path)
             if target is None:
                 continue
             existing = state.get_file(note.relative_path)
-            if existing is None or existing.note_id is None or existing.vault_id == str(target.id):
+            if (
+                existing is None
+                or existing.note_id is None
+                or existing.vault_id == str(target.id)
+                or (
+                    existing.vault_id is None
+                    and active_vault_uuid is not None
+                    and active_vault_uuid == str(target.id)
+                )
+            ):
                 continue
             pending_migrations[note.relative_path] = (existing.note_id, target)
 
@@ -819,8 +850,17 @@ async def sync_vault(
                     is_migration_return = (
                         target is not None
                         and existing_row is not None
-                        and existing_row.vault_id is not None
-                        and existing_row.vault_id != str(target.id)
+                        and (
+                            (
+                                existing_row.vault_id is not None
+                                and existing_row.vault_id != str(target.id)
+                            )
+                            or (
+                                existing_row.vault_id is None
+                                and active_vault_uuid is not None
+                                and active_vault_uuid != str(target.id)
+                            )
+                        )
                     )
                     if not is_migration_return:
                         await api.set_note_status(note_uuid, 'active')

--- a/packages/cli/src/memex_cli/sync/engine.py
+++ b/packages/cli/src/memex_cli/sync/engine.py
@@ -609,23 +609,45 @@ async def sync_vault(
                             result.failed = final.result.failed_count
                             for err in final.result.errors:
                                 result.errors.append(str(err))
-                            # Capture per-position note_ids first.
-                            id_by_pos: dict[int, str] = {}
-                            for idx, nid in enumerate(final.result.note_ids):
-                                if idx < len(dto_notes) and nid:
-                                    id_by_pos[idx] = nid
-                                    note_ids[dto_notes[idx].relative_path] = nid
-                            # Determine success:
-                            #   - failed_count == 0 ⇒ all DTOs succeeded
-                            #     (server may omit note_ids on full success)
-                            #   - failed_count > 0 ⇒ only positions whose
-                            #     note_ids entry is populated count as
-                            #     successful; the rest were rejected.
-                            if final.result.failed_count == 0:
+                            # The server's `note_ids` list is aligned with
+                            # *processed* notes only — skipped entries are
+                            # excluded (services/ingestion.py:967). So when
+                            # the batch contains skips or partial failures,
+                            # `note_ids[idx]` does NOT correspond to
+                            # `dto_notes[idx]`. Trust positional mapping
+                            # only when the alignment is unambiguous; in
+                            # all other cases preserve existing state by
+                            # leaving `note_ids` empty and (when no
+                            # failures) treat all DTOs as ingested for
+                            # state-mark purposes (server confirms the
+                            # ingest succeeded for the totals).
+                            n_returned = len(final.result.note_ids)
+                            positional_safe = (
+                                final.result.failed_count == 0
+                                and final.result.skipped_count == 0
+                                and n_returned == len(dto_notes)
+                            )
+                            if positional_safe:
+                                for idx, nid in enumerate(final.result.note_ids):
+                                    if nid:
+                                        note_ids[dto_notes[idx].relative_path] = nid
+                                successful_notes.extend(dto_notes)
+                            elif final.result.failed_count == 0:
+                                # Skips muddle positional mapping. State
+                                # update will not overwrite note_id for
+                                # the ambiguous positions — mark_synced
+                                # only writes note_id when the key is in
+                                # the note_ids dict, which we leave empty.
                                 successful_notes.extend(dto_notes)
                             else:
-                                for idx in id_by_pos:
-                                    successful_notes.append(dto_notes[idx])
+                                # Partial failure WITH unreliable
+                                # positional mapping — conservatively
+                                # treat ALL as failed for state purposes.
+                                # The user can re-sync; the server has
+                                # already processed what it could, and
+                                # idempotency on note_key prevents
+                                # duplicates on retry.
+                                pass
                         elif final is not None and final.status == 'failed':
                             result.failed = len(dtos)
                             result.errors.append(f'Batch job {job_status.job_id} failed')
@@ -677,7 +699,21 @@ async def sync_vault(
                         if rel_path not in successful_paths:
                             continue
                         try:
-                            await api.set_note_status(UUID(old_note_id), 'archived')
+                            old_uuid = UUID(old_note_id)
+                        except ValueError:
+                            result.errors.append(
+                                f'{rel_path}: migrate archive skipped — stored '
+                                f'note_id is not a valid UUID ({old_note_id!r})'
+                            )
+                            logger.warning(
+                                'Stored note_id is not a valid UUID; '
+                                'skipping migration archive for this path',
+                                path=rel_path,
+                                old_note_id=old_note_id,
+                            )
+                            continue
+                        try:
+                            await api.set_note_status(old_uuid, 'archived')
                             result.migrated += 1
                             logger.info(
                                 'Archived prior-vault note after successful migration',

--- a/packages/cli/src/memex_cli/sync/engine.py
+++ b/packages/cli/src/memex_cli/sync/engine.py
@@ -109,30 +109,26 @@ def _build_note_dto(
 
 def _post_sync_state(
     notes: list[VaultNote],
-    overrides: dict[str, VaultDTO],
-    vault_name: str,
-    vault_id: str | None,
+    effective_targets: dict[str, VaultDTO],
     note_key_prefix: str,
 ) -> tuple[dict[str, str], dict[str, str]]:
     """Compute (note_keys, per_file_vault_ids) maps for state.mark_synced.
 
-    For notes with a resolved frontmatter override, the per-file vault_id is
-    the override's UUID and the note_key embeds the override's vault name.
-    For notes without override, we record the active sync vault_id (when set)
-    and the active vault_name; on a no-op resync this preserves invariants
-    and lets a later override be detected as a migration.
+    Only notes with an effective target (explicit frontmatter override or
+    implicit stored-state target) get an entry — mark_synced preserves
+    existing values for notes omitted from the dicts. This avoids
+    overwriting per-file vault_id when the user re-syncs a note that has
+    no override (which would silently desync state from the server's
+    actual placement of the note).
     """
     note_keys: dict[str, str] = {}
     per_file_vault_ids: dict[str, str] = {}
     for note in notes:
-        ov = overrides.get(note.relative_path)
-        if ov is not None:
-            note_keys[note.relative_path] = f'{note_key_prefix}:{ov.name}:{note.relative_path}'
-            per_file_vault_ids[note.relative_path] = str(ov.id)
-        else:
-            note_keys[note.relative_path] = f'{note_key_prefix}:{vault_name}:{note.relative_path}'
-            if vault_id is not None:
-                per_file_vault_ids[note.relative_path] = vault_id
+        target = effective_targets.get(note.relative_path)
+        if target is None:
+            continue
+        note_keys[note.relative_path] = f'{note_key_prefix}:{target.name}:{note.relative_path}'
+        per_file_vault_ids[note.relative_path] = str(target.id)
     return note_keys, per_file_vault_ids
 
 
@@ -155,14 +151,19 @@ async def _resolve_frontmatter_vaults(
     api: RemoteMemexAPI,
     notes: list[VaultNote],
     vault_key: str,
-) -> dict[str, VaultDTO]:
+) -> tuple[dict[str, VaultDTO], dict[str, VaultDTO]]:
     """Resolve frontmatter ``vault:`` overrides for the given notes.
 
-    Returns a mapping of ``relative_path → VaultDTO`` for every note whose
-    frontmatter cites a vault that resolves to an existing memex vault.
-    Notes whose frontmatter value does not resolve are skipped here; the
-    caller is expected to surface a warning and fall back to the default
-    vault for those.
+    Returns ``(overrides, by_id)`` where:
+    - ``overrides`` maps ``relative_path → VaultDTO`` for every note whose
+      frontmatter cites a vault that resolves to an existing memex vault.
+      Unknown vault names are logged once each and excluded — caller falls
+      back to the active sync vault for those paths.
+    - ``by_id`` is the full ``vault_id (str) → VaultDTO`` directory pulled
+      from ``list_vaults()``. Callers reuse this to resolve *implicit*
+      targets for notes that have a stored ``SyncedFile.vault_id`` but no
+      explicit frontmatter override (keeping repeat syncs idempotent on the
+      server's previously-stored ``note_key``).
 
     Memoizes via a single ``list_vaults()`` lookup so each unique override
     name costs zero additional HTTP round-trips after the first call.
@@ -174,7 +175,7 @@ async def _resolve_frontmatter_vaults(
             requested[note.relative_path] = raw
 
     if not requested:
-        return {}
+        return {}, {}
 
     try:
         all_vaults = await api.list_vaults()
@@ -184,7 +185,7 @@ async def _resolve_frontmatter_vaults(
             'falling back to default vault for all overrides.',
             error=str(e),
         )
-        return {}
+        return {}, {}
 
     by_name: dict[str, VaultDTO] = {v.name: v for v in all_vaults}
     by_id: dict[str, VaultDTO] = {str(v.id): v for v in all_vaults}
@@ -204,7 +205,53 @@ async def _resolve_frontmatter_vaults(
             )
             warned.add(raw)
 
-    return resolved
+    return resolved, by_id
+
+
+async def _fetch_vaults_by_id(api: RemoteMemexAPI) -> dict[str, VaultDTO]:
+    """Best-effort cache of vault_id → VaultDTO for implicit-target lookup."""
+    try:
+        all_vaults = await api.list_vaults()
+    except Exception as e:
+        logger.warning(
+            'Failed to list vaults; implicit vault targets unresolved.',
+            error=str(e),
+        )
+        return {}
+    return {str(v.id): v for v in all_vaults}
+
+
+def _compute_effective_targets(
+    notes: list[VaultNote],
+    overrides: dict[str, VaultDTO],
+    state: SyncStateDB,
+    vaults_by_id: dict[str, VaultDTO],
+) -> dict[str, VaultDTO]:
+    """Compose explicit frontmatter overrides with implicit stored-state
+    targets to produce per-note routing decisions.
+
+    Priority per note:
+    1. Frontmatter override (caller already resolved to a VaultDTO).
+    2. Stored ``SyncedFile.vault_id`` looked up in ``vaults_by_id`` — so a
+       note that was previously routed via override and then had its
+       override removed continues to be ingested into the same vault on
+       subsequent syncs (the documented "removing the override does not
+       auto-revert" behavior).
+    3. None — caller falls back to the active sync vault.
+    """
+    targets: dict[str, VaultDTO] = {}
+    for note in notes:
+        explicit = overrides.get(note.relative_path)
+        if explicit is not None:
+            targets[note.relative_path] = explicit
+            continue
+        existing = state.get_file(note.relative_path)
+        if existing is None or existing.vault_id is None:
+            continue
+        implicit = vaults_by_id.get(existing.vault_id)
+        if implicit is not None:
+            targets[note.relative_path] = implicit
+    return targets
 
 
 async def _poll_job(
@@ -420,21 +467,44 @@ async def sync_vault(
             return result
 
         # Resolve frontmatter vault overrides for changed + returning notes.
-        # Returned mapping covers only the paths whose override resolved to a
-        # known vault; unknown vault names fall back to the default (warned).
+        # ``overrides`` maps rel_path → VaultDTO for paths whose frontmatter
+        # cites a known vault (unknown names log a warning and are excluded).
+        # ``vaults_by_id`` is the directory used both here and to resolve
+        # implicit targets (stored-state) without a second HTTP round-trip.
         override_candidates = list(changed) + list(returning)
-        overrides = await _resolve_frontmatter_vaults(
+        overrides, vaults_by_id = await _resolve_frontmatter_vaults(
             api,
             override_candidates,
             sync_config.exclude.frontmatter_vault_key,
         )
+        if not vaults_by_id:
+            # No overrides were requested → directory not fetched yet, but we
+            # still need it to honor implicit targets for previously-routed
+            # notes. One extra HTTP call only when at least one tracked note
+            # has a non-null SyncedFile.vault_id.
+            if any(
+                (existing := state.get_file(n.relative_path)) is not None
+                and existing.vault_id is not None
+                for n in override_candidates
+            ):
+                vaults_by_id = await _fetch_vaults_by_id(api)
 
-        # Detect migrations: a note already tracked in SyncedFile whose
-        # resolved frontmatter override differs from its previously-recorded
-        # vault_id. We archive the old note (by note_id, which is globally
-        # unique) before re-ingesting it into the target vault. This prevents
-        # orphan-create when vault_name is embedded in note_key.
-        migrations: list[tuple[str, str, VaultDTO]] = []  # (rel_path, old_note_id, target)
+        # Compose effective per-note routing target (explicit override OR
+        # implicit-from-stored-vault_id). All downstream code uses this map.
+        effective_targets = _compute_effective_targets(
+            override_candidates,
+            overrides,
+            state,
+            vaults_by_id,
+        )
+
+        # Detect *pending* migrations: a note already tracked in SyncedFile
+        # whose explicit frontmatter override differs from its previously-
+        # recorded vault_id. We materialize them into a dict keyed by
+        # relative_path; the post-ingest pass archives the old note ONLY for
+        # paths whose new ingest succeeded. Archiving up front would lose the
+        # user's note if the new ingest fails.
+        pending_migrations: dict[str, tuple[str, VaultDTO]] = {}
         for note in changed:
             target = overrides.get(note.relative_path)
             if target is None:
@@ -442,32 +512,7 @@ async def sync_vault(
             existing = state.get_file(note.relative_path)
             if existing is None or existing.note_id is None or existing.vault_id == str(target.id):
                 continue
-            migrations.append((note.relative_path, existing.note_id, target))
-
-        if migrations:
-            if on_progress:
-                on_progress('migrating', 0, len(migrations), 'Migrating notes to new vault...')
-            for i, (rel_path, old_note_id, target) in enumerate(migrations):
-                try:
-                    await api.set_note_status(UUID(old_note_id), 'archived')
-                    result.migrated += 1
-                    logger.info(
-                        'Archived note in prior vault for frontmatter override migration',
-                        path=rel_path,
-                        old_note_id=old_note_id,
-                        target_vault=target.name,
-                        target_vault_id=str(target.id),
-                    )
-                except Exception as e:
-                    result.errors.append(f'{rel_path}: migrate archive failed: {e}')
-                    logger.error(
-                        'Failed to archive prior version during vault migration',
-                        path=rel_path,
-                        old_note_id=old_note_id,
-                        error=str(e),
-                    )
-                if on_progress:
-                    on_progress('migrating', i + 1, len(migrations), rel_path)
+            pending_migrations[note.relative_path] = (existing.note_id, target)
 
         # 3. Build DTOs and ingest
         # 3a. Ingest changed notes
@@ -475,6 +520,7 @@ async def sync_vault(
             if on_progress:
                 on_progress('preparing', 0, len(changed), 'Preparing notes...')
             dtos: list[NoteCreateDTO] = []
+            dto_notes: list[VaultNote] = []
             for i, note in enumerate(changed):
                 try:
                     dto = _build_note_dto(
@@ -483,9 +529,10 @@ async def sync_vault(
                         vault_id,
                         note_key_prefix=sync_config.note_key_prefix,
                         tags=list(sync_config.default_tags),
-                        override_vault=overrides.get(note.relative_path),
+                        override_vault=effective_targets.get(note.relative_path),
                     )
                     dtos.append(dto)
+                    dto_notes.append(note)
                 except Exception as e:
                     result.failed += 1
                     result.errors.append(f'{note.relative_path}: {e}')
@@ -497,6 +544,10 @@ async def sync_vault(
                     on_progress('ingesting', 0, len(dtos), 'Submitting to Memex...')
 
                 note_ids: dict[str, str] = {}
+                # Track which notes actually succeeded — used for state
+                # persistence AND deferred migration archival so we never
+                # archive an old version when the new ingest failed.
+                successful_notes: list[VaultNote] = []
 
                 if len(dtos) == 1:
                     try:
@@ -508,9 +559,14 @@ async def sync_vault(
                         if resp.status == 'success':
                             result.ingested = 1
                             if resp.note_id:
-                                note_ids[changed[0].relative_path] = resp.note_id
+                                note_ids[dto_notes[0].relative_path] = resp.note_id
+                            successful_notes.append(dto_notes[0])
                         elif resp.status == 'skipped':
                             result.skipped = 1
+                            # Skipped means server found a match by note_key
+                            # — the target vault already has this note. Safe
+                            # to persist state + archive any prior version.
+                            successful_notes.append(dto_notes[0])
                         else:
                             result.failed = 1
                             if resp.reason:
@@ -522,7 +578,7 @@ async def sync_vault(
                     # When any DTO carries a frontmatter override, suppress the
                     # batch-level vault_id so per-note vault_id is respected;
                     # otherwise server-side batch override would clobber it.
-                    batch_vault_id = None if overrides else vault_id
+                    batch_vault_id = None if effective_targets else vault_id
                     try:
                         job_status = await api.ingest_batch(
                             dtos,
@@ -553,10 +609,23 @@ async def sync_vault(
                             result.failed = final.result.failed_count
                             for err in final.result.errors:
                                 result.errors.append(str(err))
-                            # Map note_ids back to changed notes by index
+                            # Capture per-position note_ids first.
+                            id_by_pos: dict[int, str] = {}
                             for idx, nid in enumerate(final.result.note_ids):
-                                if idx < len(changed) and nid:
-                                    note_ids[changed[idx].relative_path] = nid
+                                if idx < len(dto_notes) and nid:
+                                    id_by_pos[idx] = nid
+                                    note_ids[dto_notes[idx].relative_path] = nid
+                            # Determine success:
+                            #   - failed_count == 0 ⇒ all DTOs succeeded
+                            #     (server may omit note_ids on full success)
+                            #   - failed_count > 0 ⇒ only positions whose
+                            #     note_ids entry is populated count as
+                            #     successful; the rest were rejected.
+                            if final.result.failed_count == 0:
+                                successful_notes.extend(dto_notes)
+                            else:
+                                for idx in id_by_pos:
+                                    successful_notes.append(dto_notes[idx])
                         elif final is not None and final.status == 'failed':
                             result.failed = len(dtos)
                             result.errors.append(f'Batch job {job_status.job_id} failed')
@@ -580,22 +649,51 @@ async def sync_vault(
                         result.failed = len(dtos)
                         result.errors.append(str(e))
 
-                # Update state with note_ids
-                if result.ingested > 0 or result.skipped > 0:
+                # Update state ONLY for notes whose ingest succeeded — and
+                # only emit per_file_vault_ids/note_keys when we have an
+                # effective target (explicit override or implicit stored).
+                # mark_synced preserves prior values for notes omitted from
+                # the dicts, keeping state aligned with the server when an
+                # override is later removed.
+                if successful_notes:
                     note_keys, per_file_vault_ids = _post_sync_state(
-                        changed,
-                        overrides,
-                        vault_name,
-                        vault_id,
+                        successful_notes,
+                        effective_targets,
                         sync_config.note_key_prefix,
                     )
                     state.mark_synced(
-                        changed,
+                        successful_notes,
                         vault_id,
                         note_ids=note_ids,
                         note_keys=note_keys,
                         per_file_vault_ids=per_file_vault_ids,
                     )
+
+                    # Deferred migration archive — only for notes whose
+                    # new ingest succeeded. Archiving up front would leave
+                    # the user with no active note on partial failures.
+                    successful_paths = {n.relative_path for n in successful_notes}
+                    for rel_path, (old_note_id, target) in pending_migrations.items():
+                        if rel_path not in successful_paths:
+                            continue
+                        try:
+                            await api.set_note_status(UUID(old_note_id), 'archived')
+                            result.migrated += 1
+                            logger.info(
+                                'Archived prior-vault note after successful migration',
+                                path=rel_path,
+                                old_note_id=old_note_id,
+                                target_vault=target.name,
+                                target_vault_id=str(target.id),
+                            )
+                        except Exception as e:
+                            result.errors.append(f'{rel_path}: migrate archive failed: {e}')
+                            logger.error(
+                                'Failed to archive prior version during vault migration',
+                                path=rel_path,
+                                old_note_id=old_note_id,
+                                error=str(e),
+                            )
 
         # 3b. Handle deleted files
         if deleted and handle_deletes:
@@ -628,14 +726,12 @@ async def sync_vault(
                             vault_id,
                             note_key_prefix=sync_config.note_key_prefix,
                             tags=list(sync_config.default_tags),
-                            override_vault=overrides.get(note.relative_path),
+                            override_vault=effective_targets.get(note.relative_path),
                         )
                         resp = await api.ingest(dto, background=False)
                         nks, pvids = _post_sync_state(
                             [note],
-                            overrides,
-                            vault_name,
-                            vault_id,
+                            effective_targets,
                             sync_config.note_key_prefix,
                         )
                         if resp.status == 'success':
@@ -679,7 +775,7 @@ async def sync_vault(
                         vault_id,
                         note_key_prefix=sync_config.note_key_prefix,
                         tags=list(sync_config.default_tags),
-                        override_vault=overrides.get(note.relative_path),
+                        override_vault=effective_targets.get(note.relative_path),
                     )
                     resp = await api.ingest(dto, background=False)
                     if resp.status == 'success':
@@ -688,9 +784,7 @@ async def sync_vault(
                         result.skipped += 1
                     nks, pvids = _post_sync_state(
                         [note],
-                        overrides,
-                        vault_name,
-                        vault_id,
+                        effective_targets,
                         sync_config.note_key_prefix,
                     )
                     state.mark_synced(

--- a/packages/cli/src/memex_cli/sync/engine.py
+++ b/packages/cli/src/memex_cli/sync/engine.py
@@ -240,6 +240,7 @@ def _compute_effective_targets(
     3. None — caller falls back to the active sync vault.
     """
     targets: dict[str, VaultDTO] = {}
+    warned_orphans: set[str] = set()
     for note in notes:
         explicit = overrides.get(note.relative_path)
         if explicit is not None:
@@ -251,6 +252,18 @@ def _compute_effective_targets(
         implicit = vaults_by_id.get(existing.vault_id)
         if implicit is not None:
             targets[note.relative_path] = implicit
+        elif existing.vault_id not in warned_orphans:
+            # Stored vault_id no longer resolves — the vault was deleted
+            # or renamed-out-from-under us. Caller will silently re-route
+            # to the active sync vault; surface a warning so the user can
+            # decide whether to recreate the original vault.
+            logger.warning(
+                'Stored target vault for note is no longer known to the server; '
+                'falling back to active sync vault.',
+                path=note.relative_path,
+                stored_vault_id=existing.vault_id,
+            )
+            warned_orphans.add(existing.vault_id)
     return targets
 
 
@@ -772,7 +785,7 @@ async def sync_vault(
                         )
                         if resp.status == 'success':
                             result.ingested += 1
-                            nids = {}
+                            nids: dict[str, str] = {}
                             if resp.note_id:
                                 nids[note.relative_path] = resp.note_id
                             state.mark_synced(
@@ -795,40 +808,79 @@ async def sync_vault(
                     continue
                 try:
                     note_uuid = UUID(note_id_str)
-                    await api.set_note_status(note_uuid, 'active')
-                    state.unarchive_file(note.relative_path, note.mtime)
-                    result.unarchived += 1
-                    logger.info(
-                        'Unarchived note',
-                        path=note.relative_path,
-                        note_id=note_id_str,
+                    target = effective_targets.get(note.relative_path)
+                    existing_row = state.get_file(note.relative_path)
+                    # Migration return: the note was archived in vault A, now
+                    # returns with frontmatter routing it to vault B. Do NOT
+                    # unarchive the old note (it should stay archived in A);
+                    # instead build a fresh DTO for the target vault. The
+                    # old SyncedFile row is taken out of "archived" state by
+                    # the upcoming mark_synced (it clears `archived=False`).
+                    is_migration_return = (
+                        target is not None
+                        and existing_row is not None
+                        and existing_row.vault_id is not None
+                        and existing_row.vault_id != str(target.id)
                     )
+                    if not is_migration_return:
+                        await api.set_note_status(note_uuid, 'active')
+                        state.unarchive_file(note.relative_path, note.mtime)
+                        result.unarchived += 1
+                        logger.info(
+                            'Unarchived note',
+                            path=note.relative_path,
+                            note_id=note_id_str,
+                        )
 
                     # Re-ingest to pick up any content changes while skipped
+                    # (or to create a fresh record in the target vault for a
+                    # migration return).
                     dto = _build_note_dto(
                         note,
                         vault_name,
                         vault_id,
                         note_key_prefix=sync_config.note_key_prefix,
                         tags=list(sync_config.default_tags),
-                        override_vault=effective_targets.get(note.relative_path),
+                        override_vault=target,
                     )
                     resp = await api.ingest(dto, background=False)
-                    if resp.status == 'success':
-                        result.ingested += 1
-                    elif resp.status == 'skipped':
-                        result.skipped += 1
                     nks, pvids = _post_sync_state(
                         [note],
                         effective_targets,
                         sync_config.note_key_prefix,
                     )
-                    state.mark_synced(
-                        [note],
-                        vault_id,
-                        note_keys=nks,
-                        per_file_vault_ids=pvids,
-                    )
+                    if resp.status == 'success':
+                        result.ingested += 1
+                        nids = {}
+                        if resp.note_id:
+                            nids[note.relative_path] = resp.note_id
+                        state.mark_synced(
+                            [note],
+                            vault_id,
+                            note_ids=nids,
+                            note_keys=nks,
+                            per_file_vault_ids=pvids,
+                        )
+                    elif resp.status == 'skipped':
+                        result.skipped += 1
+                        state.mark_synced(
+                            [note],
+                            vault_id,
+                            note_keys=nks,
+                            per_file_vault_ids=pvids,
+                        )
+                    if is_migration_return and resp.status in ('success', 'skipped'):
+                        # The old note in vault A was already archived (it
+                        # came in via `returning`) — count it as a migration
+                        # for the user-visible counter. No additional
+                        # set_note_status call needed.
+                        result.migrated += 1
+                        logger.info(
+                            'Returned-archived note routed to new vault via override',
+                            path=note.relative_path,
+                            old_note_id=note_id_str,
+                            target_vault=target.name if target else None,
+                        )
                 except Exception as e:
                     result.errors.append(f'{note.relative_path}: unarchive failed: {e}')
                     logger.error(

--- a/packages/cli/src/memex_cli/sync/scanner.py
+++ b/packages/cli/src/memex_cli/sync/scanner.py
@@ -68,6 +68,33 @@ def _is_excluded(path: Path, vault_path: Path, exclude: ExcludeConfig) -> bool:
     return False
 
 
+def parse_frontmatter(content: str) -> dict[str, str]:
+    """Parse a note's YAML frontmatter into a flat string-keyed mapping.
+
+    Returns an empty dict when the file has no leading ``---``-delimited
+    block. Only top-level scalar ``key: value`` lines are surfaced; nested
+    YAML is silently dropped. Values have surrounding quotes stripped but
+    case is preserved — callers needing case-insensitive comparison must
+    lower the value themselves.
+
+    Lightweight by design: skip-marker checks and the vault-override path
+    both need string-keyed scalars only; a full YAML parser would inflate
+    the CLI dependency surface for no benefit.
+    """
+    m = _FRONTMATTER_RE.match(content)
+    if not m:
+        return {}
+
+    fm: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        line = line.strip()
+        if ':' not in line:
+            continue
+        k, _, v = line.partition(':')
+        fm[k.strip()] = v.strip().strip('"\'')
+    return fm
+
+
 def _should_skip_frontmatter(content: str, exclude: ExcludeConfig) -> bool:
     """Check if a note's frontmatter contains the skip marker.
 
@@ -80,23 +107,9 @@ def _should_skip_frontmatter(content: str, exclude: ExcludeConfig) -> bool:
 
     The check is case-insensitive on the value.
     """
-    m = _FRONTMATTER_RE.match(content)
-    if not m:
-        return False
-
-    fm_block = m.group(1)
-    key = exclude.frontmatter_skip_key
+    fm = parse_frontmatter(content)
     skip_val = exclude.frontmatter_skip_value.lower()
-
-    for line in fm_block.splitlines():
-        line = line.strip()
-        if ':' not in line:
-            continue
-        k, _, v = line.partition(':')
-        if k.strip() == key and v.strip().strip('"\'').lower() == skip_val:
-            return True
-
-    return False
+    return fm.get(exclude.frontmatter_skip_key, '').lower() == skip_val
 
 
 def _allowed_asset_extensions(asset_config: AssetConfig) -> set[str]:

--- a/packages/cli/src/memex_cli/sync/state.py
+++ b/packages/cli/src/memex_cli/sync/state.py
@@ -31,6 +31,17 @@ class SyncedFile(SQLModel, table=True):  # type: ignore[call-arg]
         default=False,
         description='Whether this file has been archived in Memex (e.g. due to skip tag).',
     )
+    note_key: str | None = Field(
+        default=None,
+        description='note_key used at last ingest. Needed to archive the old key '
+        'when a frontmatter vault override moves the note to a different vault.',
+    )
+    vault_id: str | None = Field(
+        default=None,
+        description='Vault ID the file was last ingested into. When this differs from '
+        'the current target vault (resolved from frontmatter override), the sync '
+        'engine archives the prior ingest and re-ingests into the new vault.',
+    )
 
 
 class SyncMeta(SQLModel, table=True):  # type: ignore[call-arg]
@@ -63,6 +74,8 @@ class SyncStateDB:
         self._engine = create_engine(f'sqlite:///{db_path}', echo=False)
         _create_sync_tables(self._engine)
         self._migrate_add_archived()
+        self._migrate_add_note_key()
+        self._migrate_add_vault_id()
 
     def _migrate_add_archived(self) -> None:
         """Add 'archived' column to synced_files if it doesn't exist (schema migration)."""
@@ -71,6 +84,24 @@ class SyncStateDB:
                 conn.execute(
                     text('ALTER TABLE synced_files ADD COLUMN archived BOOLEAN NOT NULL DEFAULT 0')
                 )
+                conn.commit()
+            except Exception:
+                pass  # Column already exists
+
+    def _migrate_add_note_key(self) -> None:
+        """Add 'note_key' column to synced_files if it doesn't exist (schema migration)."""
+        with self._engine.connect() as conn:
+            try:
+                conn.execute(text('ALTER TABLE synced_files ADD COLUMN note_key VARCHAR'))
+                conn.commit()
+            except Exception:
+                pass  # Column already exists
+
+    def _migrate_add_vault_id(self) -> None:
+        """Add 'vault_id' column to synced_files if it doesn't exist (schema migration)."""
+        with self._engine.connect() as conn:
+            try:
+                conn.execute(text('ALTER TABLE synced_files ADD COLUMN vault_id VARCHAR'))
                 conn.commit()
             except Exception:
                 pass  # Column already exists
@@ -110,16 +141,26 @@ class SyncStateDB:
         notes: list[VaultNote],
         vault_id: str | None = None,
         note_ids: dict[str, str] | None = None,
+        note_keys: dict[str, str] | None = None,
+        per_file_vault_ids: dict[str, str] | None = None,
     ) -> None:
         """Record successfully synced notes and update metadata.
 
         Args:
             notes: Notes that were synced.
-            vault_id: Memex vault ID used.
+            vault_id: Memex vault ID used for sync_meta (fallback / active vault).
             note_ids: Optional mapping of relative_path -> Memex note_id.
+            note_keys: Optional mapping of relative_path -> note_key used at ingest.
+                Stored on SyncedFile so a later frontmatter vault override can
+                archive the prior key in its original vault.
+            per_file_vault_ids: Optional mapping of relative_path -> vault_id the
+                file was ingested into. When this differs from the target vault on
+                a subsequent sync, the engine migrates the note.
         """
         now = datetime.now(timezone.utc).isoformat()
         note_ids = note_ids or {}
+        note_keys = note_keys or {}
+        per_file_vault_ids = per_file_vault_ids or {}
         with Session(self._engine) as session:
             for note in notes:
                 existing = session.get(SyncedFile, note.relative_path)
@@ -129,6 +170,10 @@ class SyncStateDB:
                     existing.archived = False
                     if note.relative_path in note_ids:
                         existing.note_id = note_ids[note.relative_path]
+                    if note.relative_path in note_keys:
+                        existing.note_key = note_keys[note.relative_path]
+                    if note.relative_path in per_file_vault_ids:
+                        existing.vault_id = per_file_vault_ids[note.relative_path]
                     session.add(existing)
                 else:
                     session.add(
@@ -137,6 +182,8 @@ class SyncStateDB:
                             mtime=note.mtime,
                             note_id=note_ids.get(note.relative_path),
                             synced_at=now,
+                            note_key=note_keys.get(note.relative_path),
+                            vault_id=per_file_vault_ids.get(note.relative_path),
                         )
                     )
 

--- a/packages/cli/tests/test_sync_engine.py
+++ b/packages/cli/tests/test_sync_engine.py
@@ -399,6 +399,56 @@ class TestFrontmatterVaultOverride:
         assert row.note_key == 'obsidian:B-vault:note.md'
         state2.close()
 
+    def test_legacy_row_with_override_to_active_vault_no_migration(
+        self, tmp_path: Path, mock_api: AsyncMock, sync_config: SyncConfig
+    ) -> None:
+        """Legacy SyncedFile (vault_id=None, pre-override schema) re-synced
+        with a frontmatter override that resolves to the *active* sync vault
+        must NOT trigger a migration — the note is already in that vault."""
+        from memex_common.schemas import VaultDTO
+
+        from memex_cli.sync.scanner import VaultNote
+
+        note_path = tmp_path / 'note.md'
+        old_note_id = str(uuid4())
+        active_vault_id = uuid4()
+        note_path.write_text('---\nvault: Active-vault\n---\n\nbody')
+        stat = note_path.stat()
+
+        state = SyncStateDB(tmp_path / sync_config.state_file)
+        state.mark_synced(
+            [
+                VaultNote(
+                    path=note_path,
+                    relative_path='note.md',
+                    mtime=stat.st_mtime - 100,
+                    size=stat.st_size,
+                    assets=[],
+                )
+            ],
+            vault_id=str(active_vault_id),
+            note_ids={'note.md': old_note_id},
+        )
+        state.close()
+
+        mock_api.list_vaults.return_value = [
+            VaultDTO(id=active_vault_id, name='Active-vault'),
+        ]
+        mock_api.ingest.return_value = IngestResponse(
+            status='success',
+            note_id=str(uuid4()),
+            unit_ids=[],
+            reason=None,
+            overlapping_notes=[],
+        )
+
+        result = asyncio.run(
+            sync_vault(tmp_path, mock_api, sync_config, vault_id=str(active_vault_id))
+        )
+
+        assert result.migrated == 0
+        mock_api.set_note_status.assert_not_called()
+
 
 class TestFrontmatterVaultOverrideSafety:
     """Adversarial-review regressions: archive-after-success, failed-ingest

--- a/packages/cli/tests/test_sync_engine.py
+++ b/packages/cli/tests/test_sync_engine.py
@@ -129,6 +129,30 @@ class TestBuildNoteDto:
         dto = _build_note_dto(note, 'my-vault', 'test-vault')
         assert dto.filename is None
 
+    def test_honors_vault_override(self, vault: Path) -> None:
+        """When override_vault is supplied, note_key embeds the target vault
+        name and vault_id is the target UUID — not the active sync vault."""
+        from memex_common.schemas import VaultDTO
+
+        from memex_cli.sync.scanner import VaultNote
+
+        override = VaultDTO(id=uuid4(), name='B-vault')
+        note = VaultNote(
+            path=vault / 'hello.md',
+            relative_path='hello.md',
+            mtime=1000.0,
+            size=13,
+            assets=[],
+        )
+        dto = _build_note_dto(
+            note,
+            'A-vault',
+            'A-vault-id',
+            override_vault=override,
+        )
+        assert dto.note_key == 'obsidian:B-vault:hello.md'
+        assert dto.vault_id == str(override.id)
+
 
 class TestSyncVault:
     def test_dry_run_does_not_ingest(
@@ -248,6 +272,132 @@ class TestSyncVault:
         ids = state.get_note_ids_for_paths(['only.md'])
         assert ids.get('only.md') == note_id
         state.close()
+
+
+class TestFrontmatterVaultOverride:
+    def test_warns_and_falls_back_when_vault_unknown(
+        self, tmp_path: Path, mock_api: AsyncMock, sync_config: SyncConfig
+    ) -> None:
+        """Frontmatter cites a vault the server does not know.
+
+        Expected behavior: list_vaults returns no match → warning logged,
+        note falls back to the active vault (note_key uses vault_name, no
+        per-file vault_id stored beyond the active default).
+        """
+        from memex_common.schemas import VaultDTO
+
+        (tmp_path / 'note.md').write_text('---\nvault: nonexistent\n---\n\nbody')
+
+        mock_api.list_vaults.return_value = [
+            VaultDTO(id=uuid4(), name='A-vault'),
+        ]
+        mock_api.ingest.return_value = IngestResponse(
+            status='success',
+            note_id=str(uuid4()),
+            unit_ids=[],
+            reason=None,
+            overlapping_notes=[],
+        )
+
+        result = asyncio.run(sync_vault(tmp_path, mock_api, sync_config, vault_id='A-vault-id'))
+
+        assert result.ingested == 1
+        assert result.migrated == 0
+        called_dto = mock_api.ingest.call_args.args[0]
+        # No override resolved → note_key uses active vault folder name
+        assert called_dto.note_key == f'obsidian:{tmp_path.name}:note.md'
+
+    def test_routes_to_override_vault(
+        self, tmp_path: Path, mock_api: AsyncMock, sync_config: SyncConfig
+    ) -> None:
+        """Frontmatter cites a known vault → note_key embeds override name
+        and DTO.vault_id is the override UUID."""
+        from memex_common.schemas import VaultDTO
+
+        (tmp_path / 'note.md').write_text('---\nvault: B-vault\n---\n\nbody')
+
+        b_id = uuid4()
+        mock_api.list_vaults.return_value = [
+            VaultDTO(id=uuid4(), name='A-vault'),
+            VaultDTO(id=b_id, name='B-vault'),
+        ]
+        mock_api.ingest.return_value = IngestResponse(
+            status='success',
+            note_id=str(uuid4()),
+            unit_ids=[],
+            reason=None,
+            overlapping_notes=[],
+        )
+
+        result = asyncio.run(sync_vault(tmp_path, mock_api, sync_config, vault_id='A-vault-id'))
+
+        assert result.ingested == 1
+        called_dto = mock_api.ingest.call_args.args[0]
+        assert called_dto.note_key == 'obsidian:B-vault:note.md'
+        assert called_dto.vault_id == str(b_id)
+
+    def test_migration_archives_prior_and_increments_counter(
+        self, tmp_path: Path, mock_api: AsyncMock, sync_config: SyncConfig
+    ) -> None:
+        """Note already synced into A; user adds vault: B; re-sync archives
+        the prior note in A, re-ingests into B, and migrated counter is 1."""
+        from memex_common.schemas import VaultDTO
+
+        from memex_cli.sync.scanner import VaultNote
+
+        note_path = tmp_path / 'note.md'
+        # First, "previously ingested in A" state — record vault_id explicitly.
+        old_note_id = str(uuid4())
+        state = SyncStateDB(tmp_path / sync_config.state_file)
+        # Write file content matching a state mtime in the past.
+        note_path.write_text('---\nvault: B-vault\n---\n\nbody')
+        stat = note_path.stat()
+        state.mark_synced(
+            [
+                VaultNote(
+                    path=note_path,
+                    relative_path='note.md',
+                    mtime=stat.st_mtime - 100,  # older than the now-written file
+                    size=stat.st_size,
+                    assets=[],
+                )
+            ],
+            vault_id='A-vault-id',
+            note_ids={'note.md': old_note_id},
+            note_keys={'note.md': 'obsidian:A-vault:note.md'},
+            per_file_vault_ids={'note.md': 'A-vault-id'},
+        )
+        state.close()
+
+        b_id = uuid4()
+        mock_api.list_vaults.return_value = [
+            VaultDTO(id=b_id, name='B-vault'),
+        ]
+        mock_api.set_note_status.return_value = None
+        mock_api.ingest.return_value = IngestResponse(
+            status='success',
+            note_id=str(uuid4()),
+            unit_ids=[],
+            reason=None,
+            overlapping_notes=[],
+        )
+
+        result = asyncio.run(sync_vault(tmp_path, mock_api, sync_config, vault_id='A-vault-id'))
+
+        assert result.migrated == 1
+        assert result.ingested == 1
+        mock_api.set_note_status.assert_called_once()
+        args, _ = mock_api.set_note_status.call_args
+        assert str(args[0]) == old_note_id
+        assert args[1] == 'archived'
+
+        # State now reflects target vault.
+        state2 = SyncStateDB(tmp_path / sync_config.state_file)
+        row = state2.get_file('note.md')
+        assert row is not None
+        assert row.vault_id == str(b_id)
+        assert row.note_key == 'obsidian:B-vault:note.md'
+        state2.close()
 
 
 class TestDeleteHandling:

--- a/packages/cli/tests/test_sync_engine.py
+++ b/packages/cli/tests/test_sync_engine.py
@@ -808,6 +808,89 @@ class TestDeleteHandling:
         mock_api.set_note_status.assert_not_called()
 
 
+class TestFrontmatterVaultOverrideReturning:
+    """Returning-archived notes with a NEW vault override must migrate
+    (old note stays archived in source vault, new note created in target),
+    not duplicate (old reactivated AND new created in another vault)."""
+
+    def test_returning_archived_with_override_migrates_not_duplicates(
+        self, tmp_path: Path, mock_api: AsyncMock, sync_config: SyncConfig
+    ) -> None:
+        from memex_common.schemas import VaultDTO
+
+        from memex_cli.sync.scanner import VaultNote
+
+        note_path = tmp_path / 'note.md'
+        # Note previously synced into A, then deleted from disk
+        # → state has archived=True row, vault_id=A.
+        old_note_id = str(uuid4())
+        a_vault_id = str(uuid4())
+        state = SyncStateDB(tmp_path / sync_config.state_file)
+        state.mark_synced(
+            [
+                VaultNote(
+                    path=note_path,
+                    relative_path='note.md',
+                    mtime=100.0,
+                    size=10,
+                    assets=[],
+                )
+            ],
+            vault_id=a_vault_id,
+            note_ids={'note.md': old_note_id},
+            note_keys={'note.md': 'obsidian:A-vault:note.md'},
+            per_file_vault_ids={'note.md': a_vault_id},
+        )
+        state.archive_files(['note.md'])
+        state.close()
+
+        # File reappears with vault: B frontmatter.
+        note_path.write_text('---\nvault: B-vault\n---\n\nfresh body')
+
+        b_id = uuid4()
+        mock_api.list_vaults.return_value = [
+            VaultDTO(id=UUID(a_vault_id), name='A-vault'),
+            VaultDTO(id=b_id, name='B-vault'),
+        ]
+        new_note_id = str(uuid4())
+        mock_api.ingest.return_value = IngestResponse(
+            status='success',
+            note_id=new_note_id,
+            unit_ids=[],
+            reason=None,
+            overlapping_notes=[],
+        )
+
+        result = asyncio.run(sync_vault(tmp_path, mock_api, sync_config, vault_id='A-vault-id'))
+
+        # No unarchive should fire — old note stays archived in A.
+        # set_note_status with 'active' must NOT be called.
+        for call in mock_api.set_note_status.call_args_list:
+            args = call.args
+            assert args[1] != 'active', (
+                'returning-migration must NOT reactivate the old note in the source vault'
+            )
+
+        assert result.ingested == 1
+        # migrated counter increments for the returning-migration case.
+        assert result.migrated == 1
+
+        # The new ingest used the override vault.
+        called_dto = mock_api.ingest.call_args.args[0]
+        assert called_dto.note_key == 'obsidian:B-vault:note.md'
+        assert called_dto.vault_id == str(b_id)
+
+        # State now points at the new note in vault B; old archived row
+        # cleared because mark_synced flips archived=False.
+        state2 = SyncStateDB(tmp_path / sync_config.state_file)
+        row = state2.get_file('note.md')
+        assert row is not None
+        assert row.archived is False
+        assert row.vault_id == str(b_id)
+        assert row.note_id == new_note_id
+        state2.close()
+
+
 class TestUnarchiveOnReturn:
     def test_unarchive_returning_note(
         self, vault: Path, mock_api: AsyncMock, sync_config: SyncConfig

--- a/packages/cli/tests/test_sync_engine.py
+++ b/packages/cli/tests/test_sync_engine.py
@@ -400,6 +400,166 @@ class TestFrontmatterVaultOverride:
         state2.close()
 
 
+class TestFrontmatterVaultOverrideSafety:
+    """Adversarial-review regressions: archive-after-success, failed-ingest
+    state isolation, override-removed preserves stored routing."""
+
+    def test_archive_skipped_when_new_ingest_fails(
+        self, tmp_path: Path, mock_api: AsyncMock, sync_config: SyncConfig
+    ) -> None:
+        """If the new ingest fails after migration was detected, the old
+        note must NOT be archived. Losing the user's only copy of the note
+        would be catastrophic."""
+        from memex_common.schemas import VaultDTO
+
+        from memex_cli.sync.scanner import VaultNote
+
+        note_path = tmp_path / 'note.md'
+        old_note_id = str(uuid4())
+        state = SyncStateDB(tmp_path / sync_config.state_file)
+        note_path.write_text('---\nvault: B-vault\n---\n\nbody')
+        stat = note_path.stat()
+        state.mark_synced(
+            [
+                VaultNote(
+                    path=note_path,
+                    relative_path='note.md',
+                    mtime=stat.st_mtime - 100,
+                    size=stat.st_size,
+                    assets=[],
+                )
+            ],
+            vault_id='A-vault-id',
+            note_ids={'note.md': old_note_id},
+            note_keys={'note.md': 'obsidian:A-vault:note.md'},
+            per_file_vault_ids={'note.md': 'A-vault-id'},
+        )
+        state.close()
+
+        b_id = uuid4()
+        mock_api.list_vaults.return_value = [VaultDTO(id=b_id, name='B-vault')]
+        mock_api.ingest.return_value = IngestResponse(
+            status='failed',
+            note_id=None,
+            unit_ids=[],
+            reason='simulated failure',
+            overlapping_notes=[],
+        )
+
+        result = asyncio.run(sync_vault(tmp_path, mock_api, sync_config, vault_id='A-vault-id'))
+
+        assert result.failed == 1
+        assert result.migrated == 0
+        mock_api.set_note_status.assert_not_called()
+
+    def test_state_unchanged_when_ingest_fails(
+        self, tmp_path: Path, mock_api: AsyncMock, sync_config: SyncConfig
+    ) -> None:
+        """A failed ingest must not clobber an existing SyncedFile's
+        vault_id/note_key — preserving alignment with the server."""
+        from memex_common.schemas import VaultDTO
+
+        from memex_cli.sync.scanner import VaultNote
+
+        note_path = tmp_path / 'note.md'
+        old_note_id = str(uuid4())
+        state = SyncStateDB(tmp_path / sync_config.state_file)
+        note_path.write_text('---\nvault: B-vault\n---\n\nbody')
+        stat = note_path.stat()
+        state.mark_synced(
+            [
+                VaultNote(
+                    path=note_path,
+                    relative_path='note.md',
+                    mtime=stat.st_mtime - 100,
+                    size=stat.st_size,
+                    assets=[],
+                )
+            ],
+            vault_id='A-vault-id',
+            note_ids={'note.md': old_note_id},
+            note_keys={'note.md': 'obsidian:A-vault:note.md'},
+            per_file_vault_ids={'note.md': 'A-vault-id'},
+        )
+        state.close()
+
+        b_id = uuid4()
+        mock_api.list_vaults.return_value = [VaultDTO(id=b_id, name='B-vault')]
+        mock_api.ingest.return_value = IngestResponse(
+            status='failed',
+            note_id=None,
+            unit_ids=[],
+            reason='simulated failure',
+            overlapping_notes=[],
+        )
+
+        asyncio.run(sync_vault(tmp_path, mock_api, sync_config, vault_id='A-vault-id'))
+
+        state2 = SyncStateDB(tmp_path / sync_config.state_file)
+        row = state2.get_file('note.md')
+        assert row is not None
+        # Pre-existing routing preserved exactly.
+        assert row.vault_id == 'A-vault-id'
+        assert row.note_key == 'obsidian:A-vault:note.md'
+        assert row.note_id == old_note_id
+        state2.close()
+
+    def test_override_removed_preserves_prior_routing(
+        self, tmp_path: Path, mock_api: AsyncMock, sync_config: SyncConfig
+    ) -> None:
+        """User adds vault: B → syncs. Then removes the frontmatter key →
+        re-syncs. Code should keep ingesting into B (implicit target) using
+        the same note_key — not silently overwrite to the active vault."""
+        from memex_common.schemas import VaultDTO
+
+        from memex_cli.sync.scanner import VaultNote
+
+        note_path = tmp_path / 'note.md'
+        b_id = uuid4()
+        prior_note_id = str(uuid4())
+        state = SyncStateDB(tmp_path / sync_config.state_file)
+        note_path.write_text('# updated body without frontmatter\n')
+        stat = note_path.stat()
+        state.mark_synced(
+            [
+                VaultNote(
+                    path=note_path,
+                    relative_path='note.md',
+                    mtime=stat.st_mtime - 100,
+                    size=stat.st_size,
+                    assets=[],
+                )
+            ],
+            vault_id='A-vault-id',
+            note_ids={'note.md': prior_note_id},
+            note_keys={'note.md': 'obsidian:B-vault:note.md'},
+            per_file_vault_ids={'note.md': str(b_id)},
+        )
+        state.close()
+
+        # User has previously routed via override; vaults_by_id MUST be
+        # consulted even when no current note has a frontmatter override.
+        mock_api.list_vaults.return_value = [VaultDTO(id=b_id, name='B-vault')]
+        mock_api.ingest.return_value = IngestResponse(
+            status='success',
+            note_id=prior_note_id,
+            unit_ids=[],
+            reason=None,
+            overlapping_notes=[],
+        )
+
+        result = asyncio.run(sync_vault(tmp_path, mock_api, sync_config, vault_id='A-vault-id'))
+
+        assert result.ingested == 1
+        assert result.migrated == 0
+        # DTO sent to server uses the implicit B-vault target — not the
+        # active sync vault — so the existing server-side note is updated
+        # idempotently rather than duplicated.
+        called_dto = mock_api.ingest.call_args.args[0]
+        assert called_dto.note_key == 'obsidian:B-vault:note.md'
+        assert called_dto.vault_id == str(b_id)
+
+
 class TestDeleteHandling:
     def test_archive_on_delete_default(
         self, vault: Path, mock_api: AsyncMock, sync_config: SyncConfig

--- a/packages/cli/tests/test_sync_engine.py
+++ b/packages/cli/tests/test_sync_engine.py
@@ -504,6 +504,59 @@ class TestFrontmatterVaultOverrideSafety:
         assert row.note_id == old_note_id
         state2.close()
 
+    def test_batch_skip_does_not_corrupt_note_id_mapping(
+        self, tmp_path: Path, mock_api: AsyncMock, sync_config: SyncConfig
+    ) -> None:
+        """Server returns note_ids aligned to *processed* notes only —
+        skipped entries are excluded. When the batch contains skips, the
+        CLI must NOT trust positional alignment with input DTOs (which
+        previously caused state corruption: skipped note received a
+        successor's note_id)."""
+        from memex_cli.sync.scanner import VaultNote
+
+        # 3 notes — middle one will be reported as skipped by the server.
+        for name in ('a.md', 'b.md', 'c.md'):
+            (tmp_path / name).write_text(f'# {name}')
+
+        state = SyncStateDB(tmp_path / sync_config.state_file)
+        # Pre-record an existing note_id for 'b.md' that must NOT be
+        # overwritten by the corrupt positional mapping.
+        existing_b_id = str(uuid4())
+        state.mark_synced(
+            [VaultNote(path=tmp_path / 'b.md', relative_path='b.md', mtime=0.0, size=1, assets=[])],
+            note_ids={'b.md': existing_b_id},
+        )
+        state.close()
+
+        new_a_id = str(uuid4())
+        new_c_id = str(uuid4())
+        mock_batch = BatchJobStatus(
+            job_id=uuid4(),
+            status='completed',
+            progress=None,
+            result=BatchIngestResponse(
+                processed_count=2,
+                skipped_count=1,
+                failed_count=0,
+                # Server returns 2 entries — for a.md and c.md (b.md was
+                # skipped). Positional alignment with the 3-DTO input is
+                # therefore broken.
+                note_ids=[new_a_id, new_c_id],
+                errors=[],
+            ),
+        )
+        mock_api.ingest_batch.return_value = mock_batch
+        mock_api.get_job_status.return_value = mock_batch
+
+        asyncio.run(sync_vault(tmp_path, mock_api, sync_config, vault_id='active'))
+
+        state2 = SyncStateDB(tmp_path / sync_config.state_file)
+        # b.md's existing note_id must NOT be overwritten.
+        b_row = state2.get_file('b.md')
+        assert b_row is not None
+        assert b_row.note_id == existing_b_id
+        state2.close()
+
     def test_override_removed_preserves_prior_routing(
         self, tmp_path: Path, mock_api: AsyncMock, sync_config: SyncConfig
     ) -> None:

--- a/packages/cli/tests/test_sync_scanner.py
+++ b/packages/cli/tests/test_sync_scanner.py
@@ -10,6 +10,7 @@ from memex_cli.sync.scanner import (
     _allowed_asset_extensions,
     _is_excluded,
     _should_skip_frontmatter,
+    parse_frontmatter,
     resolve_assets,
     scan_vault,
 )
@@ -251,6 +252,36 @@ class TestShouldSkipFrontmatter:
 
     def test_empty_file(self) -> None:
         assert _should_skip_frontmatter('', ExcludeConfig()) is False
+
+
+class TestParseFrontmatter:
+    def test_returns_empty_for_no_frontmatter(self) -> None:
+        assert parse_frontmatter('# Heading\nbody') == {}
+
+    def test_parses_scalar_keys(self) -> None:
+        fm = parse_frontmatter('---\ntitle: Test\nvault: personal\n---\n\nbody')
+        assert fm == {'title': 'Test', 'vault': 'personal'}
+
+    def test_strips_quotes_from_values(self) -> None:
+        fm = parse_frontmatter('---\nvault: "personal"\nother: \'work\'\n---\n')
+        assert fm['vault'] == 'personal'
+        assert fm['other'] == 'work'
+
+    def test_handles_malformed_yaml(self) -> None:
+        # Lines without ':' are silently dropped; nested YAML left to its own
+        # devices. The helper must not raise on garbage.
+        fm = parse_frontmatter(
+            '---\nvalid: yes\nthis-has-no-colon\n  nested:\n    skipped: true\n---'
+        )
+        assert fm['valid'] == 'yes'
+        assert 'this-has-no-colon' not in fm
+
+    def test_preserves_value_case(self) -> None:
+        fm = parse_frontmatter('---\nvault: PersonalVault\n---\n')
+        assert fm['vault'] == 'PersonalVault'
+
+    def test_empty_input(self) -> None:
+        assert parse_frontmatter('') == {}
 
 
 class TestIgnoreFolders:

--- a/packages/cli/tests/test_sync_state.py
+++ b/packages/cli/tests/test_sync_state.py
@@ -161,6 +161,59 @@ class TestSyncStateDB:
         assert f.note_id == 'id-a-new'
 
 
+class TestNoteKeyAndVaultIdMigration:
+    """V2: SyncedFile gained note_key and vault_id columns for migration detection."""
+
+    def test_mark_synced_stores_note_key_and_vault_id(self, db: SyncStateDB) -> None:
+        db.mark_synced(
+            [_make_note('a.md', 1000.0)],
+            vault_id='active-vault',
+            note_keys={'a.md': 'obsidian:vault-A:a.md'},
+            per_file_vault_ids={'a.md': 'vault-A-uuid'},
+        )
+        f = db.get_file('a.md')
+        assert f is not None
+        assert f.note_key == 'obsidian:vault-A:a.md'
+        assert f.vault_id == 'vault-A-uuid'
+
+    def test_migration_existing_row_updates_note_key_and_vault_id(self, db: SyncStateDB) -> None:
+        """A subsequent sync recording a different vault_id/note_key for the
+        same relative_path must overwrite — not insert a duplicate."""
+        db.mark_synced(
+            [_make_note('a.md', 1000.0)],
+            note_ids={'a.md': 'note-id'},
+            note_keys={'a.md': 'obsidian:vault-A:a.md'},
+            per_file_vault_ids={'a.md': 'vault-A-uuid'},
+        )
+        db.mark_synced(
+            [_make_note('a.md', 2000.0)],
+            note_ids={'a.md': 'note-id-new'},
+            note_keys={'a.md': 'obsidian:vault-B:a.md'},
+            per_file_vault_ids={'a.md': 'vault-B-uuid'},
+        )
+
+        f = db.get_file('a.md')
+        assert f is not None
+        assert f.note_key == 'obsidian:vault-B:a.md'
+        assert f.vault_id == 'vault-B-uuid'
+        assert f.note_id == 'note-id-new'
+
+    def test_migration_idempotent_when_columns_exist(self, tmp_path: Path) -> None:
+        """Re-opening a state DB twice must not fail on the additive ALTER
+        TABLE — the try/except: pass idiom handles SQLite's lack of
+        IF NOT EXISTS on ADD COLUMN."""
+        db_path = tmp_path / 'state.db'
+
+        state1 = SyncStateDB(db_path)
+        state1.mark_synced([_make_note('a.md', 1000.0)])
+        state1.close()
+
+        # Re-opening triggers the migrations again — must be a no-op.
+        state2 = SyncStateDB(db_path)
+        assert state2.file_count() == 1
+        state2.close()
+
+
 class TestArchiveFiles:
     def test_archive_files(self, db: SyncStateDB) -> None:
         db.mark_synced(


### PR DESCRIPTION
## Summary

Adds a `vault:` key to Obsidian-sync frontmatter that routes the note to a different memex vault than the active sync target. On a subsequent sync with the override added or changed, the prior version is archived in its original vault (by `note_id`) and re-ingested into the target — no orphan-create.

## Why

The bug ticket V2 flagged a latent issue: `note_key` embeds `vault_name` (CLI/sync/engine.py), so a naive override would leave orphaned notes in the source vault. This PR ships migration semantics + state-DB columns to detect when the target vault changes per-file.

## What changed

- **`parse_frontmatter`** lifted out of `_should_skip_frontmatter` (scanner.py) — single regex pass, public helper.
- **`SyncedFile.note_key` + `SyncedFile.vault_id`** — two additive columns via the existing `_migrate_add_*` idempotent ALTER-TABLE pattern. Pre-existing rows get nulls; first override on a previously-synced file triggers migration archive via `note_id`.
- **`_resolve_frontmatter_vaults`** — one `list_vaults()` call, in-memory match by name/UUID. Unknown vault names log a warning and fall back to the active vault.
- **`_build_note_dto(override_vault=...)`** — when set, substitutes the override's `name` into `note_key` and `id` into the DTO's `vault_id`.
- **Migration archival** — `await api.set_note_status(UUID(old_note_id), 'archived')`; counts in `SyncResult.migrated`.
- **Batch ingest** — passes `vault_id=None` to `ingest_batch` when any override is present so the server respects per-DTO routing.
- **`mark_synced`** — accepts `note_keys` and `per_file_vault_ids` dicts and persists them.

## Configuration

```toml
[sync.exclude]
frontmatter_vault_key = "vault"  # change to a different key if desired
```

## Tests

| Layer | File | Cases |
|---|---|---|
| Unit | `test_sync_scanner.py::TestParseFrontmatter` | 6 (empty, scalar, quotes, malformed, case-preserved, empty input) |
| Unit | `test_sync_engine.py::TestBuildNoteDto::test_honors_vault_override` | 1 |
| Unit | `test_sync_state.py::TestNoteKeyAndVaultIdMigration` | 3 (stores fields, overwrites on migration, idempotent re-open) |
| Integration | `test_sync_engine.py::TestFrontmatterVaultOverride` | 3 (unknown→fallback, override→route, migration→archive+counter) |

All 106 sync tests pass locally.

## Docs

- New `docs/how-to/override-vault-with-frontmatter.md`
- `docs/how-to/sync-notes.md` — new section + toml field reference
- `docs/index.md` — index entry

## Out of scope

- Internal eval regression scenarios (would touch eval; per `feedback_eval_only_changes` defer to a follow-up if needed).
- Deeper fix that stores `vault_id` (UUID) in `note_key` to remove the `vault_name`-rename latent limitation. Captured in `_build_note_dto`'s WHY-docstring.
- Reverting an override (removing the `vault:` key) — currently the note stays in its current target. Documented as a known edge case.

## Test plan

- [ ] CI lint + tests green on this branch
- [ ] Apply on a real Obsidian vault: add `vault: B` to a note already synced into A → re-sync → confirm note in B, archived in A, `migrated: 1` in CLI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)