### PR TITLE
feat: explicit contradiction winner-proposal in lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,546%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,549%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,521%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,530%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,512%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,521%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,533%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,544%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,544%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,546%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,530%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,533%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,470%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,512%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/docs/how-to/resolve-contradictions.md
+++ b/docs/how-to/resolve-contradictions.md
@@ -1,0 +1,95 @@
+# Resolve Contradictions
+
+Memex's lint pipeline detects when two memory units about the same fact
+disagree. When the disagreement carries a high enough signal, the
+LLM-driven lint pass proposes a winner, a recommended action, and a
+calibrated confidence — all packaged as a normal lint finding you can
+review, apply, or dismiss like any other.
+
+This guide walks through the full loop:
+
+1. Confirm a pending winner-proposal finding exists.
+2. Apply the recommended action.
+3. Reverse the action if the apply was premature.
+
+## Prerequisites
+
+- A vault that has accumulated contradictions (typically when the FSFM
+  lint pass has emitted `composite_deprioritize_candidate` findings
+  whose `flag_reason` is `low_credibility_contradiction_only` or
+  `components_disagree`).
+- The LLM-gated lint pass enabled
+  (`server.memory.lint_llm.enabled=true`) and the per-check flag
+  `server.memory.lint_llm.checks.propose_contradiction_winner.enabled=true`.
+
+## 1. Find pending winner-proposal findings
+
+```bash
+memex lint findings --vault my-vault --type quality
+```
+
+In the output, look for rows whose `rule_name` is
+`propose_contradiction_winner`. Each row's `evidence` payload carries:
+
+- `winner_unit_id` / `loser_unit_id` — the two units in tension.
+- `action` — one of `mark_loser_stale`, `supersede_loser_note`,
+  `refine_not_contradict`, `inconclusive`.
+- `confidence` — the LLM's calibrated confidence in the proposal.
+- `rationale` — a one- or two-sentence justification.
+- `linked_to_finding` — the upstream FSFM finding that triggered this
+  proposal.
+
+## 2. Apply the recommended action
+
+```bash
+memex lint apply <finding_id>
+```
+
+The action drives the mutation:
+
+| Action                  | Effect                                                                                                                  |
+|-------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `mark_loser_stale`      | Flips `MemoryUnit.status` of the loser to `'stale'`.                                                                    |
+| `supersede_loser_note`  | Sets `Note.superseded_by` of the loser's parent note to the winner's parent note id. Falls back to `mark_loser_stale` when both units share the same parent note (the fallback reason is recorded under `evidence.resolution.fallback_reason`). |
+| `refine_not_contradict` | Rewrites the inbound `MemoryLink.link_type` from `'contradicts'` to `'refines'` (graph-pressure weight `0.0`).          |
+| `inconclusive`          | No-op write; flips the finding to `resolved`.                                                                           |
+
+Each apply captures the affected row's pre-mutation state under
+`evidence.resolution.prior_state` so the action is fully reversible.
+
+## 3. Reverse a previously applied action
+
+```bash
+memex lint reverse <finding_id>
+```
+
+The reverse path reads `evidence.resolution.prior_state` and atomically
+restores the affected row(s) in a single transaction. It also writes a
+paired audit row (`rule_name=propose_contradiction_winner_reversal`) so
+the audit trail records both the apply and the reverse. The original
+finding stays in `resolved` status — the unique partial index on
+pending findings is preserved.
+
+## Agent surfaces
+
+The same actions are available via MCP and the Hermes plugin:
+
+- MCP: `memex_lint_apply_winner(finding_id)` /
+  `memex_lint_reverse_winner(finding_id)`.
+- Hermes: `memex_lint_apply_winner` / `memex_lint_reverse_winner`
+  (registered alongside `memex_get_lint_flags`).
+
+The Claude Code `recall` skill is wired to call
+`memex_lint_apply_winner` after surfacing the proposal to the user, so
+the agent does not auto-apply silently.
+
+## Tuning
+
+- `server.memory.lint_llm.propose_winner_min_confidence` — minimum
+  DSPy-reported confidence below which an `inconclusive` proposal is
+  suppressed. Definitive (`unit_a` / `unit_b`) proposals are always
+  emitted; only the `inconclusive` branch is gated by this threshold.
+  Env: `MEMEX_SERVER_LINT_LLM_PROPOSE_WINNER_MIN_CONFIDENCE`. Default
+  `0.6`.
+- `server.memory.lint_llm.checks.propose_contradiction_winner.enabled`
+  — per-check feature flag.

--- a/docs/how-to/resolve-contradictions.md
+++ b/docs/how-to/resolve-contradictions.md
@@ -86,10 +86,13 @@ the agent does not auto-apply silently.
 ## Tuning
 
 - `server.memory.lint_llm.propose_winner_min_confidence` — minimum
-  DSPy-reported confidence below which an `inconclusive` proposal is
-  suppressed. Definitive (`unit_a` / `unit_b`) proposals are always
-  emitted; only the `inconclusive` branch is gated by this threshold.
-  Env: `MEMEX_SERVER_LINT_LLM_PROPOSE_WINNER_MIN_CONFIDENCE`. Default
-  `0.6`.
+  DSPy-reported confidence for a definitive winner verdict. Definitive
+  (`unit_a` / `unit_b`) verdicts with `confidence < min_confidence` are
+  emitted with `action='inconclusive'` so the audit trail survives but
+  the apply path is blocked. Increase the threshold to require higher
+  LLM confidence before mutations can land; decrease to permit
+  lower-confidence verdicts. Inconclusive verdicts from the LLM itself
+  are always emitted regardless of confidence. Env:
+  `MEMEX_SERVER_LINT_LLM_PROPOSE_WINNER_MIN_CONFIDENCE`. Default `0.6`.
 - `server.memory.lint_llm.checks.propose_contradiction_winner.enabled`
   — per-check feature flag.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ Goal-oriented recipes for specific tasks. Assumes you have a working Memex insta
 | [Note Templates](how-to/note-templates.md) | Create, register, and use note templates for consistent structure. |
 | [Sync Notes](how-to/sync-notes.md) | Sync a folder of Markdown notes to Memex with incremental updates. |
 | [Firefox Extension](how-to/firefox-extension.md) | Capture articles and PDFs from Firefox directly into Memex. |
+| [Resolve Contradictions](how-to/resolve-contradictions.md) | Review and apply LLM-proposed winners between contradicting memory units. |
 
 ---
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -377,6 +377,84 @@ memex memory lineage note 550e8400-e29b-41d4-a716-446655440000 --depth 5 --json
 
 ---
 
+## `lint`
+
+Manage the maintenance ledger (rule-based and LLM-driven hygiene findings).
+
+### `lint status`
+
+```
+memex lint status [--vault <name>|--global|--all]
+```
+
+Pending finding counts.
+
+### `lint findings`
+
+```
+memex lint findings [--vault <name>] [--type <category>] [--status <state>] [--limit <n>]
+```
+
+List maintenance findings.
+
+### `lint dismiss`
+
+```
+memex lint dismiss <finding_id>
+```
+
+Flip a pending finding to `dismissed`.
+
+### `lint resolve`
+
+```
+memex lint resolve <finding_id>
+```
+
+Flip a pending finding to `resolved`.
+
+### `lint apply`
+
+```
+memex lint apply <finding_id>
+```
+
+Apply the recommended action on a winner-proposal finding
+(`rule_name=propose_contradiction_winner`). Dispatches on the action
+literal in `evidence.action`:
+
+- `mark_loser_stale` — flip the loser `MemoryUnit.status` to `'stale'`.
+- `supersede_loser_note` — set the loser note's `superseded_by` to the
+  winner's note id (falls back to `mark_loser_stale` when both units
+  share the same parent note).
+- `refine_not_contradict` — rewrite the inbound `MemoryLink.link_type`
+  from `'contradicts'` to `'refines'`.
+- `inconclusive` — no-op write; flips the finding to resolved.
+
+Each apply captures `prior_state` under `evidence.resolution` so the
+mutation is reversible via `memex lint reverse`.
+
+### `lint reverse`
+
+```
+memex lint reverse <finding_id>
+```
+
+Reverse a previously applied winner-proposal. Atomically restores the
+row(s) recorded under `evidence.resolution.prior_state` and writes a
+paired audit row (`propose_contradiction_winner_reversal`).
+
+### `lint review`
+
+```
+memex lint review [--vault <name>|--global|--all] [--type <category>] [--apply] [--limit <n>]
+```
+
+Interactively walk pending findings (analogous to `git add -p`). Default
+is dry-run; pass `--apply` to persist verdicts.
+
+---
+
 ## `note`
 
 Manage and view source notes.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -382,6 +382,21 @@ Protects against cascading failures from LLM provider outages.
 | `failure_threshold` | int | `5` | >= 1 | Number of consecutive failures before opening the circuit. |
 | `reset_timeout_seconds` | float | `60.0` | > 0 | Seconds to stay open before allowing a probe request. |
 
+#### LLM Lint (`server.memory.lint_llm`)
+
+Surprise-gated LLM-driven lint pass. Adds an extra pass over candidate
+memory units to flag semantic contradictions, schema drift, and propose
+winners between FSFM-flagged contradicting pairs.
+
+| Key | Type | Default | Constraints | Description |
+|:----|:-----|:--------|:------------|:------------|
+| `enabled` | bool | `true` | — | Master switch; when false the tick is a no-op. |
+| `cost_cap_per_24h` | int | `10` | >= 0 | Max LLM lint calls per vault per 24h. `0` disables the tick. |
+| `propose_winner_min_confidence` | float | `0.6` | `[0.0, 1.0]` | Minimum DSPy-reported confidence below which an `inconclusive` winner proposal is suppressed. Env: `MEMEX_SERVER_LINT_LLM_PROPOSE_WINNER_MIN_CONFIDENCE`. |
+| `checks.semantic_contradiction.enabled` | bool | `true` | — | Per-check feature flag for the semantic-contradiction signature. |
+| `checks.schema_drift.enabled` | bool | `true` | — | Per-check feature flag for the schema-drift signature. |
+| `checks.propose_contradiction_winner.enabled` | bool | `true` | — | Per-check feature flag for the ProposeContradictionWinner signature (fires on FSFM contradiction-pressure findings). |
+
 ---
 
 ### Document Search (`server.document`)

--- a/packages/claude-code-plugin/skills/recall/SKILL.md
+++ b/packages/claude-code-plugin/skills/recall/SKILL.md
@@ -18,6 +18,6 @@ argument-hint: "[search query]"
 4. **Procedure recall**: for "how do I X?" queries, check `procedure:` KV namespace first:
    - `memex_kv_list(namespaces=["procedure"])` → `memex_kv_get(key)` for active value
 
-5. **Memory hygiene**: when asked about stale facts, call `memex_get_lint_flags(vault_id=...)`. Act autonomously on low-risk findings.
+5. **Memory hygiene**: when asked about stale facts, call `memex_get_lint_flags(vault_id=...)`. Act autonomously on low-risk findings. When a finding has `rule_name='propose_contradiction_winner'`, call `memex_lint_apply_winner` after surfacing the proposal to the user.
 
 6. **Diagnostics**: "how is this vault doing?" → `memex_get_diagnostics_summary(vault_id=...)`.

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -6,6 +6,8 @@ Subcommands:
 * ``memex lint findings [--type ...]`` — list findings.
 * ``memex lint dismiss <finding_id>`` — flip to dismissed.
 * ``memex lint resolve <finding_id>`` — flip to resolved.
+* ``memex lint apply <finding_id>`` — apply a winner-proposal action.
+* ``memex lint reverse <finding_id>`` — reverse an applied winner-proposal.
 * ``memex lint review [--vault X | --global | --all] [--apply]`` —
   interactive triage.
 
@@ -204,6 +206,67 @@ async def lint_resolve_cmd(
             handle_api_error(e)
             return
     console.print(f'[green]resolved:[/green] {payload["finding_id"]}')
+
+
+@app.command('apply')
+@async_command
+async def lint_apply_cmd(
+    ctx: typer.Context,
+    finding_id: Annotated[
+        str,
+        typer.Argument(help='Finding UUID (winner-proposal) to apply.'),
+    ],
+):
+    """Apply a winner-proposal finding's recorded action.
+
+    The finding's ``evidence.action`` drives the mutation: mark a unit
+    stale, mark a note superseded, rewrite a contradicts link as refines,
+    or a no-op write when inconclusive. Captures ``prior_state`` so the
+    change can be reversed with ``memex lint reverse``.
+    """
+    parse_uuid(finding_id, 'finding_id')
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            payload = await api.lint_apply_winner(finding_id)
+        except Exception as e:
+            handle_api_error(e)
+            return
+    effective = payload.get('effective_action', 'unknown')
+    console.print(
+        f'[green]applied:[/green] {payload["finding_id"]} [dim](action={effective})[/dim]'
+    )
+    fallback = payload.get('fallback_reason')
+    if fallback:
+        console.print(f'[yellow]fallback:[/yellow] {fallback}')
+
+
+@app.command('reverse')
+@async_command
+async def lint_reverse_cmd(
+    ctx: typer.Context,
+    finding_id: Annotated[
+        str,
+        typer.Argument(help='Finding UUID (winner-proposal) to reverse.'),
+    ],
+):
+    """Reverse a previously applied winner-proposal.
+
+    Restores the row(s) recorded under ``evidence.resolution.prior_state``
+    and writes a paired audit row. The original finding stays resolved.
+    """
+    parse_uuid(finding_id, 'finding_id')
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            payload = await api.lint_reverse_winner(finding_id)
+        except Exception as e:
+            handle_api_error(e)
+            return
+    effective = payload.get('effective_action', 'unknown')
+    console.print(
+        f'[green]reversed:[/green] {payload["finding_id"]} [dim](action={effective})[/dim]'
+    )
 
 
 @app.command('review')

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -1322,6 +1322,23 @@ class RemoteMemexAPI:
         """Flip a pending finding to ``resolved``."""
         return await self._post(f'lint/findings/{finding_id}/resolve', {})
 
+    async def lint_apply_winner(self, finding_id: str) -> dict[str, Any]:
+        """Apply a winner-proposal finding's recorded action.
+
+        The finding's ``evidence.action`` literal drives the mutation —
+        mark a unit stale, mark a note superseded, or rewrite a contradicts
+        link as refines. Returns the applied details; raises on conflict.
+        """
+        return await self._post(f'lint/findings/{finding_id}/apply', {})
+
+    async def lint_reverse_winner(self, finding_id: str) -> dict[str, Any]:
+        """Reverse a previously applied winner-proposal.
+
+        Restores the row(s) recorded under ``evidence.resolution.prior_state``
+        and writes a paired audit row. The original finding stays resolved.
+        """
+        return await self._post(f'lint/findings/{finding_id}/reverse', {})
+
     async def run_lint_rules(self, vault_id: str | UUID) -> dict[str, Any]:
         """Synchronously run the V1 lint rule registry for ``vault_id``.
 

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1499,10 +1499,11 @@ class LintLLMConfig(BaseModel):
         ge=0.0,
         le=1.0,
         description=(
-            'Minimum DSPy-reported confidence below which an inconclusive winner '
-            'proposal is suppressed. Definitive (unit_a / unit_b) proposals are '
-            'always emitted; only the inconclusive branch is gated by this '
-            'threshold. Env: MEMEX_SERVER_LINT_LLM_PROPOSE_WINNER_MIN_CONFIDENCE.'
+            'Minimum confidence for a definitive winner proposal. Below this, '
+            'a definitive (unit_a / unit_b) verdict is downgraded to inconclusive '
+            'before the finding is emitted — the audit trail survives but the '
+            'apply path is blocked until a human re-reviews. '
+            'Env: MEMEX_SERVER_LINT_LLM_PROPOSE_WINNER_MIN_CONFIDENCE.'
         ),
     )
 

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1499,10 +1499,10 @@ class LintLLMConfig(BaseModel):
         ge=0.0,
         le=1.0,
         description=(
-            'Minimum confidence for a definitive winner proposal. Below this, '
-            'a definitive (unit_a / unit_b) verdict is downgraded to inconclusive '
-            'before the finding is emitted — the audit trail survives but the '
-            'apply path is blocked until a human re-reviews. '
+            'Minimum confidence for a definitive winner proposal. Below this '
+            'threshold, definitive verdicts are downgraded to `inconclusive` — '
+            'the proposal lands in the lint ledger for audit but the apply '
+            'path is blocked. '
             'Env: MEMEX_SERVER_LINT_LLM_PROPOSE_WINNER_MIN_CONFIDENCE.'
         ),
     )

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1411,6 +1411,14 @@ class LintLLMChecksConfig(BaseModel):
         default_factory=LintLLMCheckConfig,
         description='CheckSchemaDrift signature (date format / id style / structure).',
     )
+    propose_contradiction_winner: LintLLMCheckConfig = Field(
+        default_factory=LintLLMCheckConfig,
+        description=(
+            'ProposeContradictionWinner signature — fires on FSFM contradiction-pressure '
+            'findings (flag_reason ∈ low_credibility_contradiction_only | components_disagree) '
+            'and emits a reversible winner proposal.'
+        ),
+    )
 
 
 class LintLLMConfig(BaseModel):
@@ -1485,6 +1493,17 @@ class LintLLMConfig(BaseModel):
         description='NLI polarity classifier configuration (entailment / neutral / '
         'contradiction). The NLI branch only fires when cosine surprise is below '
         'surprise_threshold, so this is a fallback signal — never a primary gate.',
+    )
+    propose_winner_min_confidence: float = Field(
+        default=0.6,
+        ge=0.0,
+        le=1.0,
+        description=(
+            'Minimum DSPy-reported confidence below which an inconclusive winner '
+            'proposal is suppressed. Definitive (unit_a / unit_b) proposals are '
+            'always emitted; only the inconclusive branch is gated by this '
+            'threshold. Env: MEMEX_SERVER_LINT_LLM_PROPOSE_WINNER_MIN_CONFIDENCE.'
+        ),
     )
 
 

--- a/packages/core/src/memex_core/alembic/versions/037_link_type_refines.py
+++ b/packages/core/src/memex_core/alembic/versions/037_link_type_refines.py
@@ -18,6 +18,12 @@ appended. No data is modified. The downgrade drops ``refines`` from the
 literal list; if any rows currently use ``refines`` it raises a clear
 error directing the operator to re-classify them first.
 
+Both upgrade and downgrade rely on the standard migration discipline:
+migrations run with sole DB access (no concurrent writes mid-deploy).
+The drop-and-recreate is therefore safe; a concurrent INSERT between
+DROP CONSTRAINT and ADD CONSTRAINT would otherwise admit a row that
+violates the new check, but the deploy contract precludes that.
+
 Revision ID: 037_link_type_refines
 Revises: 036_fsfm_cooldown_index
 Create Date: 2026-05-11

--- a/packages/core/src/memex_core/alembic/versions/037_link_type_refines.py
+++ b/packages/core/src/memex_core/alembic/versions/037_link_type_refines.py
@@ -1,0 +1,74 @@
+"""Add 'refines' to the memory_links link_type CHECK constraint.
+
+The contradiction-resolution lint surface introduces a new
+``refines`` link type for cases where two memory units appear to
+contradict at the topical level but are actually compatible
+refinements. The lint rule rewrites the inbound ``contradicts``
+link as ``refines`` so:
+
+- the graph-pressure aggregate at services/lint.py drops to zero for
+  that link (``refines`` weight is 0.0 in both the SQL CTE and the
+  Python parity pass), and
+- the audit trail records that a human-reviewed agent judged the two
+  units to be refinements, not contradictions.
+
+The upgrade is additive — drops and recreates the
+``memory_links_link_type_check`` CHECK constraint with the new literal
+appended. No data is modified. The downgrade drops ``refines`` from the
+literal list; if any rows currently use ``refines`` it raises a clear
+error directing the operator to re-classify them first.
+
+Revision ID: 037_link_type_refines
+Revises: 036_fsfm_cooldown_index
+Create Date: 2026-05-11
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = '037_link_type_refines'
+down_revision: Union[str, None] = '036_fsfm_cooldown_index'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_CONSTRAINT_NAME = 'memory_links_link_type_check'
+
+_LITERALS_WITH_REFINES = (
+    "'temporal', 'semantic', 'entity', 'causes', 'caused_by', "
+    "'enables', 'prevents', 'reinforces', 'weakens', 'contradicts', 'refines'"
+)
+
+_LITERALS_WITHOUT_REFINES = (
+    "'temporal', 'semantic', 'entity', 'causes', 'caused_by', "
+    "'enables', 'prevents', 'reinforces', 'weakens', 'contradicts'"
+)
+
+
+def upgrade() -> None:
+    op.execute(f'ALTER TABLE memory_links DROP CONSTRAINT IF EXISTS {_CONSTRAINT_NAME}')
+    op.execute(
+        f'ALTER TABLE memory_links ADD CONSTRAINT {_CONSTRAINT_NAME} '
+        f'CHECK (link_type IN ({_LITERALS_WITH_REFINES}))'
+    )
+
+
+def downgrade() -> None:
+    refining_rows = (
+        op.get_bind()
+        .exec_driver_sql("SELECT COUNT(*) FROM memory_links WHERE link_type = 'refines'")
+        .scalar()
+    )
+    if refining_rows:
+        raise RuntimeError(
+            f'Cannot downgrade: {refining_rows} memory_links row(s) still use '
+            "link_type='refines'. Re-classify these rows (e.g. back to "
+            "'contradicts' or 'semantic') before downgrading."
+        )
+    op.execute(f'ALTER TABLE memory_links DROP CONSTRAINT IF EXISTS {_CONSTRAINT_NAME}')
+    op.execute(
+        f'ALTER TABLE memory_links ADD CONSTRAINT {_CONSTRAINT_NAME} '
+        f'CHECK (link_type IN ({_LITERALS_WITHOUT_REFINES}))'
+    )

--- a/packages/core/src/memex_core/memory/lint_llm/checks.py
+++ b/packages/core/src/memex_core/memory/lint_llm/checks.py
@@ -26,6 +26,7 @@ import memex_core.llm as _llm
 from memex_core.memory.lint_llm.signatures import (
     CheckSchemaDrift,
     CheckSemanticContradiction,
+    ProposeContradictionWinner,
 )
 from memex_core.memory.lint_llm.surprise import compute_unit_surprise
 from memex_core.memory.lint_llm.types import (
@@ -41,6 +42,20 @@ logger = logging.getLogger('memex.core.memory.lint_llm.checks')
 
 _RULE_LLM_SEMANTIC_CONTRADICTION = 'llm_semantic_contradiction'
 _RULE_LLM_SCHEMA_DRIFT = 'llm_schema_drift'
+_RULE_PROPOSE_CONTRADICTION_WINNER = 'propose_contradiction_winner'
+
+_QUALIFYING_FLAG_REASONS: frozenset[str] = frozenset(
+    {
+        'low_credibility_contradiction_only',
+        'components_disagree',
+    }
+)
+
+_SUGGESTED_ACTION_PROPOSE_WINNER = (
+    'Review the proposed winner and call memex_lint_apply_winner to apply '
+    'the recommended resolution, or memex_lint_reverse_winner if the '
+    'mutation has already been applied and needs to be undone.'
+)
 
 _SUGGESTED_ACTION_CONTRADICTION = (
     'Review for semantic contradiction with the cited related unit(s); '
@@ -267,6 +282,225 @@ def make_schema_drift_check(
             related_unit_ids=[],
             extra_evidence={'drift_kind': drift_kind},
             lint_type=LintType.SCHEMA,
+        )
+
+    return _check
+
+
+_LOAD_FSFM_FINDING_FOR_UNIT_SQL = text("""
+    SELECT id::text AS finding_id, evidence
+    FROM maintenance_proposals
+    WHERE rule_name = 'composite_deprioritize_candidate'
+      AND target_type = 'memory_unit'
+      AND target_id = :unit_id
+      AND status = 'pending'
+      AND (vault_id = :vault_id OR vault_id IS NULL)
+    ORDER BY created_at DESC
+    LIMIT 1
+""")
+
+
+_EXISTING_WINNER_PROPOSAL_SQL = text("""
+    SELECT 1
+    FROM maintenance_proposals
+    WHERE rule_name = 'propose_contradiction_winner'
+      AND target_type = 'memory_unit'
+      AND target_id = :unit_id
+      AND status = 'pending'
+      AND (vault_id = :vault_id OR vault_id IS NULL)
+    LIMIT 1
+""")
+
+
+_LOAD_TOP_CONTRADICTS_LINK_SQL = text("""
+    SELECT
+        ml.id::text AS link_id,
+        ml.from_unit_id::text AS source_unit_id,
+        ml.weight AS weight,
+        ml.created_at AS link_created_at,
+        src.text AS source_text,
+        src.created_at AS source_created_at,
+        src.confidence AS source_confidence,
+        ((src.success_co_count + 1.0) /
+         (src.success_co_count + src.failure_co_count + 2)) AS source_mw,
+        src.note_id::text AS source_note_id,
+        src_note.metadata AS source_note_metadata
+    FROM memory_links ml
+    JOIN memory_units src ON src.id = ml.from_unit_id
+    LEFT JOIN notes src_note ON src_note.id = src.note_id
+    WHERE ml.to_unit_id = :unit_id
+      AND ml.vault_id = :vault_id
+      AND src.vault_id = :vault_id
+      AND ml.link_type = 'contradicts'
+      AND src.status = 'active'
+    ORDER BY ml.weight DESC, ml.created_at DESC
+    LIMIT 1
+""")
+
+
+_LOAD_UNIT_WITH_NOTE_SQL = text("""
+    SELECT
+        mu.text AS unit_text,
+        mu.created_at AS unit_created_at,
+        mu.confidence AS unit_confidence,
+        ((mu.success_co_count + 1.0) /
+         (mu.success_co_count + mu.failure_co_count + 2)) AS unit_mw,
+        mu.note_id::text AS note_id,
+        n.metadata AS note_metadata
+    FROM memory_units mu
+    LEFT JOIN notes n ON n.id = mu.note_id
+    WHERE mu.id = :unit_id
+""")
+
+
+def _authority_from_metadata(metadata: Any) -> str:
+    if not isinstance(metadata, dict):
+        return ''
+    for key in ('authority', 'source_authority', 'template'):
+        v = metadata.get(key)
+        if isinstance(v, str) and v.strip():
+            return v
+    return ''
+
+
+def make_propose_contradiction_winner_check(
+    lm: dspy.LM,
+    *,
+    min_confidence: float = 0.6,
+) -> RunLLMCheck:
+    """Build a ``RunLLMCheck`` that wraps :class:`ProposeContradictionWinner`.
+
+    Operates as a follow-on to FSFM lint: only fires on units that already
+    carry a pending ``composite_deprioritize_candidate`` finding whose
+    ``flag_reason`` ∈ {``low_credibility_contradiction_only``,
+    ``components_disagree``}. Locates the highest-pressure inbound
+    ``contradicts`` link, loads both units and their source-note
+    authority labels, and asks the LLM to nominate a winner + an action.
+
+    Returns ``None`` when no qualifying FSFM finding exists, when a
+    winner-proposal is already pending for the unit, when the LLM
+    returns ``inconclusive`` below ``min_confidence``, or when the
+    contradicting peer cannot be located.
+    """
+    predictor = dspy.Predict(ProposeContradictionWinner)
+
+    async def _check(
+        unit_id: UUID,
+        vault_id: UUID,
+        session: AsyncSession,
+        context: CheckContext | None = None,
+    ) -> LLMLintFinding | None:
+        fsfm_row = (
+            await session.execute(
+                _LOAD_FSFM_FINDING_FOR_UNIT_SQL,
+                {'unit_id': str(unit_id), 'vault_id': str(vault_id)},
+            )
+        ).first()
+        if fsfm_row is None:
+            return None
+        evidence = fsfm_row.evidence or {}
+        flag_reason = str(evidence.get('flag_reason') or '')
+        if flag_reason not in _QUALIFYING_FLAG_REASONS:
+            return None
+
+        existing = (
+            await session.execute(
+                _EXISTING_WINNER_PROPOSAL_SQL,
+                {'unit_id': str(unit_id), 'vault_id': str(vault_id)},
+            )
+        ).first()
+        if existing is not None:
+            return None
+
+        peer_row = (
+            await session.execute(
+                _LOAD_TOP_CONTRADICTS_LINK_SQL,
+                {'unit_id': str(unit_id), 'vault_id': str(vault_id)},
+            )
+        ).first()
+        if peer_row is None:
+            return None
+
+        loser_row = (
+            await session.execute(
+                _LOAD_UNIT_WITH_NOTE_SQL,
+                {'unit_id': str(unit_id)},
+            )
+        ).first()
+        if loser_row is None or loser_row.unit_text is None:
+            return None
+
+        prediction = await _llm.run_dspy_operation(
+            lm=lm,
+            predictor=predictor,
+            input_kwargs={
+                'unit_a_text': str(peer_row.source_text or ''),
+                'unit_b_text': str(loser_row.unit_text),
+                'unit_a_created_at': (
+                    peer_row.source_created_at.isoformat()
+                    if peer_row.source_created_at is not None
+                    else ''
+                ),
+                'unit_b_created_at': (
+                    loser_row.unit_created_at.isoformat()
+                    if loser_row.unit_created_at is not None
+                    else ''
+                ),
+                'unit_a_source_credibility': float(peer_row.source_mw or 0.0),
+                'unit_b_source_credibility': float(loser_row.unit_mw or 0.0),
+                'unit_a_source_authority': _authority_from_metadata(peer_row.source_note_metadata),
+                'unit_b_source_authority': _authority_from_metadata(loser_row.note_metadata),
+                'fsfm_evidence': dict(evidence),
+            },
+            operation_name='lint_llm.propose_contradiction_winner',
+        )
+
+        confidence = float(getattr(prediction, 'confidence', 0.0) or 0.0)
+        action = str(getattr(prediction, 'action', 'inconclusive') or 'inconclusive')
+        winner_id_label = str(getattr(prediction, 'winner_id', 'inconclusive') or 'inconclusive')
+        loser_id_label = str(getattr(prediction, 'loser_id', 'none') or 'none')
+        rationale = str(getattr(prediction, 'rationale', '') or '')
+
+        if winner_id_label == 'inconclusive' and confidence < min_confidence:
+            return None
+
+        if winner_id_label == 'unit_a':
+            resolved_winner_unit_id = peer_row.source_unit_id
+            resolved_loser_unit_id = str(unit_id)
+        elif winner_id_label == 'unit_b':
+            resolved_winner_unit_id = str(unit_id)
+            resolved_loser_unit_id = peer_row.source_unit_id
+        else:
+            resolved_winner_unit_id = None
+            resolved_loser_unit_id = str(unit_id)
+
+        target_id = resolved_loser_unit_id or str(unit_id)
+
+        extra_evidence: dict[str, Any] = {
+            'linked_to_finding': str(fsfm_row.finding_id),
+            'flag_reason': flag_reason,
+            'winner_id': winner_id_label,
+            'loser_id': loser_id_label,
+            'winner_unit_id': resolved_winner_unit_id,
+            'loser_unit_id': resolved_loser_unit_id,
+            'peer_unit_id': peer_row.source_unit_id,
+            'link_id': peer_row.link_id,
+            'confidence': confidence,
+            'action': action,
+            'rationale': rationale,
+        }
+
+        return LLMLintFinding(
+            rule_name=_RULE_PROPOSE_CONTRADICTION_WINNER,
+            check_type='propose_contradiction_winner',
+            target_type='memory_unit',
+            target_id=target_id,
+            suggested_action=_SUGGESTED_ACTION_PROPOSE_WINNER,
+            surprise_score=0.0,
+            explanation=rationale,
+            related_unit_ids=[peer_row.source_unit_id],
+            extra_evidence=extra_evidence,
+            lint_type=LintType.QUALITY,
         )
 
     return _check

--- a/packages/core/src/memex_core/memory/lint_llm/checks.py
+++ b/packages/core/src/memex_core/memory/lint_llm/checks.py
@@ -461,8 +461,12 @@ def make_propose_contradiction_winner_check(
         loser_id_label = str(getattr(prediction, 'loser_id', 'none') or 'none')
         rationale = str(getattr(prediction, 'rationale', '') or '')
 
-        if winner_id_label == 'inconclusive' and confidence < min_confidence:
-            return None
+        # Below-threshold definitive verdicts are downgraded (not dropped) so
+        # the audit trail survives while the apply path is blocked.
+        if winner_id_label in ('unit_a', 'unit_b') and confidence < min_confidence:
+            winner_id_label = 'inconclusive'
+            loser_id_label = 'none'
+            action = 'inconclusive'
 
         if winner_id_label == 'unit_a':
             resolved_winner_unit_id = peer_row.source_unit_id

--- a/packages/core/src/memex_core/memory/lint_llm/checks.py
+++ b/packages/core/src/memex_core/memory/lint_llm/checks.py
@@ -377,10 +377,15 @@ def make_propose_contradiction_winner_check(
     ``contradicts`` link, loads both units and their source-note
     authority labels, and asks the LLM to nominate a winner + an action.
 
-    Returns ``None`` when no qualifying FSFM finding exists, when a
-    winner-proposal is already pending for the unit, when the LLM
-    returns ``inconclusive`` below ``min_confidence``, or when the
-    contradicting peer cannot be located.
+    A finding is emitted for *any* verdict the LLM returns — including
+    ``inconclusive`` — so the audit trail records that lint ran. Confidence
+    no longer drives ``None``: a definitive ``unit_a`` / ``unit_b`` verdict
+    with ``confidence < min_confidence`` is downgraded to ``inconclusive``
+    (so the apply path is blocked) but still emitted.
+
+    Returns ``None`` only on the pre-check filters: no qualifying FSFM
+    finding for the unit, an existing pending winner-proposal for the
+    same unit, or no inbound contradicts-link peer row.
     """
     predictor = dspy.Predict(ProposeContradictionWinner)
 
@@ -461,8 +466,10 @@ def make_propose_contradiction_winner_check(
         loser_id_label = str(getattr(prediction, 'loser_id', 'none') or 'none')
         rationale = str(getattr(prediction, 'rationale', '') or '')
 
-        # Below-threshold definitive verdicts are downgraded (not dropped) so
-        # the audit trail survives while the apply path is blocked.
+        # Confidence gate is inclusive on the threshold: ``confidence >=
+        # min_confidence`` passes; strictly below ``min_confidence`` is
+        # downgraded to ``inconclusive`` (not dropped) so the audit trail
+        # survives while the apply path is blocked.
         if winner_id_label in ('unit_a', 'unit_b') and confidence < min_confidence:
             winner_id_label = 'inconclusive'
             loser_id_label = 'none'

--- a/packages/core/src/memex_core/memory/lint_llm/checks.py
+++ b/packages/core/src/memex_core/memory/lint_llm/checks.py
@@ -475,6 +475,10 @@ def make_propose_contradiction_winner_check(
             loser_id_label = 'none'
             action = 'inconclusive'
 
+        if winner_id_label == 'inconclusive':
+            action = 'inconclusive'
+            loser_id_label = 'none'
+
         if winner_id_label == 'unit_a':
             resolved_winner_unit_id = peer_row.source_unit_id
             resolved_loser_unit_id = str(unit_id)

--- a/packages/core/src/memex_core/memory/lint_llm/signatures.py
+++ b/packages/core/src/memex_core/memory/lint_llm/signatures.py
@@ -22,9 +22,21 @@ sign-of-meaning signal (NLI label) available.
 
 from __future__ import annotations
 
+from typing import Any, Literal
+
 import dspy
+from pydantic import field_validator
 
 from memex_core.memory.lint_llm.types import PolarityLiteral
+
+WinnerLiteral = Literal['unit_a', 'unit_b', 'inconclusive']
+LoserLiteral = Literal['unit_a', 'unit_b', 'none']
+ResolutionActionLiteral = Literal[
+    'mark_loser_stale',
+    'supersede_loser_note',
+    'refine_not_contradict',
+    'inconclusive',
+]
 
 
 class CheckSemanticContradiction(dspy.Signature):
@@ -121,3 +133,88 @@ class CheckSchemaDrift(dspy.Signature):
             'mismatch. Empty when has_drift is False.'
         )
     )
+
+
+class ProposeContradictionWinner(dspy.Signature):
+    """Given two memory units flagged by FSFM lint as in tension, propose
+    which one should win, the recommended action, and a calibrated
+    confidence.
+
+    Inputs include the two units' text plus per-side recency and source
+    metadata so the LLM can reason about authority and freshness. The
+    fsfm_evidence field carries the upstream finding's evidence payload
+    (flag_reason, component scores) so the proposal is anchored in the
+    same signals the human reviewer sees.
+
+    STRICT RULES:
+    - Only propose ``mark_loser_stale`` when one unit is clearly wrong
+      and the other clearly right. The loser must be the older / lower-
+      authority unit unless authority strongly inverts.
+    - Use ``supersede_loser_note`` when the winner's source note is a
+      genuinely newer recording of the same fact and the agent wants the
+      parent note marked superseded (not just the unit).
+    - Use ``refine_not_contradict`` when the units are compatible
+      refinements (different aspects of the same fact), NOT semantic
+      inversions.
+    - Use ``inconclusive`` when the signal is too weak to judge.
+    """
+
+    unit_a_text: str = dspy.InputField(desc='Text of the first memory unit (unit_a).')
+    unit_b_text: str = dspy.InputField(desc='Text of the second memory unit (unit_b).')
+    unit_a_created_at: str = dspy.InputField(
+        desc='ISO-8601 created_at of unit_a (string form for prompt-friendly serialisation).'
+    )
+    unit_b_created_at: str = dspy.InputField(desc='ISO-8601 created_at of unit_b.')
+    unit_a_source_credibility: float = dspy.InputField(
+        desc='Memory Worth posterior of unit_a (0..1). Higher = more credible.'
+    )
+    unit_b_source_credibility: float = dspy.InputField(
+        desc='Memory Worth posterior of unit_b (0..1). Higher = more credible.'
+    )
+    unit_a_source_authority: str = dspy.InputField(
+        desc=(
+            "Free-text authority label for unit_a's source note "
+            "(e.g. 'official-doc', 'chat-log', 'user-edit'). Empty when unknown."
+        )
+    )
+    unit_b_source_authority: str = dspy.InputField(
+        desc="Free-text authority label for unit_b's source note. Empty when unknown."
+    )
+    fsfm_evidence: dict[str, Any] = dspy.InputField(
+        desc=(
+            'Evidence payload from the upstream FSFM finding — includes '
+            'flag_reason and the component score breakdown.'
+        )
+    )
+
+    winner_id: WinnerLiteral = dspy.OutputField(
+        desc="Which unit wins: 'unit_a' | 'unit_b' | 'inconclusive'."
+    )
+    loser_id: LoserLiteral = dspy.OutputField(
+        desc=("Which unit loses: 'unit_a' | 'unit_b' | 'none'. 'none' when winner is inconclusive.")
+    )
+    rationale: str = dspy.OutputField(
+        desc='One- or two-sentence English justification anchored in the inputs.'
+    )
+    confidence: float = dspy.OutputField(
+        desc='Calibrated confidence in the proposal (clamped to [0.0, 1.0]).'
+    )
+    action: ResolutionActionLiteral = dspy.OutputField(
+        desc=(
+            "Recommended resolution action: 'mark_loser_stale' | "
+            "'supersede_loser_note' | 'refine_not_contradict' | 'inconclusive'."
+        )
+    )
+
+    @field_validator('confidence', mode='before')
+    @classmethod
+    def _clamp_confidence(cls, v: Any) -> float:
+        try:
+            f = float(v)
+        except (TypeError, ValueError):
+            return 0.0
+        if f < 0.0:
+            return 0.0
+        if f > 1.0:
+            return 1.0
+        return f

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -1341,7 +1341,7 @@ class MemoryLink(SQLModel, table=True):  # type: ignore
 
     __table_args__ = (
         CheckConstraint(
-            "link_type IN ('temporal', 'semantic', 'entity', 'causes', 'caused_by', 'enables', 'prevents', 'reinforces', 'weakens', 'contradicts')",
+            "link_type IN ('temporal', 'semantic', 'entity', 'causes', 'caused_by', 'enables', 'prevents', 'reinforces', 'weakens', 'contradicts', 'refines')",
             name='memory_links_link_type_check',
         ),
         CheckConstraint('weight >= 0.0 AND weight <= 1.0', name='memory_links_weight_check'),

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -307,6 +307,18 @@ LINT_RUN_DURATION_SECONDS = Histogram(
     buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0),
 )
 
+CONTRADICTION_RESOLUTION_APPLIED_TOTAL = Counter(
+    'memex_contradiction_resolution_applied_total',
+    'Winner-proposal applies by resolution action (bounded literals).',
+    ['action', 'vault_id'],
+)
+
+CONTRADICTION_RESOLUTION_REVERSED_TOTAL = Counter(
+    'memex_contradiction_resolution_reversed_total',
+    'Winner-proposal reversals by vault.',
+    ['vault_id'],
+)
+
 # ---------------------------------------------------------------------------
 # Per-entity advisory lock + reconsolidate / consolidate metrics
 # ---------------------------------------------------------------------------

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -206,6 +206,7 @@ async def periodic_lint_llm_task(api: 'MemexAPI'):
     whatever the first one left.
     """
     from memex_core.memory.lint_llm.checks import (
+        make_propose_contradiction_winner_check,
         make_schema_drift_check,
         make_semantic_contradiction_check,
     )
@@ -248,7 +249,14 @@ async def periodic_lint_llm_task(api: 'MemexAPI'):
     if settings.checks.schema_drift.enabled:
         checks.append(('schema_drift', make_schema_drift_check(api.lm, k=settings.surprise_k)))
 
-    if not checks:
+    propose_winner_check: object | None = None
+    if settings.checks.propose_contradiction_winner.enabled:
+        propose_winner_check = make_propose_contradiction_winner_check(
+            api.lm,
+            min_confidence=settings.propose_winner_min_confidence,
+        )
+
+    if not checks and propose_winner_check is None:
         logger.info('Scheduler: Lint_llm — no checks enabled, skipping tick')
         return
 
@@ -286,6 +294,29 @@ async def periodic_lint_llm_task(api: 'MemexAPI'):
                         logger.warning(
                             'Scheduler: Lint_llm[%s] failed for vault %s: %s',
                             check_name,
+                            vault.name,
+                            e,
+                        )
+
+                if propose_winner_check is not None:
+                    try:
+                        summary = await api.lint_llm.tick_propose_winner(
+                            vault.id,
+                            run_llm_check=propose_winner_check,
+                        )
+                        if summary.findings_emitted or summary.deferred:
+                            logger.info(
+                                'Scheduler: Lint_llm[propose_contradiction_winner] '
+                                'vault=%s: evaluated=%d emitted=%d deferred=%d',
+                                vault.name,
+                                summary.candidates_evaluated,
+                                summary.findings_emitted,
+                                summary.deferred,
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            'Scheduler: Lint_llm[propose_contradiction_winner] '
+                            'failed for vault %s: %s',
                             vault.name,
                             e,
                         )

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -17,6 +17,7 @@ opaque cursor pagination, mirrored by ``memex_get_lint_flags`` MCP.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Annotated, Any
 from uuid import UUID
 
@@ -37,6 +38,33 @@ from memex_core.server.common import _handle_error, get_api
 from memex_core.services.lint import LintSubsystemNotInitializedError
 
 logger = logging.getLogger('memex.core.server.lint')
+
+_UNATTENDED_OPT_IN_ENV = 'MEMEX_LINT_ALLOW_UNATTENDED_APPLY'
+
+
+def _require_attended_mode(api: MemexAPI) -> None:
+    """Block destructive lint mutations when auth is disabled.
+
+    The apply / reverse endpoints mutate memory units, notes, and link
+    typing — the audit row identifies the call path but does not gate the
+    write. When ``server.auth.enabled=False`` no human principal is on the
+    request, so an unattended LLM driver could end-to-end drive both calls
+    without review. Refuse unless the operator explicitly opts in via
+    ``MEMEX_LINT_ALLOW_UNATTENDED_APPLY=1`` (or ``true`` / ``yes``).
+    """
+    if api.config.server.auth.enabled:
+        return
+    opt_in = os.environ.get(_UNATTENDED_OPT_IN_ENV, '').strip().lower()
+    if opt_in in ('1', 'true', 'yes'):
+        return
+    raise HTTPException(
+        status_code=403,
+        detail=(
+            'Destructive lint mutations require auth enabled. '
+            f'Set {_UNATTENDED_OPT_IN_ENV}=1 to override (e.g. for trusted CI).'
+        ),
+    )
+
 
 router = APIRouter(prefix='/api/v1/lint')
 
@@ -236,6 +264,7 @@ async def lint_apply(
         apply_winner_proposal,
     )
 
+    _require_attended_mode(api)
     finding_vault = await _gate_finding_for_write(finding_id, api, auth)
     actor = _audit_actor()
     try:
@@ -264,6 +293,7 @@ async def lint_reverse(
         reverse_winner_proposal,
     )
 
+    _require_attended_mode(api)
     finding_vault = await _gate_finding_for_write(finding_id, api, auth)
     actor = _audit_actor()
     try:

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -126,17 +126,40 @@ async def lint_findings(
         raise _handle_error(e, 'Failed to list lint findings')
 
 
+def _resolve_actor(auth: AuthContext | None) -> str | None:
+    """Derive a stable actor label from the auth context for audit rows.
+
+    Prefers the human-readable ``key_name`` (set in ApiKeyConfig.description)
+    and falls back to ``key_prefix`` so the audit trail still identifies
+    *which* key applied the resolution even when the operator forgot to
+    label it.
+    """
+    if auth is None:
+        return None
+    key_name = getattr(auth, 'key_name', None)
+    if key_name:
+        return str(key_name)
+    key_prefix = getattr(auth, 'key_prefix', None)
+    if key_prefix:
+        return f'key:{key_prefix}'
+    return None
+
+
 async def _gate_finding_for_write(
     finding_id: UUID,
     api: MemexAPI,
     auth: AuthContext | None,
 ) -> UUID | None:
-    """Defense-in-depth helper for ``/findings/{id}/dismiss`` + ``/resolve``.
+    """Defense-in-depth vault-scope helper for finding write endpoints.
 
     Looks up the finding's vault_id, then gates the auth context against it.
     Returns the resolved vault_id (or ``None`` for global findings) so the
     caller can pass it through to ``LintService.set_status`` for SQL-level
     constraint as well (cross-vault mutation rejected: route + service layered checks).
+
+    Does NOT check the finding's status — the service layer raises a 409
+    with the correct status-transition semantics (pending vs. resolved
+    constraints differ by endpoint).
 
     Raises:
       - 404 if the finding does not exist.
@@ -144,7 +167,7 @@ async def _gate_finding_for_write(
     """
     found, finding_vault = await api.lint.get_finding_vault_id(finding_id)
     if not found:
-        raise HTTPException(status_code=404, detail='Finding not found or not pending')
+        raise HTTPException(status_code=404, detail='Finding not found')
     if finding_vault is not None:
         await check_vault_access(auth, [finding_vault], api, permission=Permission.WRITE)
     return finding_vault
@@ -214,9 +237,7 @@ async def lint_apply(
     )
 
     finding_vault = await _gate_finding_for_write(finding_id, api, auth)
-    actor = None
-    if auth is not None:
-        actor = getattr(auth, 'principal', None) or getattr(auth, 'subject', None)
+    actor = _resolve_actor(auth)
     try:
         return await apply_winner_proposal(api, finding_id, vault_id=finding_vault, actor=actor)
     except ContradictionResolutionError as exc:
@@ -243,17 +264,8 @@ async def lint_reverse(
         reverse_winner_proposal,
     )
 
-    # Re-use the same vault gate the apply path uses; however the finding
-    # is in 'resolved' state, so we look up its vault directly and check
-    # write access.
-    found, finding_vault = await api.lint.get_finding_vault_id(finding_id)
-    if not found:
-        raise HTTPException(status_code=404, detail='Finding not found')
-    if finding_vault is not None:
-        await check_vault_access(auth, [finding_vault], api, permission=Permission.WRITE)
-    actor = None
-    if auth is not None:
-        actor = getattr(auth, 'principal', None) or getattr(auth, 'subject', None)
+    finding_vault = await _gate_finding_for_write(finding_id, api, auth)
+    actor = _resolve_actor(auth)
     try:
         return await reverse_winner_proposal(api, finding_id, vault_id=finding_vault, actor=actor)
     except ContradictionResolutionError as exc:
@@ -327,6 +339,7 @@ async def lint_llm_run(
     (the cap-zero gate that short-circuits the periodic task).
     """
     from memex_core.memory.lint_llm.checks import (
+        make_propose_contradiction_winner_check,
         make_schema_drift_check,
         make_semantic_contradiction_check,
     )
@@ -368,7 +381,14 @@ async def lint_llm_run(
     if settings.checks.schema_drift.enabled:
         checks.append(('schema_drift', make_schema_drift_check(api.lm, k=settings.surprise_k)))
 
-    if not checks:
+    propose_winner_check: Any | None = None
+    if settings.checks.propose_contradiction_winner.enabled:
+        propose_winner_check = make_propose_contradiction_winner_check(
+            api.lm,
+            min_confidence=settings.propose_winner_min_confidence,
+        )
+
+    if not checks and propose_winner_check is None:
         return {
             'vault_id': str(vault_id),
             'summaries': [],
@@ -397,6 +417,25 @@ async def lint_llm_run(
         except Exception as exc:
             logger.warning('lint_llm[%s] failed: %s', check_name, exc)
             summaries.append({'check': check_name, 'error': str(exc)})
+
+    if propose_winner_check is not None:
+        try:
+            s = await api.lint_llm.tick_propose_winner(
+                vault_id,
+                run_llm_check=propose_winner_check,
+            )
+            summaries.append(
+                {
+                    'check': 'propose_contradiction_winner',
+                    'evaluated': s.candidates_evaluated,
+                    'emitted': s.findings_emitted,
+                    'deferred': s.deferred,
+                    'deferred_processed': s.deferred_processed,
+                }
+            )
+        except Exception as exc:
+            logger.warning('lint_llm[propose_contradiction_winner] failed: %s', exc)
+            summaries.append({'check': 'propose_contradiction_winner', 'error': str(exc)})
 
     return {'vault_id': str(vault_id), 'summaries': summaries}
 

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -25,6 +25,7 @@ from sqlalchemy import text
 
 from memex_common.config import Permission
 from memex_core.api import MemexAPI
+from memex_core.context import get_actor
 from memex_core.server.auth import (
     AuthContext,
     check_vault_access,
@@ -126,23 +127,20 @@ async def lint_findings(
         raise _handle_error(e, 'Failed to list lint findings')
 
 
-def _resolve_actor(auth: AuthContext | None) -> str | None:
-    """Derive a stable actor label from the auth context for audit rows.
+def _audit_actor() -> str:
+    """Return the audit-trail actor label for the current request.
 
-    Prefers the human-readable ``key_name`` (set in ApiKeyConfig.description)
-    and falls back to ``key_prefix`` so the audit trail still identifies
-    *which* key applied the resolution even when the operator forgot to
-    label it.
+    Reads from :func:`memex_core.context.get_actor`, which is set by
+    ``auth_middleware`` for authenticated requests (shape:
+    ``f'{key_name} ({key_prefix})'``). When auth is disabled, the
+    contextvar default is ``'anonymous'``; we promote that to ``'system'``
+    so the apply / reverse endpoints stay reachable in dev/test/CI and
+    the audit row still identifies the call path.
     """
-    if auth is None:
-        return None
-    key_name = getattr(auth, 'key_name', None)
-    if key_name:
-        return str(key_name)
-    key_prefix = getattr(auth, 'key_prefix', None)
-    if key_prefix:
-        return f'key:{key_prefix}'
-    return None
+    actor = get_actor()
+    if not actor or actor == 'anonymous':
+        return 'system'
+    return actor
 
 
 async def _gate_finding_for_write(
@@ -237,7 +235,7 @@ async def lint_apply(
     )
 
     finding_vault = await _gate_finding_for_write(finding_id, api, auth)
-    actor = _resolve_actor(auth)
+    actor = _audit_actor()
     try:
         return await apply_winner_proposal(api, finding_id, vault_id=finding_vault, actor=actor)
     except ContradictionResolutionError as exc:
@@ -265,7 +263,7 @@ async def lint_reverse(
     )
 
     finding_vault = await _gate_finding_for_write(finding_id, api, auth)
-    actor = _resolve_actor(auth)
+    actor = _audit_actor()
     try:
         return await reverse_winner_proposal(api, finding_id, vault_id=finding_vault, actor=actor)
     except ContradictionResolutionError as exc:

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -6,6 +6,8 @@ Routes:
 - GET    /api/v1/lint/flags                           — cursor-paginated agent surface
 - POST   /api/v1/lint/findings/{finding_id}/dismiss   — flip status to 'dismissed'
 - POST   /api/v1/lint/findings/{finding_id}/resolve   — flip status to 'resolved'
+- POST   /api/v1/lint/findings/{finding_id}/apply     — apply a winner-proposal action
+- POST   /api/v1/lint/findings/{finding_id}/reverse   — reverse a previously applied winner-proposal
 
 The ``findings`` endpoint backs ``memex lint findings`` (CLI). The
 ``flags`` endpoint is the agent surface — shape-stable returns and
@@ -190,6 +192,74 @@ async def lint_resolve(
     if not ok:
         raise HTTPException(status_code=404, detail='Finding not found or not pending')
     return {'finding_id': str(finding_id), 'status': 'resolved'}
+
+
+@router.post('/findings/{finding_id}/apply', dependencies=[Depends(require_write)])
+async def lint_apply(
+    finding_id: UUID,
+    api: Annotated[MemexAPI, Depends(get_api)],
+    auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
+) -> dict[str, Any]:
+    """Apply a winner-proposal finding's recorded action.
+
+    Gates by the finding's vault (same path as resolve/dismiss). The action
+    semantics — mark_loser_stale / supersede_loser_note /
+    refine_not_contradict / inconclusive — are captured under
+    ``evidence.action`` when the finding is emitted; this endpoint dispatches
+    on that literal and records ``prior_state`` so the change is reversible.
+    """
+    from memex_core.services.contradiction_resolution import (
+        ContradictionResolutionError,
+        apply_winner_proposal,
+    )
+
+    finding_vault = await _gate_finding_for_write(finding_id, api, auth)
+    actor = None
+    if auth is not None:
+        actor = getattr(auth, 'principal', None) or getattr(auth, 'subject', None)
+    try:
+        return await apply_winner_proposal(api, finding_id, vault_id=finding_vault, actor=actor)
+    except ContradictionResolutionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception as e:
+        raise _handle_error(e, 'Failed to apply winner proposal')
+
+
+@router.post('/findings/{finding_id}/reverse', dependencies=[Depends(require_write)])
+async def lint_reverse(
+    finding_id: UUID,
+    api: Annotated[MemexAPI, Depends(get_api)],
+    auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
+) -> dict[str, Any]:
+    """Reverse a previously applied winner-proposal.
+
+    Reads ``evidence.resolution.prior_state`` and atomically restores the
+    affected rows. Writes a paired ``propose_contradiction_winner_reversal``
+    audit row; the original resolved finding stays resolved so the unique
+    partial index on pending findings remains valid.
+    """
+    from memex_core.services.contradiction_resolution import (
+        ContradictionResolutionError,
+        reverse_winner_proposal,
+    )
+
+    # Re-use the same vault gate the apply path uses; however the finding
+    # is in 'resolved' state, so we look up its vault directly and check
+    # write access.
+    found, finding_vault = await api.lint.get_finding_vault_id(finding_id)
+    if not found:
+        raise HTTPException(status_code=404, detail='Finding not found')
+    if finding_vault is not None:
+        await check_vault_access(auth, [finding_vault], api, permission=Permission.WRITE)
+    actor = None
+    if auth is not None:
+        actor = getattr(auth, 'principal', None) or getattr(auth, 'subject', None)
+    try:
+        return await reverse_winner_proposal(api, finding_id, vault_id=finding_vault, actor=actor)
+    except ContradictionResolutionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception as e:
+        raise _handle_error(e, 'Failed to reverse winner proposal')
 
 
 @router.post('/run/{vault_id}', dependencies=[Depends(require_write)])

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -133,13 +133,15 @@ def _audit_actor() -> str:
     Reads from :func:`memex_core.context.get_actor`, which is set by
     ``auth_middleware`` for authenticated requests (shape:
     ``f'{key_name} ({key_prefix})'``). When auth is disabled, the
-    contextvar default is ``'anonymous'``; we promote that to ``'system'``
-    so the apply / reverse endpoints stay reachable in dev/test/CI and
-    the audit row still identifies the call path.
+    contextvar default is ``'anonymous'``; we promote that to
+    ``'system:auth-disabled'`` so the apply / reverse endpoints stay
+    reachable in dev/test/CI, the audit row still identifies the call
+    path, and the value cannot be confused with a real principal whose
+    key is literally named "system".
     """
     actor = get_actor()
     if not actor or actor == 'anonymous':
-        return 'system'
+        return 'system:auth-disabled'
     return actor
 
 

--- a/packages/core/src/memex_core/services/contradiction_resolution.py
+++ b/packages/core/src/memex_core/services/contradiction_resolution.py
@@ -202,10 +202,15 @@ async def apply_winner_proposal(
 
         if effective_action == 'mark_loser_stale':
             prior_state['loser_unit_status'] = loser_row.status
-            await session.execute(
+            result = await session.execute(
                 _UPDATE_UNIT_STATUS_SQL,
                 {'unit_id': str(loser_unit_id), 'status': 'stale'},
             )
+            if not result.rowcount:
+                raise ContradictionResolutionError(
+                    f'apply failed — loser unit {loser_unit_id} no longer exists '
+                    '(concurrent delete)'
+                )
             applied['loser_unit_status'] = 'stale'
             applied_state['loser_unit_status'] = 'stale'
 
@@ -221,13 +226,18 @@ async def apply_winner_proposal(
             prior_state['loser_note_superseded_by'] = (
                 note_row.superseded_by if note_row is not None else None
             )
-            await session.execute(
+            result = await session.execute(
                 _UPDATE_NOTE_SUPERSEDED_BY_SQL,
                 {
                     'note_id': loser_row.note_id,
                     'superseded_by': winner_row.note_id,
                 },
             )
+            if not result.rowcount:
+                raise ContradictionResolutionError(
+                    f'apply failed — loser note {loser_row.note_id} no longer exists '
+                    '(concurrent delete)'
+                )
             applied['loser_note_superseded_by'] = winner_row.note_id
             applied_state['loser_note_id'] = loser_row.note_id
             applied_state['loser_note_superseded_by'] = winner_row.note_id
@@ -242,10 +252,14 @@ async def apply_winner_proposal(
                 raise ContradictionResolutionError(f'link {link_id} no longer exists')
             prior_state['link_id'] = link_row.id
             prior_state['link_type'] = link_row.link_type
-            await session.execute(
+            result = await session.execute(
                 _UPDATE_LINK_TYPE_SQL,
                 {'link_id': str(link_id), 'link_type': 'refines'},
             )
+            if not result.rowcount:
+                raise ContradictionResolutionError(
+                    f'apply failed — link {link_id} no longer exists (concurrent delete)'
+                )
             applied['link_type'] = 'refines'
             applied_state['link_id'] = link_row.id
             applied_state['link_type'] = 'refines'

--- a/packages/core/src/memex_core/services/contradiction_resolution.py
+++ b/packages/core/src/memex_core/services/contradiction_resolution.py
@@ -178,6 +178,7 @@ async def apply_winner_proposal(
         link_id = evidence.get('link_id')
 
         prior_state: dict[str, Any] = {}
+        applied_state: dict[str, Any] = {}
         applied: dict[str, Any] = {'action': action}
         fallback_reason: str | None = None
 
@@ -206,6 +207,7 @@ async def apply_winner_proposal(
                 {'unit_id': str(loser_unit_id), 'status': 'stale'},
             )
             applied['loser_unit_status'] = 'stale'
+            applied_state['loser_unit_status'] = 'stale'
 
         elif effective_action == 'supersede_loser_note':
             if loser_row.note_id is None or winner_row is None or winner_row.note_id is None:
@@ -227,6 +229,8 @@ async def apply_winner_proposal(
                 },
             )
             applied['loser_note_superseded_by'] = winner_row.note_id
+            applied_state['loser_note_id'] = loser_row.note_id
+            applied_state['loser_note_superseded_by'] = winner_row.note_id
 
         elif effective_action == 'refine_not_contradict':
             if not link_id:
@@ -243,6 +247,8 @@ async def apply_winner_proposal(
                 {'link_id': str(link_id), 'link_type': 'refines'},
             )
             applied['link_type'] = 'refines'
+            applied_state['link_id'] = link_row.id
+            applied_state['link_type'] = 'refines'
 
         elif effective_action == 'inconclusive':
             applied['noop'] = True
@@ -255,6 +261,7 @@ async def apply_winner_proposal(
             'effective_action': effective_action,
             'actor': actor,
             'prior_state': prior_state,
+            'applied_state': applied_state,
             'applied': applied,
         }
         if fallback_reason is not None:
@@ -346,14 +353,35 @@ async def reverse_winner_proposal(
             raise ContradictionResolutionError(f'finding {finding_id} has already been reversed')
         effective_action = str(resolution.get('effective_action') or '')
         prior_state = resolution.get('prior_state') or {}
+        applied_state = resolution.get('applied_state') or {}
 
         if effective_action == 'mark_loser_stale':
             loser_unit_id = evidence.get('loser_unit_id') or proposal.target_id
             prev_status = prior_state.get('loser_unit_status', 'active')
-            await session.execute(
+            # CAS: refuse to reverse if the row has diverged from what apply wrote.
+            # ``applied_state`` may be missing on findings applied before this
+            # guard existed — skip the check in that case for backward-compat.
+            current_unit = (
+                await session.execute(_LOAD_UNIT_SQL, {'unit_id': str(loser_unit_id)})
+            ).first()
+            if current_unit is None:
+                raise ContradictionResolutionError(
+                    f'cannot reverse — loser unit {loser_unit_id} no longer exists'
+                )
+            expected_status = applied_state.get('loser_unit_status')
+            if expected_status is not None and current_unit.status != expected_status:
+                raise ContradictionResolutionError(
+                    'cannot reverse — current state has diverged from the applied state. '
+                    'Manual reconciliation required.'
+                )
+            result = await session.execute(
                 _UPDATE_UNIT_STATUS_SQL,
                 {'unit_id': str(loser_unit_id), 'status': prev_status},
             )
+            if not result.rowcount:
+                raise ContradictionResolutionError(
+                    f'cannot reverse — loser unit {loser_unit_id} no longer exists'
+                )
 
         elif effective_action == 'supersede_loser_note':
             note_id = prior_state.get('loser_note_id')
@@ -362,18 +390,38 @@ async def reverse_winner_proposal(
                 raise ContradictionResolutionError(
                     'cannot reverse supersede_loser_note without prior_state.loser_note_id'
                 )
+            current_note = (
+                await session.execute(_LOAD_NOTE_SQL, {'note_id': str(note_id)})
+            ).first()
+            if current_note is None:
+                raise ContradictionResolutionError(
+                    f'cannot reverse — loser note {note_id} no longer exists'
+                )
+            expected_superseded_by = applied_state.get('loser_note_superseded_by')
+            if expected_superseded_by is not None and (
+                current_note.superseded_by is None
+                or str(current_note.superseded_by) != str(expected_superseded_by)
+            ):
+                raise ContradictionResolutionError(
+                    'cannot reverse — current state has diverged from the applied state. '
+                    'Manual reconciliation required.'
+                )
             if prev_superseded_by is None:
-                await session.execute(
+                result = await session.execute(
                     _UPDATE_NOTE_SUPERSEDED_BY_NULL_SQL,
                     {'note_id': str(note_id)},
                 )
             else:
-                await session.execute(
+                result = await session.execute(
                     _UPDATE_NOTE_SUPERSEDED_BY_SQL,
                     {
                         'note_id': str(note_id),
                         'superseded_by': str(prev_superseded_by),
                     },
+                )
+            if not result.rowcount:
+                raise ContradictionResolutionError(
+                    f'cannot reverse — loser note {note_id} no longer exists'
                 )
 
         elif effective_action == 'refine_not_contradict':
@@ -383,10 +431,27 @@ async def reverse_winner_proposal(
                 raise ContradictionResolutionError(
                     'cannot reverse refine_not_contradict without prior_state.link_id'
                 )
-            await session.execute(
+            current_link = (
+                await session.execute(_LOAD_LINK_SQL, {'link_id': str(link_id)})
+            ).first()
+            if current_link is None:
+                raise ContradictionResolutionError(
+                    f'cannot reverse — link {link_id} no longer exists'
+                )
+            expected_link_type = applied_state.get('link_type')
+            if expected_link_type is not None and current_link.link_type != expected_link_type:
+                raise ContradictionResolutionError(
+                    'cannot reverse — current state has diverged from the applied state. '
+                    'Manual reconciliation required.'
+                )
+            result = await session.execute(
                 _UPDATE_LINK_TYPE_SQL,
                 {'link_id': str(link_id), 'link_type': prev_link_type},
             )
+            if not result.rowcount:
+                raise ContradictionResolutionError(
+                    f'cannot reverse — link {link_id} no longer exists'
+                )
 
         elif effective_action == 'inconclusive':
             pass

--- a/packages/core/src/memex_core/services/contradiction_resolution.py
+++ b/packages/core/src/memex_core/services/contradiction_resolution.py
@@ -149,6 +149,10 @@ async def apply_winner_proposal(
     so :func:`reverse_winner_proposal` can undo the change atomically.
     Flips the finding status to ``resolved`` in the same transaction.
     """
+    if not actor:
+        raise ContradictionResolutionError('actor required to record the resolution audit trail')
+    if vault_id is None:
+        raise ContradictionResolutionError('vault_id required to apply a winner proposal')
     async with api.metastore.session() as session:
         proposal = (
             await session.execute(_LOAD_PROPOSAL_SQL, {'finding_id': str(finding_id)})
@@ -164,11 +168,7 @@ async def apply_winner_proposal(
             raise ContradictionResolutionError(
                 f'finding {finding_id} is not pending (status={proposal.status!r})'
             )
-        if (
-            vault_id is not None
-            and proposal.vault_id is not None
-            and str(vault_id) != proposal.vault_id
-        ):
+        if proposal.vault_id is not None and str(vault_id) != proposal.vault_id:
             raise ContradictionResolutionError('vault_id mismatch between caller and finding')
 
         evidence = _coerce_evidence(proposal.evidence)
@@ -280,7 +280,7 @@ async def apply_winner_proposal(
     try:
         _metrics.CONTRADICTION_RESOLUTION_APPLIED_TOTAL.labels(
             action=effective_action,
-            vault_id=str(vault_id) if vault_id is not None else 'global',
+            vault_id=proposal.vault_id if proposal.vault_id is not None else 'global',
         ).inc()
     except Exception:
         logger.debug('metrics increment failed', exc_info=True)
@@ -319,6 +319,10 @@ async def reverse_winner_proposal(
     that would violate the partial unique index on pending findings.
     Instead the original carries ``evidence.resolution.reversed_at``.
     """
+    if not actor:
+        raise ContradictionResolutionError('actor required to record the resolution audit trail')
+    if vault_id is None:
+        raise ContradictionResolutionError('vault_id required to reverse a winner proposal')
     async with api.metastore.session() as session:
         proposal = (
             await session.execute(_LOAD_PROPOSAL_SQL, {'finding_id': str(finding_id)})
@@ -333,11 +337,7 @@ async def reverse_winner_proposal(
             raise ContradictionResolutionError(
                 f'finding {finding_id} is not resolved (status={proposal.status!r})'
             )
-        if (
-            vault_id is not None
-            and proposal.vault_id is not None
-            and str(vault_id) != proposal.vault_id
-        ):
+        if proposal.vault_id is not None and str(vault_id) != proposal.vault_id:
             raise ContradictionResolutionError('vault_id mismatch between caller and finding')
 
         evidence = _coerce_evidence(proposal.evidence)
@@ -430,7 +430,7 @@ async def reverse_winner_proposal(
 
     try:
         _metrics.CONTRADICTION_RESOLUTION_REVERSED_TOTAL.labels(
-            vault_id=str(vault_id) if vault_id is not None else 'global',
+            vault_id=proposal.vault_id if proposal.vault_id is not None else 'global',
         ).inc()
     except Exception:
         logger.debug('metrics increment failed', exc_info=True)

--- a/packages/core/src/memex_core/services/contradiction_resolution.py
+++ b/packages/core/src/memex_core/services/contradiction_resolution.py
@@ -1,0 +1,450 @@
+"""Apply / reverse a contradiction winner-proposal lint finding.
+
+A ``propose_contradiction_winner`` finding nominates a winner / loser
+between two memory units that FSFM lint has flagged as in tension. Each
+finding carries an ``action`` literal under ``evidence.action``:
+
+- ``mark_loser_stale`` — flip the loser MemoryUnit.status to ``'stale'``.
+- ``supersede_loser_note`` — set the loser's parent Note.superseded_by
+  to the winner's parent note id. Falls back to ``mark_loser_stale``
+  (and records the fallback) when both units share the same note.
+- ``refine_not_contradict`` — rewrite the inbound MemoryLink.link_type
+  from ``'contradicts'`` to ``'refines'`` (graph-pressure weight 0.0).
+- ``inconclusive`` — no-op mutation; just flips the finding to resolved.
+
+Each apply captures ``prior_state`` under ``evidence.resolution`` so the
+reverse path can restore exactly what was changed. Reverse writes a
+``reversal`` row alongside the resolved one (status stays resolved so
+the unique partial index on pending findings is not violated).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from sqlalchemy import text
+
+from memex_core import metrics as _metrics
+
+if TYPE_CHECKING:
+    from memex_core.api import MemexAPI
+
+logger = logging.getLogger('memex.core.services.contradiction_resolution')
+
+
+_LOAD_PROPOSAL_SQL = text("""
+    SELECT id::text AS id,
+           vault_id::text AS vault_id,
+           rule_name,
+           target_type,
+           target_id,
+           evidence,
+           status
+    FROM maintenance_proposals
+    WHERE id = :finding_id
+""")
+
+
+_UPDATE_RESOLVED_SQL = text("""
+    UPDATE maintenance_proposals
+    SET status = 'resolved',
+        resolved_at = now(),
+        resolved_by = :actor,
+        evidence = :evidence
+    WHERE id = :finding_id
+      AND status = 'pending'
+""")
+
+
+_UPDATE_EVIDENCE_SQL = text("""
+    UPDATE maintenance_proposals
+    SET evidence = :evidence
+    WHERE id = :finding_id
+""")
+
+
+_INSERT_REVERSAL_SQL = text("""
+    INSERT INTO maintenance_proposals (
+        vault_id, lint_type, target_type, target_id,
+        rule_name, evidence, suggested_action, status, source,
+        resolved_at, resolved_by
+    )
+    VALUES (
+        :vault_id, :lint_type, :target_type, :target_id,
+        :rule_name, CAST(:evidence AS jsonb), :suggested_action,
+        'resolved', 'llm', now(), :actor
+    )
+""")
+
+
+_LOAD_UNIT_SQL = text("""
+    SELECT id::text AS id, status, note_id::text AS note_id
+    FROM memory_units WHERE id = :unit_id
+""")
+
+
+_UPDATE_UNIT_STATUS_SQL = text("""
+    UPDATE memory_units SET status = :status WHERE id = :unit_id
+""")
+
+
+_LOAD_NOTE_SQL = text("""
+    SELECT id::text AS id, superseded_by::text AS superseded_by
+    FROM notes WHERE id = :note_id
+""")
+
+
+_UPDATE_NOTE_SUPERSEDED_BY_SQL = text("""
+    UPDATE notes SET superseded_by = :superseded_by WHERE id = :note_id
+""")
+
+
+_UPDATE_NOTE_SUPERSEDED_BY_NULL_SQL = text("""
+    UPDATE notes SET superseded_by = NULL WHERE id = :note_id
+""")
+
+
+_LOAD_LINK_SQL = text("""
+    SELECT id::text AS id, link_type, from_unit_id::text AS from_unit_id,
+           to_unit_id::text AS to_unit_id
+    FROM memory_links WHERE id = :link_id
+""")
+
+
+_UPDATE_LINK_TYPE_SQL = text("""
+    UPDATE memory_links SET link_type = :link_type WHERE id = :link_id
+""")
+
+
+class ContradictionResolutionError(RuntimeError):
+    """Raised when apply/reverse cannot be performed safely."""
+
+
+def _coerce_evidence(raw: Any) -> dict[str, Any]:
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+    if isinstance(raw, dict):
+        return dict(raw)
+    return {}
+
+
+async def apply_winner_proposal(
+    api: 'MemexAPI',
+    finding_id: UUID,
+    *,
+    vault_id: UUID | None,
+    actor: str | None = None,
+) -> dict[str, Any]:
+    """Apply the action recorded on a winner-proposal finding.
+
+    Captures pre-mutation state under ``evidence.resolution.prior_state``
+    so :func:`reverse_winner_proposal` can undo the change atomically.
+    Flips the finding status to ``resolved`` in the same transaction.
+    """
+    async with api.metastore.session() as session:
+        proposal = (
+            await session.execute(_LOAD_PROPOSAL_SQL, {'finding_id': str(finding_id)})
+        ).first()
+        if proposal is None:
+            raise ContradictionResolutionError(f'finding {finding_id} not found')
+        if proposal.rule_name != 'propose_contradiction_winner':
+            raise ContradictionResolutionError(
+                f'finding {finding_id} is not a propose_contradiction_winner '
+                f'finding (rule_name={proposal.rule_name!r})'
+            )
+        if proposal.status != 'pending':
+            raise ContradictionResolutionError(
+                f'finding {finding_id} is not pending (status={proposal.status!r})'
+            )
+        if (
+            vault_id is not None
+            and proposal.vault_id is not None
+            and str(vault_id) != proposal.vault_id
+        ):
+            raise ContradictionResolutionError('vault_id mismatch between caller and finding')
+
+        evidence = _coerce_evidence(proposal.evidence)
+        action = str(evidence.get('action') or 'inconclusive')
+        winner_unit_id = evidence.get('winner_unit_id')
+        loser_unit_id = evidence.get('loser_unit_id') or proposal.target_id
+        link_id = evidence.get('link_id')
+
+        prior_state: dict[str, Any] = {}
+        applied: dict[str, Any] = {'action': action}
+        fallback_reason: str | None = None
+
+        loser_row = (await session.execute(_LOAD_UNIT_SQL, {'unit_id': str(loser_unit_id)})).first()
+        if loser_row is None:
+            raise ContradictionResolutionError(f'loser unit {loser_unit_id} no longer exists')
+
+        winner_row = None
+        if winner_unit_id:
+            winner_row = (
+                await session.execute(_LOAD_UNIT_SQL, {'unit_id': str(winner_unit_id)})
+            ).first()
+
+        effective_action = action
+        if action == 'supersede_loser_note':
+            if winner_row is None:
+                raise ContradictionResolutionError('supersede_loser_note requires a winner unit')
+            if loser_row.note_id == winner_row.note_id:
+                effective_action = 'mark_loser_stale'
+                fallback_reason = 'shared_parent_note'
+
+        if effective_action == 'mark_loser_stale':
+            prior_state['loser_unit_status'] = loser_row.status
+            await session.execute(
+                _UPDATE_UNIT_STATUS_SQL,
+                {'unit_id': str(loser_unit_id), 'status': 'stale'},
+            )
+            applied['loser_unit_status'] = 'stale'
+
+        elif effective_action == 'supersede_loser_note':
+            if loser_row.note_id is None or winner_row is None or winner_row.note_id is None:
+                raise ContradictionResolutionError(
+                    'both units must have note_id set to supersede a note'
+                )
+            note_row = (
+                await session.execute(_LOAD_NOTE_SQL, {'note_id': loser_row.note_id})
+            ).first()
+            prior_state['loser_note_id'] = loser_row.note_id
+            prior_state['loser_note_superseded_by'] = (
+                note_row.superseded_by if note_row is not None else None
+            )
+            await session.execute(
+                _UPDATE_NOTE_SUPERSEDED_BY_SQL,
+                {
+                    'note_id': loser_row.note_id,
+                    'superseded_by': winner_row.note_id,
+                },
+            )
+            applied['loser_note_superseded_by'] = winner_row.note_id
+
+        elif effective_action == 'refine_not_contradict':
+            if not link_id:
+                raise ContradictionResolutionError(
+                    'refine_not_contradict requires link_id in evidence'
+                )
+            link_row = (await session.execute(_LOAD_LINK_SQL, {'link_id': str(link_id)})).first()
+            if link_row is None:
+                raise ContradictionResolutionError(f'link {link_id} no longer exists')
+            prior_state['link_id'] = link_row.id
+            prior_state['link_type'] = link_row.link_type
+            await session.execute(
+                _UPDATE_LINK_TYPE_SQL,
+                {'link_id': str(link_id), 'link_type': 'refines'},
+            )
+            applied['link_type'] = 'refines'
+
+        elif effective_action == 'inconclusive':
+            applied['noop'] = True
+
+        else:
+            raise ContradictionResolutionError(f'unknown action: {action!r}')
+
+        resolution = {
+            'action': action,
+            'effective_action': effective_action,
+            'actor': actor,
+            'prior_state': prior_state,
+            'applied': applied,
+        }
+        if fallback_reason is not None:
+            resolution['fallback_reason'] = fallback_reason
+        evidence['resolution'] = resolution
+
+        result = await session.execute(
+            _UPDATE_RESOLVED_SQL,
+            {
+                'finding_id': str(finding_id),
+                'actor': actor,
+                'evidence': json.dumps(evidence),
+            },
+        )
+        if not result.rowcount:
+            await session.rollback()
+            raise ContradictionResolutionError(
+                f'finding {finding_id} could not be flipped to resolved'
+            )
+
+        await session.commit()
+
+    try:
+        _metrics.CONTRADICTION_RESOLUTION_APPLIED_TOTAL.labels(
+            action=effective_action,
+            vault_id=str(vault_id) if vault_id is not None else 'global',
+        ).inc()
+    except Exception:
+        logger.debug('metrics increment failed', exc_info=True)
+
+    logger.info(
+        'contradiction_resolution.applied',
+        extra={
+            'finding_id': str(finding_id),
+            'loser_unit_id': str(loser_unit_id),
+            'effective_action': effective_action,
+            'fallback_reason': fallback_reason,
+        },
+    )
+
+    return {
+        'finding_id': str(finding_id),
+        'status': 'resolved',
+        'effective_action': effective_action,
+        'fallback_reason': fallback_reason,
+        'applied': applied,
+    }
+
+
+async def reverse_winner_proposal(
+    api: 'MemexAPI',
+    finding_id: UUID,
+    *,
+    vault_id: UUID | None,
+    actor: str | None = None,
+) -> dict[str, Any]:
+    """Undo a previously applied winner-proposal.
+
+    Reads ``evidence.resolution.prior_state``, restores the affected
+    rows, and writes a paired ``reversal`` MaintenanceProposal row.
+    The original resolved finding is NOT flipped back to pending —
+    that would violate the partial unique index on pending findings.
+    Instead the original carries ``evidence.resolution.reversed_at``.
+    """
+    async with api.metastore.session() as session:
+        proposal = (
+            await session.execute(_LOAD_PROPOSAL_SQL, {'finding_id': str(finding_id)})
+        ).first()
+        if proposal is None:
+            raise ContradictionResolutionError(f'finding {finding_id} not found')
+        if proposal.rule_name != 'propose_contradiction_winner':
+            raise ContradictionResolutionError(
+                f'finding {finding_id} is not a propose_contradiction_winner finding'
+            )
+        if proposal.status != 'resolved':
+            raise ContradictionResolutionError(
+                f'finding {finding_id} is not resolved (status={proposal.status!r})'
+            )
+        if (
+            vault_id is not None
+            and proposal.vault_id is not None
+            and str(vault_id) != proposal.vault_id
+        ):
+            raise ContradictionResolutionError('vault_id mismatch between caller and finding')
+
+        evidence = _coerce_evidence(proposal.evidence)
+        resolution = evidence.get('resolution') or {}
+        if resolution.get('reversed_at') is not None:
+            raise ContradictionResolutionError(f'finding {finding_id} has already been reversed')
+        effective_action = str(resolution.get('effective_action') or '')
+        prior_state = resolution.get('prior_state') or {}
+
+        if effective_action == 'mark_loser_stale':
+            loser_unit_id = evidence.get('loser_unit_id') or proposal.target_id
+            prev_status = prior_state.get('loser_unit_status', 'active')
+            await session.execute(
+                _UPDATE_UNIT_STATUS_SQL,
+                {'unit_id': str(loser_unit_id), 'status': prev_status},
+            )
+
+        elif effective_action == 'supersede_loser_note':
+            note_id = prior_state.get('loser_note_id')
+            prev_superseded_by = prior_state.get('loser_note_superseded_by')
+            if note_id is None:
+                raise ContradictionResolutionError(
+                    'cannot reverse supersede_loser_note without prior_state.loser_note_id'
+                )
+            if prev_superseded_by is None:
+                await session.execute(
+                    _UPDATE_NOTE_SUPERSEDED_BY_NULL_SQL,
+                    {'note_id': str(note_id)},
+                )
+            else:
+                await session.execute(
+                    _UPDATE_NOTE_SUPERSEDED_BY_SQL,
+                    {
+                        'note_id': str(note_id),
+                        'superseded_by': str(prev_superseded_by),
+                    },
+                )
+
+        elif effective_action == 'refine_not_contradict':
+            link_id = prior_state.get('link_id')
+            prev_link_type = prior_state.get('link_type', 'contradicts')
+            if link_id is None:
+                raise ContradictionResolutionError(
+                    'cannot reverse refine_not_contradict without prior_state.link_id'
+                )
+            await session.execute(
+                _UPDATE_LINK_TYPE_SQL,
+                {'link_id': str(link_id), 'link_type': prev_link_type},
+            )
+
+        elif effective_action == 'inconclusive':
+            pass
+
+        else:
+            raise ContradictionResolutionError(
+                f'unknown effective_action on resolved finding: {effective_action!r}'
+            )
+
+        from datetime import datetime, timezone
+
+        resolution['reversed_at'] = datetime.now(timezone.utc).isoformat()
+        resolution['reversal_actor'] = actor
+        evidence['resolution'] = resolution
+
+        await session.execute(
+            _UPDATE_EVIDENCE_SQL,
+            {'finding_id': str(finding_id), 'evidence': json.dumps(evidence)},
+        )
+
+        reversal_evidence = {
+            'reverses_finding_id': str(finding_id),
+            'effective_action': effective_action,
+            'prior_state': prior_state,
+        }
+        await session.execute(
+            _INSERT_REVERSAL_SQL,
+            {
+                'vault_id': proposal.vault_id,
+                'lint_type': 'quality',
+                'target_type': proposal.target_type,
+                'target_id': proposal.target_id,
+                'rule_name': 'propose_contradiction_winner_reversal',
+                'evidence': json.dumps(reversal_evidence),
+                'suggested_action': ('Audit row: reverses a previously applied winner-proposal.'),
+                'actor': actor,
+            },
+        )
+
+        await session.commit()
+
+    try:
+        _metrics.CONTRADICTION_RESOLUTION_REVERSED_TOTAL.labels(
+            vault_id=str(vault_id) if vault_id is not None else 'global',
+        ).inc()
+    except Exception:
+        logger.debug('metrics increment failed', exc_info=True)
+
+    logger.warning(
+        'contradiction_resolution.reversed',
+        extra={
+            'finding_id': str(finding_id),
+            'effective_action': effective_action,
+        },
+    )
+
+    return {
+        'finding_id': str(finding_id),
+        'status': 'reversed',
+        'effective_action': effective_action,
+    }

--- a/packages/core/src/memex_core/services/contradiction_resolution.py
+++ b/packages/core/src/memex_core/services/contradiction_resolution.py
@@ -119,6 +119,9 @@ _UPDATE_LINK_TYPE_SQL = text("""
 """)
 
 
+_RESOLUTION_SCHEMA_VERSION = 1
+
+
 class ContradictionResolutionError(RuntimeError):
     """Raised when apply/reverse cannot be performed safely."""
 
@@ -207,10 +210,15 @@ async def apply_winner_proposal(
                 {'unit_id': str(loser_unit_id), 'status': 'stale'},
             )
             if not result.rowcount:
-                raise ContradictionResolutionError(
-                    f'apply failed — loser unit {loser_unit_id} no longer exists '
-                    '(concurrent delete)'
+                logger.warning(
+                    'contradiction_resolution.apply.rowcount_zero',
+                    extra={
+                        'finding_id': str(finding_id),
+                        'effective_action': effective_action,
+                        'loser_unit_id': str(loser_unit_id),
+                    },
                 )
+                raise ContradictionResolutionError('Concurrent modification — retry the request.')
             applied['loser_unit_status'] = 'stale'
             applied_state['loser_unit_status'] = 'stale'
 
@@ -234,10 +242,15 @@ async def apply_winner_proposal(
                 },
             )
             if not result.rowcount:
-                raise ContradictionResolutionError(
-                    f'apply failed — loser note {loser_row.note_id} no longer exists '
-                    '(concurrent delete)'
+                logger.warning(
+                    'contradiction_resolution.apply.rowcount_zero',
+                    extra={
+                        'finding_id': str(finding_id),
+                        'effective_action': effective_action,
+                        'loser_note_id': str(loser_row.note_id),
+                    },
                 )
+                raise ContradictionResolutionError('Concurrent modification — retry the request.')
             applied['loser_note_superseded_by'] = winner_row.note_id
             applied_state['loser_note_id'] = loser_row.note_id
             applied_state['loser_note_superseded_by'] = winner_row.note_id
@@ -257,9 +270,15 @@ async def apply_winner_proposal(
                 {'link_id': str(link_id), 'link_type': 'refines'},
             )
             if not result.rowcount:
-                raise ContradictionResolutionError(
-                    f'apply failed — link {link_id} no longer exists (concurrent delete)'
+                logger.warning(
+                    'contradiction_resolution.apply.rowcount_zero',
+                    extra={
+                        'finding_id': str(finding_id),
+                        'effective_action': effective_action,
+                        'link_id': str(link_id),
+                    },
                 )
+                raise ContradictionResolutionError('Concurrent modification — retry the request.')
             applied['link_type'] = 'refines'
             applied_state['link_id'] = link_row.id
             applied_state['link_type'] = 'refines'
@@ -271,6 +290,7 @@ async def apply_winner_proposal(
             raise ContradictionResolutionError(f'unknown action: {action!r}')
 
         resolution = {
+            'schema_version': _RESOLUTION_SCHEMA_VERSION,
             'action': action,
             'effective_action': effective_action,
             'actor': actor,
@@ -292,9 +312,14 @@ async def apply_winner_proposal(
         )
         if not result.rowcount:
             await session.rollback()
-            raise ContradictionResolutionError(
-                f'finding {finding_id} could not be flipped to resolved'
+            logger.warning(
+                'contradiction_resolution.apply.flip_to_resolved_rowcount_zero',
+                extra={
+                    'finding_id': str(finding_id),
+                    'effective_action': effective_action,
+                },
             )
+            raise ContradictionResolutionError('Concurrent modification — retry the request.')
 
         await session.commit()
 
@@ -365,6 +390,16 @@ async def reverse_winner_proposal(
         resolution = evidence.get('resolution') or {}
         if resolution.get('reversed_at') is not None:
             raise ContradictionResolutionError(f'finding {finding_id} has already been reversed')
+        schema_version = resolution.get('schema_version')
+        try:
+            schema_version_int = int(schema_version) if schema_version is not None else 0
+        except (TypeError, ValueError):
+            schema_version_int = 0
+        if schema_version_int < _RESOLUTION_SCHEMA_VERSION:
+            raise ContradictionResolutionError(
+                'Cannot reverse — proposal applied before CAS guard existed. '
+                'Manual reconciliation required.'
+            )
         effective_action = str(resolution.get('effective_action') or '')
         prior_state = resolution.get('prior_state') or {}
         applied_state = resolution.get('applied_state') or {}
@@ -373,8 +408,7 @@ async def reverse_winner_proposal(
             loser_unit_id = evidence.get('loser_unit_id') or proposal.target_id
             prev_status = prior_state.get('loser_unit_status', 'active')
             # CAS: refuse to reverse if the row has diverged from what apply wrote.
-            # ``applied_state`` may be missing on findings applied before this
-            # guard existed — skip the check in that case for backward-compat.
+            # schema_version >= 1 guarantees applied_state is present.
             current_unit = (
                 await session.execute(_LOAD_UNIT_SQL, {'unit_id': str(loser_unit_id)})
             ).first()
@@ -393,9 +427,15 @@ async def reverse_winner_proposal(
                 {'unit_id': str(loser_unit_id), 'status': prev_status},
             )
             if not result.rowcount:
-                raise ContradictionResolutionError(
-                    f'cannot reverse — loser unit {loser_unit_id} no longer exists'
+                logger.warning(
+                    'contradiction_resolution.reverse.rowcount_zero',
+                    extra={
+                        'finding_id': str(finding_id),
+                        'effective_action': effective_action,
+                        'loser_unit_id': str(loser_unit_id),
+                    },
                 )
+                raise ContradictionResolutionError('Concurrent modification — retry the request.')
 
         elif effective_action == 'supersede_loser_note':
             note_id = prior_state.get('loser_note_id')
@@ -434,9 +474,15 @@ async def reverse_winner_proposal(
                     },
                 )
             if not result.rowcount:
-                raise ContradictionResolutionError(
-                    f'cannot reverse — loser note {note_id} no longer exists'
+                logger.warning(
+                    'contradiction_resolution.reverse.rowcount_zero',
+                    extra={
+                        'finding_id': str(finding_id),
+                        'effective_action': effective_action,
+                        'loser_note_id': str(note_id),
+                    },
                 )
+                raise ContradictionResolutionError('Concurrent modification — retry the request.')
 
         elif effective_action == 'refine_not_contradict':
             link_id = prior_state.get('link_id')
@@ -463,9 +509,15 @@ async def reverse_winner_proposal(
                 {'link_id': str(link_id), 'link_type': prev_link_type},
             )
             if not result.rowcount:
-                raise ContradictionResolutionError(
-                    f'cannot reverse — link {link_id} no longer exists'
+                logger.warning(
+                    'contradiction_resolution.reverse.rowcount_zero',
+                    extra={
+                        'finding_id': str(finding_id),
+                        'effective_action': effective_action,
+                        'link_id': str(link_id),
+                    },
                 )
+                raise ContradictionResolutionError('Concurrent modification — retry the request.')
 
         elif effective_action == 'inconclusive':
             pass

--- a/packages/core/src/memex_core/services/contradiction_resolution.py
+++ b/packages/core/src/memex_core/services/contradiction_resolution.py
@@ -66,6 +66,14 @@ _UPDATE_EVIDENCE_SQL = text("""
 """)
 
 
+_UPDATE_EVIDENCE_REVERSAL_SQL = text("""
+    UPDATE maintenance_proposals
+    SET evidence = :evidence
+    WHERE id = :finding_id
+      AND (evidence -> 'resolution' ->> 'reversed_at') IS NULL
+""")
+
+
 _INSERT_REVERSAL_SQL = text("""
     INSERT INTO maintenance_proposals (
         vault_id, lint_type, target_type, target_id,
@@ -533,10 +541,21 @@ async def reverse_winner_proposal(
         resolution['reversal_actor'] = actor
         evidence['resolution'] = resolution
 
-        await session.execute(
-            _UPDATE_EVIDENCE_SQL,
+        evidence_result = await session.execute(
+            _UPDATE_EVIDENCE_REVERSAL_SQL,
             {'finding_id': str(finding_id), 'evidence': json.dumps(evidence)},
         )
+        if not evidence_result.rowcount:
+            logger.warning(
+                'contradiction_resolution.reverse.already_reversed',
+                extra={
+                    'finding_id': str(finding_id),
+                    'effective_action': effective_action,
+                },
+            )
+            raise ContradictionResolutionError(
+                f'finding {finding_id} has already been reversed by a concurrent caller'
+            )
 
         reversal_evidence = {
             'reverses_finding_id': str(finding_id),

--- a/packages/core/src/memex_core/services/contradiction_resolution.py
+++ b/packages/core/src/memex_core/services/contradiction_resolution.py
@@ -99,6 +99,13 @@ _UPDATE_UNIT_STATUS_SQL = text("""
 """)
 
 
+_UPDATE_UNIT_STATUS_CAS_SQL = text("""
+    UPDATE memory_units SET status = :status
+    WHERE id = :unit_id
+      AND status = :expected_status
+""")
+
+
 _LOAD_NOTE_SQL = text("""
     SELECT id::text AS id, superseded_by::text AS superseded_by
     FROM notes WHERE id = :note_id
@@ -107,6 +114,13 @@ _LOAD_NOTE_SQL = text("""
 
 _UPDATE_NOTE_SUPERSEDED_BY_SQL = text("""
     UPDATE notes SET superseded_by = :superseded_by WHERE id = :note_id
+""")
+
+
+_UPDATE_NOTE_SUPERSEDED_BY_CAS_SQL = text("""
+    UPDATE notes SET superseded_by = :superseded_by
+    WHERE id = :note_id
+      AND superseded_by IS NOT DISTINCT FROM :expected_superseded_by
 """)
 
 
@@ -124,6 +138,13 @@ _LOAD_LINK_SQL = text("""
 
 _UPDATE_LINK_TYPE_SQL = text("""
     UPDATE memory_links SET link_type = :link_type WHERE id = :link_id
+""")
+
+
+_UPDATE_LINK_TYPE_CAS_SQL = text("""
+    UPDATE memory_links SET link_type = :link_type
+    WHERE id = :link_id
+      AND link_type = :expected_link_type
 """)
 
 
@@ -214,8 +235,12 @@ async def apply_winner_proposal(
         if effective_action == 'mark_loser_stale':
             prior_state['loser_unit_status'] = loser_row.status
             result = await session.execute(
-                _UPDATE_UNIT_STATUS_SQL,
-                {'unit_id': str(loser_unit_id), 'status': 'stale'},
+                _UPDATE_UNIT_STATUS_CAS_SQL,
+                {
+                    'unit_id': str(loser_unit_id),
+                    'status': 'stale',
+                    'expected_status': loser_row.status,
+                },
             )
             if not result.rowcount:
                 logger.warning(
@@ -243,10 +268,13 @@ async def apply_winner_proposal(
                 note_row.superseded_by if note_row is not None else None
             )
             result = await session.execute(
-                _UPDATE_NOTE_SUPERSEDED_BY_SQL,
+                _UPDATE_NOTE_SUPERSEDED_BY_CAS_SQL,
                 {
                     'note_id': loser_row.note_id,
                     'superseded_by': winner_row.note_id,
+                    'expected_superseded_by': (
+                        note_row.superseded_by if note_row is not None else None
+                    ),
                 },
             )
             if not result.rowcount:
@@ -274,8 +302,12 @@ async def apply_winner_proposal(
             prior_state['link_id'] = link_row.id
             prior_state['link_type'] = link_row.link_type
             result = await session.execute(
-                _UPDATE_LINK_TYPE_SQL,
-                {'link_id': str(link_id), 'link_type': 'refines'},
+                _UPDATE_LINK_TYPE_CAS_SQL,
+                {
+                    'link_id': str(link_id),
+                    'link_type': 'refines',
+                    'expected_link_type': link_row.link_type,
+                },
             )
             if not result.rowcount:
                 logger.warning(

--- a/packages/core/src/memex_core/services/deprioritize_score.py
+++ b/packages/core/src/memex_core/services/deprioritize_score.py
@@ -59,6 +59,7 @@ _LINK_TYPE_WEIGHT: dict[str, float] = {
     'caused_by': -0.1,
     'enables': -0.1,
     'prevents': -0.1,
+    'refines': 0.0,
     # 'temporal' / 'semantic' / 'entity' are clustering hints, not quality
     # judgments; they do not contribute to deprioritization pressure.
 }

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -311,6 +311,7 @@ _FSFM_COMPOSITE_DEPRIORITIZE_SQL = """
                         WHEN 'caused_by' THEN -0.1
                         WHEN 'enables' THEN -0.1
                         WHEN 'prevents' THEN -0.1
+                        WHEN 'refines' THEN 0.0
                         ELSE 0.0
                     END
                     * ml.weight
@@ -325,7 +326,7 @@ _FSFM_COMPOSITE_DEPRIORITIZE_SQL = """
                   AND src.vault_id = mu.vault_id
                   AND ml.link_type IN (
                     'contradicts', 'weakens', 'reinforces',
-                    'causes', 'caused_by', 'enables', 'prevents'
+                    'causes', 'caused_by', 'enables', 'prevents', 'refines'
                   )
             ) AS graph_pressure_raw,
             (

--- a/packages/core/src/memex_core/services/lint_llm.py
+++ b/packages/core/src/memex_core/services/lint_llm.py
@@ -292,6 +292,32 @@ _SELECT_TICK_CANDIDATES_SQL = text("""
 """)
 
 
+_SELECT_PROPOSE_WINNER_CANDIDATES_SQL = text("""
+    SELECT (fsfm.target_id)::uuid AS unit_id
+    FROM maintenance_proposals fsfm
+    JOIN memory_units mu ON mu.id::text = fsfm.target_id
+    WHERE fsfm.rule_name = 'composite_deprioritize_candidate'
+      AND fsfm.target_type = 'memory_unit'
+      AND fsfm.status = 'pending'
+      AND fsfm.vault_id = :vault_id
+      AND mu.vault_id = :vault_id
+      AND mu.status = 'active'
+      AND (fsfm.evidence ->> 'flag_reason') IN (
+          'low_credibility_contradiction_only', 'components_disagree'
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM maintenance_proposals p
+          WHERE p.rule_name = 'propose_contradiction_winner'
+            AND p.target_type = 'memory_unit'
+            AND p.target_id = fsfm.target_id
+            AND p.vault_id = :vault_id
+            AND p.status = 'pending'
+      )
+    ORDER BY fsfm.created_at DESC
+    LIMIT :limit
+""")
+
+
 # ---------------------------------------------------------------------------
 # Service
 # ---------------------------------------------------------------------------
@@ -853,4 +879,61 @@ class LintLLMService(BaseService):
                 summary.deferred += 1
             if outcome.finding_emitted:
                 summary.findings_emitted += 1
+        return summary
+
+    async def tick_propose_winner(
+        self,
+        vault_id: UUID,
+        *,
+        run_llm_check: RunLLMCheck,
+    ) -> LintLLMTickSummary:
+        """Dedicated tick for the contradiction-winner-proposal rule.
+
+        Picks candidate units from pending ``composite_deprioritize_candidate``
+        FSFM findings whose ``flag_reason`` qualifies (escalation-only
+        patterns: ``low_credibility_contradiction_only`` or
+        ``components_disagree``). Bypasses the surprise / polarity gates —
+        the FSFM finding's existence is the gate. Quota is still enforced.
+
+        Ordered AFTER the FSFM rule-based lint pass so the candidate pool is
+        populated before this tick runs.
+        """
+        summary = LintLLMTickSummary(vault_id=vault_id)
+        settings = self._settings
+        if not settings.enabled or settings.cost_cap_per_24h <= 0:
+            return summary
+
+        async with self.metastore.session() as session:
+            rows = await session.execute(
+                _SELECT_PROPOSE_WINNER_CANDIDATES_SQL,
+                {
+                    'vault_id': str(vault_id),
+                    'limit': settings.units_per_tick,
+                },
+            )
+            candidates: list[UUID] = [r.unit_id for r in rows]
+
+        for unit_id in candidates:
+            async with self.metastore.session() as session:
+                try:
+                    admitted = await self.check_and_increment_quota(vault_id, session=session)
+                    if not admitted:
+                        summary.deferred += 1
+                        await session.commit()
+                        continue
+                    finding = await _invoke_check(run_llm_check, unit_id, vault_id, session, None)
+                    if finding is not None:
+                        inserted = await self.write_finding(finding, vault_id, session=session)
+                        if inserted:
+                            summary.findings_emitted += 1
+                    await session.commit()
+                except Exception:
+                    await session.rollback()
+                    logger.exception(
+                        'tick_propose_winner: failed for unit %s in vault %s',
+                        unit_id,
+                        vault_id,
+                    )
+                    continue
+            summary.candidates_evaluated += 1
         return summary

--- a/packages/core/tests/integration/memory/test_propose_winner_real_lm.py
+++ b/packages/core/tests/integration/memory/test_propose_winner_real_lm.py
@@ -1,0 +1,55 @@
+"""Real-LM smoke test for ProposeContradictionWinner.
+
+Drives one golden contradiction pair through the DSPy signature
+against a live model. Gated by ``@pytest.mark.llm`` so normal CI
+(without LLM credentials) skips it. Asserts the model returns a
+parseable schema and a non-empty rationale.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = [pytest.mark.llm, pytest.mark.integration]
+
+
+@pytest.mark.asyncio
+async def test_real_lm_returns_parseable_schema() -> None:
+    if not os.getenv('ANTHROPIC_API_KEY') and not os.getenv('OPENAI_API_KEY'):
+        pytest.skip('no LLM credentials in env')
+
+    import dspy
+
+    from memex_core.memory.lint_llm.signatures import ProposeContradictionWinner
+
+    lm = dspy.LM(
+        model=os.getenv('MEMEX_TEST_LM_MODEL', 'openai/gpt-4o-mini'),
+        cache=False,
+    )
+    predictor = dspy.Predict(ProposeContradictionWinner)
+
+    with dspy.context(lm=lm):
+        prediction = await predictor.acall(
+            unit_a_text='The deploy runs at 09:00 UTC daily.',
+            unit_b_text='Deploys happen at 17:00 UTC on weekdays.',
+            unit_a_created_at='2026-04-01T00:00:00+00:00',
+            unit_b_created_at='2026-05-10T00:00:00+00:00',
+            unit_a_source_credibility=0.5,
+            unit_b_source_credibility=0.85,
+            unit_a_source_authority='chat-log',
+            unit_b_source_authority='official-doc',
+            fsfm_evidence={'flag_reason': 'low_credibility_contradiction_only'},
+        )
+
+    assert prediction.winner_id in ('unit_a', 'unit_b', 'inconclusive')
+    assert prediction.loser_id in ('unit_a', 'unit_b', 'none')
+    assert prediction.action in (
+        'mark_loser_stale',
+        'supersede_loser_note',
+        'refine_not_contradict',
+        'inconclusive',
+    )
+    assert 0.0 <= float(prediction.confidence) <= 1.0
+    assert prediction.rationale.strip() != ''

--- a/packages/core/tests/integration/services/test_int_contradiction_resolution_roundtrip.py
+++ b/packages/core/tests/integration/services/test_int_contradiction_resolution_roundtrip.py
@@ -1,0 +1,310 @@
+"""Integration test — apply/reverse roundtrip for winner-proposal findings.
+
+For each ``action`` literal:
+1. Seed a pending ``propose_contradiction_winner`` finding with the
+   action's required evidence payload.
+2. Apply via :func:`apply_winner_proposal`; assert the target mutation
+   is persisted.
+3. Reverse via :func:`reverse_winner_proposal`; assert the mutation is
+   undone and a paired audit row is written.
+
+Requires Docker/Postgres via the standard ``api`` / ``session`` fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core.memory.sql_models import (
+    MemoryLink,
+    MemoryUnit,
+    Note,
+    Vault,
+)
+from memex_core.services.contradiction_resolution import (
+    apply_winner_proposal,
+    reverse_winner_proposal,
+)
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def _seed_two_units(
+    session: AsyncSession,
+    *,
+    same_note: bool = False,
+) -> tuple[tuple[UUID, UUID, UUID, UUID, UUID], UUID]:
+    """Seed two units (winner=A, loser=B) and an A→B contradicts link.
+
+    Returns
+    -------
+    ``((vault_id, winner_unit_id, loser_unit_id, winner_note_id, loser_note_id), link_id)``.
+    """
+    vault = Vault(name=f'V5-int-{uuid4().hex[:8]}')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+
+    winner_note = Note(
+        id=uuid4(),
+        vault_id=vault.id,
+        content_hash=f'hash-{uuid4().hex[:8]}',
+        original_text='winner',
+    )
+    loser_note = (
+        winner_note
+        if same_note
+        else Note(
+            id=uuid4(),
+            vault_id=vault.id,
+            content_hash=f'hash-{uuid4().hex[:8]}',
+            original_text='loser',
+        )
+    )
+    session.add(winner_note)
+    if not same_note:
+        session.add(loser_note)
+    await session.commit()
+
+    winner = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault.id,
+        note_id=winner_note.id,
+        text='canonical winner fact',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        risk_class='none',
+        event_date=datetime.now(timezone.utc),
+        embedding=[0.1] * 384,
+    )
+    loser = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault.id,
+        note_id=loser_note.id,
+        text='outdated loser fact',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        risk_class='none',
+        event_date=datetime.now(timezone.utc),
+        embedding=[0.1] * 384,
+    )
+    session.add_all([winner, loser])
+    await session.commit()
+
+    link = MemoryLink(
+        id=uuid4(),
+        vault_id=vault.id,
+        from_unit_id=winner.id,
+        to_unit_id=loser.id,
+        link_type='contradicts',
+        weight=0.9,
+    )
+    session.add(link)
+    await session.commit()
+
+    return (vault.id, winner.id, loser.id, winner_note.id, loser_note.id), link.id
+
+
+async def _seed_proposal(
+    session: AsyncSession,
+    *,
+    vault_id: UUID,
+    loser_unit_id: UUID,
+    winner_unit_id: UUID,
+    link_id: UUID | None,
+    action: str,
+) -> UUID:
+    evidence = {
+        'check_type': 'propose_contradiction_winner',
+        'action': action,
+        'winner_id': 'unit_a',
+        'loser_id': 'unit_b',
+        'winner_unit_id': str(winner_unit_id),
+        'loser_unit_id': str(loser_unit_id),
+        'peer_unit_id': str(winner_unit_id),
+        'link_id': str(link_id) if link_id else None,
+        'linked_to_finding': str(uuid4()),
+        'flag_reason': 'low_credibility_contradiction_only',
+        'confidence': 0.85,
+        'rationale': 'integration-test seed',
+    }
+    finding_id = uuid4()
+    await session.execute(
+        text("""
+            INSERT INTO maintenance_proposals (
+                id, vault_id, lint_type, target_type, target_id,
+                rule_name, evidence, suggested_action, status, source
+            )
+            VALUES (
+                :id, :vault_id, 'quality', 'memory_unit', :target_id,
+                'propose_contradiction_winner', CAST(:evidence AS jsonb),
+                'integration test', 'pending', 'llm'
+            )
+        """),
+        {
+            'id': str(finding_id),
+            'vault_id': str(vault_id),
+            'target_id': str(loser_unit_id),
+            'evidence': json.dumps(evidence),
+        },
+    )
+    await session.commit()
+    return finding_id
+
+
+async def _read_proposal_evidence(session: AsyncSession, finding_id: UUID) -> dict:
+    row = (
+        await session.execute(
+            text('SELECT evidence FROM maintenance_proposals WHERE id = :id'),
+            {'id': str(finding_id)},
+        )
+    ).first()
+    return dict(row.evidence) if row else {}
+
+
+async def _read_unit_status(session: AsyncSession, unit_id: UUID) -> str:
+    row = (
+        await session.execute(
+            text('SELECT status FROM memory_units WHERE id = :id'),
+            {'id': str(unit_id)},
+        )
+    ).first()
+    return row.status if row else ''
+
+
+async def _read_link_type(session: AsyncSession, link_id: UUID) -> str:
+    row = (
+        await session.execute(
+            text('SELECT link_type FROM memory_links WHERE id = :id'),
+            {'id': str(link_id)},
+        )
+    ).first()
+    return row.link_type if row else ''
+
+
+async def _read_note_superseded_by(session: AsyncSession, note_id: UUID):
+    row = (
+        await session.execute(
+            text('SELECT superseded_by FROM notes WHERE id = :id'),
+            {'id': str(note_id)},
+        )
+    ).first()
+    return row.superseded_by if row else None
+
+
+async def test_mark_loser_stale_roundtrip(session: AsyncSession, api) -> None:
+    (vault_id, winner_id, loser_id, _, _), link_id = await _seed_two_units(session)
+    finding_id = await _seed_proposal(
+        session,
+        vault_id=vault_id,
+        loser_unit_id=loser_id,
+        winner_unit_id=winner_id,
+        link_id=link_id,
+        action='mark_loser_stale',
+    )
+
+    await apply_winner_proposal(api, finding_id, vault_id=vault_id, actor='itest')
+    assert await _read_unit_status(session, loser_id) == 'stale'
+
+    await reverse_winner_proposal(api, finding_id, vault_id=vault_id, actor='itest')
+    assert await _read_unit_status(session, loser_id) == 'active'
+
+    reversal = (
+        await session.execute(
+            text("""
+                SELECT id FROM maintenance_proposals
+                WHERE rule_name = 'propose_contradiction_winner_reversal'
+                  AND evidence ->> 'reverses_finding_id' = :fid
+            """),
+            {'fid': str(finding_id)},
+        )
+    ).first()
+    assert reversal is not None
+
+
+async def test_supersede_loser_note_roundtrip(session: AsyncSession, api) -> None:
+    (vault_id, winner_id, loser_id, winner_note, loser_note), link_id = await _seed_two_units(
+        session
+    )
+    finding_id = await _seed_proposal(
+        session,
+        vault_id=vault_id,
+        loser_unit_id=loser_id,
+        winner_unit_id=winner_id,
+        link_id=link_id,
+        action='supersede_loser_note',
+    )
+
+    await apply_winner_proposal(api, finding_id, vault_id=vault_id, actor='itest')
+    assert await _read_note_superseded_by(session, loser_note) == winner_note
+
+    await reverse_winner_proposal(api, finding_id, vault_id=vault_id, actor='itest')
+    assert await _read_note_superseded_by(session, loser_note) is None
+
+
+async def test_supersede_loser_note_shared_parent_falls_back(session: AsyncSession, api) -> None:
+    (vault_id, winner_id, loser_id, _, shared_note), link_id = await _seed_two_units(
+        session, same_note=True
+    )
+    finding_id = await _seed_proposal(
+        session,
+        vault_id=vault_id,
+        loser_unit_id=loser_id,
+        winner_unit_id=winner_id,
+        link_id=link_id,
+        action='supersede_loser_note',
+    )
+
+    result = await apply_winner_proposal(api, finding_id, vault_id=vault_id, actor='itest')
+    assert result['effective_action'] == 'mark_loser_stale'
+    assert result['fallback_reason'] == 'shared_parent_note'
+    assert await _read_unit_status(session, loser_id) == 'stale'
+
+    evidence = await _read_proposal_evidence(session, finding_id)
+    assert evidence['resolution']['fallback_reason'] == 'shared_parent_note'
+
+
+async def test_refine_not_contradict_roundtrip(session: AsyncSession, api) -> None:
+    (vault_id, winner_id, loser_id, _, _), link_id = await _seed_two_units(session)
+    finding_id = await _seed_proposal(
+        session,
+        vault_id=vault_id,
+        loser_unit_id=loser_id,
+        winner_unit_id=winner_id,
+        link_id=link_id,
+        action='refine_not_contradict',
+    )
+
+    await apply_winner_proposal(api, finding_id, vault_id=vault_id, actor='itest')
+    assert await _read_link_type(session, link_id) == 'refines'
+
+    await reverse_winner_proposal(api, finding_id, vault_id=vault_id, actor='itest')
+    assert await _read_link_type(session, link_id) == 'contradicts'
+
+
+async def test_inconclusive_is_noop(session: AsyncSession, api) -> None:
+    (vault_id, winner_id, loser_id, _, _), link_id = await _seed_two_units(session)
+    finding_id = await _seed_proposal(
+        session,
+        vault_id=vault_id,
+        loser_unit_id=loser_id,
+        winner_unit_id=winner_id,
+        link_id=link_id,
+        action='inconclusive',
+    )
+
+    await apply_winner_proposal(api, finding_id, vault_id=vault_id, actor='itest')
+    assert await _read_unit_status(session, loser_id) == 'active'
+    assert await _read_link_type(session, link_id) == 'contradicts'
+
+    # Reversal is also a no-op write but still produces a paired audit row.
+    await reverse_winner_proposal(api, finding_id, vault_id=vault_id, actor='itest')
+    assert await _read_unit_status(session, loser_id) == 'active'

--- a/packages/core/tests/integration/services/test_int_contradiction_winner_pipeline.py
+++ b/packages/core/tests/integration/services/test_int_contradiction_winner_pipeline.py
@@ -1,0 +1,155 @@
+"""Integration test — FSFM → propose_contradiction_winner pipeline.
+
+Seeds two contradicting units with differing source credibility, runs
+the rule-based FSFM lint pass, then drives the
+``propose_contradiction_winner`` LLM check against a deterministic
+mock and asserts exactly one winner-proposal finding is emitted
+linked back to the FSFM finding.
+
+Marked ``llm_mock`` + ``integration`` — needs Postgres via testcontainers.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.types import FactTypes
+from memex_core.memory.lint_llm.checks import make_propose_contradiction_winner_check
+from memex_core.memory.sql_models import (
+    MemoryLink,
+    MemoryUnit,
+    Note,
+    Vault,
+)
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.llm_mock, pytest.mark.asyncio]
+
+
+async def test_winner_proposal_links_back_to_fsfm_finding(session: AsyncSession, api) -> None:
+    vault = Vault(name=f'V5-pipeline-{uuid4().hex[:8]}')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+
+    winner_note = Note(
+        id=uuid4(),
+        vault_id=vault.id,
+        content_hash=f'hash-{uuid4().hex[:8]}',
+        original_text='high-authority',
+        note_metadata={'authority': 'official-doc'},
+    )
+    loser_note = Note(
+        id=uuid4(),
+        vault_id=vault.id,
+        content_hash=f'hash-{uuid4().hex[:8]}',
+        original_text='low-authority',
+        note_metadata={'authority': 'chat-log'},
+    )
+    session.add_all([winner_note, loser_note])
+    await session.commit()
+
+    winner = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault.id,
+        note_id=winner_note.id,
+        text='canonical winner fact',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        risk_class='none',
+        success_co_count=10,
+        failure_co_count=0,
+        event_date=datetime.now(timezone.utc),
+        embedding=[0.1] * 384,
+    )
+    loser = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault.id,
+        note_id=loser_note.id,
+        text='outdated loser fact',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        risk_class='none',
+        success_co_count=0,
+        failure_co_count=5,
+        event_date=datetime.now(timezone.utc),
+        embedding=[0.1] * 384,
+    )
+    session.add_all([winner, loser])
+    await session.commit()
+
+    link = MemoryLink(
+        id=uuid4(),
+        vault_id=vault.id,
+        from_unit_id=winner.id,
+        to_unit_id=loser.id,
+        link_type='contradicts',
+        weight=0.9,
+    )
+    session.add(link)
+    await session.commit()
+
+    fsfm_finding_id = uuid4()
+    await session.execute(
+        text("""
+            INSERT INTO maintenance_proposals (
+                id, vault_id, lint_type, target_type, target_id,
+                rule_name, evidence, suggested_action, status, source
+            )
+            VALUES (
+                :id, :vault_id, 'quality', 'memory_unit', :target_id,
+                'composite_deprioritize_candidate', CAST(:evidence AS jsonb),
+                'test seed', 'pending', 'rule'
+            )
+        """),
+        {
+            'id': str(fsfm_finding_id),
+            'vault_id': str(vault.id),
+            'target_id': str(loser.id),
+            'evidence': json.dumps(
+                {
+                    'composite_score': 0.62,
+                    'flag_reason': 'low_credibility_contradiction_only',
+                    'contradicts_count': 1,
+                    'contradicts_credibility_sum': 0.2,
+                }
+            ),
+        },
+    )
+    await session.commit()
+
+    fake_lm = MagicMock()
+    check = make_propose_contradiction_winner_check(fake_lm, min_confidence=0.5)
+
+    async def _fake_run_dspy(**kwargs):
+        return MagicMock(
+            winner_id='unit_a',
+            loser_id='unit_b',
+            rationale='winner is higher authority and more outcomes',
+            confidence=0.9,
+            action='mark_loser_stale',
+        )
+
+    import memex_core.llm as _llm
+
+    _orig = _llm.run_dspy_operation
+    _llm.run_dspy_operation = AsyncMock(side_effect=_fake_run_dspy)
+    try:
+        finding = await check(loser.id, vault.id, session)
+    finally:
+        _llm.run_dspy_operation = _orig
+
+    assert finding is not None
+    assert finding.rule_name == 'propose_contradiction_winner'
+    assert finding.target_id == str(loser.id)
+    assert finding.extra_evidence['linked_to_finding'] == str(fsfm_finding_id)
+    assert finding.extra_evidence['action'] == 'mark_loser_stale'
+    assert finding.extra_evidence['winner_unit_id'] == str(winner.id)
+    assert finding.extra_evidence['loser_unit_id'] == str(loser.id)

--- a/packages/core/tests/unit/memory/test_propose_contradiction_winner_check.py
+++ b/packages/core/tests/unit/memory/test_propose_contradiction_winner_check.py
@@ -159,3 +159,33 @@ async def test_inconclusive_verdict_emitted_for_audit_trail(
     assert finding is not None
     assert finding.extra_evidence['action'] == 'inconclusive'
     assert finding.extra_evidence['winner_unit_id'] is None
+
+
+@pytest.mark.asyncio
+async def test_inconclusive_winner_forces_inconclusive_action(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When the LLM returns winner_id='inconclusive' but a definitive
+    action (e.g. mark_loser_stale), the emitted finding must normalize
+    the action to ``inconclusive`` and loser_id to ``none`` so the apply
+    path cannot run a definitive mutation with no real winner."""
+    fake_prediction = SimpleNamespace(
+        winner_id='inconclusive',
+        loser_id='unit_b',
+        action='mark_loser_stale',
+        confidence=0.95,
+        rationale='conflicting signals from LLM',
+    )
+    mock_run = AsyncMock(return_value=fake_prediction)
+    monkeypatch.setattr('memex_core.llm.run_dspy_operation', mock_run)
+
+    session = _make_session([_fsfm_row(), None, _peer_row(), _loser_row()])
+    check = make_propose_contradiction_winner_check(lm=object(), min_confidence=0.6)
+
+    finding = await check(uuid4(), uuid4(), session, None)
+
+    assert finding is not None
+    assert finding.extra_evidence['action'] == 'inconclusive'
+    assert finding.extra_evidence['winner_id'] == 'inconclusive'
+    assert finding.extra_evidence['loser_id'] == 'none'
+    assert finding.extra_evidence['winner_unit_id'] is None

--- a/packages/core/tests/unit/memory/test_propose_contradiction_winner_check.py
+++ b/packages/core/tests/unit/memory/test_propose_contradiction_winner_check.py
@@ -1,0 +1,161 @@
+"""Unit tests for ``make_propose_contradiction_winner_check`` gating.
+
+Focused on the confidence gate: a definitive (unit_a / unit_b) verdict
+below ``min_confidence`` must be downgraded to ``inconclusive`` before
+the finding is emitted, so the apply path cannot mutate user data on
+the back of low-confidence LLM output.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from memex_core.memory.lint_llm.checks import make_propose_contradiction_winner_check
+
+
+def _row(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+class _Result:
+    def __init__(self, row):
+        self._row = row
+
+    def first(self):
+        return self._row
+
+
+def _make_session(rows: list):
+    captured: list = []
+
+    async def execute(sql, params=None):
+        captured.append((str(getattr(sql, 'text', sql)), params))
+        idx = len(captured) - 1
+        if idx < len(rows):
+            return _Result(rows[idx])
+        return _Result(None)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=execute)
+    return session
+
+
+def _fsfm_row():
+    return _row(
+        finding_id=str(uuid4()),
+        evidence={'flag_reason': 'low_credibility_contradiction_only'},
+    )
+
+
+def _peer_row():
+    return _row(
+        link_id=str(uuid4()),
+        source_unit_id=str(uuid4()),
+        weight=1.0,
+        link_created_at=datetime.now(timezone.utc),
+        source_text='Peer text',
+        source_created_at=datetime.now(timezone.utc),
+        source_confidence=0.7,
+        source_mw=0.6,
+        source_note_id=str(uuid4()),
+        source_note_metadata={'authority': 'official-doc'},
+    )
+
+
+def _loser_row():
+    return _row(
+        unit_text='Audited unit text',
+        unit_created_at=datetime.now(timezone.utc),
+        unit_confidence=0.5,
+        unit_mw=0.4,
+        note_id=str(uuid4()),
+        note_metadata={'authority': 'chat-log'},
+    )
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_definitive_verdict_is_downgraded_to_inconclusive(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A confident-looking unit_a / unit_b verdict with confidence below
+    the gate must be emitted as ``inconclusive`` so apply is blocked."""
+    fake_prediction = SimpleNamespace(
+        winner_id='unit_a',
+        loser_id='unit_b',
+        action='mark_loser_stale',
+        confidence=0.2,
+        rationale='not actually confident',
+    )
+    mock_run = AsyncMock(return_value=fake_prediction)
+    monkeypatch.setattr('memex_core.llm.run_dspy_operation', mock_run)
+
+    session = _make_session([_fsfm_row(), None, _peer_row(), _loser_row()])
+    check = make_propose_contradiction_winner_check(lm=object(), min_confidence=0.6)
+
+    finding = await check(uuid4(), uuid4(), session, None)
+
+    assert finding is not None
+    assert finding.extra_evidence['winner_id'] == 'inconclusive'
+    assert finding.extra_evidence['loser_id'] == 'none'
+    assert finding.extra_evidence['action'] == 'inconclusive'
+    assert finding.extra_evidence['winner_unit_id'] is None
+
+
+@pytest.mark.asyncio
+async def test_high_confidence_definitive_verdict_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A high-confidence definitive verdict must be emitted as-is."""
+    peer = _peer_row()
+    fake_prediction = SimpleNamespace(
+        winner_id='unit_a',
+        loser_id='unit_b',
+        action='mark_loser_stale',
+        confidence=0.9,
+        rationale='strong evidence',
+    )
+    mock_run = AsyncMock(return_value=fake_prediction)
+    monkeypatch.setattr('memex_core.llm.run_dspy_operation', mock_run)
+
+    session = _make_session([_fsfm_row(), None, peer, _loser_row()])
+    check = make_propose_contradiction_winner_check(lm=object(), min_confidence=0.6)
+
+    finding = await check(uuid4(), uuid4(), session, None)
+
+    assert finding is not None
+    assert finding.extra_evidence['winner_id'] == 'unit_a'
+    assert finding.extra_evidence['loser_id'] == 'unit_b'
+    assert finding.extra_evidence['action'] == 'mark_loser_stale'
+    assert finding.extra_evidence['winner_unit_id'] == peer.source_unit_id
+
+
+@pytest.mark.asyncio
+async def test_inconclusive_verdict_emitted_for_audit_trail(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An ``inconclusive`` verdict must still be emitted as a finding,
+    regardless of confidence — the audit trail records that the LLM tried
+    and the apply dispatcher treats it as a no-op."""
+    fake_prediction = SimpleNamespace(
+        winner_id='inconclusive',
+        loser_id='none',
+        action='inconclusive',
+        confidence=0.95,
+        rationale='cannot tell them apart',
+    )
+    mock_run = AsyncMock(return_value=fake_prediction)
+    monkeypatch.setattr('memex_core.llm.run_dspy_operation', mock_run)
+
+    session = _make_session([_fsfm_row(), None, _peer_row(), _loser_row()])
+    check = make_propose_contradiction_winner_check(lm=object(), min_confidence=0.6)
+
+    finding = await check(uuid4(), uuid4(), session, None)
+
+    assert finding is not None
+    assert finding.extra_evidence['action'] == 'inconclusive'
+    assert finding.extra_evidence['winner_unit_id'] is None

--- a/packages/core/tests/unit/memory/test_propose_contradiction_winner_signature.py
+++ b/packages/core/tests/unit/memory/test_propose_contradiction_winner_signature.py
@@ -1,0 +1,94 @@
+"""Unit tests for the ProposeContradictionWinner DSPy signature.
+
+Covers:
+- Field-set shape (inputs / outputs).
+- Confidence clamping via @field_validator.
+- Literal rejection on winner_id / loser_id / action.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from memex_core.memory.lint_llm.signatures import ProposeContradictionWinner
+
+
+def _valid_kwargs(**overrides):
+    base = {
+        'unit_a_text': 'A',
+        'unit_b_text': 'B',
+        'unit_a_created_at': '2026-01-01T00:00:00+00:00',
+        'unit_b_created_at': '2026-02-01T00:00:00+00:00',
+        'unit_a_source_credibility': 0.7,
+        'unit_b_source_credibility': 0.4,
+        'unit_a_source_authority': 'official-doc',
+        'unit_b_source_authority': 'chat-log',
+        'fsfm_evidence': {'flag_reason': 'low_credibility_contradiction_only'},
+        'winner_id': 'unit_a',
+        'loser_id': 'unit_b',
+        'rationale': 'higher authority, more recent',
+        'confidence': 0.8,
+        'action': 'mark_loser_stale',
+    }
+    base.update(overrides)
+    return base
+
+
+def test_signature_has_expected_fields():
+    fields = set(ProposeContradictionWinner.model_fields)
+    assert {
+        'unit_a_text',
+        'unit_b_text',
+        'unit_a_created_at',
+        'unit_b_created_at',
+        'unit_a_source_credibility',
+        'unit_b_source_credibility',
+        'unit_a_source_authority',
+        'unit_b_source_authority',
+        'fsfm_evidence',
+        'winner_id',
+        'loser_id',
+        'rationale',
+        'confidence',
+        'action',
+    }.issubset(fields)
+
+
+def test_confidence_clamped_to_unit_interval_above():
+    inst = ProposeContradictionWinner(**_valid_kwargs(confidence=1.7))
+    assert inst.confidence == 1.0
+
+
+def test_confidence_clamped_to_unit_interval_below():
+    inst = ProposeContradictionWinner(**_valid_kwargs(confidence=-0.5))
+    assert inst.confidence == 0.0
+
+
+def test_confidence_non_numeric_falls_back_to_zero():
+    inst = ProposeContradictionWinner(**_valid_kwargs(confidence='not-a-number'))
+    assert inst.confidence == 0.0
+
+
+def test_winner_id_rejects_unknown_literal():
+    with pytest.raises(ValidationError):
+        ProposeContradictionWinner(**_valid_kwargs(winner_id='unit_c'))
+
+
+def test_loser_id_rejects_unknown_literal():
+    with pytest.raises(ValidationError):
+        ProposeContradictionWinner(**_valid_kwargs(loser_id='unit_c'))
+
+
+def test_action_rejects_unknown_literal():
+    with pytest.raises(ValidationError):
+        ProposeContradictionWinner(**_valid_kwargs(action='delete_everything'))
+
+
+def test_inconclusive_literals_accepted():
+    inst = ProposeContradictionWinner(
+        **_valid_kwargs(winner_id='inconclusive', loser_id='none', action='inconclusive')
+    )
+    assert inst.winner_id == 'inconclusive'
+    assert inst.loser_id == 'none'
+    assert inst.action == 'inconclusive'

--- a/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
+++ b/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
@@ -430,6 +430,7 @@ def _resolved_proposal(
                 'loser_unit_id': loser_unit_id,
                 'link_id': link_id,
                 'resolution': {
+                    'schema_version': 1,
                     'action': effective_action,
                     'effective_action': effective_action,
                     'actor': 'unit-test',
@@ -630,7 +631,7 @@ async def test_apply_mark_loser_stale_refuses_when_unit_deleted_mid_txn():
     session, cm = _make_session_with_rowcounts(rows_and_rowcounts)
     api = _api_with_session(cm)
 
-    with pytest.raises(ContradictionResolutionError, match='apply failed'):
+    with pytest.raises(ContradictionResolutionError, match='Concurrent modification'):
         await apply_winner_proposal(
             api,
             uuid4(),
@@ -662,7 +663,7 @@ async def test_apply_supersede_loser_note_refuses_when_note_deleted_mid_txn():
     session, cm = _make_session_with_rowcounts(rows_and_rowcounts)
     api = _api_with_session(cm)
 
-    with pytest.raises(ContradictionResolutionError, match='apply failed'):
+    with pytest.raises(ContradictionResolutionError, match='Concurrent modification'):
         await apply_winner_proposal(
             api,
             uuid4(),
@@ -703,7 +704,7 @@ async def test_apply_refine_not_contradict_refuses_when_link_deleted_mid_txn():
     session, cm = _make_session_with_rowcounts(rows_and_rowcounts)
     api = _api_with_session(cm)
 
-    with pytest.raises(ContradictionResolutionError, match='apply failed'):
+    with pytest.raises(ContradictionResolutionError, match='Concurrent modification'):
         await apply_winner_proposal(
             api,
             uuid4(),
@@ -711,3 +712,122 @@ async def test_apply_refine_not_contradict_refuses_when_link_deleted_mid_txn():
             actor='unit-test',
         )
     assert not session.commit.await_count, 'apply must not commit when rowcount=0'
+
+
+# ---------------------------------------------------------------------------
+# Reverse-path schema-version guard: refuses when applied state predates the
+# CAS guard (resolution.schema_version missing or < 1). Apply stamps the
+# marker, so any post-V5 proposal carries it; the guard exists to refuse
+# hand-written or future-bugged proposals that would otherwise sneak past
+# the CAS check by omitting applied_state.
+# ---------------------------------------------------------------------------
+
+
+def _resolved_proposal_without_schema_version(loser_unit_id: str) -> SimpleNamespace:
+    return _row(
+        id=str(uuid4()),
+        vault_id='11111111-1111-1111-1111-111111111111',
+        rule_name='propose_contradiction_winner',
+        target_type='memory_unit',
+        target_id=loser_unit_id,
+        evidence=json.dumps(
+            {
+                'action': 'mark_loser_stale',
+                'loser_unit_id': loser_unit_id,
+                'resolution': {
+                    'action': 'mark_loser_stale',
+                    'effective_action': 'mark_loser_stale',
+                    'actor': 'unit-test',
+                    'prior_state': {'loser_unit_status': 'active'},
+                    'applied_state': {'loser_unit_status': 'stale'},
+                    'applied': {'action': 'mark_loser_stale'},
+                },
+            }
+        ),
+        status='resolved',
+    )
+
+
+@pytest.mark.asyncio
+async def test_reverse_refuses_when_schema_version_missing():
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    loser_id = str(uuid4())
+    proposal = _resolved_proposal_without_schema_version(loser_id)
+    session, cm = _make_session_with_rowcounts([proposal])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='CAS guard'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+
+@pytest.mark.asyncio
+async def test_reverse_refuses_when_schema_version_too_low():
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    loser_id = str(uuid4())
+    proposal = _row(
+        id=str(uuid4()),
+        vault_id='11111111-1111-1111-1111-111111111111',
+        rule_name='propose_contradiction_winner',
+        target_type='memory_unit',
+        target_id=loser_id,
+        evidence=json.dumps(
+            {
+                'action': 'mark_loser_stale',
+                'loser_unit_id': loser_id,
+                'resolution': {
+                    'schema_version': 0,
+                    'action': 'mark_loser_stale',
+                    'effective_action': 'mark_loser_stale',
+                    'actor': 'unit-test',
+                    'prior_state': {'loser_unit_status': 'active'},
+                    'applied_state': {'loser_unit_status': 'stale'},
+                    'applied': {'action': 'mark_loser_stale'},
+                },
+            }
+        ),
+        status='resolved',
+    )
+    session, cm = _make_session_with_rowcounts([proposal])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='CAS guard'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_records_schema_version_in_resolution():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    proposal = _proposal('mark_loser_stale', loser_unit_id=loser_id, winner_unit_id=winner_id)
+    loser_row = _row(id=loser_id, status='active', note_id=str(uuid4()))
+    winner_row = _row(id=winner_id, status='active', note_id=str(uuid4()))
+    session, cm = _make_session([proposal, loser_row, winner_row])
+    api = _api_with_session(cm)
+
+    await apply_winner_proposal(
+        api,
+        uuid4(),
+        vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+        actor='unit-test',
+    )
+
+    evidence_writes = [
+        params
+        for sql, params in session._captured
+        if isinstance(params, dict) and 'evidence' in params and isinstance(params['evidence'], str)
+    ]
+    assert evidence_writes, 'expected at least one evidence UPDATE'
+    written = json.loads(evidence_writes[-1]['evidence'])
+    assert written['resolution']['schema_version'] == 1

--- a/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
+++ b/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
@@ -715,6 +715,145 @@ async def test_apply_refine_not_contradict_refuses_when_link_deleted_mid_txn():
 
 
 # ---------------------------------------------------------------------------
+# Apply-path CAS guards — refuse the UPDATE when another writer has mutated
+# the target row's value between the row loader (SELECT) and the mutating
+# UPDATE inside the same transaction. The WHERE clause matches the captured
+# pre-mutation value; a concurrent flip away from that value yields
+# rowcount=0 and the existing rowcount-zero check raises.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_mark_loser_stale_refuses_when_status_changed_mid_txn():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    proposal = _proposal('mark_loser_stale', loser_unit_id=loser_id, winner_unit_id=winner_id)
+    loser_row = _row(id=loser_id, status='active', note_id=str(uuid4()))
+    winner_row = _row(id=winner_id, status='active', note_id=str(uuid4()))
+    rows_and_rowcounts: list = [
+        proposal,
+        loser_row,
+        winner_row,
+        (None, 0),
+    ]
+    session, cm = _make_session_with_rowcounts(rows_and_rowcounts)
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='Concurrent modification'):
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+    update_calls = [
+        params
+        for sql, params in session._captured
+        if isinstance(params, dict) and params.get('status') == 'stale'
+    ]
+    assert update_calls, 'expected the stale UPDATE to be attempted'
+    assert update_calls[0].get('expected_status') == 'active', (
+        'CAS guard must carry the captured pre-mutation status'
+    )
+    assert not session.commit.await_count, 'apply must not commit when CAS fails'
+
+
+@pytest.mark.asyncio
+async def test_apply_supersede_loser_note_refuses_when_already_superseded():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    loser_note = str(uuid4())
+    winner_note = str(uuid4())
+    other_note = str(uuid4())
+    proposal = _proposal('supersede_loser_note', loser_unit_id=loser_id, winner_unit_id=winner_id)
+    loser_row = _row(id=loser_id, status='active', note_id=loser_note)
+    winner_row = _row(id=winner_id, status='active', note_id=winner_note)
+    note_row = _row(id=loser_note, superseded_by=None)
+    rows_and_rowcounts: list = [
+        proposal,
+        loser_row,
+        winner_row,
+        note_row,
+        (None, 0),
+    ]
+    session, cm = _make_session_with_rowcounts(rows_and_rowcounts)
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='Concurrent modification'):
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+    update_calls = [
+        params
+        for sql, params in session._captured
+        if isinstance(params, dict) and params.get('superseded_by') == winner_note
+    ]
+    assert update_calls, 'expected the superseded_by UPDATE to be attempted'
+    assert 'expected_superseded_by' in update_calls[0], (
+        'CAS guard must carry the captured pre-mutation superseded_by'
+    )
+    assert update_calls[0].get('expected_superseded_by') is None
+    # Sanity: the value the test pretends collided with is distinct from the
+    # captured prior_state, which is what makes the CAS UPDATE match zero rows.
+    assert other_note != winner_note
+    assert not session.commit.await_count, 'apply must not commit when CAS fails'
+
+
+@pytest.mark.asyncio
+async def test_apply_refine_not_contradict_refuses_when_link_type_changed():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    link_id = str(uuid4())
+    proposal = _proposal(
+        'refine_not_contradict',
+        loser_unit_id=loser_id,
+        winner_unit_id=winner_id,
+        link_id=link_id,
+    )
+    loser_row = _row(id=loser_id, status='active', note_id=str(uuid4()))
+    winner_row = _row(id=winner_id, status='active', note_id=str(uuid4()))
+    link_row = _row(
+        id=link_id,
+        link_type='contradicts',
+        from_unit_id=winner_id,
+        to_unit_id=loser_id,
+    )
+    rows_and_rowcounts: list = [
+        proposal,
+        loser_row,
+        winner_row,
+        link_row,
+        (None, 0),
+    ]
+    session, cm = _make_session_with_rowcounts(rows_and_rowcounts)
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='Concurrent modification'):
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+    update_calls = [
+        params
+        for sql, params in session._captured
+        if isinstance(params, dict) and params.get('link_type') == 'refines'
+    ]
+    assert update_calls, 'expected the link_type=refines UPDATE to be attempted'
+    assert update_calls[0].get('expected_link_type') == 'contradicts', (
+        'CAS guard must carry the captured pre-mutation link_type'
+    )
+    assert not session.commit.await_count, 'apply must not commit when CAS fails'
+
+
+# ---------------------------------------------------------------------------
 # Reverse-path schema-version guard: refuses when applied state predates the
 # CAS guard (resolution.schema_version missing or < 1). Apply stamps the
 # marker, so any post-V5 proposal carries it; the guard exists to refuse

--- a/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
+++ b/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
@@ -357,3 +357,245 @@ async def test_reverse_requires_vault_id():
             vault_id=None,
             actor='unit-test',
         )
+
+
+# ---------------------------------------------------------------------------
+# Reverse-path guards: CAS state-divergence checks and rowcount checks.
+# ---------------------------------------------------------------------------
+
+
+def _make_session_with_rowcounts(rows_and_rowcounts: list):
+    """Like ``_make_session`` but each entry is ``(row, rowcount)``.
+
+    Lets a test simulate "UPDATE matched zero rows" (deleted target) by
+    yielding a zero-rowcount Result on the appropriate UPDATE call.
+    """
+    captured: list[tuple] = []
+
+    class _Result:
+        def __init__(self, row, rowcount=1):
+            self._row = row
+            self.rowcount = rowcount
+
+        def first(self):
+            return self._row
+
+    async def execute(sql, params=None):
+        try:
+            sql_text = str(getattr(sql, 'text', sql))
+        except Exception:
+            sql_text = ''
+        captured.append((sql_text, params))
+        idx = len(captured) - 1
+        if idx < len(rows_and_rowcounts):
+            entry = rows_and_rowcounts[idx]
+            if isinstance(entry, tuple):
+                row, rowcount = entry
+                return _Result(row, rowcount=rowcount)
+            return _Result(entry)
+        return _Result(None)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=execute)
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session._captured = captured
+
+    cm = AsyncMock()
+    cm.__aenter__.return_value = session
+    cm.__aexit__.return_value = None
+    return session, cm
+
+
+def _resolved_proposal(
+    *,
+    effective_action: str,
+    loser_unit_id: str | None = None,
+    winner_unit_id: str | None = None,
+    link_id: str | None = None,
+    prior_state: dict | None = None,
+    applied_state: dict | None = None,
+):
+    """Build a resolved proposal row for reverse-path tests."""
+    return _row(
+        id=str(uuid4()),
+        vault_id='11111111-1111-1111-1111-111111111111',
+        rule_name='propose_contradiction_winner',
+        target_type='memory_unit',
+        target_id=loser_unit_id or str(uuid4()),
+        evidence=json.dumps(
+            {
+                'action': effective_action,
+                'winner_unit_id': winner_unit_id,
+                'loser_unit_id': loser_unit_id,
+                'link_id': link_id,
+                'resolution': {
+                    'action': effective_action,
+                    'effective_action': effective_action,
+                    'actor': 'unit-test',
+                    'prior_state': prior_state or {},
+                    'applied_state': applied_state or {},
+                    'applied': {'action': effective_action},
+                },
+            }
+        ),
+        status='resolved',
+    )
+
+
+@pytest.mark.asyncio
+async def test_reverse_mark_loser_stale_refuses_when_state_diverged():
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    loser_id = str(uuid4())
+    proposal = _resolved_proposal(
+        effective_action='mark_loser_stale',
+        loser_unit_id=loser_id,
+        prior_state={'loser_unit_status': 'active'},
+        applied_state={'loser_unit_status': 'stale'},
+    )
+    # Current state is 'archived' — diverged from applied 'stale'.
+    current_unit = _row(id=loser_id, status='archived', note_id=str(uuid4()))
+    session, cm = _make_session_with_rowcounts([proposal, current_unit])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='diverged'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+
+@pytest.mark.asyncio
+async def test_reverse_supersede_loser_note_refuses_when_state_diverged():
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    loser_note = str(uuid4())
+    winner_note = str(uuid4())
+    other_note = str(uuid4())
+    proposal = _resolved_proposal(
+        effective_action='supersede_loser_note',
+        loser_unit_id=str(uuid4()),
+        winner_unit_id=str(uuid4()),
+        prior_state={'loser_note_id': loser_note, 'loser_note_superseded_by': None},
+        applied_state={'loser_note_id': loser_note, 'loser_note_superseded_by': winner_note},
+    )
+    # Current superseded_by points elsewhere — diverged.
+    current_note = _row(id=loser_note, superseded_by=other_note)
+    session, cm = _make_session_with_rowcounts([proposal, current_note])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='diverged'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+
+@pytest.mark.asyncio
+async def test_reverse_refine_not_contradict_refuses_when_state_diverged():
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    link_id = str(uuid4())
+    proposal = _resolved_proposal(
+        effective_action='refine_not_contradict',
+        loser_unit_id=str(uuid4()),
+        winner_unit_id=str(uuid4()),
+        link_id=link_id,
+        prior_state={'link_id': link_id, 'link_type': 'contradicts'},
+        applied_state={'link_id': link_id, 'link_type': 'refines'},
+    )
+    # Link is now 'supports' — someone else mutated it after apply.
+    current_link = _row(
+        id=link_id, link_type='supports', from_unit_id=str(uuid4()), to_unit_id=str(uuid4())
+    )
+    session, cm = _make_session_with_rowcounts([proposal, current_link])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='diverged'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+
+@pytest.mark.asyncio
+async def test_reverse_mark_loser_stale_refuses_when_unit_deleted():
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    loser_id = str(uuid4())
+    proposal = _resolved_proposal(
+        effective_action='mark_loser_stale',
+        loser_unit_id=loser_id,
+        prior_state={'loser_unit_status': 'active'},
+        applied_state={'loser_unit_status': 'stale'},
+    )
+    # Loader returns None — unit no longer exists.
+    session, cm = _make_session_with_rowcounts([proposal, None])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='no longer exists'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+
+@pytest.mark.asyncio
+async def test_reverse_supersede_loser_note_refuses_when_note_deleted():
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    loser_note = str(uuid4())
+    winner_note = str(uuid4())
+    proposal = _resolved_proposal(
+        effective_action='supersede_loser_note',
+        loser_unit_id=str(uuid4()),
+        winner_unit_id=str(uuid4()),
+        prior_state={'loser_note_id': loser_note, 'loser_note_superseded_by': None},
+        applied_state={'loser_note_id': loser_note, 'loser_note_superseded_by': winner_note},
+    )
+    # Note loader returns None — note no longer exists.
+    session, cm = _make_session_with_rowcounts([proposal, None])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='no longer exists'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+
+@pytest.mark.asyncio
+async def test_reverse_refine_not_contradict_refuses_when_link_deleted():
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    link_id = str(uuid4())
+    proposal = _resolved_proposal(
+        effective_action='refine_not_contradict',
+        loser_unit_id=str(uuid4()),
+        winner_unit_id=str(uuid4()),
+        link_id=link_id,
+        prior_state={'link_id': link_id, 'link_type': 'contradicts'},
+        applied_state={'link_id': link_id, 'link_type': 'refines'},
+    )
+    # Link loader returns None — link no longer exists.
+    session, cm = _make_session_with_rowcounts([proposal, None])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='no longer exists'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )

--- a/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
+++ b/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
@@ -807,6 +807,45 @@ async def test_reverse_refuses_when_schema_version_too_low():
 
 
 @pytest.mark.asyncio
+async def test_concurrent_reverse_loses_second_caller():
+    """Two concurrent reverses both observe ``reversed_at=None`` on the
+    initial SELECT. Caller A commits first; caller B's evidence UPDATE
+    must match zero rows (guarded by the partial WHERE clause on
+    ``reversed_at``) and raise ``already been reversed`` so the second
+    caller doesn't double-write a reversal audit row."""
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    loser_id = str(uuid4())
+    proposal = _resolved_proposal(
+        effective_action='mark_loser_stale',
+        loser_unit_id=loser_id,
+        prior_state={'loser_unit_status': 'active'},
+        applied_state={'loser_unit_status': 'stale'},
+    )
+    # Loader sees pre-reversal state (concurrent caller A hasn't committed yet);
+    # the prior_state restore UPDATE succeeds; but the evidence UPDATE matches
+    # zero rows because A's commit landed in between with reversed_at set.
+    current_unit = _row(id=loser_id, status='stale', note_id=str(uuid4()))
+    rows_and_rowcounts: list = [
+        proposal,
+        current_unit,
+        (None, 1),  # restore unit status UPDATE: succeeds
+        (None, 0),  # evidence UPDATE: 0 rows matched — A already reversed.
+    ]
+    session, cm = _make_session_with_rowcounts(rows_and_rowcounts)
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='already been reversed'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+    assert not session.commit.await_count, 'reverse must not commit on race loss'
+
+
+@pytest.mark.asyncio
 async def test_apply_records_schema_version_in_resolution():
     loser_id = str(uuid4())
     winner_id = str(uuid4())

--- a/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
+++ b/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
@@ -599,3 +599,115 @@ async def test_reverse_refine_not_contradict_refuses_when_link_deleted():
             vault_id=UUID('11111111-1111-1111-1111-111111111111'),
             actor='unit-test',
         )
+
+
+# ---------------------------------------------------------------------------
+# Apply-path rowcount guards — symmetric with the reverse-path guards above.
+# Simulate a concurrent DELETE between the row loader (SELECT) and the
+# mutating UPDATE inside the same transaction. The UPDATE matches zero rows;
+# without the rowcount guard, the apply path would record applied_state and
+# flip the finding to resolved as if the mutation succeeded, leaving the
+# audit trail lying. With the guard, the apply path raises and the
+# transaction rolls back via the existing async context manager.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_mark_loser_stale_refuses_when_unit_deleted_mid_txn():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    proposal = _proposal('mark_loser_stale', loser_unit_id=loser_id, winner_unit_id=winner_id)
+    loser_row = _row(id=loser_id, status='active', note_id=str(uuid4()))
+    winner_row = _row(id=winner_id, status='active', note_id=str(uuid4()))
+    # SELECT proposal -> SELECT loser unit -> SELECT winner unit ->
+    # UPDATE unit status (rowcount=0, concurrent delete after the SELECT).
+    rows_and_rowcounts: list = [
+        proposal,
+        loser_row,
+        winner_row,
+        (None, 0),
+    ]
+    session, cm = _make_session_with_rowcounts(rows_and_rowcounts)
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='apply failed'):
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+    assert not session.commit.await_count, 'apply must not commit when rowcount=0'
+
+
+@pytest.mark.asyncio
+async def test_apply_supersede_loser_note_refuses_when_note_deleted_mid_txn():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    loser_note = str(uuid4())
+    winner_note = str(uuid4())
+    proposal = _proposal('supersede_loser_note', loser_unit_id=loser_id, winner_unit_id=winner_id)
+    loser_row = _row(id=loser_id, status='active', note_id=loser_note)
+    winner_row = _row(id=winner_id, status='active', note_id=winner_note)
+    note_row = _row(id=loser_note, superseded_by=None)
+    # SELECT proposal -> SELECT loser unit -> SELECT winner unit ->
+    # SELECT note -> UPDATE note.superseded_by (rowcount=0, concurrent delete).
+    rows_and_rowcounts: list = [
+        proposal,
+        loser_row,
+        winner_row,
+        note_row,
+        (None, 0),
+    ]
+    session, cm = _make_session_with_rowcounts(rows_and_rowcounts)
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='apply failed'):
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+    assert not session.commit.await_count, 'apply must not commit when rowcount=0'
+
+
+@pytest.mark.asyncio
+async def test_apply_refine_not_contradict_refuses_when_link_deleted_mid_txn():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    link_id = str(uuid4())
+    proposal = _proposal(
+        'refine_not_contradict',
+        loser_unit_id=loser_id,
+        winner_unit_id=winner_id,
+        link_id=link_id,
+    )
+    loser_row = _row(id=loser_id, status='active', note_id=str(uuid4()))
+    winner_row = _row(id=winner_id, status='active', note_id=str(uuid4()))
+    link_row = _row(
+        id=link_id,
+        link_type='contradicts',
+        from_unit_id=winner_id,
+        to_unit_id=loser_id,
+    )
+    # SELECT proposal -> SELECT loser unit -> SELECT winner unit ->
+    # SELECT link -> UPDATE link.link_type (rowcount=0, concurrent delete).
+    rows_and_rowcounts: list = [
+        proposal,
+        loser_row,
+        winner_row,
+        link_row,
+        (None, 0),
+    ]
+    session, cm = _make_session_with_rowcounts(rows_and_rowcounts)
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='apply failed'):
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+    assert not session.commit.await_count, 'apply must not commit when rowcount=0'

--- a/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
+++ b/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -110,7 +110,12 @@ async def test_mark_loser_stale_dispatches_unit_status_update():
     session, cm = _make_session([proposal, loser_row, winner_row])
     api = _api_with_session(cm)
 
-    result = await apply_winner_proposal(api, uuid4(), vault_id=None, actor='unit-test')
+    result = await apply_winner_proposal(
+        api,
+        uuid4(),
+        vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+        actor='unit-test',
+    )
 
     assert result['status'] == 'resolved'
     assert result['effective_action'] == 'mark_loser_stale'
@@ -134,7 +139,12 @@ async def test_supersede_loser_note_falls_back_when_shared_parent():
     session, cm = _make_session([proposal, loser_row, winner_row])
     api = _api_with_session(cm)
 
-    result = await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+    result = await apply_winner_proposal(
+        api,
+        uuid4(),
+        vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+        actor='unit-test',
+    )
 
     assert result['effective_action'] == 'mark_loser_stale'
     assert result['fallback_reason'] == 'shared_parent_note'
@@ -153,7 +163,12 @@ async def test_supersede_loser_note_updates_note_superseded_by():
     session, cm = _make_session([proposal, loser_row, winner_row, note_row])
     api = _api_with_session(cm)
 
-    result = await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+    result = await apply_winner_proposal(
+        api,
+        uuid4(),
+        vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+        actor='unit-test',
+    )
 
     assert result['effective_action'] == 'supersede_loser_note'
     superseded = [
@@ -186,7 +201,12 @@ async def test_refine_not_contradict_rewrites_link_type():
     session, cm = _make_session([proposal, loser_row, winner_row, link_row])
     api = _api_with_session(cm)
 
-    result = await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+    result = await apply_winner_proposal(
+        api,
+        uuid4(),
+        vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+        actor='unit-test',
+    )
 
     assert result['effective_action'] == 'refine_not_contradict'
     refines = [
@@ -205,7 +225,12 @@ async def test_inconclusive_is_a_noop_write():
     session, cm = _make_session([proposal, loser_row])
     api = _api_with_session(cm)
 
-    result = await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+    result = await apply_winner_proposal(
+        api,
+        uuid4(),
+        vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+        actor='unit-test',
+    )
 
     assert result['effective_action'] == 'inconclusive'
     # No status flip, no note update, no link update.
@@ -231,7 +256,12 @@ async def test_unknown_action_raises():
     api = _api_with_session(cm)
 
     with pytest.raises(ContradictionResolutionError):
-        await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
 
 
 @pytest.mark.asyncio
@@ -240,4 +270,90 @@ async def test_missing_finding_raises():
     api = _api_with_session(cm)
 
     with pytest.raises(ContradictionResolutionError):
-        await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='unit-test',
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_requires_actor():
+    api = MagicMock()
+    with pytest.raises(ContradictionResolutionError, match='actor required'):
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_requires_actor_when_empty_string():
+    api = MagicMock()
+    with pytest.raises(ContradictionResolutionError, match='actor required'):
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor='',
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_requires_vault_id():
+    api = MagicMock()
+    with pytest.raises(ContradictionResolutionError, match='vault_id required'):
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=None,
+            actor='unit-test',
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_vault_mismatch():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    proposal = _proposal('mark_loser_stale', loser_unit_id=loser_id, winner_unit_id=winner_id)
+    session, cm = _make_session([proposal])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError, match='vault_id mismatch'):
+        await apply_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('22222222-2222-2222-2222-222222222222'),
+            actor='unit-test',
+        )
+
+
+@pytest.mark.asyncio
+async def test_reverse_requires_actor():
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    api = MagicMock()
+    with pytest.raises(ContradictionResolutionError, match='actor required'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=UUID('11111111-1111-1111-1111-111111111111'),
+            actor=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_reverse_requires_vault_id():
+    from memex_core.services.contradiction_resolution import reverse_winner_proposal
+
+    api = MagicMock()
+    with pytest.raises(ContradictionResolutionError, match='vault_id required'):
+        await reverse_winner_proposal(
+            api,
+            uuid4(),
+            vault_id=None,
+            actor='unit-test',
+        )

--- a/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
+++ b/packages/core/tests/unit/services/test_contradiction_resolution_actions.py
@@ -1,0 +1,243 @@
+"""Unit tests for contradiction_resolution action dispatch.
+
+Drives ``apply_winner_proposal`` against a mock AsyncSession capturing
+every SQL statement so each ``action`` literal's dispatch logic is
+exercised without booting Postgres. Covers:
+
+- mark_loser_stale flips unit status.
+- supersede_loser_note rewrites note.superseded_by.
+- supersede_loser_note falls back to mark_loser_stale when both units
+  share the same parent note (records evidence.resolution.fallback_reason).
+- refine_not_contradict rewrites the link's link_type.
+- inconclusive is a no-op write.
+- unknown action raises ContradictionResolutionError.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from memex_core.services.contradiction_resolution import (
+    ContradictionResolutionError,
+    apply_winner_proposal,
+)
+
+
+def _row(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def _make_session(rows_by_query: list):
+    """Build an AsyncSession mock that yields rows in call order.
+
+    Each entry in ``rows_by_query`` is the ``.first()`` result of the
+    matching ``session.execute(...)`` call (None when no row).
+    """
+    captured: list[tuple] = []
+
+    class _Result:
+        def __init__(self, row):
+            self._row = row
+            self.rowcount = 1
+
+        def first(self):
+            return self._row
+
+    async def execute(sql, params=None):
+        try:
+            sql_text = str(getattr(sql, 'text', sql))
+        except Exception:
+            sql_text = ''
+        captured.append((sql_text, params))
+        idx = len(captured) - 1
+        if idx < len(rows_by_query):
+            return _Result(rows_by_query[idx])
+        return _Result(None)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=execute)
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session._captured = captured
+
+    cm = AsyncMock()
+    cm.__aenter__.return_value = session
+    cm.__aexit__.return_value = None
+    return session, cm
+
+
+def _api_with_session(cm):
+    api = MagicMock()
+    api.metastore.session = MagicMock(return_value=cm)
+    return api
+
+
+def _proposal(action, *, loser_unit_id=None, winner_unit_id=None, link_id=None):
+    return _row(
+        id=str(uuid4()),
+        vault_id='11111111-1111-1111-1111-111111111111',
+        rule_name='propose_contradiction_winner',
+        target_type='memory_unit',
+        target_id=loser_unit_id or str(uuid4()),
+        evidence=json.dumps(
+            {
+                'action': action,
+                'winner_unit_id': winner_unit_id,
+                'loser_unit_id': loser_unit_id,
+                'link_id': link_id,
+                'winner_id': 'unit_a',
+                'loser_id': 'unit_b',
+                'confidence': 0.8,
+                'rationale': 'mock',
+            }
+        ),
+        status='pending',
+    )
+
+
+@pytest.mark.asyncio
+async def test_mark_loser_stale_dispatches_unit_status_update():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    proposal = _proposal('mark_loser_stale', loser_unit_id=loser_id, winner_unit_id=winner_id)
+    loser_row = _row(id=loser_id, status='active', note_id=str(uuid4()))
+    winner_row = _row(id=winner_id, status='active', note_id=str(uuid4()))
+    session, cm = _make_session([proposal, loser_row, winner_row])
+    api = _api_with_session(cm)
+
+    result = await apply_winner_proposal(api, uuid4(), vault_id=None, actor='unit-test')
+
+    assert result['status'] == 'resolved'
+    assert result['effective_action'] == 'mark_loser_stale'
+    assert result['fallback_reason'] is None
+    statuses = [
+        params
+        for sql, params in session._captured
+        if isinstance(params, dict) and params.get('status') == 'stale'
+    ]
+    assert statuses, 'expected a status=stale UPDATE'
+
+
+@pytest.mark.asyncio
+async def test_supersede_loser_note_falls_back_when_shared_parent():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    shared_note = str(uuid4())
+    proposal = _proposal('supersede_loser_note', loser_unit_id=loser_id, winner_unit_id=winner_id)
+    loser_row = _row(id=loser_id, status='active', note_id=shared_note)
+    winner_row = _row(id=winner_id, status='active', note_id=shared_note)
+    session, cm = _make_session([proposal, loser_row, winner_row])
+    api = _api_with_session(cm)
+
+    result = await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+
+    assert result['effective_action'] == 'mark_loser_stale'
+    assert result['fallback_reason'] == 'shared_parent_note'
+
+
+@pytest.mark.asyncio
+async def test_supersede_loser_note_updates_note_superseded_by():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    loser_note = str(uuid4())
+    winner_note = str(uuid4())
+    proposal = _proposal('supersede_loser_note', loser_unit_id=loser_id, winner_unit_id=winner_id)
+    loser_row = _row(id=loser_id, status='active', note_id=loser_note)
+    winner_row = _row(id=winner_id, status='active', note_id=winner_note)
+    note_row = _row(id=loser_note, superseded_by=None)
+    session, cm = _make_session([proposal, loser_row, winner_row, note_row])
+    api = _api_with_session(cm)
+
+    result = await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+
+    assert result['effective_action'] == 'supersede_loser_note'
+    superseded = [
+        params
+        for sql, params in session._captured
+        if isinstance(params, dict) and params.get('superseded_by') == winner_note
+    ]
+    assert superseded, 'expected a superseded_by UPDATE'
+
+
+@pytest.mark.asyncio
+async def test_refine_not_contradict_rewrites_link_type():
+    loser_id = str(uuid4())
+    winner_id = str(uuid4())
+    link_id = str(uuid4())
+    proposal = _proposal(
+        'refine_not_contradict',
+        loser_unit_id=loser_id,
+        winner_unit_id=winner_id,
+        link_id=link_id,
+    )
+    loser_row = _row(id=loser_id, status='active', note_id=str(uuid4()))
+    winner_row = _row(id=winner_id, status='active', note_id=str(uuid4()))
+    link_row = _row(
+        id=link_id,
+        link_type='contradicts',
+        from_unit_id=winner_id,
+        to_unit_id=loser_id,
+    )
+    session, cm = _make_session([proposal, loser_row, winner_row, link_row])
+    api = _api_with_session(cm)
+
+    result = await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+
+    assert result['effective_action'] == 'refine_not_contradict'
+    refines = [
+        params
+        for sql, params in session._captured
+        if isinstance(params, dict) and params.get('link_type') == 'refines'
+    ]
+    assert refines, 'expected a link_type=refines UPDATE'
+
+
+@pytest.mark.asyncio
+async def test_inconclusive_is_a_noop_write():
+    loser_id = str(uuid4())
+    proposal = _proposal('inconclusive', loser_unit_id=loser_id, winner_unit_id=None)
+    loser_row = _row(id=loser_id, status='active', note_id=str(uuid4()))
+    session, cm = _make_session([proposal, loser_row])
+    api = _api_with_session(cm)
+
+    result = await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+
+    assert result['effective_action'] == 'inconclusive'
+    # No status flip, no note update, no link update.
+    mutating = [
+        params
+        for sql, params in session._captured
+        if isinstance(params, dict)
+        and (
+            params.get('status') == 'stale'
+            or params.get('superseded_by') is not None
+            or params.get('link_type') == 'refines'
+        )
+    ]
+    assert not mutating, 'inconclusive must not mutate target rows'
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_raises():
+    loser_id = str(uuid4())
+    proposal = _proposal('eat_the_database', loser_unit_id=loser_id, winner_unit_id=None)
+    loser_row = _row(id=loser_id, status='active', note_id=str(uuid4()))
+    session, cm = _make_session([proposal, loser_row])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError):
+        await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)
+
+
+@pytest.mark.asyncio
+async def test_missing_finding_raises():
+    session, cm = _make_session([None])
+    api = _api_with_session(cm)
+
+    with pytest.raises(ContradictionResolutionError):
+        await apply_winner_proposal(api, uuid4(), vault_id=None, actor=None)

--- a/packages/core/tests/unit/test_lint_audit_actor.py
+++ b/packages/core/tests/unit/test_lint_audit_actor.py
@@ -1,0 +1,33 @@
+"""Audit-actor resolution for the lint apply / reverse endpoints.
+
+When ``auth.enabled=False`` (dev/test/CI), ``auth_middleware`` never runs
+and the ``actor`` contextvar keeps its default ``'anonymous'`` value. The
+service layer requires a non-empty actor, so the lint apply / reverse
+endpoints would be unreachable without a fallback. ``_audit_actor`` promotes
+the anonymous default to ``'system'`` so the endpoints stay reachable and
+the audit trail still identifies the call path.
+
+When auth IS enabled, ``auth_middleware`` sets the contextvar to
+``f'{key_name} ({key_prefix})'``; ``_audit_actor`` passes that through
+unchanged so audit-string shape matches every other audit-emitting code path.
+"""
+
+from __future__ import annotations
+
+from memex_core.context import set_actor
+from memex_core.server.lint import _audit_actor
+
+
+def test_audit_actor_promotes_anonymous_default_to_system():
+    set_actor('anonymous')
+    assert _audit_actor() == 'system'
+
+
+def test_audit_actor_promotes_empty_to_system():
+    set_actor('')
+    assert _audit_actor() == 'system'
+
+
+def test_audit_actor_passes_through_authenticated_label():
+    set_actor('scoped-writer (abc123de...)')
+    assert _audit_actor() == 'scoped-writer (abc123de...)'

--- a/packages/core/tests/unit/test_lint_audit_actor.py
+++ b/packages/core/tests/unit/test_lint_audit_actor.py
@@ -11,12 +11,21 @@ cannot collide with a real principal literally named ``'system'``.
 When auth IS enabled, ``auth_middleware`` sets the contextvar to
 ``f'{key_name} ({key_prefix})'``; ``_audit_actor`` passes that through
 unchanged so audit-string shape matches every other audit-emitting code path.
+
+Also covers ``_require_attended_mode``: when auth is disabled the apply /
+reverse handlers refuse unless the operator opts in via
+``MEMEX_LINT_ALLOW_UNATTENDED_APPLY``.
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
 from memex_core.context import set_actor
-from memex_core.server.lint import _audit_actor
+from memex_core.server.lint import _audit_actor, _require_attended_mode
 
 
 def test_audit_actor_promotes_anonymous_default_to_system():
@@ -32,3 +41,40 @@ def test_audit_actor_promotes_empty_to_system():
 def test_audit_actor_passes_through_authenticated_label():
     set_actor('scoped-writer (abc123de...)')
     assert _audit_actor() == 'scoped-writer (abc123de...)'
+
+
+def _api_with_auth(enabled: bool):
+    return SimpleNamespace(
+        config=SimpleNamespace(server=SimpleNamespace(auth=SimpleNamespace(enabled=enabled)))
+    )
+
+
+def test_apply_requires_auth_enabled_or_opt_in(monkeypatch):
+    monkeypatch.delenv('MEMEX_LINT_ALLOW_UNATTENDED_APPLY', raising=False)
+    with pytest.raises(HTTPException) as excinfo:
+        _require_attended_mode(_api_with_auth(False))
+    assert excinfo.value.status_code == 403
+    assert 'MEMEX_LINT_ALLOW_UNATTENDED_APPLY' in excinfo.value.detail
+
+
+def test_apply_allowed_when_opt_in_env_set(monkeypatch):
+    monkeypatch.setenv('MEMEX_LINT_ALLOW_UNATTENDED_APPLY', '1')
+    _require_attended_mode(_api_with_auth(False))
+
+
+@pytest.mark.parametrize('value', ['true', 'TRUE', 'yes', 'YES'])
+def test_apply_opt_in_accepts_truthy_values(monkeypatch, value):
+    monkeypatch.setenv('MEMEX_LINT_ALLOW_UNATTENDED_APPLY', value)
+    _require_attended_mode(_api_with_auth(False))
+
+
+def test_apply_opt_in_rejects_other_values(monkeypatch):
+    monkeypatch.setenv('MEMEX_LINT_ALLOW_UNATTENDED_APPLY', 'maybe')
+    with pytest.raises(HTTPException) as excinfo:
+        _require_attended_mode(_api_with_auth(False))
+    assert excinfo.value.status_code == 403
+
+
+def test_apply_passthrough_when_auth_enabled(monkeypatch):
+    monkeypatch.delenv('MEMEX_LINT_ALLOW_UNATTENDED_APPLY', raising=False)
+    _require_attended_mode(_api_with_auth(True))

--- a/packages/core/tests/unit/test_lint_audit_actor.py
+++ b/packages/core/tests/unit/test_lint_audit_actor.py
@@ -4,8 +4,9 @@ When ``auth.enabled=False`` (dev/test/CI), ``auth_middleware`` never runs
 and the ``actor`` contextvar keeps its default ``'anonymous'`` value. The
 service layer requires a non-empty actor, so the lint apply / reverse
 endpoints would be unreachable without a fallback. ``_audit_actor`` promotes
-the anonymous default to ``'system'`` so the endpoints stay reachable and
-the audit trail still identifies the call path.
+the anonymous default to ``'system:auth-disabled'`` so the endpoints stay
+reachable, the audit trail still identifies the call path, and the value
+cannot collide with a real principal literally named ``'system'``.
 
 When auth IS enabled, ``auth_middleware`` sets the contextvar to
 ``f'{key_name} ({key_prefix})'``; ``_audit_actor`` passes that through
@@ -20,12 +21,12 @@ from memex_core.server.lint import _audit_actor
 
 def test_audit_actor_promotes_anonymous_default_to_system():
     set_actor('anonymous')
-    assert _audit_actor() == 'system'
+    assert _audit_actor() == 'system:auth-disabled'
 
 
 def test_audit_actor_promotes_empty_to_system():
     set_actor('')
-    assert _audit_actor() == 'system'
+    assert _audit_actor() == 'system:auth-disabled'
 
 
 def test_audit_actor_passes_through_authenticated_label():

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -153,6 +153,7 @@ def format_briefing_block(
     diagnostics_summary: dict[str, Any] | None = None,
     procedural_observations: list[dict[str, Any]] | None = None,
     lint_pending_count: int | None = None,
+    lint_pending_winner_proposals: int | None = None,
 ) -> str:
     """Compose the Memex system-prompt block."""
     lines = ['## Memex Memory']
@@ -184,7 +185,13 @@ def format_briefing_block(
         lines.append('\n' + _render_procedural_block(procedural_observations))
 
     if lint_pending_count is not None and lint_pending_count > 0:
-        lines.append('\n' + _render_lint_block(lint_pending_count))
+        lines.append(
+            '\n'
+            + _render_lint_block(
+                lint_pending_count,
+                pending_winner_proposals=lint_pending_winner_proposals,
+            )
+        )
 
     if diagnostics_summary:
         lines.append('\n' + _render_diagnostics_block(diagnostics_summary))
@@ -204,11 +211,21 @@ __all__ = ['BriefingCache', 'format_briefing_block']
 # ============================================================
 
 
-def _render_lint_block(pending_count: int) -> str:
-    return (
-        f'### Maintenance findings\n'
-        f'- {pending_count} pending lint findings. Inspect with `memex lint findings`.'
-    )
+def _render_lint_block(
+    pending_count: int,
+    *,
+    pending_winner_proposals: int | None = None,
+) -> str:
+    lines = [
+        '### Maintenance findings',
+        f'- {pending_count} pending lint findings. Inspect with `memex lint findings`.',
+    ]
+    if pending_winner_proposals is not None and pending_winner_proposals > 0:
+        lines.append(
+            f'- {pending_winner_proposals} have proposed winners. '
+            'Apply with `memex_lint_apply_winner` after surfacing to the user.'
+        )
+    return '\n'.join(lines)
 
 
 def _render_procedural_block(observations: list[dict[str, Any]]) -> str:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -254,6 +254,7 @@ class MemexMemoryProvider(MemoryProvider):
             kv_instructions_if_no_vault=self._vault_name is None,
             procedural_observations=self._fetch_top_procedure_outcomes(),
             lint_pending_count=self._fetch_lint_pending_count(),
+            lint_pending_winner_proposals=self._fetch_pending_winner_proposals(),
         )
 
     def _fetch_top_procedure_outcomes(self) -> list[dict[str, Any]] | None:
@@ -292,6 +293,29 @@ class MemexMemoryProvider(MemoryProvider):
             return int(payload.get('pending', 0))
         except Exception as e:
             logger.debug('lint_status fetch failed: %s', e)
+            return None
+
+    def _fetch_pending_winner_proposals(self) -> int | None:
+        """Count pending winner-proposal findings for the briefing cue.
+
+        Best-effort: any failure returns None and the briefing renders
+        without the extra cue.
+        """
+        if self._api is None or self._vault_id is None:
+            return None
+        try:
+            payload = run_sync(
+                self._api.lint_findings(
+                    vault_id=str(self._vault_id),
+                    status='pending',
+                    limit=200,
+                ),
+                timeout=2.0,
+            )
+            findings = payload.get('findings') or []
+            return sum(1 for f in findings if f.get('rule_name') == 'propose_contradiction_winner')
+        except Exception as e:
+            logger.debug('pending_winner_proposals fetch failed: %s', e)
             return None
 
     # -- Tools ---------------------------------------------------------------

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -139,6 +139,10 @@ class MemexAPIProtocol(Protocol):
     # F8 — Lint flags (read-only agent surface)
     async def lint_get_flags(self, *args: Any, **kwargs: Any) -> Any: ...
 
+    # Lint resolution (winner-proposal apply / reverse)
+    async def lint_apply_winner(self, *args: Any, **kwargs: Any) -> Any: ...
+    async def lint_reverse_winner(self, *args: Any, **kwargs: Any) -> Any: ...
+
     # F9 — Per-entity advisory lock + vault-wide consolidate
     async def reconsolidate_entity(self, *args: Any, **kwargs: Any) -> Any: ...
     async def consolidate_vault(self, *args: Any, **kwargs: Any) -> Any: ...
@@ -3940,6 +3944,94 @@ def handle_get_lint_flags(
 
 HANDLERS['memex_get_lint_flags'] = handle_get_lint_flags
 ALL_SCHEMAS.append(GET_LINT_FLAGS_SCHEMA)
+
+
+LINT_APPLY_WINNER_SCHEMA: dict[str, Any] = {
+    'name': 'memex_lint_apply_winner',
+    'description': (
+        'Apply the recommended action on a winner-proposal lint finding '
+        "(rule_name=propose_contradiction_winner). The finding's "
+        'evidence.action drives the mutation: mark a unit stale, mark a '
+        'note superseded, rewrite a contradicts link as refines, or a '
+        'no-op write when inconclusive. Captures prior_state so the change '
+        'is reversible via memex_lint_reverse_winner.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'finding_id': {
+                'type': 'string',
+                'description': 'UUID of the pending winner-proposal finding.',
+            },
+        },
+        'required': ['finding_id'],
+    },
+}
+
+
+LINT_REVERSE_WINNER_SCHEMA: dict[str, Any] = {
+    'name': 'memex_lint_reverse_winner',
+    'description': (
+        'Reverse a previously applied winner-proposal lint finding. Restores '
+        'the row(s) recorded under evidence.resolution.prior_state and '
+        'writes a paired audit row. The original finding stays resolved.'
+    ),
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'finding_id': {
+                'type': 'string',
+                'description': (
+                    'UUID of the previously applied (status=resolved) '
+                    'winner-proposal finding to reverse.'
+                ),
+            },
+        },
+        'required': ['finding_id'],
+    },
+}
+
+
+def handle_lint_apply_winner(
+    api: MemexAPIProtocol,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+    args: dict[str, Any],
+) -> str:
+    """Sync wrapper around RemoteMemexAPI.lint_apply_winner."""
+    finding_id = args.get('finding_id')
+    if not finding_id:
+        return tool_error('memex_lint_apply_winner requires finding_id')
+    try:
+        result = run_sync(api.lint_apply_winner(str(finding_id)), timeout=30.0)
+    except Exception as e:
+        logger.warning('memex_lint_apply_winner failed: %s', e)
+        return tool_error(f'Lint apply failed: {e}')
+    return json.dumps(result, default=str)
+
+
+def handle_lint_reverse_winner(
+    api: MemexAPIProtocol,
+    config: HermesMemexConfig,
+    vault_id: UUID | None,
+    args: dict[str, Any],
+) -> str:
+    """Sync wrapper around RemoteMemexAPI.lint_reverse_winner."""
+    finding_id = args.get('finding_id')
+    if not finding_id:
+        return tool_error('memex_lint_reverse_winner requires finding_id')
+    try:
+        result = run_sync(api.lint_reverse_winner(str(finding_id)), timeout=30.0)
+    except Exception as e:
+        logger.warning('memex_lint_reverse_winner failed: %s', e)
+        return tool_error(f'Lint reverse failed: {e}')
+    return json.dumps(result, default=str)
+
+
+HANDLERS['memex_lint_apply_winner'] = handle_lint_apply_winner
+HANDLERS['memex_lint_reverse_winner'] = handle_lint_reverse_winner
+ALL_SCHEMAS.append(LINT_APPLY_WINNER_SCHEMA)
+ALL_SCHEMAS.append(LINT_REVERSE_WINNER_SCHEMA)
 
 
 # --- F9 ---  (filled by WS-locks)

--- a/packages/mcp/src/memex_mcp/_lint_resolution_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_lint_resolution_descriptions.py
@@ -1,0 +1,45 @@
+"""Verbatim agent prompt text for the lint resolution write tools.
+
+When the spec changes, the verbatim test fails — that is the contract.
+"""
+
+from __future__ import annotations
+
+MEMEX_LINT_APPLY_WINNER_DESCRIPTION = (
+    'memex_lint_apply_winner — Apply the recommended action on a '
+    'winner-proposal lint finding (rule_name=propose_contradiction_winner).\n'
+    'Use after surfacing the proposal to the user and confirming the agent '
+    'has authority to apply the recorded action.\n'
+    '\n'
+    '- finding_id (required): UUID of the pending winner-proposal finding.\n'
+    '\n'
+    'The action recorded under evidence.action drives the mutation:\n'
+    '  mark_loser_stale       — flip the loser memory_unit.status to stale.\n'
+    '  supersede_loser_note   — set the loser note.superseded_by to the winner '
+    'note id (falls back to mark_loser_stale when both units share the same '
+    'parent note; the fallback reason is recorded under '
+    'evidence.resolution.fallback_reason).\n'
+    '  refine_not_contradict  — rewrite the inbound link from contradicts to '
+    'refines (graph-pressure weight 0.0).\n'
+    '  inconclusive           — no-op write; flips the finding to resolved.\n'
+    '\n'
+    'Each apply captures prior_state under evidence.resolution so the '
+    'mutation is fully reversible via memex_lint_reverse_winner.'
+)
+
+MEMEX_LINT_REVERSE_WINNER_DESCRIPTION = (
+    'memex_lint_reverse_winner — Reverse a previously applied winner-proposal '
+    'lint finding.\n'
+    'Reads the prior_state captured at apply-time and atomically restores '
+    'the affected memory_unit.status, note.superseded_by, or '
+    'memory_link.link_type. Writes a paired audit row '
+    '(rule_name=propose_contradiction_winner_reversal); the original '
+    'finding stays resolved so the partial unique index on pending findings '
+    'remains valid.\n'
+    '\n'
+    '- finding_id (required): UUID of the previously applied (status='
+    'resolved) winner-proposal finding.\n'
+    '\n'
+    'Use when the apply was premature or the user rejects the action after '
+    'review.'
+)

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -4068,6 +4068,62 @@ async def memex_get_lint_flags(
         raise ToolError(f'memex_get_lint_flags failed: {e}')
 
 
+from memex_mcp._lint_resolution_descriptions import (
+    MEMEX_LINT_APPLY_WINNER_DESCRIPTION,
+    MEMEX_LINT_REVERSE_WINNER_DESCRIPTION,
+)
+
+
+@mcp.tool(
+    name='memex_lint_apply_winner',
+    description=MEMEX_LINT_APPLY_WINNER_DESCRIPTION,
+    tags={'write', 'storage', 'diagnostics'},
+    annotations={'readOnlyHint': False, 'destructiveHint': False, 'idempotentHint': True},
+    timeout=30.0,
+)
+async def memex_lint_apply_winner(
+    ctx: Context,
+    finding_id: Annotated[
+        str,
+        Field(description='UUID of the pending winner-proposal finding to apply.'),
+    ],
+) -> dict[str, Any]:
+    """Write surface: apply the recommended action on a winner-proposal finding."""
+    try:
+        api = get_api(ctx)
+        return await api.lint_apply_winner(finding_id)
+    except ToolError:
+        raise
+    except Exception as e:
+        logger.error(f'memex_lint_apply_winner failed: {e}', exc_info=True)
+        raise ToolError(f'memex_lint_apply_winner failed: {e}')
+
+
+@mcp.tool(
+    name='memex_lint_reverse_winner',
+    description=MEMEX_LINT_REVERSE_WINNER_DESCRIPTION,
+    tags={'write', 'storage', 'diagnostics'},
+    annotations={'readOnlyHint': False, 'destructiveHint': False, 'idempotentHint': True},
+    timeout=30.0,
+)
+async def memex_lint_reverse_winner(
+    ctx: Context,
+    finding_id: Annotated[
+        str,
+        Field(description='UUID of the previously applied winner-proposal finding to reverse.'),
+    ],
+) -> dict[str, Any]:
+    """Write surface: reverse a previously applied winner-proposal."""
+    try:
+        api = get_api(ctx)
+        return await api.lint_reverse_winner(finding_id)
+    except ToolError:
+        raise
+    except Exception as e:
+        logger.error(f'memex_lint_reverse_winner failed: {e}', exc_info=True)
+        raise ToolError(f'memex_lint_reverse_winner failed: {e}')
+
+
 # --- Consolidation ---
 
 from memex_mcp._reconsolidate_descriptions import (


### PR DESCRIPTION
## Summary

Adds an LLM-driven lint rule that, given an FSFM contradiction-pressure finding (`flag_reason ∈ {low_credibility_contradiction_only, components_disagree}`), proposes which of the two contradicting memory units should win, the recommended action, and a calibrated confidence. The proposal lands as a regular maintenance-ledger finding and can be **applied** (one of four action literals) or **reversed** through a fully reversible service path.

## What landed

- **Alembic 037 — `link_type_refines`**: drops + recreates the `memory_links_link_type_check` constraint with `'refines'` added; downgrade refuses if any `'refines'` rows exist. The new literal is threaded through:
  - `MemoryLink.__table_args__` CHECK constraint (sql_models.py).
  - FSFM SQL CTE (`CASE link_type` + `WHERE link_type IN`).
  - `_LINK_TYPE_WEIGHT` Python parity table (weight `0.0`).
- **`ProposeContradictionWinner` DSPy signature** (`memex_core.memory.lint_llm.signatures`) with `@field_validator` clamping `confidence` to `[0.0, 1.0]` (no caller-side helper — per project rule `feedback_pydantic_validators_in_signatures`).
- **`make_propose_contradiction_winner_check` factory** — gates on a pending qualifying FSFM finding, loads the highest-pressure inbound contradicts link, calls the DSPy signature, emits an `LLMLintFinding(rule_name='propose_contradiction_winner')` with `evidence={linked_to_finding, winner/loser_unit_id, link_id, confidence, action, rationale}`.
- **`LintLLMService.tick_propose_winner`** — dedicated tick that picks candidates directly from qualifying FSFM findings (bypasses surprise gate; quota still enforced).
- **`services/contradiction_resolution.py`** — `apply_winner_proposal` dispatches on `evidence.action` (mark_loser_stale / supersede_loser_note / refine_not_contradict / inconclusive), captures `prior_state`, flips status to `resolved`. `reverse_winner_proposal` restores from `prior_state` atomically and writes a paired audit row. Shared-parent-note fallback for `supersede_loser_note` is implemented and recorded under `evidence.resolution.fallback_reason`.
- **HTTP endpoints**: `POST /api/v1/lint/findings/{id}/apply` and `/reverse`, gated by `_gate_finding_for_write` (apply) and direct vault lookup (reverse — status is already `resolved`).
- **`RemoteMemexAPI` client**: `lint_apply_winner` / `lint_reverse_winner` matching the new endpoints.
- **MCP tools**: `memex_lint_apply_winner` / `memex_lint_reverse_winner` with verbatim descriptor file `_lint_resolution_descriptions.py`.
- **CLI**: `memex lint apply <id>` / `memex lint reverse <id>` next to `resolve` / `dismiss` / `review`.
- **Hermes plugin**: `handle_lint_apply_winner` / `handle_lint_reverse_winner` sync wrappers; briefing block adds a one-line cue when pending winner-proposals exist.
- **Claude Code plugin**: `recall` SKILL.md bullet extended with the one-line apply-winner pattern.
- **Configuration**: `LintLLMChecksConfig.propose_contradiction_winner` feature flag and `LintLLMConfig.propose_winner_min_confidence` (default `0.6`, env `MEMEX_SERVER_LINT_LLM_PROPOSE_WINNER_MIN_CONFIDENCE`).
- **Metrics**: `memex_contradiction_resolution_applied_total{action, vault_id}` and `memex_contradiction_resolution_reversed_total{vault_id}` — bounded-cardinality labels (action ∈ four fixed literals).
- **Tests**:
  - `tests/unit/memory/test_propose_contradiction_winner_signature.py` — 8 cases, signature shape + clamping + literal rejection (passing).
  - `tests/unit/services/test_contradiction_resolution_actions.py` — 7 cases, action dispatch logic with a mock AsyncSession (passing).
  - `tests/integration/services/test_int_contradiction_resolution_roundtrip.py` — 5 cases, apply → reverse for each action literal + shared-parent fallback (gated by `integration` — needs Docker).
  - `tests/integration/services/test_int_contradiction_winner_pipeline.py` — FSFM → winner-proposal pipeline linkage (gated by `integration` + `llm_mock`).
  - `tests/integration/memory/test_propose_winner_real_lm.py` — gated real-LM smoke (skipped without credentials).
- **Docs**: `docs/how-to/resolve-contradictions.md` (Diataxis how-to) + index row + cli-commands reference + configuration reference entry.

## What's deferred

- `tests/test_int_lint_resolve_cli.py` E2E CLI test — deferred; the new subcommands ride the same client+server path as the existing `lint resolve` / `lint dismiss` commands. Add when convenient.
- `DESIGN_DOCUMENT.md §2.4.4` close-out paragraph + Mermaid label edit — gitignored on this branch; mention pending in primary checkout.
- `packages/eval/` scenario additions — per project rule `feedback_eval_only_changes` they're scoped out of this PR; can be a follow-up.
- `/security-review` — user-triggered step; required before merge.

## Blockers I hit

- The MCP server on `release/tier-a-cognitive-memory` HEAD has a pre-existing import error (`memex_common.revisit` module was removed in the FSFM cleanup but `packages/mcp/src/memex_mcp/server.py:23` still imports `reject_bool_quality` from it). Not introduced by this PR — verified by `git stash && pytest`. The new MCP tools I added (`memex_lint_apply_winner` / `memex_lint_reverse_winner`) compose correctly, but the whole `memex_mcp.server` module can't import on this branch until that pre-existing bug is fixed. Two tests in `tests/unit/memory/retrieval/test_note_relations_unit.py` fail for the same reason. Tracking separately.

## Test plan

- [ ] `uv run pytest packages/core/tests/unit/memory/test_propose_contradiction_winner_signature.py packages/core/tests/unit/services/test_contradiction_resolution_actions.py -q` — 15 passing locally
- [ ] `uv run pytest -m integration packages/core/tests/integration/services/test_int_contradiction_resolution_roundtrip.py packages/core/tests/integration/services/test_int_contradiction_winner_pipeline.py -q` — gated on Docker / Postgres testcontainer
- [ ] `just db-upgrade` clean-run on a populated DB
- [ ] `just db-downgrade -1` clean-run with no `'refines'` rows
- [ ] `/security-review` cleared before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)