### PR TITLE
feat(core/contradiction): claim_type extraction + special-interest contradiction matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,470%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,513%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -995,9 +995,29 @@ class ContradictionConfig(BaseModel):
         default=0.5,
         description='Min cosine similarity for candidate retrieval.',
     )
+    similarity_threshold_explicit_claim: float = Field(
+        default=0.35,
+        ge=0.0,
+        le=1.0,
+        description=(
+            'Min cosine similarity for candidate retrieval when the new unit '
+            'carries an explicit resolution/contradiction claim. Lower than '
+            '``similarity_threshold`` because explicit claims have linguistic '
+            'evidence beyond cosine.'
+        ),
+    )
     max_candidates_per_unit: int = Field(
         default=15,
         description='Max candidates per flagged unit.',
+    )
+    claim_too_aggressive_max_links: int = Field(
+        default=5,
+        ge=1,
+        description=(
+            'Lint threshold for the ``claim_too_aggressive`` rule: when an '
+            'explicit-claim unit produces more contradicts/weakens links than '
+            'this in one pass, a maintenance finding is emitted.'
+        ),
     )
     superseded_threshold: float = Field(
         default=0.3,
@@ -1007,6 +1027,17 @@ class ContradictionConfig(BaseModel):
         default=None,
         description='LLM model for classification. None = use extraction model.',
     )
+
+    @model_validator(mode='after')
+    def _validate_explicit_claim_threshold(self) -> 'ContradictionConfig':
+        if self.similarity_threshold_explicit_claim > self.similarity_threshold:
+            raise ValueError(
+                'similarity_threshold_explicit_claim '
+                f'({self.similarity_threshold_explicit_claim}) must be <= '
+                f'similarity_threshold ({self.similarity_threshold}); explicit-claim '
+                'matching is meant to be a looser filter, not tighter.'
+            )
+        return self
 
 
 class ConsolidationConfig(BaseModel):

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1014,9 +1014,10 @@ class ContradictionConfig(BaseModel):
         default=5,
         ge=1,
         description=(
-            'Lint threshold for the ``claim_too_aggressive`` rule: when an '
-            'explicit-claim unit produces more contradicts/weakens links than '
-            'this in one pass, a maintenance finding is emitted.'
+            'Lint threshold for the ``claim_too_aggressive`` rule: when the '
+            'total ``contradicts``/``weakens`` links accumulated on an '
+            'explicit-claim unit exceed this threshold, a maintenance finding '
+            'is emitted.'
         ),
     )
     superseded_threshold: float = Field(

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -109,6 +109,10 @@ VALID_RISK_CLASSES: frozenset[str] = frozenset(c.value for c in RiskClass)
 # reference these names instead of re-typing the value tuple.
 IntentLiteral = Literal['permanent', 'durable', 'ephemeral']
 RiskLiteral = Literal['none', 'sensitive', 'private', 'safety']
+ClaimTypeLiteral = Literal['resolution', 'contradiction']
+
+
+VALID_CLAIM_TYPES: frozenset[str] = frozenset({'resolution', 'contradiction'})
 
 
 # Shared default-on-fail coercion. Both ``RawFact`` (LLM output) and
@@ -133,6 +137,20 @@ def coerce_risk_class(v: object) -> str:
     if isinstance(v, str) and v in {c.value for c in RiskClass}:
         return v
     return RiskClass.NONE.value
+
+
+def coerce_claim_type(v: object) -> str | None:
+    """Coerce ``v`` to a valid ``ClaimTypeLiteral`` string, or ``None``.
+
+    Unlike ``coerce_intent_class`` / ``coerce_risk_class``, the default for
+    invalid / absent input is ``None`` — most facts do not carry an explicit
+    resolution / contradiction claim, and silently downgrading garbage to
+    ``None`` is correct (the contradiction engine falls through to the
+    generic path).
+    """
+    if isinstance(v, str) and v in VALID_CLAIM_TYPES:
+        return v
+    return None
 
 
 class LineageDirection(str, Enum):

--- a/packages/core/src/memex_core/alembic/versions/037_memory_unit_claim_type.py
+++ b/packages/core/src/memex_core/alembic/versions/037_memory_unit_claim_type.py
@@ -1,0 +1,47 @@
+"""Add memory_units.claim_type column.
+
+Adds an additive nullable column carrying the explicit-claim signal
+('resolution' | 'contradiction' | NULL) extracted from text by the
+LLM. Pre-existing rows remain NULL — the "no explicit claim" branch
+in the contradiction engine treats NULL identically to legacy
+behaviour.
+
+No index: ``claim_type`` is read inside per-unit code paths
+(``ContradictionEngine._process_flagged_unit`` and the new
+``claim_too_aggressive`` lint), never used as a top-level query
+filter.
+
+Downgrade drops the CK constraint first, then the column.
+
+Revision ID: 037_memory_unit_claim_type
+Revises: 036_fsfm_cooldown_index
+Create Date: 2026-05-11
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '037_memory_unit_claim_type'
+down_revision: Union[str, None] = '036_fsfm_cooldown_index'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'memory_units',
+        sa.Column('claim_type', sa.Text(), nullable=True),
+    )
+    op.create_check_constraint(
+        'ck_memory_units_claim_type',
+        'memory_units',
+        "claim_type IS NULL OR claim_type IN ('resolution', 'contradiction')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('ck_memory_units_claim_type', 'memory_units', type_='check')
+    op.drop_column('memory_units', 'claim_type')

--- a/packages/core/src/memex_core/memory/contradiction/candidates.py
+++ b/packages/core/src/memex_core/memory/contradiction/candidates.py
@@ -19,6 +19,7 @@ async def get_candidates(
     vault_id: UUID,
     k: int = 15,
     threshold: float = 0.5,
+    target_entity_ids: list[UUID] | None = None,
 ) -> list[MemoryUnit]:
     """
     Retrieve candidate units that might contradict or be related to the given unit.
@@ -28,9 +29,18 @@ async def get_candidates(
     2. Semantic similarity — cosine > threshold via pgvector
     3. Merge + deduplicate
     4. Source-diverse selection — round-robin by source document, cap at k
+
+    When ``target_entity_ids`` is non-empty, both the entity-overlap and the
+    semantic paths AND-filter by membership in that list. This narrows the
+    candidate pool for explicit-claim units (where the LLM identified the
+    claim's target) so contradiction matching does not drift across topics.
     """
-    entity_candidates = await _get_entity_overlap_candidates(session, unit, vault_id)
-    semantic_candidates = await _get_semantic_candidates(session, unit, vault_id, threshold)
+    entity_candidates = await _get_entity_overlap_candidates(
+        session, unit, vault_id, target_entity_ids=target_entity_ids
+    )
+    semantic_candidates = await _get_semantic_candidates(
+        session, unit, vault_id, threshold, target_entity_ids=target_entity_ids
+    )
 
     all_candidates: dict[UUID, MemoryUnit] = {}
     for c in entity_candidates + semantic_candidates:
@@ -47,11 +57,21 @@ async def _get_entity_overlap_candidates(
     session: AsyncSession,
     unit: MemoryUnit,
     vault_id: UUID,
+    target_entity_ids: list[UUID] | None = None,
 ) -> list[MemoryUnit]:
-    """Find units that share entities with the given unit."""
+    """Find units that share entities with the given unit.
+
+    When ``target_entity_ids`` is non-empty, restrict the entity-overlap
+    join to that set instead of every entity the unit references.
+    """
     entity_stmt = select(UnitEntity.entity_id).where(UnitEntity.unit_id == unit.id)
     result = await session.exec(entity_stmt)
     entity_ids = list(result.all())
+
+    if target_entity_ids:
+        # Intersect: only narrow on entities the claim actually targets.
+        target_set = {eid for eid in target_entity_ids}
+        entity_ids = [eid for eid in entity_ids if eid in target_set]
 
     if not entity_ids:
         return []
@@ -84,6 +104,7 @@ async def _get_semantic_candidates(
     unit: MemoryUnit,
     vault_id: UUID,
     threshold: float,
+    target_entity_ids: list[UUID] | None = None,
 ) -> list[MemoryUnit]:
     """Find semantically similar units via pgvector cosine distance.
 
@@ -91,6 +112,9 @@ async def _get_semantic_candidates(
     before thresholding, so candidates are scored on a discriminative scale
     rather than the compressed [0.7, 0.95] band typical of high-dimensional
     embeddings.
+
+    When ``target_entity_ids`` is non-empty, AND-filter the SQL to units
+    that mention at least one of the listed entity IDs.
     """
     if unit.embedding is None or len(unit.embedding) == 0:
         return []
@@ -101,28 +125,49 @@ async def _get_semantic_candidates(
     # The pgvector index still bounds cost via ORDER BY + LIMIT.
     coarse_max_distance = max(0.05, 1.0 - threshold + 0.2)
 
-    # Fetch more rows than the final cap (30) so the anisotropy corrector
-    # can discriminate within a broader pool; pgvector index bounds cost.
-    stmt = text("""
-        SELECT id, 1 - (embedding <=> :embedding) AS sim
-        FROM memory_units
-        WHERE vault_id = :vault_id
-          AND id != :unit_id
-          AND status = 'active'
-          AND (embedding <=> :embedding) < :max_distance
-        ORDER BY (embedding <=> :embedding)
-        LIMIT 60
-    """)
-
-    result = await session.execute(
-        stmt,
-        {
+    if target_entity_ids:
+        sql = """
+            SELECT mu.id, 1 - (mu.embedding <=> :embedding) AS sim
+            FROM memory_units mu
+            WHERE mu.vault_id = :vault_id
+              AND mu.id != :unit_id
+              AND mu.status = 'active'
+              AND (mu.embedding <=> :embedding) < :max_distance
+              AND EXISTS (
+                  SELECT 1 FROM unit_entities ue
+                  WHERE ue.unit_id = mu.id
+                    AND ue.entity_id = ANY(:target_entity_ids)
+              )
+            ORDER BY (mu.embedding <=> :embedding)
+            LIMIT 60
+        """
+        params: dict = {
             'vault_id': str(vault_id),
             'unit_id': str(unit.id),
             'embedding': '[' + ','.join(str(float(x)) for x in unit.embedding) + ']',
             'max_distance': coarse_max_distance,
-        },
-    )
+            'target_entity_ids': [str(eid) for eid in target_entity_ids],
+        }
+    else:
+        sql = """
+            SELECT id, 1 - (embedding <=> :embedding) AS sim
+            FROM memory_units
+            WHERE vault_id = :vault_id
+              AND id != :unit_id
+              AND status = 'active'
+              AND (embedding <=> :embedding) < :max_distance
+            ORDER BY (embedding <=> :embedding)
+            LIMIT 60
+        """
+        params = {
+            'vault_id': str(vault_id),
+            'unit_id': str(unit.id),
+            'embedding': '[' + ','.join(str(float(x)) for x in unit.embedding) + ']',
+            'max_distance': coarse_max_distance,
+        }
+
+    stmt = text(sql)
+    result = await session.execute(stmt, params)
 
     corrector = get_shared_corrector()
     candidate_ids: list[UUID] = []

--- a/packages/core/src/memex_core/memory/contradiction/engine.py
+++ b/packages/core/src/memex_core/memory/contradiction/engine.py
@@ -167,6 +167,17 @@ class ContradictionEngine:
                 await session.exec(upsert_stmt)  # type: ignore[arg-type]
                 all_links = list(deduped.values())
 
+            explicit_claim_links = sum(
+                1 for lk in all_links if lk.link_metadata.get('claim_type') is not None
+            )
+            if span is not None:
+                try:
+                    span.set_attribute(
+                        'contradiction.explicit_claim_links', str(explicit_claim_links)
+                    )
+                except Exception:
+                    pass
+
             # Clamp per-unit deltas via SQL LEAST/GREATEST to prevent races on
             # overlapping units (mirrors application-level max(0, min(1, ...))).
             for unit_id, delta in confidence_deltas.items():
@@ -234,7 +245,12 @@ class ContradictionEngine:
         linguistic evidence on the claim itself substitutes for tight
         semantic matching.
         """
-        target_entity_ids = _extract_target_entity_ids(unit)
+        extracted_target_ids = _extract_target_entity_ids(unit)
+        target_entity_ids: list[UUID] | None
+        if extracted_target_ids:
+            target_entity_ids = extracted_target_ids
+        else:
+            target_entity_ids = None
         if unit.claim_type is not None:
             threshold = self.config.similarity_threshold_explicit_claim
         else:
@@ -246,7 +262,7 @@ class ContradictionEngine:
             unit.id,
             vault_id,
             unit.claim_type,
-            len(target_entity_ids),
+            len(target_entity_ids) if target_entity_ids else 0,
             threshold,
         )
 
@@ -256,7 +272,7 @@ class ContradictionEngine:
             vault_id,
             k=self.config.max_candidates_per_unit,
             threshold=threshold,
-            target_entity_ids=target_entity_ids or None,
+            target_entity_ids=target_entity_ids,
         )
 
         if not candidates:
@@ -349,16 +365,12 @@ class ContradictionEngine:
 
         Default contradiction-engine link weight is 1.0. For explicit-claim
         units, weight depends on the claim_type:
-          - claim_type='contradiction' + 'contradict' relation: 1.0
-            (direct negation — strongest signal).
           - claim_type='resolution' + 'weaken' relation: 0.7
             (resolution softens the prior but does not negate it).
           - All other combinations: 1.0 (default).
         """
         if claim_type == 'resolution' and relation == 'weaken':
             return 0.7
-        if claim_type == 'contradiction' and relation == 'contradict':
-            return 1.0
         return 1.0
 
     async def _classify(

--- a/packages/core/src/memex_core/memory/contradiction/engine.py
+++ b/packages/core/src/memex_core/memory/contradiction/engine.py
@@ -27,6 +27,30 @@ from memex_core.memory.sql_models import MemoryLink, MemoryUnit, Note
 logger = logging.getLogger('memex.core.memory.contradiction')
 
 
+def _extract_target_entity_ids(unit: MemoryUnit) -> list[UUID]:
+    """Pull ``target_entity_ids`` from ``unit.unit_metadata['claim_target']``.
+
+    Returns an empty list when the unit has no claim_target or stores
+    invalid UUID strings. Tolerant of malformed JSONB; downstream callers
+    treat an empty list as "no narrowing — use the generic candidate pool".
+    """
+    if not unit.unit_metadata:
+        return []
+    claim_target = unit.unit_metadata.get('claim_target')
+    if not isinstance(claim_target, dict):
+        return []
+    raw_ids = claim_target.get('target_entity_ids') or []
+    if not isinstance(raw_ids, list):
+        return []
+    result: list[UUID] = []
+    for rid in raw_ids:
+        try:
+            result.append(UUID(str(rid)))
+        except (ValueError, TypeError):
+            continue
+    return result
+
+
 class ContradictionEngine:
     """Detects and records contradictions between memory units."""
 
@@ -68,7 +92,7 @@ class ContradictionEngine:
                 'contradiction.vault_id': str(vault_id),
                 'contradiction.unit_count': str(len(unit_ids)),
             },
-        ):
+        ) as span:
             new_units = await self._load_units(session, unit_ids)
             if not new_units:
                 logger.info('No units found for IDs %s — already deleted?', unit_ids)
@@ -85,6 +109,14 @@ class ContradictionEngine:
                 len(flagged_units),
                 len(new_units),
             )
+            explicit_claim_count = sum(1 for u in flagged_units if u.claim_type is not None)
+            if span is not None:
+                try:
+                    span.set_attribute(
+                        'contradiction.explicit_claim_count', str(explicit_claim_count)
+                    )
+                except Exception:
+                    pass
 
             all_links: list[MemoryLink] = []
             # Accumulate signed alpha-step deltas per target; apply via
@@ -195,20 +227,44 @@ class ContradictionEngine:
 
         Returns (links, confidence_deltas, evidence_bumps). Deltas are signed
         alpha-steps so the caller can sum per-unit without overwrite races.
+
+        When the unit carries an explicit ``claim_type`` (resolution or
+        contradiction), the candidate retrieval is narrowed by the claim's
+        target entity IDs and uses a looser similarity threshold — the
+        linguistic evidence on the claim itself substitutes for tight
+        semantic matching.
         """
+        target_entity_ids = _extract_target_entity_ids(unit)
+        if unit.claim_type is not None:
+            threshold = self.config.similarity_threshold_explicit_claim
+        else:
+            threshold = self.config.similarity_threshold
+
+        logger.info(
+            'process_flagged_unit unit_id=%s vault_id=%s claim_type=%s '
+            'target_entity_count=%d threshold=%.2f',
+            unit.id,
+            vault_id,
+            unit.claim_type,
+            len(target_entity_ids),
+            threshold,
+        )
+
         candidates = await get_candidates(
             session,
             unit,
             vault_id,
             k=self.config.max_candidates_per_unit,
-            threshold=self.config.similarity_threshold,
+            threshold=threshold,
+            target_entity_ids=target_entity_ids or None,
         )
 
         if not candidates:
             logger.info(
-                'Unit %s: no candidates found (threshold=%.2f)',
+                'Unit %s: no candidates found (threshold=%.2f, claim_type=%s)',
                 unit.id,
-                self.config.similarity_threshold,
+                threshold,
+                unit.claim_type,
             )
             return [], {}, {}
 
@@ -260,27 +316,50 @@ class ContradictionEngine:
             else:
                 continue
 
+            link_weight = self._weight_for_relation(relation, unit.claim_type)
+            link_metadata: dict[str, Any] = {
+                'authoritative_unit_id': str(authoritative.id),
+                'superseded_unit_id': str(superseded.id),
+                'reasoning': reasoning,
+                'temporal_basis': (
+                    'llm_override'
+                    if authoritative_hint != self._temporal_default(unit, existing_unit)
+                    else 'timestamp'
+                ),
+                'superseding_note_title': note_title,
+            }
+            if unit.claim_type is not None:
+                link_metadata['claim_type'] = unit.claim_type
+
             link = MemoryLink(
                 from_unit_id=authoritative.id,
                 to_unit_id=superseded.id,
                 link_type=link_type,
                 vault_id=vault_id,
-                weight=1.0,
-                link_metadata={
-                    'authoritative_unit_id': str(authoritative.id),
-                    'superseded_unit_id': str(superseded.id),
-                    'reasoning': reasoning,
-                    'temporal_basis': (
-                        'llm_override'
-                        if authoritative_hint != self._temporal_default(unit, existing_unit)
-                        else 'timestamp'
-                    ),
-                    'superseding_note_title': note_title,
-                },
+                weight=link_weight,
+                link_metadata=link_metadata,
             )
             links.append(link)
 
         return links, confidence_deltas, evidence_bumps
+
+    @staticmethod
+    def _weight_for_relation(relation: str, claim_type: str | None) -> float:
+        """Weight policy for newly-created MemoryLinks.
+
+        Default contradiction-engine link weight is 1.0. For explicit-claim
+        units, weight depends on the claim_type:
+          - claim_type='contradiction' + 'contradict' relation: 1.0
+            (direct negation — strongest signal).
+          - claim_type='resolution' + 'weaken' relation: 0.7
+            (resolution softens the prior but does not negate it).
+          - All other combinations: 1.0 (default).
+        """
+        if claim_type == 'resolution' and relation == 'weaken':
+            return 0.7
+        if claim_type == 'contradiction' and relation == 'contradict':
+            return 1.0
+        return 1.0
 
     async def _classify(
         self, unit: MemoryUnit, candidates: list[MemoryUnit]

--- a/packages/core/src/memex_core/memory/extraction/core.py
+++ b/packages/core/src/memex_core/memory/extraction/core.py
@@ -76,6 +76,22 @@ class ExtractSemanticFacts(dspy.Signature):
     surrounding text.
 
     risk_class: none (default), sensitive (flagged), private (excluded from retrieval), safety (blocked).
+
+    claim_type — explicit corrective-claim signal. DEFAULT is null/absent.
+    Only set when the fact EXPLICITLY negates / supersedes / resolves a
+    PRIOR claim that exists elsewhere in memory. Do NOT set on general
+    statements, first-time observations, or descriptive facts.
+      - 'resolution': the fact resolves or decides a prior open question
+        or issue. Signals: "the X problem is solved", "we figured out
+        that X", "X is no longer an issue".
+      - 'contradiction': the fact directly disagrees with a prior claim.
+        Signals: "X is NOT true", "we no longer use X", "we changed our
+        mind about X".
+    When claim_type is set, also populate claim_target.target_topic with
+    a short noun-phrase paraphrase of what is being resolved/contradicted
+    (e.g. "the note-search bug", "the Postgres decision"). Leave
+    claim_target.target_entity_ids empty — entity IDs are populated
+    downstream by the extraction engine.
     """
 
     chunk_text: str = dspy.InputField(

--- a/packages/core/src/memex_core/memory/extraction/engine.py
+++ b/packages/core/src/memex_core/memory/extraction/engine.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import re
 from datetime import datetime, timezone
+from typing import Any
 from uuid import UUID
 
 import dspy
@@ -602,6 +603,8 @@ class ExtractionEngine:
                         vault_id=vault_id,
                         intent_class=raw_fact.intent_class,
                         risk_class=raw_fact.risk_class,
+                        claim_type=raw_fact.claim_type,
+                        claim_target=raw_fact.claim_target,
                     )
                     all_extracted_facts.append(ef)
 
@@ -639,6 +642,8 @@ class ExtractionEngine:
                             vault_id=vault_id,
                             intent_class=f.intent_class,
                             risk_class=f.risk_class,
+                            claim_type=f.claim_type,
+                            claim_target=f.claim_target,
                         )
                         all_extracted_facts.append(ef)
                 if user_notes_text:
@@ -675,6 +680,8 @@ class ExtractionEngine:
                             vault_id=vault_id,
                             intent_class=f.intent_class,
                             risk_class=f.risk_class,
+                            claim_type=f.claim_type,
+                            claim_target=f.claim_target,
                         )
                         all_extracted_facts.append(ef)
 
@@ -1004,6 +1011,8 @@ class ExtractionEngine:
                             vault_id=vault_id,
                             intent_class=f.intent_class,
                             risk_class=f.risk_class,
+                            claim_type=f.claim_type,
+                            claim_target=f.claim_target,
                         )
                         extracted_facts.append(ef)
                         global_fact_idx += 1
@@ -1245,6 +1254,8 @@ class ExtractionEngine:
                     vault_id=vault_id,
                     intent_class=f.intent_class,
                     risk_class=f.risk_class,
+                    claim_type=f.claim_type,
+                    claim_target=f.claim_target,
                 )
                 extracted_facts.append(ef)
                 global_fact_idx += 1
@@ -1282,6 +1293,8 @@ class ExtractionEngine:
                         vault_id=vault_id,
                         intent_class=f.intent_class,
                         risk_class=f.risk_class,
+                        claim_type=f.claim_type,
+                        claim_target=f.claim_target,
                     )
                     extracted_facts.append(ef)
                     global_fact_idx += 1
@@ -1317,6 +1330,8 @@ class ExtractionEngine:
                         vault_id=vault_id,
                         intent_class=f.intent_class,
                         risk_class=f.risk_class,
+                        claim_type=f.claim_type,
+                        claim_target=f.claim_target,
                     )
                     extracted_facts.append(ef)
                     global_fact_idx += 1
@@ -1543,6 +1558,8 @@ class ExtractionEngine:
                         vault_id=content.vault_id,
                         intent_class=f.intent_class,
                         risk_class=f.risk_class,
+                        claim_type=f.claim_type,
+                        claim_target=f.claim_target,
                     )
                     extracted_facts.append(ef)
                     global_fact_idx += 1
@@ -1583,6 +1600,8 @@ class ExtractionEngine:
                         vault_id=contents[0].vault_id,
                         intent_class=f.intent_class,
                         risk_class=f.risk_class,
+                        claim_type=f.claim_type,
+                        claim_target=f.claim_target,
                     )
                     extracted_facts.append(ef)
             if user_notes_text:
@@ -1617,6 +1636,8 @@ class ExtractionEngine:
                         vault_id=contents[0].vault_id,
                         intent_class=f.intent_class,
                         risk_class=f.risk_class,
+                        claim_type=f.claim_type,
+                        claim_target=f.claim_target,
                     )
                     extracted_facts.append(ef)
                 global_fact_idx += 1
@@ -1728,7 +1749,65 @@ class ExtractionEngine:
                 return set()
             raise
 
+        await self._backfill_claim_target_entity_ids(session, unit_ids, facts, unit_entity_pairs)
+
         return {UUID(rid) for rid in resolved_ids}
+
+    async def _backfill_claim_target_entity_ids(
+        self,
+        session: AsyncSession,
+        unit_ids: list[str],
+        facts: list[ProcessedFact],
+        unit_entity_pairs: list[tuple[Any, str]],
+    ) -> None:
+        """Populate ``claim_target.target_entity_ids`` for explicit-claim units.
+
+        First-pass strategy: use the union of all entities resolved on the
+        unit. Coarse but correct — the contradiction-engine filter narrows
+        candidates that share ANY of these entity IDs. Refine later if eval
+        shows precision loss.
+        """
+        from sqlalchemy import bindparam
+        from sqlalchemy.dialects.postgresql import JSONB
+        from sqlalchemy import text as sa_text
+
+        per_unit_entities: dict[str, list[str]] = {}
+        for unit_id_str, entity_id_str in unit_entity_pairs:
+            per_unit_entities.setdefault(str(unit_id_str), []).append(str(entity_id_str))
+
+        updates: list[dict[str, Any]] = []
+        for i, fact in enumerate(facts):
+            if fact.claim_type is None or fact.claim_target is None:
+                continue
+            uid = unit_ids[i]
+            eids = per_unit_entities.get(str(uid), [])
+            updates.append(
+                {
+                    'unit_id': uid,
+                    'target_entity_ids': eids,
+                }
+            )
+
+        if not updates:
+            return
+
+        # Merge ``target_entity_ids`` into ``metadata->claim_target`` JSONB.
+        # ``claim_type``-bearing rows already carry a ``claim_target`` dict
+        # written by storage.insert_facts_batch; jsonb_set respects existing
+        # keys (target_topic).
+        stmt = sa_text(
+            'UPDATE memory_units '
+            'SET metadata = jsonb_set('
+            "    coalesce(metadata, '{}'::jsonb),"
+            "    '{claim_target,target_entity_ids}',"
+            '    :target_entity_ids,'
+            '    true'
+            ') '
+            'WHERE id = :unit_id'
+        ).bindparams(bindparam('target_entity_ids', type_=JSONB))
+
+        for upd in updates:
+            await session.execute(stmt, upd)
 
     async def prepare_user_notes(
         self,
@@ -1779,6 +1858,8 @@ class ExtractionEngine:
                 vault_id=vault_id,
                 intent_class=f.intent_class,
                 risk_class=f.risk_class,
+                claim_type=f.claim_type,
+                claim_target=f.claim_target,
             )
             for f in un_facts
         ]

--- a/packages/core/src/memex_core/memory/extraction/models.py
+++ b/packages/core/src/memex_core/memory/extraction/models.py
@@ -15,10 +15,12 @@ from pydantic import BaseModel, field_serializer, field_validator, model_validat
 from memex_core.types import CausalRelationshipTypes, FactTypes, FactKindTypes
 from memex_core.config import GLOBAL_VAULT_ID
 from memex_common.schemas import (
+    ClaimTypeLiteral,
     IntentClass,
     IntentLiteral,
     RiskClass,
     RiskLiteral,
+    coerce_claim_type as _shared_coerce_claim_type,
     coerce_intent_class as _shared_coerce_intent_class,
     coerce_risk_class as _shared_coerce_risk_class,
 )
@@ -392,6 +394,31 @@ class BaseFact(SQLModel):
         return fact_type.value
 
 
+class ClaimTarget(BaseModel):
+    """Target of an explicit resolution / contradiction claim.
+
+    ``target_topic`` is a short noun-phrase paraphrase of what the new fact
+    is resolving or contradicting (LLM-produced). ``target_entity_ids`` is
+    populated downstream after entity resolution — the LLM leaves it empty.
+    """
+
+    target_topic: str | None = Field(
+        default=None,
+        description=(
+            'Short noun-phrase paraphrase of what the claim resolves or '
+            "contradicts (e.g. 'the note-search bug'). LLM-produced."
+        ),
+    )
+    target_entity_ids: list[UUID] = Field(
+        default_factory=list,
+        description=(
+            'UUIDs of entities the claim targets. Populated by the '
+            'extraction engine after entity resolution; the LLM leaves '
+            'this empty.'
+        ),
+    )
+
+
 class RawFact(BaseFact):
     """A single fact extracted from text by an LLM."""
 
@@ -477,6 +504,26 @@ class RawFact(BaseFact):
         "'private' = excluded from default retrieval (PII, medical). "
         "'safety' = recorded but passed through (deferred blocking).",
     )
+    claim_type: ClaimTypeLiteral | None = Field(
+        default=None,
+        description=(
+            'Explicit corrective-claim signal. Only set when the fact '
+            'explicitly negates / supersedes / resolves a PRIOR claim. '
+            'Do NOT set on general statements or first-time observations. '
+            "'resolution' = the fact resolves or decides a prior question "
+            "or open issue. 'contradiction' = the fact directly disagrees "
+            'with a prior claim. Default null = no explicit claim signal.'
+        ),
+    )
+    claim_target: ClaimTarget | None = Field(
+        default=None,
+        description=(
+            'Topic + entity targets for the claim. REQUIRED when claim_type '
+            "is set; the LLM populates 'target_topic' as a short noun-phrase "
+            "paraphrase ('the note-search bug') and leaves 'target_entity_ids' "
+            'empty — the extraction engine fills entity IDs downstream.'
+        ),
+    )
     occurred_start: str | None = Field(
         default=None,
         description='ISO 8601 date (YYYY-MM-DD). Only for fact_kind="dated". Leave null for conversations.',
@@ -509,6 +556,29 @@ class RawFact(BaseFact):
     @classmethod
     def coerce_risk_class(cls, v: object) -> str:
         return _shared_coerce_risk_class(v)
+
+    @field_validator('claim_type', mode='before')
+    @classmethod
+    def coerce_claim_type(cls, v: object) -> str | None:
+        return _shared_coerce_claim_type(v)
+
+    @model_validator(mode='after')
+    def _enforce_claim_target_with_claim_type(self) -> 'RawFact':
+        """Drop ``claim_target`` when ``claim_type`` is None; default a target
+        when ``claim_type`` is set but ``claim_target`` was omitted.
+
+        The extraction LLM occasionally produces a ``claim_type`` without a
+        matching ``claim_target`` or vice-versa. Be permissive (extraction
+        must never fail on a classification mishap) but coherent: an
+        explicit claim always carries a (possibly empty-topic) target so
+        the downstream contradiction branch has somewhere to attach entity
+        IDs.
+        """
+        if self.claim_type is None:
+            object.__setattr__(self, 'claim_target', None)
+        elif self.claim_target is None:
+            object.__setattr__(self, 'claim_target', ClaimTarget())
+        return self
 
     @field_validator('occurred_start', 'occurred_end')
     @classmethod
@@ -612,6 +682,20 @@ class ExtractedFact(BaseFact):
         description='Write-time risk class produced by the extraction LLM '
         '(none | sensitive | private | safety). Coerced to default on invalid input.',
     )
+    claim_type: ClaimTypeLiteral | None = Field(
+        default=None,
+        description=(
+            'Explicit corrective-claim signal carried through from RawFact. '
+            'None when the fact is not an explicit resolution/contradiction.'
+        ),
+    )
+    claim_target: ClaimTarget | None = Field(
+        default=None,
+        description=(
+            'Topic + entity targets for the claim. Required when claim_type '
+            'is set; coerced to None when claim_type is None.'
+        ),
+    )
 
     # Mirror RawFact's default-on-fail coercion so direct construction with
     # an invalid string degrades gracefully.
@@ -628,6 +712,19 @@ class ExtractedFact(BaseFact):
     @classmethod
     def coerce_risk_class(cls, v: object) -> str:
         return _shared_coerce_risk_class(v)
+
+    @field_validator('claim_type', mode='before')
+    @classmethod
+    def coerce_claim_type(cls, v: object) -> str | None:
+        return _shared_coerce_claim_type(v)
+
+    @model_validator(mode='after')
+    def _enforce_claim_target_with_claim_type(self) -> 'ExtractedFact':
+        if self.claim_type is None:
+            object.__setattr__(self, 'claim_target', None)
+        elif self.claim_target is None:
+            object.__setattr__(self, 'claim_target', ClaimTarget())
+        return self
 
 
 class ProcessedFact(SQLModel):
@@ -691,6 +788,17 @@ class ProcessedFact(SQLModel):
         default=RiskClass.NONE,
         description='Write-time risk class (none | sensitive | private | safety).',
     )
+    claim_type: ClaimTypeLiteral | None = Field(
+        default=None,
+        description=(
+            'Explicit corrective-claim signal. None when the fact is not an '
+            'explicit resolution/contradiction.'
+        ),
+    )
+    claim_target: ClaimTarget | None = Field(
+        default=None,
+        description='Topic + entity targets for the claim; None when claim_type is None.',
+    )
 
     @field_validator('occurred_start', 'occurred_end', 'mentioned_at')
     @classmethod
@@ -740,4 +848,6 @@ class ProcessedFact(SQLModel):
             vault_id=extracted_fact.vault_id,  # Explicitly pass vault_id
             intent_class=IntentClass(extracted_fact.intent_class),
             risk_class=RiskClass(extracted_fact.risk_class),
+            claim_type=extracted_fact.claim_type,
+            claim_target=extracted_fact.claim_target,
         )

--- a/packages/core/src/memex_core/memory/extraction/models.py
+++ b/packages/core/src/memex_core/memory/extraction/models.py
@@ -575,9 +575,9 @@ class RawFact(BaseFact):
         IDs.
         """
         if self.claim_type is None:
-            object.__setattr__(self, 'claim_target', None)
+            self.claim_target = None
         elif self.claim_target is None:
-            object.__setattr__(self, 'claim_target', ClaimTarget())
+            self.claim_target = ClaimTarget()
         return self
 
     @field_validator('occurred_start', 'occurred_end')
@@ -721,9 +721,9 @@ class ExtractedFact(BaseFact):
     @model_validator(mode='after')
     def _enforce_claim_target_with_claim_type(self) -> 'ExtractedFact':
         if self.claim_type is None:
-            object.__setattr__(self, 'claim_target', None)
+            self.claim_target = None
         elif self.claim_target is None:
-            object.__setattr__(self, 'claim_target', ClaimTarget())
+            self.claim_target = ClaimTarget()
         return self
 
 

--- a/packages/core/src/memex_core/memory/extraction/storage.py
+++ b/packages/core/src/memex_core/memory/extraction/storage.py
@@ -7,6 +7,7 @@ Handles insertion of facts into the database using SQLModel.
 import hashlib
 import logging
 from datetime import datetime, timedelta
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import case, type_coerce, update
@@ -53,13 +54,18 @@ async def insert_facts_batch(
 
         # Merge specific fields into metadata if not present on model
         # (Assuming 'tags' and 'chunk_id' go into unit_metadata based on previous schema)
-        metadata_merged: dict[str, str | list[str]] = (
+        metadata_merged: dict[str, Any] = (
             {k: v for k, v in fact.payload.items()} if fact.payload is not None else {}
         )
         if fact.tags:
             metadata_merged['tags'] = fact.tags
         if fact.chunk_id:
             metadata_merged['chunk_id'] = fact.chunk_id
+        if fact.claim_target is not None:
+            metadata_merged['claim_target'] = {
+                'target_topic': fact.claim_target.target_topic,
+                'target_entity_ids': [str(eid) for eid in fact.claim_target.target_entity_ids],
+            }
 
         row = {
             'text': fact.fact_text,
@@ -77,6 +83,7 @@ async def insert_facts_batch(
             'status': ContentStatus.ACTIVE,
             'intent_class': fact.intent_class,
             'risk_class': fact.risk_class,
+            'claim_type': fact.claim_type,
         }
         if fact.chunk_id:
             logger.debug(f'Linking fact to chunk_id: {fact.chunk_id}')
@@ -87,7 +94,21 @@ async def insert_facts_batch(
 
     results = await session.exec(stmt)
 
-    return [str(row[0]) for row in results.all()]
+    unit_id_strings = [str(row[0]) for row in results.all()]
+
+    try:
+        from memex_core.metrics import CLAIM_TYPED_UNITS_TOTAL
+
+        for fact in facts:
+            if fact.claim_type is not None:
+                CLAIM_TYPED_UNITS_TOTAL.labels(
+                    claim_type=fact.claim_type,
+                    vault_id=str(fact.vault_id if fact.vault_id else GLOBAL_VAULT_ID),
+                ).inc()
+    except Exception:
+        logger.debug('Skipping CLAIM_TYPED_UNITS_TOTAL increment', exc_info=True)
+
+    return unit_id_strings
 
 
 async def handle_document_tracking(

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -611,6 +611,15 @@ class MemoryUnit(SQLModel, MemoryUnitBase, table=True):  # type: ignore
         description='Content sensitivity set at write time: none | sensitive | private | safety.',
     )
 
+    claim_type: str | None = Field(
+        default=None,
+        sa_column=Column(Text, nullable=True),
+        description=(
+            'Explicit corrective-claim signal: resolution | contradiction | NULL. '
+            'NULL means the unit was not extracted as an explicit claim.'
+        ),
+    )
+
     confidence: float = Field(
         default=1.0,
         sa_column=Column(Float, nullable=False, server_default='1.0'),
@@ -726,6 +735,10 @@ class MemoryUnit(SQLModel, MemoryUnitBase, table=True):  # type: ignore
         CheckConstraint(
             "risk_class IN ('none', 'sensitive', 'private', 'safety')",
             name='ck_memory_units_risk_class',
+        ),
+        CheckConstraint(
+            "claim_type IS NULL OR claim_type IN ('resolution', 'contradiction')",
+            name='ck_memory_units_claim_type',
         ),
         CheckConstraint(
             'confidence >= 0.0 AND confidence <= 1.0',

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -80,6 +80,16 @@ MEMEX_AUDIT_LOG_TOTAL = Counter(
 )
 
 # ---------------------------------------------------------------------------
+# Claim-type extraction metrics
+# ---------------------------------------------------------------------------
+
+CLAIM_TYPED_UNITS_TOTAL = Counter(
+    'memex_claim_typed_units_total',
+    'Memory units extracted with an explicit claim_type signal.',
+    ['claim_type', 'vault_id'],
+)
+
+# ---------------------------------------------------------------------------
 # Extraction-pipeline in-flight gauges (wedge diagnostics)
 # ---------------------------------------------------------------------------
 

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -269,6 +269,26 @@ _DANGLING_ENTITY_REF_IN_UNIT_SQL = """
 """
 
 
+# Safety: vault_id and ``claim_too_aggressive_max_links`` are bound via
+# named placeholders; no user-controlled string interpolation. See S608
+# invariant block above ``_COLD_LOW_MW_UNIT_SQL``.
+_CLAIM_TOO_AGGRESSIVE_SQL = """
+    SELECT
+        mu.id::text AS target_id,
+        jsonb_build_object(
+            'claim_type', mu.claim_type,
+            'link_count', COUNT(ml.to_unit_id)
+        ) AS evidence
+    FROM memory_units mu
+    JOIN memory_links ml ON ml.from_unit_id = mu.id
+    WHERE mu.vault_id = :vault_id
+      AND mu.claim_type IS NOT NULL
+      AND ml.link_type IN ('contradicts', 'weakens')
+    GROUP BY mu.id, mu.claim_type
+    HAVING COUNT(*) > CAST(:claim_too_aggressive_max_links AS integer)
+"""
+
+
 # ---------------------------------------------------------------------------
 # FSFM-inspired graph-aware deprioritization scoring rules.
 #
@@ -549,6 +569,19 @@ V1_RULES: tuple[RuleSpec, ...] = (
             'contradicted_low_credibility_max',
         ),
     ),
+    RuleSpec(
+        name='claim_too_aggressive',
+        lint_type=LintType.QUALITY,
+        target_type='memory_unit',
+        suggested_action=(
+            'Explicit-claim unit produced more contradiction/weaken links '
+            'in one pass than the configured ceiling. Review for over-matching '
+            '(too-broad target_topic or stale-prior bleed) and consider tightening '
+            'the explicit-claim similarity threshold.'
+        ),
+        select_sql=_CLAIM_TOO_AGGRESSIVE_SQL,
+        param_keys=('claim_too_aggressive_max_links',),
+    ),
 )
 
 
@@ -793,6 +826,7 @@ class LintService(BaseService):
         :class:`KeyError` instead of silently falling back.
         """
         cfg = self.config.server.memory.deprioritize_score
+        contradiction_cfg = self.config.server.contradiction
         known: dict[str, Any] = {
             'lambda_link': cfg.lambda_link,
             'mu_entity': cfg.mu_entity,
@@ -805,6 +839,7 @@ class LintService(BaseService):
             'high_mw_min_outcomes': cfg.thresholds.high_mw_min_outcomes,
             'disagreement_range': cfg.thresholds.disagreement_range,
             'contradicted_low_credibility_max': cfg.thresholds.contradicted_low_credibility_max,
+            'claim_too_aggressive_max_links': contradiction_cfg.claim_too_aggressive_max_links,
         }
         try:
             return {k: known[k] for k in keys}

--- a/packages/core/tests/integration/memory/test_int_contradiction_explicit_claim.py
+++ b/packages/core/tests/integration/memory/test_int_contradiction_explicit_claim.py
@@ -85,6 +85,7 @@ def _make_entity(name: str) -> Entity:
 
 
 @pytest.mark.integration
+@pytest.mark.llm_mock
 @pytest.mark.asyncio
 async def test_get_candidates_filters_by_target_entity_ids(session: AsyncSession) -> None:
     """The entity-overlap path narrows to only listed target entity IDs."""
@@ -138,6 +139,7 @@ async def test_get_candidates_filters_by_target_entity_ids(session: AsyncSession
 
 
 @pytest.mark.integration
+@pytest.mark.llm_mock
 @pytest.mark.asyncio
 async def test_explicit_claim_link_carries_claim_type_metadata(
     session: AsyncSession, contradiction_config: ContradictionConfig

--- a/packages/core/tests/integration/memory/test_int_contradiction_explicit_claim.py
+++ b/packages/core/tests/integration/memory/test_int_contradiction_explicit_claim.py
@@ -1,0 +1,217 @@
+"""Integration tests for explicit-claim contradiction matching.
+
+Verifies that ``MemoryUnit.claim_type`` flows end-to-end through the
+contradiction engine: candidate retrieval narrows by ``target_entity_ids``,
+the lower ``similarity_threshold_explicit_claim`` widens the candidate net,
+and the resulting ``MemoryLink`` carries the explicit-claim metadata + weight.
+
+Marked ``integration`` + ``llm_mock`` — real Postgres, mocked DSPy LM.
+"""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_core.memory.contradiction.engine import ContradictionEngine
+from memex_core.memory.contradiction.candidates import get_candidates
+from memex_core.memory.sql_models import (
+    MemoryUnit,
+    MemoryLink,
+    UnitEntity,
+    Entity,
+    Note,
+)
+from memex_common.config import ContradictionConfig, GLOBAL_VAULT_ID
+from memex_common.types import FactTypes
+
+
+@pytest.fixture
+def contradiction_config() -> ContradictionConfig:
+    return ContradictionConfig(
+        enabled=True,
+        alpha=0.1,
+        similarity_threshold=0.5,
+        similarity_threshold_explicit_claim=0.35,
+        claim_too_aggressive_max_links=5,
+        max_candidates_per_unit=15,
+        superseded_threshold=0.3,
+    )
+
+
+def _make_note(vault_id) -> Note:
+    return Note(
+        id=uuid4(),
+        vault_id=vault_id,
+        title='Test Note',
+        content_hash=str(uuid4()),
+        original_text=f'Test content {uuid4()}',
+    )
+
+
+def _make_unit(
+    note_id,
+    vault_id,
+    text: str,
+    *,
+    claim_type: str | None = None,
+    unit_metadata: dict | None = None,
+    embedding: list[float] | None = None,
+) -> MemoryUnit:
+    return MemoryUnit(
+        note_id=note_id,
+        vault_id=vault_id,
+        text=text,
+        fact_type=FactTypes.WORLD,
+        confidence=1.0,
+        event_date=datetime.now(timezone.utc),
+        embedding=embedding or [0.1] * 384,
+        claim_type=claim_type,
+        unit_metadata=unit_metadata or {},
+    )
+
+
+def _make_entity(name: str) -> Entity:
+    return Entity(
+        id=uuid4(),
+        canonical_name=name,
+        entity_type='Concept',
+        first_seen=datetime.now(timezone.utc),
+        last_seen=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_candidates_filters_by_target_entity_ids(session: AsyncSession) -> None:
+    """The entity-overlap path narrows to only listed target entity IDs."""
+    vault_id = GLOBAL_VAULT_ID
+
+    note = _make_note(vault_id)
+    session.add(note)
+    await session.flush()
+
+    # Three units: A (the claim), B (shares target entity), C (shares a
+    # different entity). Expect only B to come back when target=[target_entity].
+    unit_a = _make_unit(note.id, vault_id, f'claim unit {uuid4()}')
+    unit_b = _make_unit(note.id, vault_id, f'prior on-topic {uuid4()}')
+    unit_c = _make_unit(note.id, vault_id, f'prior off-topic {uuid4()}')
+    session.add_all([unit_a, unit_b, unit_c])
+    await session.flush()
+
+    target_entity = _make_entity(f'target-{uuid4()}')
+    other_entity = _make_entity(f'other-{uuid4()}')
+    session.add_all([target_entity, other_entity])
+    await session.flush()
+
+    session.add_all(
+        [
+            UnitEntity(unit_id=unit_a.id, entity_id=target_entity.id, vault_id=vault_id),
+            UnitEntity(unit_id=unit_a.id, entity_id=other_entity.id, vault_id=vault_id),
+            UnitEntity(unit_id=unit_b.id, entity_id=target_entity.id, vault_id=vault_id),
+            UnitEntity(unit_id=unit_c.id, entity_id=other_entity.id, vault_id=vault_id),
+        ]
+    )
+    await session.commit()
+
+    # No filter: B and C should both surface (entity overlap with A).
+    unrestricted = await get_candidates(session, unit_a, vault_id, k=15, threshold=0.5)
+    unrestricted_ids = {c.id for c in unrestricted}
+    assert unit_b.id in unrestricted_ids
+    assert unit_c.id in unrestricted_ids
+
+    # With target filter: only B should surface.
+    restricted = await get_candidates(
+        session,
+        unit_a,
+        vault_id,
+        k=15,
+        threshold=0.5,
+        target_entity_ids=[target_entity.id],
+    )
+    restricted_ids = {c.id for c in restricted}
+    assert unit_b.id in restricted_ids
+    assert unit_c.id not in restricted_ids
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_explicit_claim_link_carries_claim_type_metadata(
+    session: AsyncSession, contradiction_config: ContradictionConfig
+) -> None:
+    """End-to-end: a unit with ``claim_type='contradiction'`` flagged by triage
+    yields a MemoryLink whose ``link_metadata`` carries ``claim_type`` and whose
+    ``weight`` matches the policy in ``_weight_for_relation``.
+    """
+    vault_id = GLOBAL_VAULT_ID
+
+    note = _make_note(vault_id)
+    session.add(note)
+    await session.flush()
+
+    target_entity = _make_entity(f'tgt-{uuid4()}')
+    session.add(target_entity)
+    await session.flush()
+
+    shared_emb = [0.5] * 384
+    prior = _make_unit(note.id, vault_id, f'we use Postgres {uuid4()}', embedding=shared_emb)
+    claim = _make_unit(
+        note.id,
+        vault_id,
+        f'we no longer use Postgres {uuid4()}',
+        claim_type='contradiction',
+        unit_metadata={
+            'claim_target': {
+                'target_topic': 'Postgres decision',
+                'target_entity_ids': [str(target_entity.id)],
+            }
+        },
+        embedding=shared_emb,
+    )
+    session.add_all([prior, claim])
+    await session.flush()
+
+    session.add_all(
+        [
+            UnitEntity(unit_id=prior.id, entity_id=target_entity.id, vault_id=vault_id),
+            UnitEntity(unit_id=claim.id, entity_id=target_entity.id, vault_id=vault_id),
+        ]
+    )
+    await session.commit()
+
+    mock_lm = MagicMock()
+    engine = ContradictionEngine(lm=mock_lm, config=contradiction_config)
+
+    triage_result = MagicMock()
+    triage_result.flagged_ids = [str(claim.id)]
+
+    classify_result = MagicMock()
+    rel = MagicMock()
+    rel.relation = 'contradict'
+    rel.authoritative = 'new'
+    rel.reasoning = 'mock'
+    rel.existing_id = str(prior.id)
+    classify_result.relationships = [rel]
+
+    async def fake_run(**kwargs):
+        if kwargs['operation_name'] == 'contradiction.triage':
+            return triage_result
+        return classify_result
+
+    with patch('memex_core.memory.contradiction.engine.run_dspy_operation', new=fake_run):
+        await engine._detect(session, [claim.id], vault_id)
+    await session.commit()
+
+    links_stmt = select(MemoryLink).where(
+        MemoryLink.from_unit_id == claim.id, MemoryLink.to_unit_id == prior.id
+    )
+    result = await session.exec(links_stmt)
+    links = list(result.all())
+    assert len(links) == 1
+    link = links[0]
+    assert link.link_type == 'contradicts'
+    assert link.weight == 1.0
+    assert link.link_metadata.get('claim_type') == 'contradiction'

--- a/packages/core/tests/unit/memory/contradiction/test_candidates.py
+++ b/packages/core/tests/unit/memory/contradiction/test_candidates.py
@@ -1,10 +1,12 @@
 """Unit tests for contradiction candidate retrieval."""
 
+import inspect
 from datetime import datetime, timezone
 from uuid import uuid4, UUID
 
 from memex_core.memory.contradiction.candidates import (
     _source_diverse_select,
+    get_candidates,
 )
 from memex_core.memory.sql_models import MemoryUnit, ContentStatus
 
@@ -90,3 +92,17 @@ class TestSourceDiverseSelect:
         result = _source_diverse_select(candidates, k=6)
         note_ids = {u.note_id for u in result}
         assert len(note_ids) == 3
+
+
+class TestGetCandidatesSignature:
+    """``get_candidates`` accepts an optional ``target_entity_ids`` parameter.
+
+    Pure signature + parameter-routing tests; the SQL-side filtering is
+    exercised in the contradiction integration suite where Postgres is
+    available.
+    """
+
+    def test_accepts_target_entity_ids(self) -> None:
+        sig = inspect.signature(get_candidates)
+        assert 'target_entity_ids' in sig.parameters
+        assert sig.parameters['target_entity_ids'].default is None

--- a/packages/core/tests/unit/memory/contradiction/test_engine.py
+++ b/packages/core/tests/unit/memory/contradiction/test_engine.py
@@ -541,3 +541,72 @@ class TestTemporalDefault:
         a = _make_unit(event_date=now)
         b = _make_unit(event_date=now)
         assert ContradictionEngine._temporal_default(a, b) == 'new'
+
+
+class TestWeightForRelation:
+    """``_weight_for_relation`` encodes the explicit-claim weight policy."""
+
+    def test_explicit_contradiction_is_one_point_zero(self) -> None:
+        assert ContradictionEngine._weight_for_relation('contradict', 'contradiction') == 1.0
+
+    def test_explicit_resolution_weakens_is_zero_point_seven(self) -> None:
+        assert ContradictionEngine._weight_for_relation('weaken', 'resolution') == 0.7
+
+    def test_no_claim_type_uses_default_one(self) -> None:
+        assert ContradictionEngine._weight_for_relation('weaken', None) == 1.0
+        assert ContradictionEngine._weight_for_relation('contradict', None) == 1.0
+        assert ContradictionEngine._weight_for_relation('reinforce', None) == 1.0
+
+
+class TestProcessFlaggedUnitClaimRouting:
+    """``_process_flagged_unit`` routes explicit-claim units through the
+    lower threshold and the entity-targets filter.
+    """
+
+    @pytest.mark.asyncio
+    async def test_explicit_claim_uses_lower_threshold_and_target_ids(self, engine, config) -> None:
+        target_eid = uuid4()
+        unit = _make_unit(text='the X problem is solved')
+        unit.claim_type = 'resolution'
+        unit.unit_metadata = {
+            'claim_target': {
+                'target_topic': 'the X problem',
+                'target_entity_ids': [str(target_eid)],
+            }
+        }
+
+        mock_session = AsyncMock()
+        captured: dict = {}
+
+        async def fake_get_candidates(*args, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        with patch(
+            'memex_core.memory.contradiction.engine.get_candidates', new=fake_get_candidates
+        ):
+            await engine._process_flagged_unit(mock_session, unit, uuid4())
+
+        assert captured.get('threshold') == config.similarity_threshold_explicit_claim
+        target_ids = captured.get('target_entity_ids')
+        assert target_ids is not None
+        assert target_eid in target_ids
+
+    @pytest.mark.asyncio
+    async def test_no_claim_type_uses_default_threshold(self, engine, config) -> None:
+        unit = _make_unit(text='generic fact')
+
+        mock_session = AsyncMock()
+        captured: dict = {}
+
+        async def fake_get_candidates(*args, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        with patch(
+            'memex_core.memory.contradiction.engine.get_candidates', new=fake_get_candidates
+        ):
+            await engine._process_flagged_unit(mock_session, unit, uuid4())
+
+        assert captured.get('threshold') == config.similarity_threshold
+        assert captured.get('target_entity_ids') is None

--- a/packages/core/tests/unit/memory/extraction/test_models.py
+++ b/packages/core/tests/unit/memory/extraction/test_models.py
@@ -304,3 +304,85 @@ class TestExtractedFactClassificationValidators:
         pf = ProcessedFact.from_extracted_fact(ef, [0.0] * 384)
         assert pf.intent_class.value == 'durable'
         assert pf.risk_class.value == 'none'
+
+
+class TestClaimTypeValidators:
+    """Validator + model-validator behaviour for ``claim_type`` / ``claim_target``."""
+
+    @pytest.mark.parametrize('value', ['resolution', 'contradiction', None])
+    def test_coerce_claim_type_valid(self, value: object) -> None:
+        fact = RawFact(
+            what='Test',
+            fact_type=FactTypes.WORLD,
+            fact_kind=FactKindTypes.CONVERSATION,
+            claim_type=value,  # type: ignore[arg-type]
+        )
+        assert fact.claim_type == value
+
+    @pytest.mark.parametrize('garbage', ['bogus', '', 123, ['resolution'], {'k': 'resolution'}])
+    def test_coerce_claim_type_invalid_defaults_none(self, garbage: object) -> None:
+        fact = RawFact(
+            what='Test',
+            fact_type=FactTypes.WORLD,
+            fact_kind=FactKindTypes.CONVERSATION,
+            claim_type=garbage,  # type: ignore[arg-type]
+        )
+        assert fact.claim_type is None
+
+    def test_claim_target_defaulted_when_claim_type_set_without_target(self) -> None:
+        from memex_core.memory.extraction.models import ClaimTarget
+
+        fact = RawFact(
+            what='Test',
+            fact_type=FactTypes.WORLD,
+            fact_kind=FactKindTypes.CONVERSATION,
+            claim_type='resolution',
+        )
+        assert isinstance(fact.claim_target, ClaimTarget)
+        assert fact.claim_target.target_topic is None
+        assert fact.claim_target.target_entity_ids == []
+
+    def test_claim_target_dropped_when_claim_type_none(self) -> None:
+        from memex_core.memory.extraction.models import ClaimTarget
+
+        fact = RawFact(
+            what='Test',
+            fact_type=FactTypes.WORLD,
+            fact_kind=FactKindTypes.CONVERSATION,
+            claim_type=None,
+            claim_target=ClaimTarget(target_topic='ignored'),
+        )
+        assert fact.claim_target is None
+
+    def test_extracted_fact_claim_type_propagates_through_processed(self) -> None:
+        import datetime as _dt
+
+        from memex_core.memory.extraction.models import ClaimTarget, ProcessedFact
+
+        ef = ExtractedFact(
+            fact_text='x',
+            fact_type=FactTypes.WORLD,
+            content_index=0,
+            chunk_index=0,
+            mentioned_at=_dt.datetime.now(_dt.timezone.utc),
+            claim_type='contradiction',
+            claim_target=ClaimTarget(target_topic='the X decision'),
+        )
+        pf = ProcessedFact.from_extracted_fact(ef, [0.0] * 384)
+        assert pf.claim_type == 'contradiction'
+        assert pf.claim_target is not None
+        assert pf.claim_target.target_topic == 'the X decision'
+
+    def test_extracted_fact_claim_type_invalid_coerces_to_none(self) -> None:
+        import datetime as _dt
+
+        ef = ExtractedFact(
+            fact_text='x',
+            fact_type=FactTypes.WORLD,
+            content_index=0,
+            chunk_index=0,
+            mentioned_at=_dt.datetime.now(_dt.timezone.utc),
+            claim_type='garbage',  # type: ignore[arg-type]
+        )
+        assert ef.claim_type is None
+        assert ef.claim_target is None

--- a/packages/core/tests/unit/test_seed_alembic_stubs.py
+++ b/packages/core/tests/unit/test_seed_alembic_stubs.py
@@ -56,13 +56,14 @@ def test_seed_chain_is_linear_and_correct() -> None:
     sd = ScriptDirectory.from_config(cfg)
 
     heads = sd.get_heads()
-    assert heads == ['036_fsfm_cooldown_index'], (
-        f'Expected single head 036_fsfm_cooldown_index, got {heads}'
+    assert heads == ['037_memory_unit_claim_type'], (
+        f'Expected single head 037_memory_unit_claim_type, got {heads}'
     )
 
     walk = list(sd.walk_revisions())
     top10 = [(r.revision, r.down_revision) for r in walk[:10]]
     expected_top10 = [
+        ('037_memory_unit_claim_type', '036_fsfm_cooldown_index'),
         ('036_fsfm_cooldown_index', '035_drop_fsrs_revisit_columns'),
         ('035_drop_fsrs_revisit_columns', '034_add_mw_mode'),
         ('034_add_mw_mode', '033_confidence_evidence_count'),
@@ -72,7 +73,6 @@ def test_seed_chain_is_linear_and_correct() -> None:
         ('030_revisit_last_reviewed_at', '029_lint_llm_quota'),
         ('029_lint_llm_quota', '028_procedure_outcomes'),
         ('028_procedure_outcomes', '027_consolidation_ticks'),
-        ('027_consolidation_ticks', '026_revisit_columns'),
     ]
     assert top10 == expected_top10, f'Tier A chain mismatch: got {top10}'
 


### PR DESCRIPTION
## Summary

- Extract an explicit corrective-claim signal (\`resolution\` / \`contradiction\`) alongside semantic facts and persist it on \`MemoryUnit.claim_type\`.
- Route a high-precision branch through the contradiction engine when \`claim_type\` is set: candidate retrieval narrows by the claim's target entity IDs, uses a looser similarity threshold (linguistic evidence substitutes for tight cosine match), and tunes \`MemoryLink.weight\` per the claim type (\`1.0\` for explicit contradictions, \`0.7\` for resolution-weakens) so FSFM's existing pressure mechanics deprioritize impacted priors.
- Additive, fully backward compatible: \`claim_type\` is nullable on existing rows; pre-existing units never enter the new branch.

## What changed

- \`memex_common.schemas\`: \`ClaimTypeLiteral\` + \`coerce_claim_type\` helper (defaults to \`None\`).
- Extraction models: new \`ClaimTarget\` pydantic model + \`claim_type\` / \`claim_target\` fields on \`RawFact\`, \`ExtractedFact\`, \`ProcessedFact\` with on-model validators (target dropped when claim_type is None; defaulted when claim_type is set without a target).
- \`ExtractSemanticFacts\` DSPy prompt: defines \`claim_type\` semantics + restraint guidance.
- Extraction engine: propagated through all 11 \`ExtractedFact\` construction sites; \`target_entity_ids\` is backfilled into \`unit_metadata.claim_target\` JSONB after entity resolution.
- \`MemoryUnit.claim_type\` column + CK constraint; alembic revision \`037_memory_unit_claim_type\` (additive, no backfill, no index — downgrade drops CK then column).
- Contradiction engine: branches on \`unit.claim_type\`; \`_weight_for_relation\` policy reviewable in one place; \`link_metadata\` records the \`claim_type\` signal.
- Contradiction candidates: optional \`target_entity_ids\` AND-filters the entity-overlap path AND the semantic SQL path.
- \`ContradictionConfig\`: \`similarity_threshold_explicit_claim\` (default \`0.35\`, must be ≤ \`similarity_threshold\`), \`claim_too_aggressive_max_links\` (default \`5\`).
- Lint: \`claim_too_aggressive\` rule registered in \`V1_RULES\`.
- Observability: \`memex_claim_typed_units_total{claim_type, vault_id}\` counter; \`contradiction.explicit_claim_count\` OTel attribute; structlog entry log on \`_process_flagged_unit\`.

## New files

- \`packages/core/src/memex_core/alembic/versions/037_memory_unit_claim_type.py\`
- \`packages/core/tests/integration/memory/test_int_contradiction_explicit_claim.py\`

## Test plan

- [x] Unit: \`test_models.py\` — claim_type / claim_target validators + model-validator round-trip on RawFact + ExtractedFact + ProcessedFact.
- [x] Unit: \`test_engine.py\` — \`_weight_for_relation\` policy + \`_process_flagged_unit\` routing (explicit-claim threshold + target_entity_ids pass-through).
- [x] Unit: \`test_candidates.py\` — \`get_candidates\` accepts \`target_entity_ids\` kwarg.
- [x] Integration: \`test_int_contradiction_explicit_claim.py\` — entity-id filter narrows candidates; explicit \`contradiction\` claim produces a link with \`weight=1.0\` and \`link_metadata.claim_type='contradiction'\`.
- [x] Seed test \`test_seed_alembic_stubs.py\` updated to pin the new head.
- [x] Full unit-test suite green except for 13 pre-existing unrelated failures (FastAPI server tests, missing-marker tests, missing-module \`memex_common.revisit\`) — verified on the base branch.
- [x] \`ruff check\` + \`ruff format\` clean across touched files.

## Deferred (follow-ups)

- \`DESIGN_DOCUMENT.md\` §2.4.1 + §2.4.4 paragraph additions (file is gitignored on this branch; needs primary-checkout work).
- New documentation pages (\`docs/explanation/contradiction-detection.md\`, configuration reference update).
- Eval scenarios in the \`acme_corp\` suite (10 listed in the plan).
- LLM-live test \`test_extraction_claim_type_llm.py\` (gated; not required to land V6 since unit + integration cover the contract).

## Notes

- Followed the \`feedback_pydantic_validators_in_signatures\` rule by mirroring the existing pattern (free coercer helper in \`memex_common.schemas\` + field validator on the model that delegates to it) — consistent with \`coerce_intent_class\` / \`coerce_risk_class\`.
- No ticket IDs surface in any user-facing or agent-facing string (per \`feedback_no_ticket_refs_in_user_facing_surfaces\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)