### PR TITLE
feat(outcomes): per-unit verb schema + audit log + coverage check

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,470%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,505%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,524%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,526%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,505%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,524%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/claude-code-plugin/rules/memory-resolution-flow.md
+++ b/packages/claude-code-plugin/rules/memory-resolution-flow.md
@@ -14,14 +14,17 @@
 
 4. **+5. Paired writes** against the LLM-judged-relevant subset only:
    ```
-   memex_record_outcome(unit_ids=[...], success=false, reason="user confirmed fixed")
+   memex_record_outcome(units=[
+       {"unit_id": "...", "verb": "not_helpful", "reason": "user confirmed fixed"},
+       ...
+   ])
    memex_memory_deprioritize(unit_id=..., reason="user confirmed fixed YYYY-MM-DD")
    ```
    Both against the **same** subset. The two verbs are orthogonal:
-   - `record_outcome(success=...)` — MW gradient, append-only, not reversible
+   - `record_outcome(units=[{verb: ...}])` — MW gradient, append-only, not reversible
    - `memory_deprioritize(reason)` — binary surface state, reversible via `memory_restore`
 
-**Imperfect recall is by design** — exploration is the safety net. Units that slip past will re-surface; another `record_outcome(success=false)` compounds the MW penalty.
+**Imperfect recall is by design** — exploration is the safety net. Units that slip past will re-surface; another `record_outcome` with `verb="not_helpful"` compounds the MW penalty.
 
 ## Historical / audit-query routing (NOT the resolution flow)
 

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -605,28 +605,34 @@ class RemoteMemexAPI:
     # --- Outcomes ---
     async def record_outcome(
         self,
-        unit_ids: list[str] | None,
-        success: bool,
+        unit_ids: list[str] | None = None,
+        success: bool | None = None,
         vault_id: str | None = None,
         outcome_confidence: float = 1.0,
         reason: str | None = None,
         *,
         target_type: str = 'memory_unit',
         kv_key: str | None = None,
+        units: list[dict[str, Any]] | None = None,
+        caller_id: str | None = None,
+        turn_outcome: str | None = None,
+        retrieved_set_size: int | None = None,
+        exploration_tagged: bool = False,
     ) -> dict[str, Any]:
         """Record an outcome over HTTP.
 
-        Mirrors :meth:`memex_core.api.MemexAPI.record_outcome` exactly so
-        in-process and remote callers share one call shape. ``unit_ids``
-        and ``success`` are positional; ``target_type`` and ``kv_key`` are
-        keyword-only — preserving the invariant that a kwargless call
-        cannot silently record FAILURE.
+        Preferred shape: ``units=[{unit_id, verb, reason}, ...]``. Legacy
+        ``(unit_ids, success)`` shape still accepted (server emits
+        FutureWarning on translation).
         """
         body: dict[str, Any] = {
-            'success': success,
             'outcome_confidence': outcome_confidence,
             'target_type': target_type,
         }
+        if success is not None:
+            body['success'] = success
+        if units is not None:
+            body['units'] = units
         if unit_ids is not None:
             body['unit_ids'] = unit_ids
         if vault_id is not None:
@@ -635,6 +641,14 @@ class RemoteMemexAPI:
             body['reason'] = reason
         if kv_key is not None:
             body['kv_key'] = kv_key
+        if caller_id is not None:
+            body['caller_id'] = caller_id
+        if turn_outcome is not None:
+            body['turn_outcome'] = turn_outcome
+        if retrieved_set_size is not None:
+            body['retrieved_set_size'] = retrieved_set_size
+        if exploration_tagged:
+            body['exploration_tagged'] = True
         return await self._post('outcomes/record', body)
 
     # --- Stats & Overview ---

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1003,11 +1003,11 @@ class OutcomesConfig(BaseModel):
         description=(
             'Per-link failure-counter bump applied when the contradiction '
             'engine commits a weakens or contradicts link. Stored as int; '
-            'the per-link bump = round(weight) — 0.0 disables wiring, '
-            '>=0.5 yields a +1 bump per negative-evidence link.'
+            'the per-link bump uses half-up rounding — 0.0 disables wiring, '
+            '0.5 (default) and above yield a +1 bump per negative-evidence link.'
         ),
     )
-    mw_mode_default: str = Field(
+    mw_mode_default: Literal['stationary', 'ema'] = Field(
         default='ema',
         description=(
             'Default Memory Worth counter mode for newly created vaults. '

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -980,6 +980,43 @@ class RetrievalConfig(BaseModel):
     )
 
 
+class OutcomesConfig(BaseModel):
+    """Configuration for outcome-attribution signal quality.
+
+    Owns the per-unit-verb coverage check, contradiction→failure wiring
+    weight, and the default Memory Worth counter mode for new vaults.
+    """
+
+    coverage_check_mode: Literal['strict', 'permissive'] = Field(
+        default='permissive',
+        description=(
+            "Coverage policy for record_outcome. 'strict' rejects calls where "
+            'the reported units do not cover the full retrieved set. '
+            "'permissive' accepts partial coverage and records coverage_ratio "
+            'on the audit row + metric.'
+        ),
+    )
+    contradiction_failure_weight: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description=(
+            'Per-link failure-counter bump applied when the contradiction '
+            'engine commits a weakens or contradicts link. Stored as int; '
+            'the per-link bump = round(weight) — 0.0 disables wiring, '
+            '>=0.5 yields a +1 bump per negative-evidence link.'
+        ),
+    )
+    mw_mode_default: str = Field(
+        default='ema',
+        description=(
+            'Default Memory Worth counter mode for newly created vaults. '
+            "'ema' applies EMA decay; 'stationary' keeps raw counters. "
+            'Per-vault `Vault.mw_mode` overrides this default.'
+        ),
+    )
+
+
 class ContradictionConfig(BaseModel):
     """Configuration for retain-time contradiction detection."""
 
@@ -1655,6 +1692,11 @@ class MemoryConfig(BaseModel):
         description='Configuration for contradiction detection.',
     )
 
+    outcomes: OutcomesConfig = Field(
+        default_factory=OutcomesConfig,
+        description='Configuration for outcome-attribution signal quality.',
+    )
+
     consolidation: ConsolidationConfig = Field(
         default_factory=ConsolidationConfig,
         description='Consolidation orchestrator configuration.',
@@ -2167,6 +2209,7 @@ __all__ = [
     'ExtractionConfig',
     'RetrievalConfig',
     'ContradictionConfig',
+    'OutcomesConfig',
     'MemoryConfig',
     'TracingConfig',
     'ServerConfig',

--- a/packages/common/tests/test_client_record_outcome.py
+++ b/packages/common/tests/test_client_record_outcome.py
@@ -104,22 +104,20 @@ async def test_optional_fields_only_sent_when_set(mock_client):
 
 
 def test_signature_matches_in_process_api():
-    """ADD-2 invariant: RemoteMemexAPI.record_outcome must mirror MemexAPI.record_outcome.
+    """RemoteMemexAPI.record_outcome must mirror MemexAPI.record_outcome.
 
-    Specifically: unit_ids + success are positional-or-keyword, target_type
-    and kv_key are keyword-only. A drift here means a Hermes call that works
-    in-process could fail (or worse, silently misbehave) over the wire.
+    Preferred shape is ``units=[UnitOutcome, ...]``; legacy
+    ``(unit_ids, success)`` shape is still accepted and emits FutureWarning
+    server-side. Keyword-only knobs (target_type, kv_key, units) must stay
+    keyword-only so positional drift cannot collide.
     """
     sig = inspect.signature(RemoteMemexAPI.record_outcome)
     params = sig.parameters
 
-    # Positional-or-keyword (ADD-2: success has no default — required).
     assert params['unit_ids'].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
     assert params['success'].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
-    assert params['success'].default is inspect.Parameter.empty, (
-        'success must have no default — kwargless calls cannot silently record FAILURE'
-    )
 
-    # Keyword-only — drift here would let a positional 7th-arg call collide.
+    # Keyword-only — drift here would let a positional call collide.
     assert params['target_type'].kind == inspect.Parameter.KEYWORD_ONLY
     assert params['kv_key'].kind == inspect.Parameter.KEYWORD_ONLY
+    assert params['units'].kind == inspect.Parameter.KEYWORD_ONLY

--- a/packages/core/src/memex_core/alembic/versions/037_outcome_per_unit_schema.py
+++ b/packages/core/src/memex_core/alembic/versions/037_outcome_per_unit_schema.py
@@ -32,6 +32,7 @@ depends_on: Union[str, Sequence[str], None] = None
 _AUDIT_TABLE = 'outcome_audit_log'
 _AUDIT_VAULT_TS_INDEX = 'idx_outcome_audit_log_vault_ts'
 _AUDIT_CALLER_INDEX = 'idx_outcome_audit_log_caller'
+_AUDIT_UNITS_IS_ARRAY = 'outcome_audit_log_units_is_array'
 
 
 def upgrade() -> None:
@@ -62,8 +63,12 @@ def upgrade() -> None:
             sa.ForeignKey('vaults.id', ondelete='CASCADE'),
             nullable=False,
         ),
-        sa.Column('caller_id', sa.Text(), nullable=True),
+        sa.Column('caller_id', sa.String(length=128), nullable=True),
         sa.Column('units', JSONB(), nullable=False),
+        sa.CheckConstraint(
+            "jsonb_typeof(units) = 'array'",
+            name=_AUDIT_UNITS_IS_ARRAY,
+        ),
         sa.Column('turn_outcome', sa.Text(), nullable=True),
         sa.Column('retrieved_set_size', sa.Integer(), nullable=True),
         sa.Column('coverage_ratio', sa.Float(), nullable=True),

--- a/packages/core/src/memex_core/alembic/versions/037_outcome_per_unit_schema.py
+++ b/packages/core/src/memex_core/alembic/versions/037_outcome_per_unit_schema.py
@@ -1,0 +1,96 @@
+"""Outcome per-unit schema: add `unused_co_count` columns + `outcome_audit_log`.
+
+Adds an engagement metric counter (`unused_co_count`) to the three Memory
+Worth tables (`memory_units`, `unit_entities`, `mental_models`) and creates
+the `outcome_audit_log` table that records one row per `record_outcome`
+call. The engagement counter is bumped when a unit was retrieved but the
+caller marked it as `not_used` (caller verb taxonomy: `helpful` /
+`not_helpful` / `not_used`).
+
+Additive only. New columns use a NOT NULL server default of 0 so existing
+rows backfill implicitly; the new table is empty at upgrade time. No data
+migration required.
+
+Revision ID: 037_outcome_per_unit_schema
+Revises: 036_fsfm_cooldown_index
+Create Date: 2026-05-11
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = '037_outcome_per_unit_schema'
+down_revision: Union[str, None] = '036_fsfm_cooldown_index'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_AUDIT_TABLE = 'outcome_audit_log'
+_AUDIT_VAULT_TS_INDEX = 'idx_outcome_audit_log_vault_ts'
+_AUDIT_CALLER_INDEX = 'idx_outcome_audit_log_caller'
+
+
+def upgrade() -> None:
+    # 1. unused_co_count on the three Memory Worth counter tables.
+    for table in ('memory_units', 'unit_entities', 'mental_models'):
+        op.add_column(
+            table,
+            sa.Column(
+                'unused_co_count',
+                sa.Integer(),
+                nullable=False,
+                server_default='0',
+            ),
+        )
+
+    # 2. outcome_audit_log table — one row per record_outcome call.
+    op.create_table(
+        _AUDIT_TABLE,
+        sa.Column(
+            'id',
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text('gen_random_uuid()'),
+        ),
+        sa.Column(
+            'vault_id',
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('vaults.id', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column('caller_id', sa.Text(), nullable=True),
+        sa.Column('units', JSONB(), nullable=False),
+        sa.Column('turn_outcome', sa.Text(), nullable=True),
+        sa.Column('retrieved_set_size', sa.Integer(), nullable=True),
+        sa.Column('coverage_ratio', sa.Float(), nullable=True),
+        sa.Column(
+            'exploration_tagged',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text('false'),
+        ),
+        sa.Column(
+            'created_at',
+            sa.dialects.postgresql.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        _AUDIT_VAULT_TS_INDEX,
+        _AUDIT_TABLE,
+        ['vault_id', sa.text('created_at DESC')],
+    )
+    op.create_index(_AUDIT_CALLER_INDEX, _AUDIT_TABLE, ['caller_id'])
+
+
+def downgrade() -> None:
+    op.drop_index(_AUDIT_CALLER_INDEX, table_name=_AUDIT_TABLE)
+    op.drop_index(_AUDIT_VAULT_TS_INDEX, table_name=_AUDIT_TABLE)
+    op.drop_table(_AUDIT_TABLE)
+    for table in ('memory_units', 'unit_entities', 'mental_models'):
+        op.drop_column(table, 'unused_co_count')

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -106,7 +106,7 @@ class AutoDeprioritizeSummary:
         return len(self.deprioritized)
 
 
-from memex_core.services.outcomes import OutcomeService
+from memex_core.services.outcomes import OutcomeService, UnitOutcome
 from memex_core.services.reflection import ReflectionService
 from memex_core.services.search import SearchService
 from memex_core.services.stats import StatsService
@@ -1599,7 +1599,7 @@ class MemexAPI:
         *,
         target_type: str = 'memory_unit',
         kv_key: str | None = None,
-        units: list[Any] | None = None,
+        units: list[UnitOutcome] | list[dict[str, Any]] | None = None,
         caller_id: str | None = None,
         turn_outcome: str | None = None,
         retrieved_set_size: int | None = None,
@@ -1607,8 +1607,15 @@ class MemexAPI:
     ) -> dict[str, Any]:
         """Record an outcome. Delegates to OutcomeService.
 
-        Preferred shape: ``units=[UnitOutcome, ...]``. Legacy
-        ``(unit_ids, success)`` shape still accepted with a FutureWarning.
+        Two accepted shapes for ``units``:
+
+        * ``list[UnitOutcome]`` — structured Pydantic objects (preferred for
+          in-process callers).
+        * ``list[dict[str, Any]]`` — typed dicts on the HTTP / Hermes wire
+          where each item has ``{unit_id, verb, reason}``.
+
+        Legacy ``(unit_ids, success)`` shape still accepted with a
+        FutureWarning.
 
         For ``target_type='kv_key'``, increments the vault-scoped
         success/failure counters on ``procedure_outcomes`` for ``kv_key``

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1591,23 +1591,31 @@ class MemexAPI:
 
     async def record_outcome(
         self,
-        unit_ids: list[str] | None,
-        success: bool,
+        unit_ids: list[str] | None = None,
+        success: bool | None = None,
         vault_id: str | None = None,
         outcome_confidence: float = 1.0,
         reason: str | None = None,
         *,
         target_type: str = 'memory_unit',
         kv_key: str | None = None,
+        units: list[Any] | None = None,
+        caller_id: str | None = None,
+        turn_outcome: str | None = None,
+        retrieved_set_size: int | None = None,
+        exploration_tagged: bool = False,
     ) -> dict[str, Any]:
         """Record an outcome. Delegates to OutcomeService.
 
+        Preferred shape: ``units=[UnitOutcome, ...]``. Legacy
+        ``(unit_ids, success)`` shape still accepted with a FutureWarning.
+
         For ``target_type='kv_key'``, increments the vault-scoped
         success/failure counters on ``procedure_outcomes`` for ``kv_key``
-        instead of memory units. See
-        :meth:`OutcomeService.record_outcome` for the full contract.
+        instead of memory units.
         """
         half_life = self.config.server.memory.retrieval.mw_ema_half_life_days
+        coverage_mode = self.config.server.memory.outcomes.coverage_check_mode
         async with self.metastore.session() as session:
             return await self._outcomes.record_outcome(
                 session=session,
@@ -1619,6 +1627,12 @@ class MemexAPI:
                 target_type=target_type,
                 kv_key=kv_key,
                 mw_ema_half_life_days=half_life,
+                units=units,
+                caller_id=caller_id,
+                turn_outcome=turn_outcome,
+                retrieved_set_size=retrieved_set_size,
+                exploration_tagged=exploration_tagged,
+                coverage_check_mode=coverage_mode,
             )
 
     async def create_vault(self, name: str, description: str | None = None) -> Any:

--- a/packages/core/src/memex_core/memory/contradiction/engine.py
+++ b/packages/core/src/memex_core/memory/contradiction/engine.py
@@ -30,9 +30,16 @@ logger = logging.getLogger('memex.core.memory.contradiction')
 class ContradictionEngine:
     """Detects and records contradictions between memory units."""
 
-    def __init__(self, lm: dspy.LM, config: ContradictionConfig):
+    def __init__(
+        self,
+        lm: dspy.LM,
+        config: ContradictionConfig,
+        *,
+        failure_co_count_weight: float = 0.5,
+    ):
         self.lm = lm
         self.config = config
+        self.failure_co_count_weight = failure_co_count_weight
         self.triage_predictor = dspy.Predict(TriageNewUnits)
         self.classify_predictor = dspy.Predict(ClassifyRelationships)
 
@@ -135,6 +142,11 @@ class ContradictionEngine:
                 await session.exec(upsert_stmt)  # type: ignore[arg-type]
                 all_links = list(deduped.values())
 
+            # Stored failure_co_count is an integer; the configured weight
+            # decides per-link bump via round() so 0.0 disables wiring and
+            # >=0.5 yields +1 per negative-evidence link.
+            failure_bump_per_link = round(max(0.0, self.failure_co_count_weight))
+
             # Clamp per-unit deltas via SQL LEAST/GREATEST to prevent races on
             # overlapping units (mirrors application-level max(0, min(1, ...))).
             for unit_id, delta in confidence_deltas.items():
@@ -152,6 +164,10 @@ class ContradictionEngine:
                         0,
                         MemoryUnit.confidence_evidence_count + bump,
                     )
+                    if failure_bump_per_link > 0:
+                        values['failure_co_count'] = (
+                            MemoryUnit.failure_co_count + bump * failure_bump_per_link
+                        )
                 stmt = update(MemoryUnit).where(MemoryUnit.id == unit_id).values(**values)
                 await session.execute(stmt)
 

--- a/packages/core/src/memex_core/memory/contradiction/engine.py
+++ b/packages/core/src/memex_core/memory/contradiction/engine.py
@@ -142,10 +142,12 @@ class ContradictionEngine:
                 await session.exec(upsert_stmt)  # type: ignore[arg-type]
                 all_links = list(deduped.values())
 
-            # Stored failure_co_count is an integer; the configured weight
-            # decides per-link bump via round() so 0.0 disables wiring and
-            # >=0.5 yields +1 per negative-evidence link.
-            failure_bump_per_link = round(max(0.0, self.failure_co_count_weight))
+            # Stored failure_co_count is an integer; half-up rounding maps the
+            # configured weight to a per-link bump so 0.0 disables wiring and
+            # >=0.5 yields +1 per negative-evidence link. (Plain round() would
+            # use banker's rounding and silently turn the 0.5 default into 0.)
+            weight = max(0.0, self.failure_co_count_weight)
+            failure_bump_per_link = 1 if weight >= 0.5 else 0
 
             # Clamp per-unit deltas via SQL LEAST/GREATEST to prevent races on
             # overlapping units (mirrors application-level max(0, min(1, ...))).

--- a/packages/core/src/memex_core/memory/engine.py
+++ b/packages/core/src/memex_core/memory/engine.py
@@ -114,7 +114,10 @@ def _build_contradiction_engine(config: MemexConfig) -> ContradictionEngine | No
             timeout=model_config.timeout,
             num_retries=model_config.num_retries,
         )
-        engine = ContradictionEngine(lm=lm, config=contradiction_config)
+        failure_weight = config.server.memory.outcomes.contradiction_failure_weight
+        engine = ContradictionEngine(
+            lm=lm, config=contradiction_config, failure_co_count_weight=failure_weight
+        )
         logger.info(
             'Contradiction engine created (model=%s, threshold=%.2f, alpha=%.2f)',
             model_config.model,

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -3,7 +3,7 @@ from enum import Enum, StrEnum
 from typing import Any
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     Boolean,
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Computed,
     ForeignKey,
     Integer,
+    String,
     Text,
     Float,
     func,
@@ -1475,14 +1476,28 @@ class OutcomeAuditLog(SQLModel, table=True):  # type: ignore
     vault_id: UUID = vault_id_field()
     caller_id: str | None = Field(
         default=None,
-        sa_column=Column(Text, nullable=True),
-        description='Session id or caller fingerprint (no PII).',
+        max_length=128,
+        sa_column=Column(String(128), nullable=True),
+        description='Session id or caller fingerprint (no PII, ≤ 128 chars).',
     )
     units: list[dict[str, Any]] = Field(
         default_factory=list,
         sa_column=Column(JSONB, nullable=False),
         description='Per-unit payload: list of {unit_id, verb, reason?}.',
     )
+
+    @field_validator('units')
+    @classmethod
+    def _units_must_be_array_of_dicts(cls, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if not isinstance(value, list):
+            raise ValueError('OutcomeAuditLog.units must be a list')
+        for idx, item in enumerate(value):
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f'OutcomeAuditLog.units[{idx}] must be a dict, got {type(item).__name__}'
+                )
+        return value
+
     turn_outcome: str | None = Field(
         default=None,
         sa_column=Column(Text, nullable=True),
@@ -1512,6 +1527,10 @@ class OutcomeAuditLog(SQLModel, table=True):  # type: ignore
     __table_args__ = (
         Index('idx_outcome_audit_log_vault_ts', 'vault_id', sql_text('created_at DESC')),
         Index('idx_outcome_audit_log_caller', 'caller_id'),
+        CheckConstraint(
+            "jsonb_typeof(units) = 'array'",
+            name='outcome_audit_log_units_is_array',
+        ),
     )
 
 

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -175,6 +175,16 @@ class MentalModel(SQLModel, table=True):  # type: ignore
         description='Memory Worth failure co-occurrence counter (vault-scoped).',
     )
 
+    unused_co_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default='0'),
+        description=(
+            'Engagement counter: bumped when a unit was retrieved but the '
+            'caller marked it as not_used. Does NOT enter the Beta-Bernoulli '
+            'posterior (engagement-only signal).'
+        ),
+    )
+
     __table_args__ = (
         # Enforce uniqueness for Entity + Vault (Global or Specific)
         Index(
@@ -593,6 +603,16 @@ class MemoryUnit(SQLModel, MemoryUnitBase, table=True):  # type: ignore
         description='Number of failure outcome co-occurrences for Memory Worth scoring.',
     )
 
+    unused_co_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default='0'),
+        description=(
+            'Engagement counter: bumped when a unit was retrieved but the '
+            'caller marked it as not_used. Does NOT enter the Beta-Bernoulli '
+            'posterior (engagement-only signal).'
+        ),
+    )
+
     is_deprioritized: bool = Field(
         default=False,
         sa_column=Column(Boolean, server_default='false'),
@@ -973,6 +993,16 @@ class UnitEntity(SQLModel, table=True):  # type: ignore
         default=0,
         sa_column=Column(Integer, server_default='0'),
         description='Memory Worth failure co-occurrence counter (vault-scoped).',
+    )
+
+    unused_co_count: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default='0'),
+        description=(
+            'Engagement counter: bumped when a unit was retrieved but the '
+            'caller marked it as not_used. Does NOT enter the Beta-Bernoulli '
+            'posterior (engagement-only signal).'
+        ),
     )
 
     # Relationships
@@ -1424,6 +1454,64 @@ class AuditLog(SQLModel, table=True):  # type: ignore
         Index('idx_audit_logs_actor', 'actor'),
         Index('idx_audit_logs_action', 'action'),
         Index('idx_audit_logs_resource', 'resource_type', 'resource_id'),
+    )
+
+
+class OutcomeAuditLog(SQLModel, table=True):  # type: ignore
+    """One row per `record_outcome` call.
+
+    Records the per-unit verb payload, coverage stats, and exploration tag
+    so signal-quality regressions can be audited offline. Append-only;
+    vault-scoped so outcome audit never leaks across tenants.
+    """
+
+    __tablename__ = 'outcome_audit_log'
+
+    id: UUID = Field(
+        default_factory=uuid4,
+        sa_column=Column(SA_UUID(), primary_key=True, server_default=sql_text('gen_random_uuid()')),
+        description='Unique identifier for this audit row.',
+    )
+    vault_id: UUID = vault_id_field()
+    caller_id: str | None = Field(
+        default=None,
+        sa_column=Column(Text, nullable=True),
+        description='Session id or caller fingerprint (no PII).',
+    )
+    units: list[dict[str, Any]] = Field(
+        default_factory=list,
+        sa_column=Column(JSONB, nullable=False),
+        description='Per-unit payload: list of {unit_id, verb, reason?}.',
+    )
+    turn_outcome: str | None = Field(
+        default=None,
+        sa_column=Column(Text, nullable=True),
+        description='Coarse turn-level outcome label (success/failure/mixed/None).',
+    )
+    retrieved_set_size: int | None = Field(
+        default=None,
+        sa_column=Column(Integer, nullable=True),
+        description='Size of the retrieved set the caller was asked to classify.',
+    )
+    coverage_ratio: float | None = Field(
+        default=None,
+        sa_column=Column(Float, nullable=True),
+        description='reported / retrieved (NULL when retrieved_set_size is unknown).',
+    )
+    exploration_tagged: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default='false'),
+        description='True iff any unit was exploration-injected on retrieval.',
+    )
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now()),
+        description='Server-side row insertion timestamp.',
+    )
+
+    __table_args__ = (
+        Index('idx_outcome_audit_log_vault_ts', 'vault_id', sql_text('created_at DESC')),
+        Index('idx_outcome_audit_log_caller', 'caller_id'),
     )
 
 

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -133,6 +133,19 @@ OUTCOME_RECORDED_TOTAL = Counter(
     ['vault_id', 'outcome'],
 )
 
+OUTCOME_VERB_TOTAL = Counter(
+    'memex_outcome_verb_total',
+    'Per-unit verb classifications recorded by record_outcome.',
+    ['vault_id', 'verb'],
+)
+
+OUTCOME_COVERAGE_RATIO = Histogram(
+    'memex_outcome_coverage_ratio',
+    'Reported / retrieved coverage ratio per record_outcome call.',
+    ['vault_id', 'mode'],
+    buckets=(0.0, 0.1, 0.25, 0.5, 0.75, 1.0),
+)
+
 MW_SCORE_DISTRIBUTION = Histogram(
     'memex_mw_score',
     'Distribution of Memory Worth scores observed during outcome recording.',

--- a/packages/core/src/memex_core/server/outcomes.py
+++ b/packages/core/src/memex_core/server/outcomes.py
@@ -34,16 +34,41 @@ logger = logging.getLogger('memex.core.server.outcomes')
 router = APIRouter(prefix='/api/v1/outcomes')
 
 
-class RecordOutcomeRequest(BaseModel):
-    success: bool = Field(
+class UnitOutcomePayload(BaseModel):
+    """HTTP wire shape mirror of `UnitOutcome`."""
+
+    unit_id: str = Field(..., description='UUID of the memory unit.')
+    verb: str = Field(
         ...,
-        description='True if the task succeeded using these memories or this procedure.',
+        description="Per-unit verb: 'helpful', 'not_helpful', or 'not_used'.",
+    )
+    reason: str | None = Field(
+        default=None,
+        description='Free-text reason. Required for helpful / not_helpful.',
+    )
+
+
+class RecordOutcomeRequest(BaseModel):
+    success: bool | None = Field(
+        default=None,
+        description=(
+            'kv_key mode only or legacy memory_unit shape (FutureWarning). '
+            'True if the task succeeded using these memories or this procedure.'
+        ),
+    )
+    units: list[UnitOutcomePayload] | None = Field(
+        default=None,
+        description=(
+            'Preferred memory_unit shape. Per-unit verb classifications '
+            '(helpful / not_helpful / not_used) with a reason.'
+        ),
     )
     unit_ids: list[str] | None = Field(
         default=None,
         description=(
-            'memory_unit mode only. UUIDs of memory units that were load-bearing '
-            "in the agent's reasoning. Required when target_type='memory_unit'."
+            'Legacy memory_unit shape (FutureWarning). UUIDs of memory units '
+            'that were load-bearing in the reasoning. Required only when '
+            "target_type='memory_unit' and `units` is not supplied."
         ),
     )
     vault_id: str | None = Field(
@@ -75,6 +100,23 @@ class RecordOutcomeRequest(BaseModel):
             "Required when target_type='kv_key'."
         ),
     )
+    caller_id: str | None = Field(
+        default=None,
+        description='Caller identifier (session id or API key fingerprint) for audit log.',
+    )
+    turn_outcome: str | None = Field(
+        default=None,
+        description='Coarse turn-level outcome label (success/failure/mixed).',
+    )
+    retrieved_set_size: int | None = Field(
+        default=None,
+        ge=0,
+        description='Size of the retrieved set the caller was asked to classify.',
+    )
+    exploration_tagged: bool = Field(
+        default=False,
+        description='True iff any unit was exploration-injected on retrieval.',
+    )
 
 
 @router.post('/record', dependencies=[Depends(require_write)])
@@ -103,6 +145,10 @@ async def post_record_outcome(
             ) from exc
         await check_vault_access(auth, [resolved_vault], api, permission=Permission.WRITE)
 
+    units_payload: list[dict[str, Any]] | None = None
+    if body.units is not None:
+        units_payload = [u.model_dump() for u in body.units]
+
     try:
         return await api.record_outcome(
             body.unit_ids,
@@ -112,6 +158,11 @@ async def post_record_outcome(
             body.reason,
             target_type=body.target_type,
             kv_key=body.kv_key,
+            units=units_payload,
+            caller_id=body.caller_id,
+            turn_outcome=body.turn_outcome,
+            retrieved_set_size=body.retrieved_set_size,
+            exploration_tagged=body.exploration_tagged,
         )
     except ValueError as exc:
         # OutcomeService raises ValueError for missing unit_ids / kv_key /

--- a/packages/core/src/memex_core/server/outcomes.py
+++ b/packages/core/src/memex_core/server/outcomes.py
@@ -13,7 +13,7 @@ Routes:
 from __future__ import annotations
 
 import logging
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -38,7 +38,7 @@ class UnitOutcomePayload(BaseModel):
     """HTTP wire shape mirror of `UnitOutcome`."""
 
     unit_id: str = Field(..., description='UUID of the memory unit.')
-    verb: str = Field(
+    verb: Literal['helpful', 'not_helpful', 'not_used'] = Field(
         ...,
         description="Per-unit verb: 'helpful', 'not_helpful', or 'not_used'.",
     )

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -274,7 +274,6 @@ class OutcomeService:
             counter_field: str,
             *,
             bump_last_outcome_at: bool,
-            propagate_to_entity_model: bool,
         ) -> tuple[int, int, int]:
             if not ids:
                 return 0, 0, 0
@@ -287,61 +286,34 @@ class OutcomeService:
                 update(MU).where(MU.id.in_(ids), MU.vault_id == vault_uuid).values(values)
             )
             mu_count = mu_result.rowcount  # type: ignore[union-attr]
-            entity_count = 0
-            model_count = 0
-            if propagate_to_entity_model:
-                entity_result = await session.exec(
-                    update(UE)
-                    .where(UE.unit_id.in_(ids), UE.vault_id == vault_uuid)
-                    .values({counter_field: UE.__table__.c[counter_field] + 1})
+            entity_result = await session.exec(
+                update(UE)
+                .where(UE.unit_id.in_(ids), UE.vault_id == vault_uuid)
+                .values({counter_field: UE.__table__.c[counter_field] + 1})
+            )
+            entity_count = entity_result.rowcount  # type: ignore[union-attr]
+            model_result = await session.exec(
+                update(MM)
+                .where(
+                    MM.entity_id.in_(
+                        select(UE.entity_id).where(UE.unit_id.in_(ids), UE.vault_id == vault_uuid)
+                    ),
+                    MM.vault_id == vault_uuid,
                 )
-                entity_count = entity_result.rowcount  # type: ignore[union-attr]
-                model_result = await session.exec(
-                    update(MM)
-                    .where(
-                        MM.entity_id.in_(
-                            select(UE.entity_id).where(
-                                UE.unit_id.in_(ids), UE.vault_id == vault_uuid
-                            )
-                        ),
-                        MM.vault_id == vault_uuid,
-                    )
-                    .values({counter_field: MM.__table__.c[counter_field] + 1})
-                )
-                model_count = model_result.rowcount  # type: ignore[union-attr]
-            else:
-                ue_result = await session.exec(
-                    update(UE)
-                    .where(UE.unit_id.in_(ids), UE.vault_id == vault_uuid)
-                    .values({counter_field: UE.__table__.c[counter_field] + 1})
-                )
-                entity_count = ue_result.rowcount  # type: ignore[union-attr]
-                mm_result = await session.exec(
-                    update(MM)
-                    .where(
-                        MM.entity_id.in_(
-                            select(UE.entity_id).where(
-                                UE.unit_id.in_(ids), UE.vault_id == vault_uuid
-                            )
-                        ),
-                        MM.vault_id == vault_uuid,
-                    )
-                    .values({counter_field: MM.__table__.c[counter_field] + 1})
-                )
-                model_count = mm_result.rowcount  # type: ignore[union-attr]
+                .values({counter_field: MM.__table__.c[counter_field] + 1})
+            )
+            model_count = model_result.rowcount  # type: ignore[union-attr]
             return mu_count, entity_count, model_count
 
         h_units, h_entities, h_models = await _bump_counter(
             helpful_ids,
             'success_co_count',
             bump_last_outcome_at=True,
-            propagate_to_entity_model=True,
         )
         nh_units, nh_entities, nh_models = await _bump_counter(
             not_helpful_ids,
             'failure_co_count',
             bump_last_outcome_at=True,
-            propagate_to_entity_model=True,
         )
         # not_used does NOT bump last_outcome_at — engagement-only signal,
         # must not reset the Beta-Bernoulli decay clock.
@@ -349,7 +321,6 @@ class OutcomeService:
             not_used_ids,
             'unused_co_count',
             bump_last_outcome_at=False,
-            propagate_to_entity_model=True,
         )
 
         units_updated = h_units + nh_units + nu_units

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -56,7 +56,11 @@ class UnitOutcome(BaseModel):
 
     unit_id: UUID = Field(..., description='UUID of the memory unit.')
     verb: UnitOutcomeVerb = Field(..., description='Per-unit verb classification.')
-    reason: str | None = Field(default=None, description='Free-text reason (≤ 200 chars).')
+    reason: str | None = Field(
+        default=None,
+        max_length=200,
+        description='Free-text reason (≤ 200 chars).',
+    )
 
     @model_validator(mode='after')
     def _reason_required_for_credit(self) -> 'UnitOutcome':
@@ -195,16 +199,25 @@ class OutcomeService:
         )
 
         if retrieved_set_size is not None and retrieved_set_size > 0:
-            coverage_ratio = min(1.0, len(resolved_units) / retrieved_set_size)
+            coverage_ratio = len(resolved_units) / retrieved_set_size
         else:
             coverage_ratio = None
 
-        if coverage_check_mode == 'strict':
-            if retrieved_set_size is not None and len(resolved_units) < retrieved_set_size:
+        if coverage_ratio is not None and coverage_ratio > 1.0:
+            logger.warning(
+                'outcome.coverage_over_one',
+                reported=len(resolved_units),
+                retrieved=retrieved_set_size,
+                coverage_ratio=coverage_ratio,
+            )
+
+        if coverage_check_mode == 'strict' and retrieved_set_size is not None:
+            if len(resolved_units) != retrieved_set_size:
                 raise ValueError(
                     'Strict coverage: reported '
                     f'{len(resolved_units)} of {retrieved_set_size} retrieved units. '
-                    'Classify every retrieved unit or switch coverage_check_mode to permissive.'
+                    'Classify exactly every retrieved unit or switch coverage_check_mode '
+                    'to permissive.'
                 )
 
         try:
@@ -465,6 +478,10 @@ class OutcomeService:
         if units is not None and unit_ids:
             raise ValueError(
                 "Pass either 'units' (preferred) or legacy ('unit_ids' + 'success'), not both."
+            )
+        if units is not None and success is not None:
+            raise ValueError(
+                "Cannot mix new 'units' shape with legacy 'success' shape; choose one."
             )
 
         resolved: list[UnitOutcome] = []

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -20,7 +20,7 @@ from typing import Any, Literal
 from uuid import UUID
 
 import structlog
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, ValidationError, model_validator
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -466,7 +466,10 @@ class OutcomeService:
                 if isinstance(item, UnitOutcome):
                     resolved.append(item)
                 elif isinstance(item, dict):
-                    resolved.append(UnitOutcome.model_validate(item))
+                    try:
+                        resolved.append(UnitOutcome.model_validate(item))
+                    except ValidationError as exc:
+                        raise ValueError(f"Invalid 'units' entry: {exc}") from exc
                 else:
                     raise ValueError(f'units entries must be UnitOutcome or dict, got {type(item)}')
             return resolved

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -457,6 +457,11 @@ class OutcomeService:
 
         resolved: list[UnitOutcome] = []
         if units is not None:
+            if len(units) == 0:
+                raise ValueError(
+                    "memory_unit mode requires at least one entry in 'units' "
+                    "(or pass legacy 'unit_ids' + 'success')."
+                )
             for item in units:
                 if isinstance(item, UnitOutcome):
                     resolved.append(item)
@@ -466,13 +471,21 @@ class OutcomeService:
                     raise ValueError(f'units entries must be UnitOutcome or dict, got {type(item)}')
             return resolved
 
-        if unit_ids is None and success is None:
-            return []
+        if (unit_ids is None or len(unit_ids) == 0) and success is None:
+            raise ValueError(
+                "memory_unit mode requires either 'units=[UnitOutcome(...)]' (preferred) "
+                "or legacy 'unit_ids' + 'success'; received neither."
+            )
 
         if success is None:
             raise ValueError(
                 "Legacy shape requires 'success' alongside 'unit_ids'. "
                 "Prefer passing 'units=[UnitOutcome(...)]' instead."
+            )
+        if unit_ids is None or len(unit_ids) == 0:
+            raise ValueError(
+                "memory_unit mode requires 'unit_ids' alongside 'success' "
+                "(or pass 'units=[UnitOutcome(...)]' instead)."
             )
         warnings.warn(
             'record_outcome called with the legacy (unit_ids, success) shape. '

--- a/packages/core/src/memex_core/services/outcomes.py
+++ b/packages/core/src/memex_core/services/outcomes.py
@@ -1,9 +1,9 @@
 """Outcome recording service for Memory Worth counters.
 
-Exposes `record_outcome()` for incrementing success/failure co-occurrence
-counters on MemoryUnit, UnitEntity, and MentalModel, and `compute_mw_score() /
-compute_mw_boost()` for the Beta-Bernoulli posterior mean used by the
-retrieval composition.
+Exposes `record_outcome()` for incrementing success/failure/unused
+co-occurrence counters on MemoryUnit, UnitEntity, and MentalModel, and
+`compute_mw_score() / compute_mw_boost()` for the Beta-Bernoulli posterior
+mean used by the retrieval composition.
 
 The Memory Worth formula uses additive-marginal composition:
     mw_score = (success_co_count + 1) / (success_co_count + failure_co_count + 2)
@@ -16,19 +16,54 @@ from __future__ import annotations
 
 import warnings
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 import structlog
+from pydantic import BaseModel, Field, model_validator
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from memex_core.memory.retrieval.mw_ema import compute_mw_ema_score
 from memex_core.memory.sql_models import MWMode, Vault
-from memex_core.metrics import OUTCOME_RECORDED_TOTAL, MW_SCORE_DISTRIBUTION
+from memex_core.metrics import (
+    MW_SCORE_DISTRIBUTION,
+    OUTCOME_COVERAGE_RATIO,
+    OUTCOME_RECORDED_TOTAL,
+    OUTCOME_VERB_TOTAL,
+)
 
 logger = structlog.get_logger(__name__)
+
+UnitOutcomeVerb = Literal['helpful', 'not_helpful', 'not_used']
+CREDIT_BEARING_VERBS: frozenset[str] = frozenset({'helpful', 'not_helpful'})
+
+
+class UnitOutcome(BaseModel):
+    """Per-unit outcome verb with a free-text reason.
+
+    Verb taxonomy:
+      * ``helpful`` — unit contributed to a successful outcome (success_co bump).
+      * ``not_helpful`` — unit was misleading or wrong (failure_co bump).
+      * ``not_used`` — unit was retrieved but the caller did not use it
+        (unused_co bump; engagement-only signal).
+
+    ``reason`` is REQUIRED for credit-bearing verbs (``helpful`` /
+    ``not_helpful``) so the audit log carries enough signal to detect
+    rich-get-richer dynamics; OPTIONAL for ``not_used``.
+    """
+
+    unit_id: UUID = Field(..., description='UUID of the memory unit.')
+    verb: UnitOutcomeVerb = Field(..., description='Per-unit verb classification.')
+    reason: str | None = Field(default=None, description='Free-text reason (≤ 200 chars).')
+
+    @model_validator(mode='after')
+    def _reason_required_for_credit(self) -> 'UnitOutcome':
+        if self.verb in CREDIT_BEARING_VERBS and not (self.reason and self.reason.strip()):
+            raise ValueError(f"UnitOutcome with verb={self.verb!r} requires a non-empty 'reason'")
+        return self
+
 
 MW_ALPHA_DEFAULT = 0.3
 MW_PRIOR_ALPHA = 1  # Beta-Bernoulli prior α
@@ -86,8 +121,8 @@ class OutcomeService:
     async def record_outcome(
         self,
         session: AsyncSession,
-        unit_ids: list[str] | None,
-        success: bool,
+        unit_ids: list[str] | None = None,
+        success: bool | None = None,
         vault_id: str | None = None,
         outcome_confidence: float = 1.0,
         reason: str | None = None,
@@ -95,58 +130,32 @@ class OutcomeService:
         target_type: str = 'memory_unit',
         kv_key: str | None = None,
         mw_ema_half_life_days: float = 60.0,
+        units: list[UnitOutcome] | list[dict[str, Any]] | None = None,
+        caller_id: str | None = None,
+        turn_outcome: str | None = None,
+        retrieved_set_size: int | None = None,
+        exploration_tagged: bool = False,
+        coverage_check_mode: Literal['strict', 'permissive'] = 'permissive',
     ) -> dict[str, Any]:
         """Record an outcome.
 
         Two target modes (selected by keyword-only ``target_type``):
 
-        * ``target_type='memory_unit'`` (default — existing positional path):
-          increments success/failure co-counters on each MemoryUnit and
-          propagates to linked UnitEntity + MentalModel rows. Requires
-          positional ``unit_ids``.
+        * ``target_type='memory_unit'`` (default): increments
+          success/failure/unused co-counters on each MemoryUnit and propagates
+          success/failure to linked UnitEntity + MentalModel rows. Accepts
+          either the per-unit ``units=[UnitOutcome, ...]`` shape (preferred)
+          or the legacy ``(unit_ids, success)`` shape (FutureWarning).
         * ``target_type='kv_key'`` (procedure outcomes): increments
           success/failure co-counters on the vault-scoped
-          ``procedure_outcomes`` row matching ``(vault_id, kv_key)``. Row
-          is upserted; ``last_outcome_at`` is set to ``now()``. Requires
-          keyword-only ``kv_key`` (must be a ``procedure:<verb>:<tag>``
-          key per the procedure key contract) plus ``success`` and ``vault_id``.
-          ``unit_ids`` MUST be ``None`` or empty for kv_key mode —
-          mixing modes is an error (silent counter divergence otherwise).
-
-        Both ``unit_ids`` and ``success`` are required (no defaults) so a
-        caller cannot accidentally invoke ``record_outcome(session)`` and
-        silently record a FAILURE outcome — the exact Memory Worth signal-quality
-        pathology the system is built to detect.
-
-        .. note::
-
-            ``outcome_confidence`` is **currently ignored** in counter
-            arithmetic — v1 uses integer increments only. Fractional
-            weighting is tracked as a future enhancement. Until it ships,
-            callers passing values other than ``1.0`` will receive a
-            ``FutureWarning`` so the silent loss of signal is visible.
-
-        Args:
-            session: Active async DB session.
-            unit_ids: UUIDs of memory units (memory_unit mode only). Pass
-                ``None`` or ``[]`` for kv_key mode.
-            success: True if outcome was successful. Required — no default.
-            vault_id: Vault scope for the outcome.
-            outcome_confidence: Weight for this outcome signal (0.0–1.0).
-                Currently recorded but not used in counter arithmetic (v1
-                uses integer increments; fractional weighting is a future
-                enhancement).
-                # TODO: fractional counter weighting
-            reason: Optional free-text reason (logged, not stored on units).
-            target_type: 'memory_unit' (default) or 'kv_key' (procedure
-                outcomes).
-            kv_key: Procedure KV key (kv_key mode only).
+          ``procedure_outcomes`` row matching ``(vault_id, kv_key)``. KV mode
+          still uses the binary ``success`` parameter.
 
         Returns:
             Dict with counts of updated rows. For ``memory_unit``:
-            ``{units_updated, entities_updated, models_updated}``. For
-            ``kv_key``: ``{kv_key, vault_id, success_co_count,
-            failure_co_count, last_outcome_at}``.
+            ``{units_updated, entities_updated, models_updated, audit_log_id,
+            verb_counts, coverage_ratio}``. For ``kv_key``: ``{kv_key,
+            vault_id, success_co_count, failure_co_count, last_outcome_at}``.
         """
         if outcome_confidence is not None and outcome_confidence != 1.0:
             warnings.warn(
@@ -159,11 +168,13 @@ class OutcomeService:
                 stacklevel=2,
             )
         if target_type == 'kv_key':
-            if unit_ids:
+            if units or unit_ids:
                 raise ValueError(
-                    'kv_key mode does not accept unit_ids; pass unit_ids only '
+                    'kv_key mode does not accept unit_ids or units; pass them only '
                     'with target_type="memory_unit"'
                 )
+            if success is None:
+                raise ValueError("kv_key mode requires the 'success' boolean.")
             return await self._record_outcome_kv_key(
                 session=session,
                 kv_key=kv_key,
@@ -173,147 +184,327 @@ class OutcomeService:
             )
         if target_type != 'memory_unit':
             raise ValueError(f"target_type must be 'memory_unit' or 'kv_key', got {target_type!r}")
-        if unit_ids is None or vault_id is None:
-            raise ValueError("memory_unit mode requires 'unit_ids' and 'vault_id'.")
+        if vault_id is None:
+            raise ValueError("memory_unit mode requires 'vault_id'.")
 
-        from memex_core.memory.sql_models import MemoryUnit as MU
+        resolved_units = self._resolve_unit_outcomes(
+            units=units,
+            unit_ids=unit_ids,
+            success=success,
+            reason=reason,
+        )
 
-        counter_field = 'success_co_count' if success else 'failure_co_count'
+        if retrieved_set_size is not None and retrieved_set_size > 0:
+            coverage_ratio = min(1.0, len(resolved_units) / retrieved_set_size)
+        else:
+            coverage_ratio = None
+
+        if coverage_check_mode == 'strict':
+            if retrieved_set_size is not None and len(resolved_units) < retrieved_set_size:
+                raise ValueError(
+                    'Strict coverage: reported '
+                    f'{len(resolved_units)} of {retrieved_set_size} retrieved units. '
+                    'Classify every retrieved unit or switch coverage_check_mode to permissive.'
+                )
+
+        try:
+            vault_uuid = UUID(vault_id)
+        except ValueError as exc:
+            raise ValueError(f'Invalid vault_id: {vault_id}') from exc
+
+        helpful_ids: list[UUID] = []
+        not_helpful_ids: list[UUID] = []
+        not_used_ids: list[UUID] = []
+        for uo in resolved_units:
+            if uo.verb == 'helpful':
+                helpful_ids.append(uo.unit_id)
+            elif uo.verb == 'not_helpful':
+                not_helpful_ids.append(uo.unit_id)
+            else:
+                not_used_ids.append(uo.unit_id)
+
         log = logger.bind(
-            unit_count=len(unit_ids),
-            outcome='success' if success else 'failure',
+            unit_count=len(resolved_units),
             vault_id=str(vault_id),
             confidence=outcome_confidence,
         )
-        log.info('outcome.record', reason=reason)
+        log.info(
+            'outcome.record',
+            helpful=len(helpful_ids),
+            not_helpful=len(not_helpful_ids),
+            not_used=len(not_used_ids),
+        )
 
-        # Resolve valid unit IDs
-        parsed_ids: list[UUID] = []
-        for uid_str in unit_ids:
-            try:
-                parsed_ids.append(UUID(uid_str))
-            except ValueError:
-                log.warning('outcome.invalid_unit_id', unit_id=uid_str)
-                continue
-
-        # Validate vault_id
-        try:
-            vault_uuid = UUID(vault_id)
-        except ValueError:
-            raise ValueError(f'Invalid vault_id: {vault_id}')
-
-        if not parsed_ids:
+        if not resolved_units:
             log.warning('outcome.no_valid_ids')
-            return {'units_updated': 0, 'entities_updated': 0, 'models_updated': 0}
+            return {
+                'units_updated': 0,
+                'entities_updated': 0,
+                'models_updated': 0,
+                'audit_log_id': None,
+                'verb_counts': {'helpful': 0, 'not_helpful': 0, 'not_used': 0},
+                'coverage_ratio': coverage_ratio,
+            }
 
-        # Single ``now`` snapshot per record_outcome call so every
-        # decay-clock bump shares one reference time with the audit log
-        # event. Same convention as the reranker's per-query snapshot.
+        from memex_core.memory.sql_models import (
+            AuditLog,
+            MemoryUnit as MU,
+            MentalModel as MM,
+            OutcomeAuditLog,
+            UnitEntity as UE,
+        )
+
         now = datetime.now(timezone.utc)
 
-        # Atomic increment on MemoryUnit rows (SQL-level, no race condition).
-        # Bump last_outcome_at on every counter update — recent
-        # behavioural signal resets the decay clock.
-        stmt = (
-            update(MU)
-            .where(MU.id.in_(parsed_ids), MU.vault_id == vault_uuid)
-            .values(
-                {
-                    counter_field: MU.__table__.c[counter_field] + 1,
-                    'last_outcome_at': now,
-                }
+        async def _bump_counter(
+            ids: list[UUID],
+            counter_field: str,
+            *,
+            bump_last_outcome_at: bool,
+            propagate_to_entity_model: bool,
+        ) -> tuple[int, int, int]:
+            if not ids:
+                return 0, 0, 0
+            values: dict[str, Any] = {
+                counter_field: MU.__table__.c[counter_field] + 1,
+            }
+            if bump_last_outcome_at:
+                values['last_outcome_at'] = now
+            mu_result = await session.exec(
+                update(MU).where(MU.id.in_(ids), MU.vault_id == vault_uuid).values(values)
             )
-        )
-        result = await session.exec(stmt)
-        units_updated = result.rowcount  # type: ignore[union-attr]
-
-        # Propagate to UnitEntity rows (atomic increment)
-        from memex_core.memory.sql_models import UnitEntity as UE
-
-        entity_stmt = (
-            update(UE)
-            .where(
-                UE.unit_id.in_(parsed_ids),
-                UE.vault_id == vault_uuid,
-            )
-            .values({counter_field: UE.__table__.c[counter_field] + 1})
-        )
-        entity_result = await session.exec(entity_stmt)
-        entity_count = entity_result.rowcount  # type: ignore[union-attr]
-
-        # Propagate to MentalModel rows (atomic increment)
-        from memex_core.memory.sql_models import MentalModel as MM
-
-        model_stmt = (
-            update(MM)
-            .where(
-                MM.entity_id.in_(
-                    select(UE.entity_id).where(
-                        UE.unit_id.in_(parsed_ids), UE.vault_id == vault_uuid
+            mu_count = mu_result.rowcount  # type: ignore[union-attr]
+            entity_count = 0
+            model_count = 0
+            if propagate_to_entity_model:
+                entity_result = await session.exec(
+                    update(UE)
+                    .where(UE.unit_id.in_(ids), UE.vault_id == vault_uuid)
+                    .values({counter_field: UE.__table__.c[counter_field] + 1})
+                )
+                entity_count = entity_result.rowcount  # type: ignore[union-attr]
+                model_result = await session.exec(
+                    update(MM)
+                    .where(
+                        MM.entity_id.in_(
+                            select(UE.entity_id).where(
+                                UE.unit_id.in_(ids), UE.vault_id == vault_uuid
+                            )
+                        ),
+                        MM.vault_id == vault_uuid,
                     )
-                ),
-                MM.vault_id == vault_uuid,
-            )
-            .values({counter_field: MM.__table__.c[counter_field] + 1})
+                    .values({counter_field: MM.__table__.c[counter_field] + 1})
+                )
+                model_count = model_result.rowcount  # type: ignore[union-attr]
+            else:
+                ue_result = await session.exec(
+                    update(UE)
+                    .where(UE.unit_id.in_(ids), UE.vault_id == vault_uuid)
+                    .values({counter_field: UE.__table__.c[counter_field] + 1})
+                )
+                entity_count = ue_result.rowcount  # type: ignore[union-attr]
+                mm_result = await session.exec(
+                    update(MM)
+                    .where(
+                        MM.entity_id.in_(
+                            select(UE.entity_id).where(
+                                UE.unit_id.in_(ids), UE.vault_id == vault_uuid
+                            )
+                        ),
+                        MM.vault_id == vault_uuid,
+                    )
+                    .values({counter_field: MM.__table__.c[counter_field] + 1})
+                )
+                model_count = mm_result.rowcount  # type: ignore[union-attr]
+            return mu_count, entity_count, model_count
+
+        h_units, h_entities, h_models = await _bump_counter(
+            helpful_ids,
+            'success_co_count',
+            bump_last_outcome_at=True,
+            propagate_to_entity_model=True,
         )
-        model_result = await session.exec(model_stmt)
-        model_count = model_result.rowcount  # type: ignore[union-attr]
+        nh_units, nh_entities, nh_models = await _bump_counter(
+            not_helpful_ids,
+            'failure_co_count',
+            bump_last_outcome_at=True,
+            propagate_to_entity_model=True,
+        )
+        # not_used does NOT bump last_outcome_at — engagement-only signal,
+        # must not reset the Beta-Bernoulli decay clock.
+        nu_units, nu_entities, nu_models = await _bump_counter(
+            not_used_ids,
+            'unused_co_count',
+            bump_last_outcome_at=False,
+            propagate_to_entity_model=True,
+        )
 
-        # Diff hook: emit one audit row per unit so consolidation_tick can find
-        # units with new outcome signal via AuditLog.action='outcome.record'.
-        from memex_core.memory.sql_models import AuditLog
+        units_updated = h_units + nh_units + nu_units
+        entity_count = h_entities + nh_entities + nu_entities
+        model_count = h_models + nh_models + nu_models
 
-        outcome_label = 'success' if success else 'failure'
-        for uid in parsed_ids:
+        # Diff hook: emit one AuditLog row per credit-bearing unit so the
+        # consolidation tick still picks up new outcome signal. not_used is
+        # excluded — it is engagement metadata, not a Memory Worth signal.
+        for uo in resolved_units:
+            if uo.verb == 'not_used':
+                continue
             session.add(
                 AuditLog(
                     action='outcome.record',
                     resource_type='memory_unit',
-                    resource_id=str(uid),
-                    details={'vault_id': str(vault_uuid), 'outcome': outcome_label},
+                    resource_id=str(uo.unit_id),
+                    details={
+                        'vault_id': str(vault_uuid),
+                        'verb': uo.verb,
+                        'outcome': 'success' if uo.verb == 'helpful' else 'failure',
+                    },
                 )
             )
 
-        # Single commit for all three counter updates — preserves co-occurrence
-        # invariant across MemoryUnit, UnitEntity, and MentalModel tables.
-        await session.commit()
-
-        # Observe Memory Worth scores post-commit (read-only, no commit needed)
-        refreshed = await session.exec(
-            select(MU).where(MU.id.in_(parsed_ids), MU.vault_id == vault_uuid)
+        audit_row = OutcomeAuditLog(
+            vault_id=vault_uuid,
+            caller_id=caller_id,
+            units=[
+                {'unit_id': str(uo.unit_id), 'verb': uo.verb, 'reason': uo.reason}
+                for uo in resolved_units
+            ],
+            turn_outcome=turn_outcome,
+            retrieved_set_size=retrieved_set_size,
+            coverage_ratio=coverage_ratio,
+            exploration_tagged=exploration_tagged,
         )
+        session.add(audit_row)
 
-        vault_row = await session.get(Vault, vault_uuid)
-        mw_mode_val = vault_row.mw_mode if vault_row else MWMode.STATIONARY
-        for unit in refreshed.all():
-            if mw_mode_val == MWMode.EMA:
-                mw_score = compute_mw_ema_score(
-                    unit.success_co_count,
-                    unit.failure_co_count,
-                    unit.last_outcome_at,
-                    half_life_days=mw_ema_half_life_days,
-                    now=now,
+        # Single commit covers all counter updates + audit rows so the
+        # co-occurrence invariant across MemoryUnit / UnitEntity / MentalModel
+        # holds atomically.
+        await session.commit()
+        await session.refresh(audit_row)
+
+        # Observe Memory Worth scores post-commit (read-only).
+        credit_ids = helpful_ids + not_helpful_ids
+        if credit_ids:
+            refreshed = await session.exec(
+                select(MU).where(MU.id.in_(credit_ids), MU.vault_id == vault_uuid)
+            )
+            vault_row = await session.get(Vault, vault_uuid)
+            mw_mode_val = vault_row.mw_mode if vault_row else MWMode.STATIONARY
+            for unit in refreshed.all():
+                if mw_mode_val == MWMode.EMA:
+                    mw_score = compute_mw_ema_score(
+                        unit.success_co_count,
+                        unit.failure_co_count,
+                        unit.last_outcome_at,
+                        half_life_days=mw_ema_half_life_days,
+                        now=now,
+                    )
+                else:
+                    mw_score = compute_mw_score(unit.success_co_count, unit.failure_co_count)
+                MW_SCORE_DISTRIBUTION.labels(vault_id=str(vault_id), mode=mw_mode_val).observe(
+                    mw_score
                 )
-            else:
-                mw_score = compute_mw_score(unit.success_co_count, unit.failure_co_count)
-            MW_SCORE_DISTRIBUTION.labels(vault_id=str(vault_id), mode=mw_mode_val).observe(mw_score)
 
-        OUTCOME_RECORDED_TOTAL.labels(
-            vault_id=str(vault_id), outcome='success' if success else 'failure'
-        ).inc(units_updated)
+        if h_units:
+            OUTCOME_RECORDED_TOTAL.labels(vault_id=str(vault_id), outcome='success').inc(h_units)
+        if nh_units:
+            OUTCOME_RECORDED_TOTAL.labels(vault_id=str(vault_id), outcome='failure').inc(nh_units)
+        for verb, count in (
+            ('helpful', len(helpful_ids)),
+            ('not_helpful', len(not_helpful_ids)),
+            ('not_used', len(not_used_ids)),
+        ):
+            if count:
+                OUTCOME_VERB_TOTAL.labels(vault_id=str(vault_id), verb=verb).inc(count)
+        if coverage_ratio is not None:
+            OUTCOME_COVERAGE_RATIO.labels(vault_id=str(vault_id), mode=coverage_check_mode).observe(
+                coverage_ratio
+            )
 
         log.info(
             'outcome.recorded',
             units_updated=units_updated,
             entities_updated=entity_count,
             models_updated=model_count,
+            verb_counts={
+                'helpful': len(helpful_ids),
+                'not_helpful': len(not_helpful_ids),
+                'not_used': len(not_used_ids),
+            },
+            coverage_ratio=coverage_ratio,
         )
 
         return {
             'units_updated': units_updated,
             'entities_updated': entity_count,
             'models_updated': model_count,
+            'audit_log_id': str(audit_row.id) if audit_row.id else None,
+            'verb_counts': {
+                'helpful': len(helpful_ids),
+                'not_helpful': len(not_helpful_ids),
+                'not_used': len(not_used_ids),
+            },
+            'coverage_ratio': coverage_ratio,
         }
+
+    @staticmethod
+    def _resolve_unit_outcomes(
+        *,
+        units: list[UnitOutcome] | list[dict[str, Any]] | None,
+        unit_ids: list[str] | None,
+        success: bool | None,
+        reason: str | None,
+    ) -> list[UnitOutcome]:
+        """Normalise inputs to a `list[UnitOutcome]`.
+
+        Accepts:
+          * ``units`` — preferred; per-unit verbs.
+          * Legacy ``unit_ids`` + ``success`` — emits FutureWarning and
+            translates to ``UnitOutcome(verb='helpful' | 'not_helpful')``.
+        """
+        if units is not None and unit_ids:
+            raise ValueError(
+                "Pass either 'units' (preferred) or legacy ('unit_ids' + 'success'), not both."
+            )
+
+        resolved: list[UnitOutcome] = []
+        if units is not None:
+            for item in units:
+                if isinstance(item, UnitOutcome):
+                    resolved.append(item)
+                elif isinstance(item, dict):
+                    resolved.append(UnitOutcome.model_validate(item))
+                else:
+                    raise ValueError(f'units entries must be UnitOutcome or dict, got {type(item)}')
+            return resolved
+
+        if unit_ids is None and success is None:
+            return []
+
+        if success is None:
+            raise ValueError(
+                "Legacy shape requires 'success' alongside 'unit_ids'. "
+                "Prefer passing 'units=[UnitOutcome(...)]' instead."
+            )
+        warnings.warn(
+            'record_outcome called with the legacy (unit_ids, success) shape. '
+            'Switch to units=[UnitOutcome(unit_id=..., verb=..., reason=...)]; '
+            'the legacy shape will be removed in a future release.',
+            FutureWarning,
+            stacklevel=3,
+        )
+        verb: UnitOutcomeVerb = 'helpful' if success else 'not_helpful'
+        legacy_reason = reason or (
+            'Legacy success outcome' if success else 'Legacy failure outcome'
+        )
+        for uid_str in unit_ids or []:
+            try:
+                parsed = UUID(uid_str)
+            except (ValueError, TypeError):
+                logger.warning('outcome.invalid_unit_id', unit_id=uid_str)
+                continue
+            resolved.append(UnitOutcome(unit_id=parsed, verb=verb, reason=legacy_reason))
+        return resolved
 
     async def _record_outcome_kv_key(
         self,

--- a/packages/core/src/memex_core/services/vaults.py
+++ b/packages/core/src/memex_core/services/vaults.py
@@ -86,7 +86,12 @@ class VaultService(BaseService):
             if existing:
                 raise ValueError(f"Vault with name '{name}' already exists.")
 
-            vault = Vault(name=name, description=description)
+            default_mode = self.config.server.memory.outcomes.mw_mode_default
+            if default_mode not in (MWMode.STATIONARY, MWMode.EMA):
+                raise ValueError(
+                    f"mw_mode_default must be 'stationary' or 'ema', got '{default_mode}'"
+                )
+            vault = Vault(name=name, description=description, mw_mode=default_mode)
             session.add(vault)
             await session.commit()
             await session.refresh(vault)

--- a/packages/core/tests/unit/conftest.py
+++ b/packages/core/tests/unit/conftest.py
@@ -248,6 +248,8 @@ def mock_config():
     consolidate_cfg.per_vault_per_seconds = 3600
     consolidate_cfg.burst = 1
     consolidate_cfg.max_keys = 1000
+    # Default Memory Worth mode for newly created vaults.
+    config.server.memory.outcomes.mw_mode_default = 'ema'
     return config
 
 

--- a/packages/core/tests/unit/memory/contradiction/test_failure_bump_rounding.py
+++ b/packages/core/tests/unit/memory/contradiction/test_failure_bump_rounding.py
@@ -1,0 +1,46 @@
+"""Failure-counter half-up rounding regression test.
+
+The contradiction engine maps `failure_co_count_weight` (float in [0, 1]) to
+an integer per-link bump. Python's builtin `round()` uses banker's rounding
+so `round(0.5) == 0`, which would silently disable the default wiring. We
+use half-up rounding instead; this test pins that behaviour.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from memex_common.config import ContradictionConfig
+from memex_core.memory.contradiction.engine import ContradictionEngine
+
+
+def _bump(weight: float) -> int:
+    """Mirror the inline expression in `ContradictionEngine._detect`."""
+    engine = ContradictionEngine(
+        lm=MagicMock(),
+        config=ContradictionConfig(),
+        failure_co_count_weight=weight,
+    )
+    w = max(0.0, engine.failure_co_count_weight)
+    return 1 if w >= 0.5 else 0
+
+
+@pytest.mark.parametrize(
+    'weight,expected',
+    [
+        (0.0, 0),
+        (0.49, 0),
+        (0.5, 1),  # default — must NOT round to 0
+        (0.51, 1),
+        (1.0, 1),
+    ],
+)
+def test_contradiction_failure_weight_half_up_rounding(weight: float, expected: int):
+    assert _bump(weight) == expected
+
+
+def test_contradiction_failure_weight_default_0p5_emits_increment():
+    """Pin the default config: weight=0.5 -> +1 bump per negative-evidence link."""
+    assert _bump(0.5) == 1

--- a/packages/core/tests/unit/memory/test_outcome_audit_log_model.py
+++ b/packages/core/tests/unit/memory/test_outcome_audit_log_model.py
@@ -1,0 +1,42 @@
+"""DB-level invariants on the OutcomeAuditLog model.
+
+SQLModel disables Pydantic validators on `table=True` classes; the real
+shape guarantees live in the migration + the SQLAlchemy column types, so
+those are what we pin here. The Pydantic validator + max_length declarations
+remain in the model for callers that build the row via `.model_validate(...)`
+(documentation + future-proofing).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import CheckConstraint, String
+
+from memex_core.memory.sql_models import OutcomeAuditLog
+
+
+def test_outcome_audit_log_units_is_array_check_constraint_declared():
+    """The `jsonb_typeof(units) = 'array'` CHECK lives on `__table_args__`."""
+    check_constraints = [
+        c for c in OutcomeAuditLog.__table_args__ if isinstance(c, CheckConstraint)
+    ]
+    matched = [c for c in check_constraints if c.name == 'outcome_audit_log_units_is_array']
+    assert matched, 'CHECK constraint outcome_audit_log_units_is_array must be declared'
+    sql = str(matched[0].sqltext)
+    assert 'jsonb_typeof' in sql
+    assert 'array' in sql
+
+
+def test_outcome_audit_log_caller_id_column_caps_at_128_chars():
+    """caller_id is `VARCHAR(128)` at the DB layer."""
+    col = OutcomeAuditLog.__table__.c['caller_id']
+    assert isinstance(col.type, String)
+    assert col.type.length == 128
+
+
+def test_outcome_audit_log_caller_id_max_length_field_metadata():
+    """The Pydantic field also declares `max_length=128` for caller-side validation."""
+    field_info = OutcomeAuditLog.model_fields['caller_id']
+    metadata_lengths = [
+        getattr(m, 'max_length', None) for m in field_info.metadata if hasattr(m, 'max_length')
+    ]
+    assert 128 in metadata_lengths

--- a/packages/core/tests/unit/services/test_outcome_coverage_policy.py
+++ b/packages/core/tests/unit/services/test_outcome_coverage_policy.py
@@ -1,0 +1,101 @@
+"""Coverage policy semantics for `record_outcome`.
+
+`coverage_ratio = reported / retrieved` is now recorded raw (no clamp), and
+strict mode rejects BOTH over- and under-coverage so the audit log is
+faithful — partial classifications are an integrity bug, not a soft signal.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from memex_core.services.outcomes import OutcomeService, UnitOutcome
+
+
+def _make_units(n: int) -> list[UnitOutcome]:
+    return [UnitOutcome(unit_id=uuid4(), verb='helpful', reason='r') for _ in range(n)]
+
+
+@pytest.mark.asyncio
+async def test_outcome_coverage_ratio_over_one_in_permissive_mode_warns():
+    """Permissive mode tolerates ratio > 1.0 but emits a structured warning."""
+    svc = OutcomeService()
+    session = AsyncMock()
+    units = _make_units(3)
+    with patch('memex_core.services.outcomes.logger') as mock_logger:
+        mock_logger.bind.return_value = mock_logger
+        try:
+            await svc.record_outcome(
+                session=session,
+                units=units,
+                vault_id=str(uuid4()),
+                retrieved_set_size=2,
+                coverage_check_mode='permissive',
+            )
+        except Exception:
+            # Downstream DB ops are mocked and may raise; the over-coverage
+            # warning is emitted BEFORE the SQL fan-out, so we still assert.
+            pass
+
+    warning_calls = [
+        c for c in mock_logger.warning.call_args_list if c.args and 'over_one' in c.args[0]
+    ]
+    assert warning_calls, 'expected an outcome.coverage_over_one warning'
+
+
+@pytest.mark.asyncio
+async def test_outcome_coverage_strict_rejects_over_coverage():
+    """Strict mode rejects len(units) > retrieved_set_size."""
+    svc = OutcomeService()
+    session = AsyncMock()
+    units = _make_units(3)
+    with pytest.raises(ValueError, match='Strict coverage'):
+        await svc.record_outcome(
+            session=session,
+            units=units,
+            vault_id=str(uuid4()),
+            retrieved_set_size=2,
+            coverage_check_mode='strict',
+        )
+
+
+@pytest.mark.asyncio
+async def test_outcome_coverage_strict_rejects_under_coverage():
+    """Strict mode continues to reject partial classification."""
+    svc = OutcomeService()
+    session = AsyncMock()
+    units = _make_units(1)
+    with pytest.raises(ValueError, match='Strict coverage'):
+        await svc.record_outcome(
+            session=session,
+            units=units,
+            vault_id=str(uuid4()),
+            retrieved_set_size=3,
+            coverage_check_mode='strict',
+        )
+
+
+@pytest.mark.asyncio
+async def test_outcome_coverage_strict_accepts_exact_match():
+    """Strict mode accepts len(units) == retrieved_set_size (no raise on guard)."""
+    svc = OutcomeService()
+    session = AsyncMock()
+    units = _make_units(2)
+    try:
+        await svc.record_outcome(
+            session=session,
+            units=units,
+            vault_id=str(uuid4()),
+            retrieved_set_size=2,
+            coverage_check_mode='strict',
+        )
+    except ValueError as exc:
+        if 'Strict coverage' in str(exc):
+            pytest.fail(f'Exact match should not raise the coverage guard: {exc}')
+    except Exception:
+        # Other DB-mock-related failures are expected; this test only pins
+        # that the strict-coverage guard does not reject exact matches.
+        pass

--- a/packages/core/tests/unit/services/test_outcome_service_per_unit.py
+++ b/packages/core/tests/unit/services/test_outcome_service_per_unit.py
@@ -146,11 +146,11 @@ class TestResolveUnitOutcomes:
                 reason=None,
             )
 
-    def test_empty_returns_empty(self):
-        out = OutcomeService._resolve_unit_outcomes(
-            units=None, unit_ids=None, success=None, reason=None
-        )
-        assert out == []
+    def test_empty_raises_value_error(self):
+        with pytest.raises(ValueError, match='received neither'):
+            OutcomeService._resolve_unit_outcomes(
+                units=None, unit_ids=None, success=None, reason=None
+            )
 
     def test_outcome_rejects_units_and_success_together(self):
         with pytest.raises(ValueError, match='Cannot mix'):

--- a/packages/core/tests/unit/services/test_outcome_service_per_unit.py
+++ b/packages/core/tests/unit/services/test_outcome_service_per_unit.py
@@ -151,3 +151,22 @@ class TestResolveUnitOutcomes:
             units=None, unit_ids=None, success=None, reason=None
         )
         assert out == []
+
+    def test_outcome_rejects_units_and_success_together(self):
+        with pytest.raises(ValueError, match='Cannot mix'):
+            OutcomeService._resolve_unit_outcomes(
+                units=[UnitOutcome(unit_id=uuid4(), verb='not_used')],
+                unit_ids=None,
+                success=True,
+                reason=None,
+            )
+
+
+class TestUnitOutcomeReasonLengthCap:
+    def test_reason_under_cap_accepted(self):
+        uo = UnitOutcome(unit_id=uuid4(), verb='helpful', reason='a' * 200)
+        assert uo.reason == 'a' * 200
+
+    def test_reason_over_cap_rejected(self):
+        with pytest.raises(ValueError):
+            UnitOutcome(unit_id=uuid4(), verb='helpful', reason='a' * 201)

--- a/packages/core/tests/unit/services/test_outcome_service_per_unit.py
+++ b/packages/core/tests/unit/services/test_outcome_service_per_unit.py
@@ -1,0 +1,153 @@
+"""Unit tests for the per-unit `UnitOutcome` schema + legacy-shim translation.
+
+These tests run against the resolver layer (`OutcomeService._resolve_unit_outcomes`)
+and the `UnitOutcome` Pydantic model directly. The DB-touching path is covered
+by the integration suite — here we pin the schema contract, the verb dispatch
+math, and the legacy `(unit_ids, success)` translation including the
+`FutureWarning` deprecation signal.
+"""
+
+from __future__ import annotations
+
+import warnings
+from uuid import uuid4
+
+import pytest
+
+from memex_core.services.outcomes import OutcomeService, UnitOutcome
+
+
+# ---------------------------------------------------------------------------
+# UnitOutcome Pydantic validator
+# ---------------------------------------------------------------------------
+
+
+class TestUnitOutcomeValidator:
+    def test_helpful_requires_reason(self):
+        with pytest.raises(ValueError, match='reason'):
+            UnitOutcome(unit_id=uuid4(), verb='helpful', reason=None)
+
+    def test_helpful_rejects_blank_reason(self):
+        with pytest.raises(ValueError, match='reason'):
+            UnitOutcome(unit_id=uuid4(), verb='helpful', reason='   ')
+
+    def test_not_helpful_requires_reason(self):
+        with pytest.raises(ValueError, match='reason'):
+            UnitOutcome(unit_id=uuid4(), verb='not_helpful', reason=None)
+
+    def test_not_used_accepts_no_reason(self):
+        uo = UnitOutcome(unit_id=uuid4(), verb='not_used')
+        assert uo.reason is None
+
+    def test_not_used_accepts_reason(self):
+        uo = UnitOutcome(unit_id=uuid4(), verb='not_used', reason='retrieved but irrelevant')
+        assert uo.reason == 'retrieved but irrelevant'
+
+    def test_invalid_verb_rejected(self):
+        with pytest.raises(ValueError):
+            UnitOutcome(unit_id=uuid4(), verb='maybe', reason='x')  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Resolver: input normalisation + legacy shim
+# ---------------------------------------------------------------------------
+
+
+class TestResolveUnitOutcomes:
+    def test_units_passthrough_objects(self):
+        u1 = UnitOutcome(unit_id=uuid4(), verb='helpful', reason='r1')
+        u2 = UnitOutcome(unit_id=uuid4(), verb='not_used')
+        out = OutcomeService._resolve_unit_outcomes(
+            units=[u1, u2], unit_ids=None, success=None, reason=None
+        )
+        assert out == [u1, u2]
+
+    def test_units_passthrough_dicts(self):
+        uid = uuid4()
+        out = OutcomeService._resolve_unit_outcomes(
+            units=[{'unit_id': str(uid), 'verb': 'helpful', 'reason': 'r'}],
+            unit_ids=None,
+            success=None,
+            reason=None,
+        )
+        assert len(out) == 1
+        assert out[0].verb == 'helpful'
+        assert out[0].unit_id == uid
+
+    def test_legacy_success_true_translates_to_helpful(self):
+        uid = uuid4()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            out = OutcomeService._resolve_unit_outcomes(
+                units=None,
+                unit_ids=[str(uid)],
+                success=True,
+                reason=None,
+            )
+        assert any(issubclass(x.category, FutureWarning) for x in w)
+        assert len(out) == 1
+        assert out[0].verb == 'helpful'
+        assert out[0].unit_id == uid
+        assert out[0].reason  # legacy supplies a default reason
+
+    def test_legacy_success_false_translates_to_not_helpful(self):
+        uid = uuid4()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            out = OutcomeService._resolve_unit_outcomes(
+                units=None,
+                unit_ids=[str(uid)],
+                success=False,
+                reason=None,
+            )
+        assert any(issubclass(x.category, FutureWarning) for x in w)
+        assert out[0].verb == 'not_helpful'
+
+    def test_legacy_reason_passes_through(self):
+        uid = uuid4()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            out = OutcomeService._resolve_unit_outcomes(
+                units=None,
+                unit_ids=[str(uid)],
+                success=True,
+                reason='custom-reason',
+            )
+        assert out[0].reason == 'custom-reason'
+
+    def test_legacy_invalid_uuids_dropped(self):
+        uid = uuid4()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            out = OutcomeService._resolve_unit_outcomes(
+                units=None,
+                unit_ids=[str(uid), 'not-a-uuid'],
+                success=True,
+                reason='r',
+            )
+        assert len(out) == 1
+        assert out[0].unit_id == uid
+
+    def test_units_and_unit_ids_simultaneously_rejected(self):
+        with pytest.raises(ValueError, match='not both'):
+            OutcomeService._resolve_unit_outcomes(
+                units=[UnitOutcome(unit_id=uuid4(), verb='not_used')],
+                unit_ids=['u1'],
+                success=True,
+                reason=None,
+            )
+
+    def test_unit_ids_without_success_rejected(self):
+        with pytest.raises(ValueError, match='success'):
+            OutcomeService._resolve_unit_outcomes(
+                units=None,
+                unit_ids=['u1'],
+                success=None,
+                reason=None,
+            )
+
+    def test_empty_returns_empty(self):
+        out = OutcomeService._resolve_unit_outcomes(
+            units=None, unit_ids=None, success=None, reason=None
+        )
+        assert out == []

--- a/packages/core/tests/unit/services/test_vault_default_mw_mode.py
+++ b/packages/core/tests/unit/services/test_vault_default_mw_mode.py
@@ -1,0 +1,77 @@
+"""Unit tests for VaultService wiring the configured Memory Worth default mode.
+
+`OutcomesConfig.mw_mode_default` is the operator dial for new vaults. The
+service must read it on `create_vault` and pass it to the `Vault` constructor
+so the default flip from 'stationary' to 'ema' actually applies; per-vault
+overrides via `set_mw_mode` continue to work unchanged.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from memex_core.memory.sql_models import MWMode
+from memex_core.services.vaults import VaultService
+
+
+@pytest.fixture
+def vault_service(mock_metastore, mock_filestore, mock_config):
+    svc = VaultService(
+        metastore=mock_metastore,
+        filestore=mock_filestore,
+        config=mock_config,
+    )
+    audit = MagicMock()
+    audit.log = MagicMock()
+    svc._audit_service = audit
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_create_vault_defaults_to_configured_mw_mode_ema(
+    vault_service, mock_session, mock_config
+):
+    """Default config (mw_mode_default='ema') applies to new vaults."""
+    mock_config.server.memory.outcomes.mw_mode_default = 'ema'
+
+    mock_result = MagicMock()
+    mock_result.first.return_value = None
+    mock_session.exec = AsyncMock(return_value=mock_result)
+    mock_session.refresh = AsyncMock()
+
+    await vault_service.create_vault('vault-ema')
+
+    added = mock_session.add.call_args.args[0]
+    assert added.mw_mode == MWMode.EMA
+
+
+@pytest.mark.asyncio
+async def test_create_vault_honours_stationary_override(vault_service, mock_session, mock_config):
+    """Operators can still pin new vaults to stationary mode."""
+    mock_config.server.memory.outcomes.mw_mode_default = 'stationary'
+
+    mock_result = MagicMock()
+    mock_result.first.return_value = None
+    mock_session.exec = AsyncMock(return_value=mock_result)
+    mock_session.refresh = AsyncMock()
+
+    await vault_service.create_vault('vault-stationary')
+
+    added = mock_session.add.call_args.args[0]
+    assert added.mw_mode == MWMode.STATIONARY
+
+
+@pytest.mark.asyncio
+async def test_create_vault_rejects_invalid_default_mode(vault_service, mock_session, mock_config):
+    """Unknown mw_mode_default values must surface a ValueError."""
+    mock_config.server.memory.outcomes.mw_mode_default = 'bogus'
+
+    mock_result = MagicMock()
+    mock_result.first.return_value = None
+    mock_session.exec = AsyncMock(return_value=mock_result)
+    mock_session.refresh = AsyncMock()
+
+    with pytest.raises(ValueError, match='mw_mode_default'):
+        await vault_service.create_vault('vault-bogus')

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/briefing.py
@@ -100,7 +100,7 @@ _RESOLUTION_FLOW_PRIMER = """### When the user reports an issue resolved (§3.5 
 3. **LLM-judge the candidates.** READ unit bodies; pick the fix-relevant subset. NEVER bulk-write.
 
 4.+5. **Paired writes** against the judged-relevant subset:
-   `memex_record_outcome(unit_ids=[...], success=false, reason="...")` AND
+   `memex_record_outcome(units=[{"unit_id":"...","verb":"not_helpful","reason":"..."}])` AND
    `memex_memory_deprioritize(unit_id=..., reason="...")`. Same subset.
 
    Orthogonal axes: `record_outcome` = MW gradient (append-only); `deprioritize` = binary surface state (reversible via `memory_restore`).
@@ -138,7 +138,7 @@ _ROUTING_GUIDE = """### How to use Memex tools
 - **KV store** — `memex_kv_write(value, key)` / `memex_kv_get(key)` / `memex_kv_search(query)` / `memex_kv_list()`. Keys MUST start with `global:`, `user:`, `project:<id>:`, `app:<id>:`, or `procedure:<verb>:<context-tag>`. The `procedure:` namespace stores learned how-tos: write via `memex_kv_write`, read active value via `memex_kv_get(key)`, inspect envelope via `memex_kv_get(key, include_history=true)`. Track outcomes via `memex_record_outcome(target_type="kv_key", kv_key=..., success=...)`. Deletion is CLI-only (`memex kv delete`).
 - **Capturing work** — `memex_add_note` for NEW/replace; `memex_append_note(note_key=..., delta=...)` to extend existing. Prefer append over re-ingesting the whole body.
 - **Templates** → `memex_list_templates` for slugs; `memex_get_template(slug)` for the scaffold; `memex_add_note(..., template=slug)` for structured captures.
-- **Curating memory** — `memex_memory_deprioritize(unit_id, reason=...)` is NON-DESTRUCTIVE (unit stays on graph, recallable via `include_deprioritized=true`; rank drops). Pair with `memex_record_outcome(success=false)` when the agent found it wrong. Reversible via `memex_memory_restore`. Archive (CLI-only) is DESTRUCTIVE — prefer deprioritize unless PII removal is required.
+- **Curating memory** — `memex_memory_deprioritize(unit_id, reason=...)` is NON-DESTRUCTIVE (unit stays on graph, recallable via `include_deprioritized=true`; rank drops). Pair with `memex_record_outcome(units=[{verb:"not_helpful", reason:"..."}])` when the agent found it wrong. Reversible via `memex_memory_restore`. Archive (CLI-only) is DESTRUCTIVE — prefer deprioritize unless PII removal is required.
 - **Synchronous consolidation** — `memex_memory_summarize_node(entity_id, scope='incremental'|'full')` when in-session facts conflict or scatter. `'incremental'` (default) consolidates new evidence only; `'full'` re-evaluates all (capped 1000 units). Rate-limited per (entity, vault); on rejection, response includes `retry_after_seconds`.
 - **Reconsolidate vs consolidate** — `memex_memory_reconsolidate(entity_id, vault_id)` is entity-scoped (contradiction detection + reflection); `memex_memory_consolidate(vault_id, dry_run)` is vault-scoped (batch deprioritizes low-MW + stale units, writes to maintenance ledger). Use `reconsolidate` on concrete contradiction signals; `consolidate` for periodic maintenance."""
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/templates.py
@@ -66,7 +66,7 @@ RESOLUTION_FLOW_PROMPT_FRAGMENT = (
     '       (C) single-note: memex_get_page_indices → memex_get_memory_units(chunk_ids=[...])\n'
     '  3. JUDGE — read candidate unit bodies; LLM-pick the fix-relevant subset.\n'
     '  4. RECORD — for each judged-relevant unit:\n'
-    "     memex_record_outcome(unit_ids=[...], success=False, reason='...')\n"
+    "     memex_record_outcome(units=[{'unit_id':'...','verb':'not_helpful','reason':'...'}])\n"
     '  5. DEPRIORITIZE — for the SAME subset:\n'
     "     memex_memory_deprioritize(unit_id=..., reason='...')\n"
     '\n'

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3798,6 +3798,20 @@ RECORD_OUTCOME_SCHEMA: dict[str, Any] = {
                     'Drives coverage_ratio on the audit log.'
                 ),
             },
+            'caller_id': {
+                'type': 'string',
+                'description': (
+                    'Caller identifier (session id or API key fingerprint) for the audit log.'
+                ),
+            },
+            'turn_outcome': {
+                'type': 'string',
+                'description': ('Coarse turn-level outcome label (e.g. success/failure/mixed).'),
+            },
+            'exploration_tagged': {
+                'type': 'boolean',
+                'description': 'True iff any unit was exploration-injected on retrieval.',
+            },
         },
     },
 }
@@ -3859,6 +3873,19 @@ def handle_record_outcome(
     reason = args.get('reason')
     retrieved_set_size = args.get('retrieved_set_size')
 
+    caller_id = args.get('caller_id')
+    if caller_id is not None and not isinstance(caller_id, str):
+        return tool_error("'caller_id' must be a string")
+
+    turn_outcome = args.get('turn_outcome')
+    if turn_outcome is not None and not isinstance(turn_outcome, str):
+        return tool_error("'turn_outcome' must be a string")
+
+    exploration_tagged_raw = args.get('exploration_tagged', False)
+    if not isinstance(exploration_tagged_raw, bool):
+        return tool_error("'exploration_tagged' must be a boolean")
+    exploration_tagged = exploration_tagged_raw
+
     try:
         result = run_sync(
             api.record_outcome(
@@ -3870,7 +3897,10 @@ def handle_record_outcome(
                 target_type=target_type,
                 kv_key=kv_key,
                 units=units,
+                caller_id=caller_id,
+                turn_outcome=turn_outcome,
                 retrieved_set_size=retrieved_set_size,
+                exploration_tagged=exploration_tagged,
             ),
             timeout=30.0,
         )

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -3703,22 +3703,25 @@ ALL_SCHEMAS.append(MEMORY_SUMMARIZE_NODE_SCHEMA)
 RECORD_OUTCOME_SCHEMA: dict[str, Any] = {
     'name': 'memex_record_outcome',
     'description': (
-        'Record whether previously retrieved memories or a stored procedure '
-        'contributed to a successful outcome. Default mode increments MW '
-        "counters on memory units (target_type='memory_unit', "
-        "unit_ids=[...]); set target_type='kv_key' with kv_key="
-        "'procedure:<verb>:<context-tag>' to score a stored procedure. Call "
-        'after you actually used the retrieved memory or the procedure.\n\n'
+        'Record how previously retrieved memories or a stored procedure '
+        'contributed to the outcome. Default mode increments MW counters on '
+        "memory units (target_type='memory_unit', units=[{unit_id, verb, "
+        'reason}]) where verb is "helpful", "not_helpful", or "not_used" — '
+        'reason is required for helpful and not_helpful. Set '
+        "target_type='kv_key' with kv_key='procedure:<verb>:<context-tag>' "
+        'to score a stored procedure. Call after you actually used the '
+        'retrieved memory or the procedure.\n\n'
         'Call generously. Silence provides no learning signal.\n\n'
         'When the user reports an issue resolved, follow the §3.5 5-step flow '
         '(see briefing): disambiguate first, route by info quality (Options '
         'A/B/C; Option B requires top_k>=30), mandatory LLM judgment over '
-        'candidates, then PAIRED writes — memex_record_outcome(success=false) '
-        'AND memex_memory_deprioritize against the LLM-judged-relevant subset '
-        'only. The two verbs are orthogonal axes (MW gradient vs binary surface '
-        'state); user-confirmed-fix is BOTH signals at once. Imperfect '
-        'cross-note recall is by design — exploration is the safety net. '
-        'For HOW-THINGS-CHANGED audit queries, route to '
+        'candidates, then PAIRED writes — memex_record_outcome with '
+        "units=[{verb: 'not_helpful', ...}] AND memex_memory_deprioritize "
+        'against the LLM-judged-relevant subset only. The two verbs are '
+        'orthogonal axes (MW gradient vs binary surface state); user-'
+        'confirmed-fix is BOTH signals at once. Imperfect cross-note recall '
+        'is by design — exploration is the safety net. For HOW-THINGS-'
+        'CHANGED audit queries, route to '
         'memex_memory_search(apply_pre_filter=False) instead.'
     ),
     'parameters': {
@@ -3727,18 +3730,35 @@ RECORD_OUTCOME_SCHEMA: dict[str, Any] = {
             'success': {
                 'type': 'boolean',
                 'description': (
-                    'True if the task succeeded using these memories, '
-                    'false if they were misleading.'
+                    'kv_key mode only or legacy memory_unit shape '
+                    '(FutureWarning). True/false. Prefer the per-unit `units` '
+                    'parameter for memory_unit mode.'
+                ),
+            },
+            'units': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'unit_id': {'type': 'string'},
+                        'verb': {
+                            'type': 'string',
+                            'enum': ['helpful', 'not_helpful', 'not_used'],
+                        },
+                        'reason': {'type': ['string', 'null']},
+                    },
+                    'required': ['unit_id', 'verb'],
+                },
+                'description': (
+                    'memory_unit mode. Per-unit verb classifications. `reason` '
+                    'is required for helpful and not_helpful, optional for '
+                    'not_used.'
                 ),
             },
             'unit_ids': {
                 'type': 'array',
                 'items': {'type': 'string'},
-                'description': (
-                    'memory_unit mode only. UUIDs of memory units you actually '
-                    'used — not all retrieved units, only the ones that were '
-                    "load-bearing in your reasoning. Required when target_type='memory_unit'."
-                ),
+                'description': ('Legacy memory_unit shape (FutureWarning). Prefer `units`.'),
             },
             'vault_id': {
                 'type': 'string',
@@ -3759,7 +3779,7 @@ RECORD_OUTCOME_SCHEMA: dict[str, Any] = {
                 'enum': ['memory_unit', 'kv_key'],
                 'description': (
                     "What the outcome scores. 'memory_unit' (default) increments "
-                    "MW counters on memory units in unit_ids. 'kv_key' "
+                    "MW counters on memory units in units/unit_ids. 'kv_key' "
                     'increments counters on the procedure_outcomes row for kv_key.'
                 ),
             },
@@ -3770,8 +3790,15 @@ RECORD_OUTCOME_SCHEMA: dict[str, Any] = {
                     "(procedure:<verb>:<context-tag>). Required when target_type='kv_key'."
                 ),
             },
+            'retrieved_set_size': {
+                'type': 'integer',
+                'minimum': 0,
+                'description': (
+                    'Size of the retrieved set the caller was asked to classify. '
+                    'Drives coverage_ratio on the audit log.'
+                ),
+            },
         },
-        'required': ['success'],
     },
 }
 
@@ -3784,24 +3811,38 @@ def handle_record_outcome(
 ) -> str:
     """Dual-mode dispatcher (memory_unit / kv_key).
 
-    Preserves the ADD-2 invariant by passing ``unit_ids`` and ``success``
-    positionally and ``target_type`` / ``kv_key`` keyword-only — same shape
-    as MemexAPI.record_outcome and RemoteMemexAPI.record_outcome.
+    Accepts the per-unit ``units`` shape (preferred) or the legacy
+    ``(unit_ids, success)`` shape (FutureWarning) for memory_unit mode.
+    kv_key mode still uses ``success``.
     """
-    try:
-        success = _require(args, 'success')
-    except ValueError as e:
-        return tool_error(str(e))
-    if not isinstance(success, bool):
-        return tool_error(f"'success' must be a boolean, got {type(success).__name__}")
-
     target_type = args.get('target_type', 'memory_unit')
     if target_type not in ('memory_unit', 'kv_key'):
         return tool_error(f"target_type must be 'memory_unit' or 'kv_key', got {target_type!r}")
 
+    units = args.get('units')
+    if units is not None and not isinstance(units, list):
+        return tool_error("'units' must be a list of {unit_id, verb, reason} objects")
+
     unit_ids = args.get('unit_ids')
     if unit_ids is not None and not isinstance(unit_ids, list):
         return tool_error("'unit_ids' must be a list of UUID strings")
+
+    success_raw = args.get('success')
+    success: bool | None
+    if success_raw is None:
+        success = None
+    elif isinstance(success_raw, bool):
+        success = success_raw
+    else:
+        return tool_error(f"'success' must be a boolean, got {type(success_raw).__name__}")
+
+    if target_type == 'memory_unit' and units is None and unit_ids is None:
+        return tool_error(
+            "memory_unit mode requires either 'units' (preferred) or "
+            "legacy ('unit_ids' + 'success')."
+        )
+    if target_type == 'kv_key' and success is None:
+        return tool_error("kv_key mode requires the 'success' boolean.")
 
     kv_key = args.get('kv_key')
     if kv_key is not None and not isinstance(kv_key, str):
@@ -3816,6 +3857,7 @@ def handle_record_outcome(
 
     outcome_confidence = args.get('outcome_confidence', 1.0)
     reason = args.get('reason')
+    retrieved_set_size = args.get('retrieved_set_size')
 
     try:
         result = run_sync(
@@ -3827,6 +3869,8 @@ def handle_record_outcome(
                 reason,
                 target_type=target_type,
                 kv_key=kv_key,
+                units=units,
+                retrieved_set_size=retrieved_set_size,
             ),
             timeout=30.0,
         )

--- a/packages/hermes-plugin/tests/test_record_outcome_f29.py
+++ b/packages/hermes-plugin/tests/test_record_outcome_f29.py
@@ -54,16 +54,29 @@ def test_handler_dispatchable():
 
 
 def test_schema_shape():
-    """Schema covers both modes; only success is required at the schema level
-    (mode-specific requirements are validated in the handler/route since they
-    depend on target_type — the JSON-schema ``required`` array can't express
-    that conditionally without oneOf bloat)."""
+    """Schema covers both shapes (per-unit `units` + legacy `unit_ids`/`success`)
+    and both modes (memory_unit / kv_key). Mode-specific requirements are
+    validated in the handler since they depend on target_type — the JSON-schema
+    `required` array can't express that conditionally without oneOf bloat."""
     props = RECORD_OUTCOME_SCHEMA['parameters']['properties']
-    assert {'success', 'unit_ids', 'kv_key', 'target_type', 'vault_id'} <= set(props)
-    assert RECORD_OUTCOME_SCHEMA['parameters']['required'] == ['success']
+    assert {
+        'success',
+        'units',
+        'unit_ids',
+        'kv_key',
+        'target_type',
+        'vault_id',
+    } <= set(props)
     assert props['target_type']['enum'] == ['memory_unit', 'kv_key']
     assert props['outcome_confidence']['minimum'] == 0.0
     assert props['outcome_confidence']['maximum'] == 1.0
+    # Per-unit shape carries verb enum.
+    units_items = props['units']['items']
+    assert units_items['properties']['verb']['enum'] == [
+        'helpful',
+        'not_helpful',
+        'not_used',
+    ]
 
 
 def test_protocol_method_present():
@@ -106,7 +119,12 @@ def test_dispatch_memory_unit_passthrough(config, vault_id):
         1.0,  # outcome_confidence
         None,  # reason
     )
-    assert call.kwargs == {'target_type': 'memory_unit', 'kv_key': None}
+    assert call.kwargs == {
+        'target_type': 'memory_unit',
+        'kv_key': None,
+        'units': None,
+        'retrieved_set_size': None,
+    }
 
 
 def test_dispatch_kv_key_mode(config, vault_id):
@@ -165,18 +183,16 @@ def test_dispatch_explicit_vault_overrides_session(config, vault_id):
 # ---------------------------------------------------------------------------
 
 
-def test_missing_success_returns_tool_error(config, vault_id):
-    """ADD-2 invariant: success is required; absent → tool_error JSON.
+def test_missing_required_fields_returns_tool_error(config, vault_id):
+    """Memory_unit mode requires either `units` or legacy `unit_ids`+`success`.
 
-    The handler must reject before calling api.record_outcome — a regression
-    that defaulted success=False would silently train MW counters with
-    failure signals on every kwargless agent call. The api mock is left
-    un-stubbed so any call would raise AttributeError and surface here.
+    A kwargless call must reject before calling api.record_outcome — silently
+    defaulting would train MW counters with phantom signal.
     """
     api = Mock(spec=[])  # spec=[] means no attributes; any access raises.
     out = dispatch(
         'memex_record_outcome',
-        {'unit_ids': ['u1']},
+        {},
         api=api,
         config=config,
         vault_id=vault_id,

--- a/packages/hermes-plugin/tests/test_record_outcome_f29.py
+++ b/packages/hermes-plugin/tests/test_record_outcome_f29.py
@@ -66,10 +66,16 @@ def test_schema_shape():
         'kv_key',
         'target_type',
         'vault_id',
+        'caller_id',
+        'turn_outcome',
+        'exploration_tagged',
     } <= set(props)
     assert props['target_type']['enum'] == ['memory_unit', 'kv_key']
     assert props['outcome_confidence']['minimum'] == 0.0
     assert props['outcome_confidence']['maximum'] == 1.0
+    assert props['caller_id']['type'] == 'string'
+    assert props['turn_outcome']['type'] == 'string'
+    assert props['exploration_tagged']['type'] == 'boolean'
     # Per-unit shape carries verb enum.
     units_items = props['units']['items']
     assert units_items['properties']['verb']['enum'] == [
@@ -123,7 +129,10 @@ def test_dispatch_memory_unit_passthrough(config, vault_id):
         'target_type': 'memory_unit',
         'kv_key': None,
         'units': None,
+        'caller_id': None,
+        'turn_outcome': None,
         'retrieved_set_size': None,
+        'exploration_tagged': False,
     }
 
 
@@ -159,6 +168,49 @@ def test_dispatch_kv_key_mode(config, vault_id):
     assert call.args[1] is False  # success
     assert call.kwargs['target_type'] == 'kv_key'
     assert call.kwargs['kv_key'] == 'procedure:run-tests:default'
+
+
+def test_dispatch_audit_fields_passthrough(config, vault_id):
+    """caller_id, turn_outcome, and exploration_tagged must flow to api.record_outcome
+    so Hermes-driven outcomes carry the same audit context the HTTP route does."""
+    api = Mock()
+    api.record_outcome = AsyncMock(return_value={'units_updated': 1})
+    dispatch(
+        'memex_record_outcome',
+        {
+            'success': True,
+            'unit_ids': ['u1'],
+            'caller_id': 'hermes-session-abc',
+            'turn_outcome': 'success',
+            'exploration_tagged': True,
+        },
+        api=api,
+        config=config,
+        vault_id=vault_id,
+    )
+    call = api.record_outcome.await_args
+    assert call is not None
+    assert call.kwargs['caller_id'] == 'hermes-session-abc'
+    assert call.kwargs['turn_outcome'] == 'success'
+    assert call.kwargs['exploration_tagged'] is True
+
+
+def test_dispatch_audit_fields_type_validation(config, vault_id):
+    """Invalid types for the new audit fields must error before the api call."""
+    api = Mock(spec=[])
+    for bad in (
+        {'success': True, 'unit_ids': ['u1'], 'caller_id': 123},
+        {'success': True, 'unit_ids': ['u1'], 'turn_outcome': 99},
+        {'success': True, 'unit_ids': ['u1'], 'exploration_tagged': 'yes'},
+    ):
+        out = dispatch(
+            'memex_record_outcome',
+            bad,
+            api=api,
+            config=config,
+            vault_id=vault_id,
+        )
+        assert 'error' in json.loads(out)
 
 
 def test_dispatch_explicit_vault_overrides_session(config, vault_id):

--- a/packages/mcp/src/memex_mcp/_outcome_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_outcome_descriptions.py
@@ -24,5 +24,7 @@ MEMEX_RECORD_OUTCOME_DESCRIPTION = (
     '"identified the failing module"}, {"unit_id": "...", "verb": "not_used", '
     '"reason": null}]. Bad example: stamping everything "helpful" — the audit '
     'log catches it and the engagement signal goes silent.\n\n'
+    'Pass `retrieved_set_size` explicitly to enable coverage tracking. '
+    'Omitting it leaves coverage_ratio as NULL.\n\n'
     'Call generously. Silence provides no learning signal.'
 )

--- a/packages/mcp/src/memex_mcp/_outcome_descriptions.py
+++ b/packages/mcp/src/memex_mcp/_outcome_descriptions.py
@@ -12,11 +12,17 @@ augmented composite.
 from __future__ import annotations
 
 MEMEX_RECORD_OUTCOME_DESCRIPTION = (
-    'Record whether previously retrieved memories or a stored procedure '
-    'contributed to a successful outcome. Default mode increments Memory Worth '
-    'counters on memory units (target_type="memory_unit", '
-    'unit_ids=[...]); set target_type="kv_key" with kv_key='
-    '"procedure:<verb>:<context-tag>" to score a stored procedure. Call '
-    'after you actually used the retrieved memory or the procedure.\n\n'
+    'Record how previously retrieved memories or a stored procedure contributed '
+    'to the outcome. Default mode increments Memory Worth counters on memory '
+    'units (target_type="memory_unit", units=[{unit_id, verb, reason}]) where '
+    '`verb` is "helpful", "not_helpful", or "not_used". `reason` is required '
+    'for helpful and not_helpful; optional for not_used. Set '
+    'target_type="kv_key" with kv_key="procedure:<verb>:<context-tag>" to '
+    'score a stored procedure. Call after you actually used the retrieved '
+    'memory or the procedure.\n\n'
+    'Good example: units=[{"unit_id": "...", "verb": "helpful", "reason": '
+    '"identified the failing module"}, {"unit_id": "...", "verb": "not_used", '
+    '"reason": null}]. Bad example: stamping everything "helpful" — the audit '
+    'log catches it and the engagement signal goes silent.\n\n'
     'Call generously. Silence provides no learning signal.'
 )

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3791,7 +3791,8 @@ async def memex_record_outcome(
             ge=0,
             description=(
                 'Size of the retrieved set the caller was asked to classify. '
-                'Drives coverage_ratio on the audit log.'
+                'Drives coverage_ratio on the audit log. Pass explicitly to '
+                'enable coverage tracking; omitting leaves coverage_ratio NULL.'
             ),
         ),
     ] = None,
@@ -3802,18 +3803,6 @@ async def memex_record_outcome(
         vault_id = vault_id or _default_write_vault(ctx)
         resolved_vid = await _resolve_vault_id(api, vault_id)
 
-        resolved_retrieved_set_size = retrieved_set_size
-        if resolved_retrieved_set_size is None and target_type == 'memory_unit':
-            try:
-                dedup = _get_session_dedup(ctx.session_id)
-                seen = len(dedup.seen_memory_ids)
-                if seen > 0:
-                    resolved_retrieved_set_size = seen
-            except Exception:
-                # Session-state lookup is best-effort; coverage_ratio simply
-                # stays None when the seen-set is unavailable.
-                pass
-
         return await api.record_outcome(
             unit_ids=unit_ids,
             success=success,
@@ -3823,7 +3812,7 @@ async def memex_record_outcome(
             target_type=target_type,
             kv_key=kv_key,
             units=units,
-            retrieved_set_size=resolved_retrieved_set_size,
+            retrieved_set_size=retrieved_set_size,
         )
 
     except ToolError:

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3802,6 +3802,18 @@ async def memex_record_outcome(
         vault_id = vault_id or _default_write_vault(ctx)
         resolved_vid = await _resolve_vault_id(api, vault_id)
 
+        resolved_retrieved_set_size = retrieved_set_size
+        if resolved_retrieved_set_size is None and target_type == 'memory_unit':
+            try:
+                dedup = _get_session_dedup(ctx.session_id)
+                seen = len(dedup.seen_memory_ids)
+                if seen > 0:
+                    resolved_retrieved_set_size = seen
+            except Exception:
+                # Session-state lookup is best-effort; coverage_ratio simply
+                # stays None when the seen-set is unavailable.
+                pass
+
         return await api.record_outcome(
             unit_ids=unit_ids,
             success=success,
@@ -3811,7 +3823,7 @@ async def memex_record_outcome(
             target_type=target_type,
             kv_key=kv_key,
             units=units,
-            retrieved_set_size=retrieved_set_size,
+            retrieved_set_size=resolved_retrieved_set_size,
         )
 
     except ToolError:

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3702,21 +3702,41 @@ from memex_mcp._resolution_flow_descriptions import (
 async def memex_record_outcome(
     ctx: Context,
     success: Annotated[
-        bool,
+        bool | None,
         BeforeValidator(_coerce_bool),
         Field(
-            description='True if the task succeeded using these memories, false if they were misleading.'
+            default=None,
+            description=(
+                'kv_key mode only or legacy memory_unit shape. True if the task '
+                'succeeded, false if it failed. For memory_unit mode prefer the '
+                '`units` parameter with per-unit verbs.'
+            ),
         ),
-    ],
+    ] = None,
+    units: Annotated[
+        list[dict] | None,
+        BeforeValidator(_coerce_list),
+        Field(
+            default=None,
+            description=(
+                'memory_unit mode only. Per-unit verb classifications. Each entry: '
+                '{unit_id: UUID, verb: "helpful"|"not_helpful"|"not_used", '
+                'reason: str}. `reason` is required for helpful and not_helpful. '
+                'Examples — good: [{"unit_id": "...", "verb": "helpful", '
+                '"reason": "named the right module"}, {"unit_id": "...", '
+                '"verb": "not_used", "reason": null}]. Bad: classifying everything '
+                'helpful or omitting reason for credit-bearing verbs.'
+            ),
+        ),
+    ] = None,
     unit_ids: Annotated[
         list[str] | None,
         BeforeValidator(_coerce_list),
         Field(
             default=None,
             description=(
-                'memory_unit mode only. UUIDs of memory units you actually used — '
-                'not all retrieved units, only the ones that were load-bearing '
-                'in your reasoning. Required when target_type="memory_unit".'
+                'Legacy memory_unit shape (FutureWarning). UUIDs of memory units '
+                'you actually used. Prefer the `units` parameter.'
             ),
         ),
     ] = None,
@@ -3747,8 +3767,8 @@ async def memex_record_outcome(
             default='memory_unit',
             description=(
                 'What the outcome scores. "memory_unit" (default) increments '
-                'Memory Worth counters on memory units in unit_ids. "kv_key" '
-                'increments vault-scoped counters on the procedure_outcomes '
+                'Memory Worth counters on the memory units in `units` or `unit_ids`. '
+                '"kv_key" increments vault-scoped counters on the procedure_outcomes '
                 'row for kv_key.'
             ),
         ),
@@ -3761,6 +3781,17 @@ async def memex_record_outcome(
                 'kv_key mode only. Procedure KV key (procedure:<verb>:<context-tag>) '
                 'whose Memory Worth counters should be incremented. '
                 'Required when target_type="kv_key".'
+            ),
+        ),
+    ] = None,
+    retrieved_set_size: Annotated[
+        int | None,
+        Field(
+            default=None,
+            ge=0,
+            description=(
+                'Size of the retrieved set the caller was asked to classify. '
+                'Drives coverage_ratio on the audit log.'
             ),
         ),
     ] = None,
@@ -3779,6 +3810,8 @@ async def memex_record_outcome(
             reason=reason,
             target_type=target_type,
             kv_key=kv_key,
+            units=units,
+            retrieved_set_size=retrieved_set_size,
         )
 
     except ToolError:

--- a/packages/mcp/tests/test_mcp_outcome.py
+++ b/packages/mcp/tests/test_mcp_outcome.py
@@ -153,3 +153,55 @@ async def test_mcp_record_outcome_default_vault(mock_api, mcp_client, mock_confi
     # Verify default write vault was used (no explicit vault_id)
     call_kwargs = mock_api.record_outcome.call_args
     assert call_kwargs.kwargs.get('vault_id') is not None
+
+
+@pytest.mark.asyncio
+async def test_mcp_record_outcome_no_retrieved_set_size_no_auto_fill(mock_api, mcp_client):
+    """Omitting retrieved_set_size leaves it as None — no session-derived fallback.
+
+    Cumulative session seen_memory_ids would conflate retrievals across calls
+    and produce misleading coverage_ratio values, so the handler must pass the
+    caller's value through unchanged (None when absent).
+    """
+    mock_api.record_outcome.return_value = {
+        'units_updated': 1,
+        'entities_updated': 0,
+        'models_updated': 0,
+    }
+
+    unit_id = str(uuid4())
+    await mcp_client.call_tool(
+        'memex_record_outcome',
+        {
+            'unit_ids': [unit_id],
+            'success': True,
+            'vault_id': str(TEST_VAULT_UUID),
+        },
+    )
+
+    call_kwargs = mock_api.record_outcome.call_args
+    assert call_kwargs.kwargs.get('retrieved_set_size') is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_record_outcome_explicit_retrieved_set_size_passthrough(mock_api, mcp_client):
+    """Caller-supplied retrieved_set_size is forwarded verbatim."""
+    mock_api.record_outcome.return_value = {
+        'units_updated': 1,
+        'entities_updated': 0,
+        'models_updated': 0,
+    }
+
+    unit_id = str(uuid4())
+    await mcp_client.call_tool(
+        'memex_record_outcome',
+        {
+            'unit_ids': [unit_id],
+            'success': True,
+            'vault_id': str(TEST_VAULT_UUID),
+            'retrieved_set_size': 10,
+        },
+    )
+
+    call_kwargs = mock_api.record_outcome.call_args
+    assert call_kwargs.kwargs.get('retrieved_set_size') == 10

--- a/tests/test_e2e_f29_outcomes_route.py
+++ b/tests/test_e2e_f29_outcomes_route.py
@@ -231,7 +231,7 @@ def test_kv_key_mode_with_unit_ids_returns_400(client: TestClient, postgres_url:
 
 
 @pytest.mark.integration
-def test_missing_success_returns_422(client: TestClient, postgres_url: str):
+def test_missing_success_returns_400(client: TestClient, postgres_url: str):
     """ADD-2 invariant: success has no default; omitting it is a caller error.
 
     Mirrors the F14 contract test — a kwargless / minimal call site cannot

--- a/tests/test_e2e_f29_outcomes_route.py
+++ b/tests/test_e2e_f29_outcomes_route.py
@@ -232,11 +232,16 @@ def test_kv_key_mode_with_unit_ids_returns_400(client: TestClient, postgres_url:
 
 @pytest.mark.integration
 def test_missing_success_returns_422(client: TestClient, postgres_url: str):
-    """ADD-2 invariant: success has no default; omitting it is a validation error.
+    """ADD-2 invariant: success has no default; omitting it is a caller error.
 
     Mirrors the F14 contract test — a kwargless / minimal call site cannot
-    silently record a FAILURE outcome. The HTTP layer must enforce this same
-    invariant via Pydantic body validation (Field(...) with no default).
+    silently record a FAILURE outcome. Under the new per-unit verb shape
+    ``success`` is optional on the wire (Pydantic accepts None), so the
+    service layer enforces the invariant and returns 400 when the legacy
+    ``unit_ids`` half of the pair is supplied without ``success``. 400 is
+    semantically more accurate than 422 here — the caller specified one
+    half of a legacy pair without the other (a contract violation), not a
+    schema violation.
     """
     _, vault_id = _seed_unit(postgres_url)
     resp = client.post(
@@ -246,7 +251,7 @@ def test_missing_success_returns_422(client: TestClient, postgres_url: str):
             'vault_id': str(vault_id),
         },
     )
-    assert resp.status_code == 422, resp.text
+    assert resp.status_code == 400, resp.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Lands the per-unit outcome-attribution redesign that closes the four residual signal-quality concerns in the academic-review pushback.

- New `UnitOutcome` Pydantic model with verb taxonomy (`helpful` / `not_helpful` / `not_used`) — `reason` is required for credit-bearing verbs (enforced via `@model_validator`).
- New `unused_co_count` integer column on `memory_units`, `unit_entities`, `mental_models` (server-default 0; no backfill window). Captures the retrieved-but-unused engagement signal that previously vanished.
- New vault-scoped `outcome_audit_log` table — one row per `record_outcome` call carrying `units` JSONB, `coverage_ratio`, `turn_outcome`, `exploration_tagged`, `caller_id`. Substrate for offline signal-quality audits.
- `OutcomesConfig` config block (`coverage_check_mode`, `contradiction_failure_weight`, `mw_mode_default`) under `MEMEX_OUTCOMES__*` env vars.
- Backwards-compat shim: `record_outcome(unit_ids=..., success=...)` still works and emits `FutureWarning`; auto-translates to `UnitOutcome(verb='helpful' | 'not_helpful', ...)`.
- Contradiction engine wires `weakens`/`contradicts` link commits into `failure_co_count`, weighted by `contradiction_failure_weight` (default 0.5, rounded to integer bump).
- New metrics: `memex_outcome_verb_total` Counter and `memex_outcome_coverage_ratio` Histogram (both vault-id labelled, bounded enum labels).
- Cross-surface description updates: MCP tool description, Hermes plugin schema + handler + briefing + templates, Claude Code resolution-flow examples.

## Migration

`packages/core/src/memex_core/alembic/versions/037_outcome_per_unit_schema.py` is additive only — three new server-defaulted columns + one new empty table. Safe `just db-upgrade`; reversible.

## Tests

- New unit test: `packages/core/tests/unit/services/test_outcome_service_per_unit.py` (15 tests) covering `UnitOutcome` validator + resolver + legacy shim translation + `FutureWarning`.
- Existing unit tests for `outcomes` / `vault_access` / `client.record_outcome` / `record_outcome_f29` all pass with updated assertions where signature shape changed.
- 9 pre-existing test failures on `release/tier-a-cognitive-memory` (FSRS-5 import drift in mcp/server.py, F33/F43 test-references) are NOT introduced by this PR — verified via `git stash` comparison.

## Deferred (per the implementation plan)

- DESIGN_DOCUMENT.md §3.5.2 + §4.8 edits (gitignored on this branch; needs primary-checkout work).
- Real-LLM-turn validation (DoD): a Hermes turn against the new MCP schema emitting a valid `UnitOutcome` payload — manual verification.
- Six eval scenarios (`outcomes_per_unit_verb_taxonomy`, `outcomes_legacy_shim`, `outcomes_coverage_strict`, `outcomes_contradiction_failure_wiring`, `outcomes_ema_default`, `outcomes_audit_log_sample_audit`) — follow-up under `packages/eval/`.
- Three additional integration test files (`test_outcome_per_unit_e2e.py`, `test_contradiction_failure_wiring.py`, `test_outcome_coverage_check.py`) — DB-bound; this branch carries the unit-test contract; integration scenarios fold into the eval suite follow-up.
- How-to docs / release-notes — follow-up.

## Notes / choices made

- `failure_co_count` is an integer column; the `contradiction_failure_weight` is rounded to an integer per-link bump (`round(weight)`). 0.0 disables; ≥0.5 yields a +1 bump per negative-evidence link. Documented in the field's docstring.
- `mw_mode_default` is exposed as a config string (`'ema'`) — the per-`Vault.mw_mode` enum override at the SQL layer is unchanged (existing rows keep their setting). New vaults can be initialised against this default in a follow-up.
- The `OUTCOME_RECORDED_TOTAL` Counter retains its existing 2-value label space (`success`/`failure`) and is bumped from `verb='helpful'` and `verb='not_helpful'` calls only; `not_used` is tracked through `OUTCOME_VERB_TOTAL` exclusively.

## Test plan

- [x] `UV_PROJECT_ENVIRONMENT=.venv uv run --no-sync ruff check` clean on all touched files
- [x] `UV_PROJECT_ENVIRONMENT=.venv uv run --no-sync ruff format` applied
- [x] `UV_PROJECT_ENVIRONMENT=.venv uv run --no-sync pytest packages/core/tests/unit/services/test_outcome_service_per_unit.py` — 15 passed
- [x] pre-commit hooks clean (ruff + ruff-format + mypy)
- [ ] `just db-upgrade` against a populated dev DB (manual)
- [ ] Real Hermes turn end-to-end (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)