### PR TITLE
feat(core): entity-cluster collapse maintenance (V4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,526%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,530%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,520%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,523%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,470%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,520%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,531%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,534%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,530%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,531%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-5,523%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-5,526%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/cli/src/memex_cli/entities.py
+++ b/packages/cli/src/memex_cli/entities.py
@@ -388,3 +388,74 @@ async def list_related(
         table.add_row(name, str(count), str(other_id))
 
     console.print(table)
+
+
+@app.command('scan-merges')
+@async_command
+async def scan_merges_cmd(
+    ctx: typer.Context,
+    top_n: Annotated[
+        int | None,
+        typer.Option(
+            '--top-n',
+            min=2,
+            max=10_000,
+            help='Override the config default for how many entities to scan.',
+        ),
+    ] = None,
+    scan_cooldown_days: Annotated[
+        int | None,
+        typer.Option(
+            '--cooldown-days',
+            min=0,
+            help='Override per-entity cooldown in days.',
+        ),
+    ] = None,
+    pair_threshold: Annotated[
+        float | None,
+        typer.Option(
+            '--pair-threshold',
+            min=0.0,
+            max=1.0,
+            help='Override minimum pairwise similarity to graph-link two entities.',
+        ),
+    ] = None,
+    cluster_min_threshold: Annotated[
+        float | None,
+        typer.Option(
+            '--cluster-min',
+            min=0.0,
+            max=1.0,
+            help=(
+                'Override min-pairwise cohesion threshold (must be '
+                '<= --pair-threshold; rope-drift guard).'
+            ),
+        ),
+    ] = None,
+):
+    """Run an on-demand cross-batch entity-cluster collapse scan.
+
+    Emits one MaintenanceProposal per surviving cluster. The merge itself is
+    NOT applied — review the proposals with ``memex lint findings`` and
+    approve via ``memex lint resolve <id> --winner <member>``. The collapse
+    affects every vault listed in ``evidence.vaults_affected``.
+    """
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        try:
+            summary = await api.scan_entity_merges(
+                top_n=top_n,
+                scan_cooldown_days=scan_cooldown_days,
+                pair_threshold=pair_threshold,
+                cluster_min_threshold=cluster_min_threshold,
+            )
+        except Exception as e:
+            handle_api_error(e)
+            return
+
+    console.print(
+        f'[green]scan complete[/green]: scanned={summary.get("scanned", 0)}, '
+        f'emitted={summary.get("clusters_emitted", 0)}, '
+        f'rejected_cohesion={summary.get("clusters_rejected_cohesion", 0)}, '
+        f'rescan_updated={summary.get("rescan_updated", 0)}'
+    )

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -15,7 +15,8 @@ for human inspection and reconciliation.
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
+from uuid import UUID
 
 import typer
 from rich.console import Console
@@ -193,13 +194,38 @@ async def lint_dismiss_cmd(
 async def lint_resolve_cmd(
     ctx: typer.Context,
     finding_id: Annotated[str, typer.Argument(help='Finding UUID to mark resolved.')],
+    winner: Annotated[
+        str | None,
+        typer.Option(
+            '--winner',
+            '-w',
+            help=(
+                'For entity_collapse_cluster findings, override the suggested winner. '
+                'Accepts either a UUID (must match a cluster member) or a canonical '
+                'name (case-sensitive match against the cluster). The collapse '
+                'affects every vault in evidence.vaults_affected.'
+            ),
+        ),
+    ] = None,
 ):
-    """Flip a pending finding to ``resolved``."""
+    """Flip a pending finding to ``resolved``.
+
+    For ``entity_collapse_cluster`` findings, optionally override the
+    suggested cluster winner with ``--winner / -w``. Without the flag,
+    the server applies the suggested winner recorded in the finding.
+    """
     parse_uuid(finding_id, 'finding_id')
     config: MemexConfig = ctx.obj
+    params: dict[str, Any] | None = None
+    if winner is not None:
+        try:
+            UUID(winner)
+            params = {'winner_id': winner}
+        except ValueError:
+            params = {'winner_canonical_name': winner}
     async with get_api_context(config) as api:
         try:
-            payload = await api.lint_resolve(finding_id)
+            payload = await api.lint_resolve(finding_id, params=params)
         except Exception as e:
             handle_api_error(e)
             return

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -531,6 +531,32 @@ class RemoteMemexAPI:
                 return False
             raise
 
+    async def scan_entity_merges(
+        self,
+        *,
+        top_n: int | None = None,
+        scan_cooldown_days: int | None = None,
+        pair_threshold: float | None = None,
+        cluster_min_threshold: float | None = None,
+    ) -> dict[str, Any]:
+        """Run a one-shot cross-batch entity-cluster collapse scan.
+
+        Emits one MaintenanceProposal per surviving cluster (cohesion-guarded);
+        on rescan, existing pending findings are UPDATEd in place. Does NOT
+        apply the collapse — operators approve via ``memex lint resolve``.
+        """
+        params: dict[str, Any] = {}
+        if top_n is not None:
+            params['top_n'] = top_n
+        if scan_cooldown_days is not None:
+            params['scan_cooldown_days'] = scan_cooldown_days
+        if pair_threshold is not None:
+            params['pair_threshold'] = pair_threshold
+        if cluster_min_threshold is not None:
+            params['cluster_min_threshold'] = cluster_min_threshold
+        response = await self.client.post('entities/scan-merges', params=params or None, json={})
+        return await self._handle_response(response)
+
     async def delete_mental_model(self, entity_id: UUID, vault_id: UUID | None = None) -> bool:
         """Delete a mental model for a specific entity in a specific vault."""
         params = {}
@@ -1318,9 +1344,22 @@ class RemoteMemexAPI:
         """Flip a pending finding to ``dismissed``."""
         return await self._post(f'lint/findings/{finding_id}/dismiss', {})
 
-    async def lint_resolve(self, finding_id: str) -> dict[str, Any]:
-        """Flip a pending finding to ``resolved``."""
-        return await self._post(f'lint/findings/{finding_id}/resolve', {})
+    async def lint_resolve(
+        self,
+        finding_id: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Flip a pending finding to ``resolved``.
+
+        ``params`` is forwarded to the server as the JSON request body and is
+        rule-specific. For ``entity_collapse_cluster`` findings, pass
+        ``{"winner_id": "<uuid>"}`` (or ``"winner_canonical_name"``) to
+        override the suggested winner; otherwise the server defaults to the
+        suggested winner recorded in the finding's evidence.
+        """
+        body: dict[str, Any] = params or {}
+        return await self._post(f'lint/findings/{finding_id}/resolve', body)
 
     async def run_lint_rules(self, vault_id: str | UUID) -> dict[str, Any]:
         """Synchronously run the V1 lint rule registry for ``vault_id``.

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1386,6 +1386,70 @@ class LintConfig(BaseModel):
     )
 
 
+class EntityMaintenanceConfig(BaseModel):
+    """Configuration for the cross-batch entity-cluster collapse loop.
+
+    Detects highly-similar entity rows that escaped the intra-batch
+    resolver (e.g. "ACME Corp" / "acme corp" / "Acme Corp") and emits a
+    cluster-aware MaintenanceProposal that a human can approve to merge
+    them into one canonical entity. Off by default — operators opt in.
+    """
+
+    scan_enabled: bool = Field(
+        default=False,
+        description=(
+            'Master switch for the periodic entity-cluster collapse scan. '
+            'Off by default — operators opt in once thresholds are tuned.'
+        ),
+    )
+    top_n: int = Field(
+        default=100,
+        ge=1,
+        description=(
+            'Maximum entities considered per scan, selected by activity '
+            '(mention_count). Empirically covers >95% of cooccurrence-weighted '
+            'activity in typical vaults.'
+        ),
+    )
+    scan_cooldown_days: int = Field(
+        default=7,
+        ge=0,
+        description=(
+            'Per-entity cooldown in days. An entity already scanned within '
+            'this window is skipped on subsequent scans.'
+        ),
+    )
+    pair_threshold: float = Field(
+        default=0.85,
+        ge=0.0,
+        le=1.0,
+        description=(
+            'Minimum pairwise similarity to connect two entities in the '
+            'candidate-cluster graph. Placeholder — empirical tuning pending.'
+        ),
+    )
+    cluster_min_threshold: float = Field(
+        default=0.70,
+        ge=0.0,
+        le=1.0,
+        description=(
+            'Cohesion guard: minimum pairwise similarity across every pair '
+            'in a candidate cluster. Clusters whose min-pair falls below this '
+            'are rejected (rope-drift protection). Must be <= pair_threshold.'
+        ),
+    )
+
+    @model_validator(mode='after')
+    def _validate_thresholds(self) -> 'EntityMaintenanceConfig':
+        if self.cluster_min_threshold > self.pair_threshold:
+            raise ValueError(
+                'cluster_min_threshold must be <= pair_threshold '
+                f'(got cluster_min_threshold={self.cluster_min_threshold}, '
+                f'pair_threshold={self.pair_threshold})'
+            )
+        return self
+
+
 class LintLLMCheckConfig(BaseModel):
     """Per-check feature flag for a DSPy lint signature."""
 
@@ -1678,6 +1742,14 @@ class MemoryConfig(BaseModel):
     lint_llm: LintLLMConfig = Field(
         default_factory=LintLLMConfig,
         description='Configuration for surprise-gated LLM-assisted lint.',
+    )
+
+    entity_maintenance: EntityMaintenanceConfig = Field(
+        default_factory=EntityMaintenanceConfig,
+        description=(
+            'Configuration for the cross-batch entity-cluster collapse loop. '
+            'Off by default; operators opt in via scan_enabled.'
+        ),
     )
 
     deprioritize_score: DeprioritizeScoreConfig = Field(

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1404,11 +1404,12 @@ class EntityMaintenanceConfig(BaseModel):
     )
     top_n: int = Field(
         default=100,
-        ge=1,
+        ge=2,
         description=(
             'Maximum entities considered per scan, selected by activity '
-            '(mention_count). Empirically covers >95% of cooccurrence-weighted '
-            'activity in typical vaults.'
+            '(mention_count). Clusters require at least two members, so '
+            'top_n must be >= 2. Empirically covers >95% of '
+            'cooccurrence-weighted activity in typical vaults.'
         ),
     )
     scan_cooldown_days: int = Field(

--- a/packages/common/tests/test_config.py
+++ b/packages/common/tests/test_config.py
@@ -178,3 +178,12 @@ class TestEntityMaintenanceConfig:
 
         cfg = EntityMaintenanceConfig(pair_threshold=0.75, cluster_min_threshold=0.75)
         assert cfg.cluster_min_threshold == cfg.pair_threshold
+
+    def test_top_n_below_two_rejected_by_config(self):
+        import pytest
+        from pydantic import ValidationError
+
+        from memex_common.config import EntityMaintenanceConfig
+
+        with pytest.raises(ValidationError):
+            EntityMaintenanceConfig(top_n=1)

--- a/packages/common/tests/test_config.py
+++ b/packages/common/tests/test_config.py
@@ -144,3 +144,37 @@ class TestVaultConfigResolution:
         )
         assert config.write_vault == 'proj'
         assert config.read_vaults == ['proj', 'shared']
+
+
+# ---------------------------------------------------------------------------
+# EntityMaintenanceConfig
+# ---------------------------------------------------------------------------
+
+
+class TestEntityMaintenanceConfig:
+    """Defaults + validator for the cross-batch entity-cluster collapse loop."""
+
+    def test_defaults_off(self):
+        from memex_common.config import EntityMaintenanceConfig
+
+        cfg = EntityMaintenanceConfig()
+        assert cfg.scan_enabled is False
+        assert cfg.top_n == 100
+        assert cfg.scan_cooldown_days == 7
+        assert cfg.pair_threshold == 0.85
+        assert cfg.cluster_min_threshold == 0.70
+
+    def test_validator_rejects_cluster_min_above_pair_threshold(self):
+        import pytest
+        from pydantic import ValidationError
+
+        from memex_common.config import EntityMaintenanceConfig
+
+        with pytest.raises(ValidationError):
+            EntityMaintenanceConfig(pair_threshold=0.7, cluster_min_threshold=0.8)
+
+    def test_validator_allows_equal_thresholds(self):
+        from memex_common.config import EntityMaintenanceConfig
+
+        cfg = EntityMaintenanceConfig(pair_threshold=0.75, cluster_min_threshold=0.75)
+        assert cfg.cluster_min_threshold == cfg.pair_threshold

--- a/packages/core/src/memex_core/alembic/versions/037_entity_last_merge_scan_at.py
+++ b/packages/core/src/memex_core/alembic/versions/037_entity_last_merge_scan_at.py
@@ -1,0 +1,75 @@
+"""entity_last_merge_scan_at — record cooldown timestamp for cross-batch entity-merge scans.
+
+Adds one nullable column to ``entities``:
+
+- ``last_merge_scan_at`` (TIMESTAMPTZ, NULL): wall-clock timestamp of the
+  most recent inclusion in an entity-cluster collapse scan. NULL = never
+  scanned (eligible on the first pass).
+
+Also creates a partial index ``idx_entities_last_merge_scan_at`` over
+non-NULL rows so the cooldown filter ``WHERE last_merge_scan_at IS NULL OR
+last_merge_scan_at < now() - interval`` can range-scan the timestamped rows
+without touching the (much larger) never-scanned set.
+
+Backfill: NULL on every existing entity — first scan post-deploy treats
+the entire population as eligible.
+
+The ``Entity`` table is global (no ``vault_id`` column). ``last_merge_scan_at``
+is therefore a single per-entity cooldown timestamp.
+
+Revision ID: 037_entity_last_merge_scan_at
+Revises: 036_fsfm_cooldown_index
+Create Date: 2026-05-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = '037_entity_last_merge_scan_at'
+down_revision: str | None = '036_fsfm_cooldown_index'
+branch_labels: str | list[str] | None = None
+depends_on: str | list[str] | None = None
+
+
+_INDEX_NAME = 'idx_entities_last_merge_scan_at'
+
+
+def _column_exists(conn, table: str, column: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            'SELECT EXISTS ('
+            '  SELECT 1 FROM information_schema.columns'
+            '  WHERE table_schema = current_schema()'
+            '    AND table_name = :table AND column_name = :column'
+            ')'
+        ),
+        {'table': table, 'column': column},
+    )
+    return bool(result.scalar())
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if not _column_exists(conn, 'entities', 'last_merge_scan_at'):
+        op.add_column(
+            'entities',
+            sa.Column('last_merge_scan_at', sa.TIMESTAMP(timezone=True), nullable=True),
+        )
+
+    op.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS {_INDEX_NAME}
+        ON entities (last_merge_scan_at)
+        WHERE last_merge_scan_at IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(f'DROP INDEX IF EXISTS {_INDEX_NAME}')
+
+    conn = op.get_bind()
+    if _column_exists(conn, 'entities', 'last_merge_scan_at'):
+        op.drop_column('entities', 'last_merge_scan_at')

--- a/packages/core/src/memex_core/alembic/versions/037_entity_last_merge_scan_at.py
+++ b/packages/core/src/memex_core/alembic/versions/037_entity_last_merge_scan_at.py
@@ -11,6 +11,13 @@ non-NULL rows so the cooldown filter ``WHERE last_merge_scan_at IS NULL OR
 last_merge_scan_at < now() - interval`` can range-scan the timestamped rows
 without touching the (much larger) never-scanned set.
 
+Additionally creates a partial expression index
+``idx_maintenance_proposals_collapse_composition`` over
+``evidence ->> 'composition_hash'`` for pending ``entity_collapse_cluster``
+proposals. The rescan-collision lookup keys by composition_hash (cluster
+membership fingerprint) so a winner shift between scans does not split into
+duplicate findings.
+
 Backfill: NULL on every existing entity — first scan post-deploy treats
 the entire population as eligible.
 
@@ -33,6 +40,7 @@ depends_on: str | list[str] | None = None
 
 
 _INDEX_NAME = 'idx_entities_last_merge_scan_at'
+_COMPOSITION_INDEX_NAME = 'idx_maintenance_proposals_collapse_composition'
 
 
 def _column_exists(conn, table: str, column: str) -> bool:
@@ -66,8 +74,17 @@ def upgrade() -> None:
         """
     )
 
+    op.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS {_COMPOSITION_INDEX_NAME}
+        ON maintenance_proposals ((evidence ->> 'composition_hash'))
+        WHERE status = 'pending' AND rule_name = 'entity_collapse_cluster'
+        """
+    )
+
 
 def downgrade() -> None:
+    op.execute(f'DROP INDEX IF EXISTS {_COMPOSITION_INDEX_NAME}')
     op.execute(f'DROP INDEX IF EXISTS {_INDEX_NAME}')
 
     conn = op.get_bind()

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -636,6 +636,10 @@ class MemexAPI:
         return self._lint
 
     @property
+    def entities(self) -> EntityService:
+        return self._entities
+
+    @property
     def consolidation(self) -> ConsolidationService:
         return self._consolidation
 

--- a/packages/core/src/memex_core/memory/entity_resolver.py
+++ b/packages/core/src/memex_core/memory/entity_resolver.py
@@ -11,7 +11,7 @@ import math
 import itertools
 
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy import func
+from sqlalchemy import case, func, null, or_
 from sqlmodel import col, text, update, select, desc
 from sqlmodel.ext.asyncio.session import AsyncSession
 from pydantic import BaseModel
@@ -651,12 +651,18 @@ class EntityResolver:
                 'cooccurrence_count': EntityCooccurrence.cooccurrence_count
                 + stmt.excluded.cooccurrence_count,
                 'last_cooccurred': stmt.excluded.last_cooccurred,
-                # Keep the earliest valid_from. LEAST(x, NULL) returns NULL in
-                # Postgres, so wrap in COALESCE to preserve the non-NULL side.
-                'valid_from': func.coalesce(
-                    func.least(EntityCooccurrence.valid_from, stmt.excluded.valid_from),
-                    EntityCooccurrence.valid_from,
-                    stmt.excluded.valid_from,
+                # NULL valid_from means "open start" — preserve it. If either
+                # side is NULL the merged interval stays open; otherwise pick
+                # the earlier date.
+                'valid_from': case(
+                    (
+                        or_(
+                            EntityCooccurrence.valid_from.is_(None),
+                            stmt.excluded.valid_from.is_(None),
+                        ),
+                        null(),
+                    ),
+                    else_=func.least(EntityCooccurrence.valid_from, stmt.excluded.valid_from),
                 ),
             },
         )

--- a/packages/core/src/memex_core/memory/entity_resolver.py
+++ b/packages/core/src/memex_core/memory/entity_resolver.py
@@ -51,6 +51,86 @@ class ResolutionResult(BaseModel):
     input_data: EntityInput
 
 
+def score_entity_pair(
+    a_name: str,
+    b_name: str,
+    a_phonetic: str | None,
+    b_phonetic: str | None,
+    a_neighbors: dict[str, int],
+    b_neighbors: dict[str, int],
+    *,
+    trigram_weight: float = 0.6,
+    phonetic_weight: float = 0.2,
+    neighbor_weight: float = 0.2,
+    phonetic_floor: float = 0.5,
+) -> float:
+    """Cross-batch entity-pair similarity used by the cluster-collapse scan.
+
+    Differs from :func:`calculate_match_score` (ingestion path) by computing
+    its own name-similarity component (trigram + phonetic) rather than
+    consuming a precomputed ``EntityCandidate``. The composition is:
+
+      - 60% trigram (case-folded Jaccard-ish ratio over character trigrams)
+      - 20% phonetic (Double Metaphone equality; gives a floor boost when
+        trigram is low but phonetic matches)
+      - 20% neighbourhood (overlap of cooccurrence partners, TF-IDF
+        weighted by partner mention frequency)
+
+    Returns a float in ``[0.0, 1.0]``. Deterministic given inputs.
+    """
+    a = (a_name or '').lower().strip()
+    b = (b_name or '').lower().strip()
+
+    name_score = _trigram_similarity(a, b)
+    phonetic_match = bool(a_phonetic and b_phonetic and a_phonetic == b_phonetic)
+    if phonetic_match and name_score < phonetic_floor:
+        name_score = phonetic_floor
+
+    score_name = name_score * trigram_weight + (1.0 if phonetic_match else 0.0) * phonetic_weight
+
+    score_neighbors = 0.0
+    if a_neighbors and b_neighbors:
+        common = set(a_neighbors.keys()) & set(b_neighbors.keys())
+        if common:
+            matched_weight = 0.0
+            for n in common:
+                freq_a = max(int(a_neighbors[n]), 0)
+                freq_b = max(int(b_neighbors[n]), 0)
+                pooled = freq_a + freq_b
+                weight = 1.0 / math.log2(2 + pooled)
+                matched_weight += weight
+            denom = max(min(len(a_neighbors), len(b_neighbors)), 1)
+            score_neighbors = min(matched_weight / denom, 1.0) * neighbor_weight
+
+    return min(max(score_name + score_neighbors, 0.0), 1.0)
+
+
+def _trigram_similarity(a: str, b: str) -> float:
+    """Pure-Python trigram similarity approximating PostgreSQL ``similarity()``.
+
+    Used in the resolver-pair scorer when no DB session is available
+    (the collapse-scan computes pair similarities for the top-N candidates
+    fully in memory). Returns the Jaccard ratio of character trigram sets.
+    """
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    if a == b:
+        return 1.0
+
+    def _trigrams(s: str) -> set[str]:
+        padded = f'  {s} '
+        return {padded[i : i + 3] for i in range(len(padded) - 2)}
+
+    ta, tb = _trigrams(a), _trigrams(b)
+    if not ta or not tb:
+        return 0.0
+    inter = len(ta & tb)
+    union = len(ta | tb)
+    return inter / union if union else 0.0
+
+
 def calculate_match_score(
     candidate: EntityCandidate,
     input_date: datetime,

--- a/packages/core/src/memex_core/memory/entity_resolver.py
+++ b/packages/core/src/memex_core/memory/entity_resolver.py
@@ -106,11 +106,12 @@ def score_entity_pair(
 
 
 def _trigram_similarity(a: str, b: str) -> float:
-    """Pure-Python trigram similarity approximating PostgreSQL ``similarity()``.
+    """Compute trigram similarity using the Jaccard ratio.
 
-    Used in the resolver-pair scorer when no DB session is available
-    (the collapse-scan computes pair similarities for the top-N candidates
-    fully in memory). Returns the Jaccard ratio of character trigram sets.
+    Returns |trigrams(a) ∩ trigrams(b)| / |trigrams(a) ∪ trigrams(b)| over the
+    character trigram sets. PostgreSQL's pg_trgm ``similarity()`` function uses
+    Sørensen-Dice (2 × intersection / (|A| + |B|)), so thresholds are NOT directly
+    portable between this helper and pg_trgm. Both are bounded in [0, 1].
     """
     if not a and not b:
         return 1.0

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -865,6 +865,14 @@ class Entity(SQLModel, table=True):  # type: ignore
         sa_column=Column(TIMESTAMP(timezone=True)),
         description='Timestamp when the entity was most recently returned in a retrieval result.',
     )
+    last_merge_scan_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(TIMESTAMP(timezone=True), nullable=True),
+        description=(
+            'Timestamp of the most recent inclusion in a cross-batch entity-merge scan. '
+            'NULL = never scanned (eligible on the first pass).'
+        ),
+    )
 
     unit_entities: list['UnitEntity'] = Relationship(
         back_populates='entity', sa_relationship_kwargs={'cascade': 'all, delete-orphan'}
@@ -896,6 +904,11 @@ class Entity(SQLModel, table=True):  # type: ignore
             'idx_entities_canonical_name_trgm',
             sql_text('lower(canonical_name) gin_trgm_ops'),
             postgresql_using='gin',
+        ),
+        Index(
+            'idx_entities_last_merge_scan_at',
+            'last_merge_scan_at',
+            postgresql_where=sql_text('last_merge_scan_at IS NOT NULL'),
         ),
     )
 

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -1,5 +1,7 @@
 """Custom Prometheus metrics for Memex application monitoring."""
 
+from typing import Literal
+
 from prometheus_client import Counter, Gauge, Histogram
 
 # ---------------------------------------------------------------------------
@@ -311,16 +313,21 @@ LINT_RUN_DURATION_SECONDS = Histogram(
 # Entity-cluster collapse maintenance
 # ---------------------------------------------------------------------------
 
+EntityCollapseScanResultLabel = Literal[
+    'proposed', 'rejected_cohesion', 'rescan_updated', 'no_candidates'
+]
+EntityCollapseApplyOutcomeLabel = Literal['success', 'failed']
+
 ENTITY_COLLAPSE_SCAN_EMITTED_TOTAL = Counter(
     'memex_entity_collapse_scan_emitted_total',
     'Cluster proposals produced by the entity-cluster collapse scan.',
-    ['result'],  # proposed | rejected_cohesion | rescan_updated
+    ['result'],
 )
 
 ENTITY_COLLAPSE_APPLY_TOTAL = Counter(
     'memex_entity_collapse_apply_total',
     'Cluster collapses applied via EntityService.collapse_cluster.',
-    ['outcome'],  # success | failed
+    ['outcome'],
 )
 
 ENTITY_COLLAPSE_APPLY_DURATION_SECONDS = Histogram(

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -316,7 +316,7 @@ LINT_RUN_DURATION_SECONDS = Histogram(
 # Convention-only label aliases. prometheus_client's ``.labels(**kwargs)``
 # accepts arbitrary strings — mypy does not narrow against these.
 EntityCollapseScanResultLabel = Literal[
-    'proposed', 'rejected_cohesion', 'rescan_updated', 'no_candidates'
+    'proposed', 'rejected_cohesion', 'rescan_updated', 'no_candidates', 'concurrent_skipped'
 ]
 EntityCollapseApplyOutcomeLabel = Literal['success', 'failed']
 

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -313,6 +313,8 @@ LINT_RUN_DURATION_SECONDS = Histogram(
 # Entity-cluster collapse maintenance
 # ---------------------------------------------------------------------------
 
+# Convention-only label aliases. prometheus_client's ``.labels(**kwargs)``
+# accepts arbitrary strings — mypy does not narrow against these.
 EntityCollapseScanResultLabel = Literal[
     'proposed', 'rejected_cohesion', 'rescan_updated', 'no_candidates'
 ]

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -308,6 +308,28 @@ LINT_RUN_DURATION_SECONDS = Histogram(
 )
 
 # ---------------------------------------------------------------------------
+# Entity-cluster collapse maintenance
+# ---------------------------------------------------------------------------
+
+ENTITY_COLLAPSE_SCAN_EMITTED_TOTAL = Counter(
+    'memex_entity_collapse_scan_emitted_total',
+    'Cluster proposals produced by the entity-cluster collapse scan.',
+    ['result'],  # proposed | rejected_cohesion | rescan_updated
+)
+
+ENTITY_COLLAPSE_APPLY_TOTAL = Counter(
+    'memex_entity_collapse_apply_total',
+    'Cluster collapses applied via EntityService.collapse_cluster.',
+    ['outcome'],  # success | failed
+)
+
+ENTITY_COLLAPSE_APPLY_DURATION_SECONDS = Histogram(
+    'memex_entity_collapse_apply_duration_seconds',
+    'Wall-clock duration of EntityService.collapse_cluster (seconds).',
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0),
+)
+
+# ---------------------------------------------------------------------------
 # Per-entity advisory lock + reconsolidate / consolidate metrics
 # ---------------------------------------------------------------------------
 

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -176,6 +176,31 @@ async def periodic_lint_task(api: 'MemexAPI'):
             logger.error(f'Scheduler: Lint task failed: {e}', exc_info=True)
 
 
+async def periodic_entity_maintenance_task(api: 'MemexAPI'):
+    """Daily cross-batch entity-cluster collapse scan.
+
+    Read-only at the entity table — emits MaintenanceProposal rows when the
+    cohesion-guarded clustering finds duplicate-entity clusters. The collapse
+    itself is operator-gated via ``memex lint resolve --winner ...``.
+    """
+    from memex_core.services.entity_maintenance import scan_collapse_clusters
+
+    async with background_session('bg-sched-entity-maintenance'):
+        try:
+            summary = await scan_collapse_clusters(api)
+            if summary.get('clusters_emitted') or summary.get('rescan_updated'):
+                logger.info(
+                    'Scheduler: entity-maintenance scan emitted=%d rescan_updated=%d '
+                    'rejected_cohesion=%d scanned=%d',
+                    summary.get('clusters_emitted', 0),
+                    summary.get('rescan_updated', 0),
+                    summary.get('clusters_rejected_cohesion', 0),
+                    summary.get('scanned', 0),
+                )
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.error(f'Scheduler: entity-maintenance task failed: {e}', exc_info=True)
+
+
 async def periodic_consolidation_task(api: 'MemexAPI', units_per_tick: int):
     """Per-vault consolidation tick under the single leader lock.
 
@@ -364,6 +389,16 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
     @clock.task(trigger=Every(seconds=7 * 86400))
     async def run_diagnostics_refresh():
         await periodic_diagnostics_refresh_task(api)
+
+    # --- Entity maintenance (cross-batch cluster collapse) ---
+    if config.server.memory.entity_maintenance.scan_enabled:
+        logger.info('Scheduler: Entity-maintenance scan ENABLED (every 24h).')
+
+        @clock.task(trigger=Every(seconds=86400))
+        async def run_entity_maintenance_job():
+            await periodic_entity_maintenance_task(api)
+    else:
+        logger.info('Scheduler: Entity-maintenance scan DISABLED (scan_enabled=False).')
 
     # --- Consolidation ---
     consolidation_cfg = config.server.memory.consolidation

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -197,8 +197,8 @@ async def periodic_entity_maintenance_task(api: 'MemexAPI'):
                     summary.get('clusters_rejected_cohesion', 0),
                     summary.get('scanned', 0),
                 )
-        except (OSError, RuntimeError, ValueError) as e:
-            logger.error(f'Scheduler: entity-maintenance task failed: {e}', exc_info=True)
+        except Exception as e:
+            logger.error('Scheduler: entity-maintenance task failed: %s', e, exc_info=True)
 
 
 async def periodic_consolidation_task(api: 'MemexAPI', units_per_tick: int):

--- a/packages/core/src/memex_core/server/entities.py
+++ b/packages/core/src/memex_core/server/entities.py
@@ -284,6 +284,36 @@ async def delete_entity(entity_id: UUID, api: Annotated[MemexAPI, Depends(get_ap
         raise _handle_error(e, 'Entity deletion failed')
 
 
+@router.post('/entities/scan-merges', dependencies=[Depends(require_read)])
+async def scan_entity_merges(
+    api: Annotated[MemexAPI, Depends(get_api)],
+    top_n: Annotated[int | None, Query(ge=2, le=10_000)] = None,
+    scan_cooldown_days: Annotated[int | None, Query(ge=0)] = None,
+    pair_threshold: Annotated[float | None, Query(ge=0.0, le=1.0)] = None,
+    cluster_min_threshold: Annotated[float | None, Query(ge=0.0, le=1.0)] = None,
+):
+    """Run a one-shot cross-batch entity-cluster collapse scan.
+
+    Complements the scheduler. Emits one MaintenanceProposal per surviving
+    cluster (after the cohesion guard); rescan-collisions UPDATE existing
+    findings in place. The merge itself is NOT applied — operators approve
+    via ``memex lint resolve --winner ...``.
+    """
+    from memex_core.services.entity_maintenance import scan_collapse_clusters
+
+    try:
+        summary = await scan_collapse_clusters(
+            api,
+            top_n=top_n,
+            scan_cooldown_days=scan_cooldown_days,
+            pair_threshold=pair_threshold,
+            cluster_min_threshold=cluster_min_threshold,
+        )
+        return summary
+    except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
+        raise _handle_error(e, 'Entity merge scan failed')
+
+
 @router.delete('/entities/{entity_id}/mental-model', dependencies=[Depends(require_delete)])
 async def delete_mental_model(
     entity_id: UUID,

--- a/packages/core/src/memex_core/server/entities.py
+++ b/packages/core/src/memex_core/server/entities.py
@@ -13,6 +13,7 @@ from memex_core.server.auth import (
     get_auth_context,
     require_delete,
     require_read,
+    require_write,
 )
 from memex_common.exceptions import MemexError
 from memex_common.schemas import (
@@ -284,7 +285,7 @@ async def delete_entity(entity_id: UUID, api: Annotated[MemexAPI, Depends(get_ap
         raise _handle_error(e, 'Entity deletion failed')
 
 
-@router.post('/entities/scan-merges', dependencies=[Depends(require_read)])
+@router.post('/entities/scan-merges', dependencies=[Depends(require_write)])
 async def scan_entity_merges(
     api: Annotated[MemexAPI, Depends(get_api)],
     top_n: Annotated[int | None, Query(ge=2, le=10_000)] = None,
@@ -293,6 +294,13 @@ async def scan_entity_merges(
     cluster_min_threshold: Annotated[float | None, Query(ge=0.0, le=1.0)] = None,
 ):
     """Run a one-shot cross-batch entity-cluster collapse scan.
+
+    Cross-vault scope; intended for operator-only access. The scan performs
+    INSERT/UPDATE against ``maintenance_proposals`` and bumps
+    ``entities.last_merge_scan_at`` for every scanned entity — including rows
+    outside the caller's vault scope — so this endpoint requires the WRITE
+    permission and is best gated behind an operator-only key in deployments
+    that enable auth.
 
     Complements the scheduler. Emits one MaintenanceProposal per surviving
     cluster (after the cohesion guard); rescan-collisions UPDATE existing

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -189,12 +189,11 @@ async def lint_resolve(
     the status flip. Cross-vault auth is enforced on every vault listed in
     ``evidence.vaults_affected`` before mutating.
     """
-    if params:
-        finding = await _load_finding_or_404(finding_id, api)
-        if finding['rule_name'] == 'entity_collapse_cluster':
-            return await _resolve_entity_collapse_cluster(
-                finding=finding, api=api, auth=auth, params=params
-            )
+    finding = await _load_finding_or_404(finding_id, api)
+    if finding['rule_name'] == 'entity_collapse_cluster':
+        return await _resolve_entity_collapse_cluster(
+            finding=finding, api=api, auth=auth, params=params or {}
+        )
 
     finding_vault = await _gate_finding_for_write(finding_id, api, auth)
     try:

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -18,7 +18,7 @@ import logging
 from typing import Annotated, Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from sqlalchemy import text
 
 from memex_common.config import Permission
@@ -175,14 +175,34 @@ async def lint_resolve(
     finding_id: UUID,
     api: Annotated[MemexAPI, Depends(get_api)],
     auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
+    params: Annotated[dict[str, Any] | None, Body(embed=False)] = None,
 ) -> dict[str, Any]:
     """Flip a pending finding to ``resolved``. Idempotent.
 
     Per vault-scoping invariant: looks up the finding's vault and
     gates the auth context BEFORE mutating, so a vault-A scoped key with a
     leaked vault-B finding_id cannot resolve the vault-B row (cross-vault check).
+
+    Rule-keyed dispatcher: for ``entity_collapse_cluster`` findings, the
+    request body MUST include ``{"winner_id": "<uuid>"}`` (or
+    ``"winner_canonical_name"``). The destructive collapse runs in the
+    same transaction as the status flip. Cross-vault auth is enforced on
+    every vault listed in ``evidence.vaults_affected`` before mutating.
     """
-    finding_vault = await _gate_finding_for_write(finding_id, api, auth)
+    finding = await _load_finding_or_404(finding_id, api)
+    finding_vault = finding['vault_id']
+    rule_name = finding['rule_name']
+
+    if rule_name == 'entity_collapse_cluster':
+        return await _resolve_entity_collapse_cluster(
+            finding=finding,
+            api=api,
+            auth=auth,
+            params=params or {},
+        )
+
+    if finding_vault is not None:
+        await check_vault_access(auth, [finding_vault], api, permission=Permission.WRITE)
     try:
         ok = await api.lint.set_status(finding_id, 'resolved', vault_id=finding_vault)
     except Exception as e:
@@ -190,6 +210,147 @@ async def lint_resolve(
     if not ok:
         raise HTTPException(status_code=404, detail='Finding not found or not pending')
     return {'finding_id': str(finding_id), 'status': 'resolved'}
+
+
+async def _load_finding_or_404(finding_id: UUID, api: MemexAPI) -> dict[str, Any]:
+    async with api.metastore.session() as session:
+        row = (
+            (
+                await session.execute(
+                    text(
+                        'SELECT id::text AS id, vault_id, rule_name, target_id, evidence, status '
+                        'FROM maintenance_proposals WHERE id = :id'
+                    ),
+                    {'id': str(finding_id)},
+                )
+            )
+            .mappings()
+            .first()
+        )
+    if row is None or row['status'] != 'pending':
+        raise HTTPException(status_code=404, detail='Finding not found or not pending')
+    return dict(row)
+
+
+async def _resolve_entity_collapse_cluster(
+    *,
+    finding: dict[str, Any],
+    api: MemexAPI,
+    auth: AuthContext | None,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply an entity-cluster collapse and flip the finding to resolved."""
+    from uuid import UUID as PyUUID
+
+    evidence = finding.get('evidence') or {}
+    cluster_members = [str(m) for m in (evidence.get('cluster_members') or [])]
+    suggested_winner = str(evidence.get('suggested_winner_id') or finding['target_id'])
+    vaults_affected = [str(v) for v in (evidence.get('vaults_affected') or [])]
+
+    # Cross-vault auth: every affected vault must allow WRITE
+    vault_uuids = [PyUUID(v) for v in vaults_affected]
+    if vault_uuids:
+        try:
+            await check_vault_access(auth, vault_uuids, api, permission=Permission.WRITE)
+        except HTTPException as exc:
+            logger.error(
+                'entity.collapse_cluster auth_denied actor=%s vaults=%d',
+                getattr(auth, 'api_key_id', None) if auth else None,
+                len(vault_uuids),
+            )
+            raise exc
+
+    # Winner resolution / validation
+    winner_param = params.get('winner_id') or params.get('winner_canonical_name')
+    if winner_param is None:
+        winner_id = suggested_winner
+    else:
+        winner_id = await _resolve_winner_id(winner_param, cluster_members, api)
+
+    if winner_id not in cluster_members:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                'winner must be a member of the cluster; non-member overrides are '
+                'not allowed in this version.'
+            ),
+        )
+
+    losers = [m for m in cluster_members if m != winner_id]
+    if not losers:
+        raise HTTPException(status_code=400, detail='cluster has no losers to collapse')
+
+    actor_id = getattr(auth, 'api_key_id', None) if auth else None
+    try:
+        summary = await api.entities.collapse_cluster(
+            winner_id=PyUUID(winner_id),
+            loser_ids=[PyUUID(lid) for lid in losers],
+            actor=actor_id,
+        )
+    except Exception as exc:
+        raise _handle_error(exc, 'Failed to apply entity cluster collapse')
+
+    try:
+        ok = await api.lint.set_status(
+            PyUUID(str(finding['id'])),
+            'resolved',
+            actor=actor_id,
+            vault_id=None,
+        )
+    except Exception as exc:
+        raise _handle_error(exc, 'Failed to mark finding resolved')
+    if not ok:
+        raise HTTPException(status_code=409, detail='Finding state changed during apply')
+
+    return {
+        'finding_id': str(finding['id']),
+        'status': 'resolved',
+        'rule_name': 'entity_collapse_cluster',
+        'winner_id': winner_id,
+        'winner_overridden': winner_id != suggested_winner,
+        'summary': summary,
+    }
+
+
+async def _resolve_winner_id(winner_param: str, cluster_members: list[str], api: MemexAPI) -> str:
+    """Resolve ``winner_param`` to a UUID string that MUST belong to the cluster.
+
+    Accepts either a UUID (returned as-is after membership check) or a
+    case-sensitive ``canonical_name`` match against the cluster members.
+    """
+    from uuid import UUID as PyUUID
+
+    try:
+        as_uuid = PyUUID(winner_param)
+        return str(as_uuid)
+    except (ValueError, TypeError):
+        pass
+
+    member_uuids = [PyUUID(m) for m in cluster_members]
+    async with api.metastore.session() as session:
+        row = (
+            (
+                await session.execute(
+                    text(
+                        'SELECT id::text AS id FROM entities '
+                        'WHERE id = ANY(CAST(:ids AS uuid[])) '
+                        'AND canonical_name = :name'
+                    ),
+                    {'ids': [str(u) for u in member_uuids], 'name': winner_param},
+                )
+            )
+            .mappings()
+            .first()
+        )
+    if row is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f'winner "{winner_param}" not found among cluster members '
+                '(case-sensitive canonical_name match required).'
+            ),
+        )
+    return row['id']
 
 
 @router.post('/run/{vault_id}', dependencies=[Depends(require_write)])

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -185,24 +185,18 @@ async def lint_resolve(
 
     Rule-keyed dispatcher: for ``entity_collapse_cluster`` findings, the
     request body MUST include ``{"winner_id": "<uuid>"}`` (or
-    ``"winner_canonical_name"``). The destructive collapse runs in the
-    same transaction as the status flip. Cross-vault auth is enforced on
-    every vault listed in ``evidence.vaults_affected`` before mutating.
+    ``"winner_canonical_name"``). The destructive collapse runs alongside
+    the status flip. Cross-vault auth is enforced on every vault listed in
+    ``evidence.vaults_affected`` before mutating.
     """
-    finding = await _load_finding_or_404(finding_id, api)
-    finding_vault = finding['vault_id']
-    rule_name = finding['rule_name']
+    if params:
+        finding = await _load_finding_or_404(finding_id, api)
+        if finding['rule_name'] == 'entity_collapse_cluster':
+            return await _resolve_entity_collapse_cluster(
+                finding=finding, api=api, auth=auth, params=params
+            )
 
-    if rule_name == 'entity_collapse_cluster':
-        return await _resolve_entity_collapse_cluster(
-            finding=finding,
-            api=api,
-            auth=auth,
-            params=params or {},
-        )
-
-    if finding_vault is not None:
-        await check_vault_access(auth, [finding_vault], api, permission=Permission.WRITE)
+    finding_vault = await _gate_finding_for_write(finding_id, api, auth)
     try:
         ok = await api.lint.set_status(finding_id, 'resolved', vault_id=finding_vault)
     except Exception as e:

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -329,7 +329,7 @@ async def _resolve_winner_id(winner_param: str, cluster_members: list[str], api:
 
     member_uuids = [PyUUID(m) for m in cluster_members]
     async with api.metastore.session() as session:
-        row = (
+        rows = (
             (
                 await session.execute(
                     text(
@@ -341,9 +341,9 @@ async def _resolve_winner_id(winner_param: str, cluster_members: list[str], api:
                 )
             )
             .mappings()
-            .first()
+            .all()
         )
-    if row is None:
+    if not rows:
         raise HTTPException(
             status_code=400,
             detail=(
@@ -351,7 +351,15 @@ async def _resolve_winner_id(winner_param: str, cluster_members: list[str], api:
                 '(case-sensitive canonical_name match required).'
             ),
         )
-    return row['id']
+    if len(rows) > 1:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f'winner "{winner_param}" is ambiguous: multiple cluster members '
+                'share that canonical_name. Provide the winner UUID to disambiguate.'
+            ),
+        )
+    return rows[0]['id']
 
 
 @router.post('/run/{vault_id}', dependencies=[Depends(require_write)])

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -241,18 +241,26 @@ async def _resolve_entity_collapse_cluster(
     suggested_winner = str(evidence.get('suggested_winner_id') or finding['target_id'])
     vaults_affected = [str(v) for v in (evidence.get('vaults_affected') or [])]
 
-    # Cross-vault auth: every affected vault must allow WRITE
+    if not vaults_affected:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                'Cluster has no vaults_affected; refusing to collapse without '
+                'scope. Re-run the scan after the cluster has unit-entity '
+                'links, or escalate manually.'
+            ),
+        )
+
     vault_uuids = [PyUUID(v) for v in vaults_affected]
-    if vault_uuids:
-        try:
-            await check_vault_access(auth, vault_uuids, api, permission=Permission.WRITE)
-        except HTTPException as exc:
-            logger.error(
-                'entity.collapse_cluster auth_denied actor=%s vaults=%d',
-                getattr(auth, 'api_key_id', None) if auth else None,
-                len(vault_uuids),
-            )
-            raise exc
+    try:
+        await check_vault_access(auth, vault_uuids, api, permission=Permission.WRITE)
+    except HTTPException as exc:
+        logger.error(
+            'entity.collapse_cluster auth_denied actor=%s vaults=%d',
+            getattr(auth, 'api_key_id', None) if auth else None,
+            len(vault_uuids),
+        )
+        raise exc
 
     # Winner resolution / validation
     winner_param = params.get('winner_id') or params.get('winner_canonical_name')

--- a/packages/core/src/memex_core/services/entities.py
+++ b/packages/core/src/memex_core/services/entities.py
@@ -33,6 +33,42 @@ def _wrap_with_metadata(entity: Any, mental_model: Any | None) -> EntityWithMeta
     return EntityWithMetadata(entity=entity, metadata=metadata, observations=observations)
 
 
+def _merge_observations(
+    winner_obs: list[dict[str, Any]],
+    loser_obs: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge two MentalModel.observations lists with deterministic dedup.
+
+    Two observations collide iff their canonical JSON serialization matches.
+    The winner's ordering is preserved for surviving rows; loser rows that
+    do not already appear are appended in their iteration order.
+    """
+    import json as _json
+
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+
+    def _key(o: dict[str, Any]) -> str:
+        try:
+            return _json.dumps(o, sort_keys=True, default=str)
+        except Exception:
+            return repr(o)
+
+    for o in winner_obs or []:
+        k = _key(o)
+        if k in seen:
+            continue
+        seen.add(k)
+        out.append(o)
+    for o in loser_obs or []:
+        k = _key(o)
+        if k in seen:
+            continue
+        seen.add(k)
+        out.append(o)
+    return out
+
+
 class EntityService(BaseService):
     """Entity CRUD, search, and graph traversal operations."""
 
@@ -260,6 +296,357 @@ class EntityService(BaseService):
 
         audit_event(self._audit_service, 'entity.deleted', 'entity', str(entity_id))
         return True
+
+    async def collapse_cluster(
+        self,
+        *,
+        winner_id: UUID,
+        loser_ids: list[UUID],
+        actor: str | None = None,
+    ) -> dict[str, Any]:
+        """Merge a cluster of duplicate entities into one canonical winner.
+
+        Resolves the six referential-integrity hazards in a single
+        transaction:
+
+        1. ``MemoryLink.entity_id`` repoint loser->winner (before the entity
+           hard-delete; otherwise FK CASCADE would drop the rows).
+        2. ``EntityCooccurrence`` re-ordered (smaller id as ``entity_id_1``)
+           and summed with ON CONFLICT DO UPDATE.
+        3. ``EntityAlias`` absorbed with ON CONFLICT (canonical_id, name)
+           DO NOTHING; the loser's canonical_name is also recorded as an
+           alias of the winner.
+        4. ``UnitEntity`` re-inserted on the winner with summed counters,
+           then loser rows dropped.
+        5. ``MentalModel`` merged per-vault: loser's observations appended
+           (dedup-aware), ``version = max(winner, loser) + 1``.
+        6. ``Entity`` hard-delete losers (LAST).
+        7. Append a single ``entity.collapse_cluster`` AuditLog row.
+
+        Returns a summary dict suitable for logging / API response.
+        """
+        from datetime import datetime, timezone
+        from uuid import UUID as PyUUID
+
+        from sqlalchemy import text
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+        from sqlmodel import col, select, update
+
+        from memex_core.memory.sql_models import (
+            Entity,
+            EntityAlias,
+            EntityCooccurrence,
+            MemoryLink,
+            MentalModel,
+            UnitEntity,
+        )
+        from memex_core.memory.utils import get_phonetic_code
+        from memex_core import metrics
+        import time as _time
+
+        if not loser_ids:
+            raise ValueError('collapse_cluster requires at least one loser_id')
+        if winner_id in loser_ids:
+            raise ValueError('winner_id must not appear in loser_ids')
+
+        try:
+            from opentelemetry import trace as _otel_trace
+
+            _tracer = _otel_trace.get_tracer('memex.entity_maintenance')
+        except Exception:  # pragma: no cover
+            _tracer = None
+
+        start = _time.perf_counter()
+        span_cm = (
+            _tracer.start_as_current_span(
+                'memex.entity_maintenance.collapse_cluster',
+                attributes={
+                    'cluster_size': len(loser_ids) + 1,
+                    'winner_id': str(winner_id),
+                },
+            )
+            if _tracer
+            else None
+        )
+        if span_cm is not None:
+            span_cm.__enter__()
+
+        outcome = 'failed'
+        try:
+            async with self.metastore.session() as session:
+                winner = await session.get(Entity, winner_id)
+                if winner is None:
+                    raise EntityNotFoundError(f'Entity {winner_id} not found.')
+
+                loser_uuids = [PyUUID(str(lid)) for lid in loser_ids]
+                stmt = select(Entity).where(col(Entity.id).in_(loser_uuids))
+                losers = list((await session.exec(stmt)).all())
+                missing = set(str(u) for u in loser_uuids) - {str(e.id) for e in losers}
+                if missing:
+                    raise EntityNotFoundError(f'Entities not found: {sorted(missing)}')
+
+                vaults_affected: set[str] = set()
+
+                # 1) MemoryLink: repoint entity_id loser -> winner BEFORE hard delete
+                ml_stmt = (
+                    update(MemoryLink)
+                    .where(col(MemoryLink.entity_id).in_(loser_uuids))
+                    .values(entity_id=winner_id)
+                )
+                ml_result = await session.exec(ml_stmt)
+                links_repointed = int(getattr(ml_result, 'rowcount', 0) or 0)
+
+                # 2) EntityCooccurrence: rewrite loser-side rows so they reference
+                # the winner instead, with canonical (smaller, larger) ordering and
+                # summed counts. Loser rows are deleted afterwards.
+                co_stmt = select(EntityCooccurrence).where(
+                    col(EntityCooccurrence.entity_id_1).in_(loser_uuids)
+                    | col(EntityCooccurrence.entity_id_2).in_(loser_uuids)
+                )
+                co_rows = list((await session.exec(co_stmt)).all())
+                cooccurrences_merged = 0
+                for row in co_rows:
+                    other = row.entity_id_2 if row.entity_id_1 in loser_uuids else row.entity_id_1
+                    if other in loser_uuids or other == winner_id:
+                        # Intra-cluster edge (loser<->loser, or loser<->winner):
+                        # roll into winner self-loop is meaningless — skip and
+                        # let the loser-row delete consume it. We still count
+                        # it as merged for visibility.
+                        cooccurrences_merged += 1
+                        continue
+                    e1, e2 = sorted([winner_id, other], key=str)
+                    upsert = (
+                        pg_insert(EntityCooccurrence)
+                        .values(
+                            entity_id_1=e1,
+                            entity_id_2=e2,
+                            vault_id=row.vault_id,
+                            cooccurrence_count=row.cooccurrence_count,
+                            last_cooccurred=row.last_cooccurred,
+                            valid_from=row.valid_from,
+                        )
+                        .on_conflict_do_update(
+                            index_elements=['entity_id_1', 'entity_id_2'],
+                            set_={
+                                'cooccurrence_count': (
+                                    EntityCooccurrence.cooccurrence_count + row.cooccurrence_count
+                                ),
+                            },
+                        )
+                    )
+                    await session.exec(upsert)
+                    cooccurrences_merged += 1
+
+                # Drop the loser-side rows (any direction)
+                await session.exec(
+                    text(
+                        'DELETE FROM entity_cooccurrences '
+                        'WHERE entity_id_1 = ANY(CAST(:ids AS uuid[])) '
+                        'OR entity_id_2 = ANY(CAST(:ids AS uuid[]))'
+                    ).bindparams(ids=[str(u) for u in loser_uuids])
+                )
+
+                # 3) EntityAlias: absorb loser aliases onto winner, plus a fresh
+                # alias for each loser's canonical_name so future lookups find
+                # the winner via the loser's spelling.
+                alias_stmt = select(EntityAlias).where(
+                    col(EntityAlias.canonical_id).in_(loser_uuids)
+                )
+                alias_rows = list((await session.exec(alias_stmt)).all())
+                alias_values = [
+                    {
+                        'canonical_id': winner_id,
+                        'name': a.name,
+                        'phonetic_code': a.phonetic_code,
+                    }
+                    for a in alias_rows
+                ]
+                for loser in losers:
+                    alias_values.append(
+                        {
+                            'canonical_id': winner_id,
+                            'name': loser.canonical_name,
+                            'phonetic_code': loser.phonetic_code
+                            or get_phonetic_code(loser.canonical_name),
+                        }
+                    )
+                aliases_absorbed = 0
+                if alias_values:
+                    alias_upsert = (
+                        pg_insert(EntityAlias)
+                        .values(alias_values)
+                        .on_conflict_do_nothing(index_elements=['canonical_id', 'name'])
+                    )
+                    await session.exec(alias_upsert)
+                    aliases_absorbed = len(alias_values)
+
+                # 4) UnitEntity: roll loser's per-unit rows onto the winner, with
+                # summed counters; then delete loser rows. Per-(unit_id, winner_id)
+                # collisions resolved via the UPDATE-after-aggregate idiom.
+                ue_stmt = select(UnitEntity).where(col(UnitEntity.entity_id).in_(loser_uuids))
+                ue_rows = list((await session.exec(ue_stmt)).all())
+                unit_entities_merged = 0
+                if ue_rows:
+                    upsert_sql = text(
+                        """
+                        INSERT INTO unit_entities (
+                            unit_id, entity_id, vault_id,
+                            success_co_count, failure_co_count
+                        )
+                        VALUES (
+                            CAST(:unit_id AS uuid),
+                            CAST(:winner_id AS uuid),
+                            CAST(:vault_id AS uuid),
+                            :success_co_count,
+                            :failure_co_count
+                        )
+                        ON CONFLICT (unit_id, entity_id) DO UPDATE SET
+                            success_co_count = unit_entities.success_co_count
+                                + EXCLUDED.success_co_count,
+                            failure_co_count = unit_entities.failure_co_count
+                                + EXCLUDED.failure_co_count
+                        """
+                    )
+                    for row in ue_rows:
+                        await session.exec(
+                            upsert_sql.bindparams(
+                                unit_id=str(row.unit_id),
+                                winner_id=str(winner_id),
+                                vault_id=str(row.vault_id),
+                                success_co_count=row.success_co_count,
+                                failure_co_count=row.failure_co_count,
+                            )
+                        )
+                        unit_entities_merged += 1
+                    await session.exec(
+                        text(
+                            'DELETE FROM unit_entities WHERE entity_id = ANY(CAST(:ids AS uuid[]))'
+                        ).bindparams(ids=[str(u) for u in loser_uuids])
+                    )
+
+                # 5) MentalModel: per-vault merge. For each vault that the
+                # losers have a model in, fold their observations into the
+                # winner's model and bump the version.
+                mm_stmt = select(MentalModel).where(
+                    col(MentalModel.entity_id).in_(loser_uuids + [winner_id])
+                )
+                mm_rows = list((await session.exec(mm_stmt)).all())
+                # Bucket by vault
+                by_vault: dict[Any, dict[str, Any]] = {}
+                for mm in mm_rows:
+                    bucket = by_vault.setdefault(mm.vault_id, {'winner': None, 'losers': []})
+                    if mm.entity_id == winner_id:
+                        bucket['winner'] = mm
+                    else:
+                        bucket['losers'].append(mm)
+
+                mental_models_merged = 0
+                for vault_id, bucket in by_vault.items():
+                    vaults_affected.add(str(vault_id))
+                    winner_mm = bucket['winner']
+                    loser_mms = bucket['losers']
+                    if not loser_mms:
+                        continue
+
+                    if winner_mm is None:
+                        # No winner MM yet — promote the highest-versioned loser
+                        # to be the winner MM in place (update entity_id), then
+                        # absorb the rest.
+                        loser_mms_sorted = sorted(loser_mms, key=lambda m: m.version, reverse=True)
+                        promoted = loser_mms_sorted[0]
+                        remaining = loser_mms_sorted[1:]
+                        merged_obs = _merge_observations(
+                            promoted.observations or [],
+                            [o for m in remaining for o in (m.observations or [])],
+                        )
+                        promoted.entity_id = winner_id
+                        promoted.observations = merged_obs
+                        promoted.version = (
+                            max([promoted.version] + [m.version for m in remaining]) + 1
+                        )
+                        promoted.last_refreshed = datetime.now(timezone.utc)
+                        session.add(promoted)
+                        for m in remaining:
+                            await session.delete(m)
+                        mental_models_merged += 1 + len(remaining)
+                    else:
+                        merged_obs = _merge_observations(
+                            winner_mm.observations or [],
+                            [o for m in loser_mms for o in (m.observations or [])],
+                        )
+                        winner_mm.observations = merged_obs
+                        winner_mm.version = (
+                            max([winner_mm.version] + [m.version for m in loser_mms]) + 1
+                        )
+                        winner_mm.last_refreshed = datetime.now(timezone.utc)
+                        session.add(winner_mm)
+                        for m in loser_mms:
+                            await session.delete(m)
+                        mental_models_merged += 1 + len(loser_mms)
+
+                # 6) Entity: hard-delete losers — LAST step before commit.
+                # Use raw SQL to bypass ORM cascade replay on already-cleaned tables.
+                await session.exec(
+                    text('DELETE FROM entities WHERE id = ANY(CAST(:ids AS uuid[]))').bindparams(
+                        ids=[str(u) for u in loser_uuids]
+                    )
+                )
+
+                # Refresh the winner's bookkeeping
+                merged_mention = winner.mention_count + sum(
+                    int(getattr(loser, 'mention_count', 0) or 0) for loser in losers
+                )
+                await session.exec(
+                    update(Entity)
+                    .where(col(Entity.id) == winner_id)
+                    .values(
+                        mention_count=merged_mention,
+                        last_seen=datetime.now(timezone.utc),
+                    )
+                )
+
+                summary = {
+                    'winner_id': str(winner_id),
+                    'loser_ids': [str(u) for u in loser_uuids],
+                    'links_repointed': links_repointed,
+                    'cooccurrences_merged': cooccurrences_merged,
+                    'aliases_absorbed': aliases_absorbed,
+                    'unit_entities_merged': unit_entities_merged,
+                    'mental_models_merged': mental_models_merged,
+                    'vaults_affected': sorted(vaults_affected),
+                }
+
+                # 7) AuditLog: append (NOTE column is `details`, not `metadata`).
+                from memex_core.memory.sql_models import AuditLog as _AuditLog
+
+                session.add(
+                    _AuditLog(
+                        actor=actor,
+                        action='entity.collapse_cluster',
+                        resource_type='entity',
+                        resource_id=str(winner_id),
+                        details=summary,
+                    )
+                )
+
+                await session.commit()
+
+            outcome = 'success'
+            metrics.ENTITY_COLLAPSE_APPLY_TOTAL.labels(outcome='success').inc()
+            return summary
+        except Exception:
+            metrics.ENTITY_COLLAPSE_APPLY_TOTAL.labels(outcome='failed').inc()
+            raise
+        finally:
+            metrics.ENTITY_COLLAPSE_APPLY_DURATION_SECONDS.observe(_time.perf_counter() - start)
+            if span_cm is not None:
+                span_cm.__exit__(None, None, None)
+            logger.info(
+                'entity.collapse_cluster outcome=%s winner_id=%s cluster_size=%d',
+                outcome,
+                winner_id,
+                len(loser_ids) + 1,
+            )
 
     async def delete_mental_model(self, entity_id: UUID, vault_id: UUID) -> bool:
         """

--- a/packages/core/src/memex_core/services/entities.py
+++ b/packages/core/src/memex_core/services/entities.py
@@ -328,7 +328,7 @@ class EntityService(BaseService):
         from datetime import datetime, timezone
         from uuid import UUID as PyUUID
 
-        from sqlalchemy import text
+        from sqlalchemy import func, text
         from sqlalchemy.dialects.postgresql import insert as pg_insert
         from sqlmodel import col, select, update
 
@@ -408,31 +408,48 @@ class EntityService(BaseService):
                 for row in co_rows:
                     other = row.entity_id_2 if row.entity_id_1 in loser_uuids else row.entity_id_1
                     if other in loser_uuids or other == winner_id:
-                        # Intra-cluster edge (loser<->loser, or loser<->winner):
-                        # roll into winner self-loop is meaningless — skip and
-                        # let the loser-row delete consume it. We still count
-                        # it as merged for visibility.
-                        cooccurrences_merged += 1
+                        # Intentional drop: post-collapse, winner and loser are
+                        # the same entity, so a W<->L (or L<->L) cooccurrence
+                        # becomes a self-loop, which the table CHECK constraint
+                        # forbids. The loser-row DELETE below consumes the row.
                         continue
                     e1, e2 = sorted([winner_id, other], key=str)
-                    upsert = (
-                        pg_insert(EntityCooccurrence)
-                        .values(
-                            entity_id_1=e1,
-                            entity_id_2=e2,
-                            vault_id=row.vault_id,
-                            cooccurrence_count=row.cooccurrence_count,
-                            last_cooccurred=row.last_cooccurred,
-                            valid_from=row.valid_from,
-                        )
-                        .on_conflict_do_update(
-                            index_elements=['entity_id_1', 'entity_id_2'],
-                            set_={
-                                'cooccurrence_count': (
-                                    EntityCooccurrence.cooccurrence_count + row.cooccurrence_count
+                    upsert = pg_insert(EntityCooccurrence).values(
+                        entity_id_1=e1,
+                        entity_id_2=e2,
+                        vault_id=row.vault_id,
+                        cooccurrence_count=row.cooccurrence_count,
+                        last_cooccurred=row.last_cooccurred,
+                        valid_from=row.valid_from,
+                        valid_to=row.valid_to,
+                    )
+                    upsert = upsert.on_conflict_do_update(
+                        index_elements=['entity_id_1', 'entity_id_2'],
+                        set_={
+                            'cooccurrence_count': (
+                                EntityCooccurrence.cooccurrence_count + row.cooccurrence_count
+                            ),
+                            'last_cooccurred': func.greatest(
+                                EntityCooccurrence.last_cooccurred,
+                                upsert.excluded.last_cooccurred,
+                            ),
+                            'valid_from': func.coalesce(
+                                func.least(
+                                    EntityCooccurrence.valid_from,
+                                    upsert.excluded.valid_from,
                                 ),
-                            },
-                        )
+                                EntityCooccurrence.valid_from,
+                                upsert.excluded.valid_from,
+                            ),
+                            'valid_to': func.coalesce(
+                                func.greatest(
+                                    EntityCooccurrence.valid_to,
+                                    upsert.excluded.valid_to,
+                                ),
+                                EntityCooccurrence.valid_to,
+                                upsert.excluded.valid_to,
+                            ),
+                        },
                     )
                     await session.exec(upsert)
                     cooccurrences_merged += 1

--- a/packages/core/src/memex_core/services/entities.py
+++ b/packages/core/src/memex_core/services/entities.py
@@ -328,7 +328,7 @@ class EntityService(BaseService):
         from datetime import datetime, timezone
         from uuid import UUID as PyUUID
 
-        from sqlalchemy import func, text
+        from sqlalchemy import case, func, null, or_, text
         from sqlalchemy.dialects.postgresql import insert as pg_insert
         from sqlmodel import col, select, update
 
@@ -433,21 +433,31 @@ class EntityService(BaseService):
                                 EntityCooccurrence.last_cooccurred,
                                 upsert.excluded.last_cooccurred,
                             ),
-                            'valid_from': func.coalesce(
-                                func.least(
+                            'valid_from': case(
+                                (
+                                    or_(
+                                        EntityCooccurrence.valid_from.is_(None),
+                                        upsert.excluded.valid_from.is_(None),
+                                    ),
+                                    null(),
+                                ),
+                                else_=func.least(
                                     EntityCooccurrence.valid_from,
                                     upsert.excluded.valid_from,
                                 ),
-                                EntityCooccurrence.valid_from,
-                                upsert.excluded.valid_from,
                             ),
-                            'valid_to': func.coalesce(
-                                func.greatest(
+                            'valid_to': case(
+                                (
+                                    or_(
+                                        EntityCooccurrence.valid_to.is_(None),
+                                        upsert.excluded.valid_to.is_(None),
+                                    ),
+                                    null(),
+                                ),
+                                else_=func.greatest(
                                     EntityCooccurrence.valid_to,
                                     upsert.excluded.valid_to,
                                 ),
-                                EntityCooccurrence.valid_to,
-                                upsert.excluded.valid_to,
                             ),
                         },
                     )

--- a/packages/core/src/memex_core/services/entities.py
+++ b/packages/core/src/memex_core/services/entities.py
@@ -611,6 +611,11 @@ class EntityService(BaseService):
                             await session.delete(m)
                         mental_models_merged += 1 + len(loser_mms)
 
+                # Materialize ORM-pending mental-model deletes before the raw
+                # SQL DELETE on entities — without this, the entity hard-delete
+                # could fire while stale MentalModel rows still hold FK references.
+                await session.flush()
+
                 # 6) Entity: hard-delete losers — LAST step before commit.
                 # Use raw SQL to bypass ORM cascade replay on already-cleaned tables.
                 await session.exec(

--- a/packages/core/src/memex_core/services/entity_maintenance.py
+++ b/packages/core/src/memex_core/services/entity_maintenance.py
@@ -1,0 +1,436 @@
+"""Cross-batch entity-cluster collapse — scan, cluster, propose.
+
+Cross-batch entity resolution drifts: ingestion-path matcher (calibrated for
+intra-batch dedup) leaves near-duplicate Entity rows ("ACME Corp" /
+"acme corp" / "Acme Corp") in production data. This module periodically
+scans the top-N most active entities, builds a candidate-pair similarity
+graph, computes connected components, applies a min-pairwise-similarity
+cohesion guard (rope-drift protection), and emits one
+``MaintenanceProposal`` per surviving cluster.
+
+The scan is a pure proposal — no entity rows are mutated here. Apply is
+handled by ``EntityService.collapse_cluster`` after a human approves the
+finding via ``memex lint resolve --winner …``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from itertools import combinations
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import text
+
+from memex_core.memory.entity_resolver import score_entity_pair
+from memex_core.memory.sql_models import LintType
+
+if TYPE_CHECKING:
+    from memex_core.api import MemexAPI
+
+try:
+    from opentelemetry import trace as _otel_trace
+
+    _tracer = _otel_trace.get_tracer('memex.entity_maintenance')
+except Exception:  # pragma: no cover
+    _tracer = None
+
+logger = logging.getLogger('memex.core.services.entity_maintenance')
+
+
+_RULE_NAME = 'entity_collapse_cluster'
+_TARGET_TYPE = 'entity'
+_SUGGESTED_ACTION = (
+    'Cluster of near-duplicate entities detected across batches. '
+    'Review the members in evidence.cluster_members and approve via '
+    '`memex lint resolve <finding_id> --winner <member_id_or_name>` to '
+    'merge them into one canonical entity. Cross-vault: the merge affects '
+    'every vault listed in evidence.vaults_affected.'
+)
+
+
+def _composition_hash(member_ids: list[str]) -> str:
+    """Order-independent fingerprint of a cluster's membership."""
+    canonical = sorted(str(m) for m in member_ids)
+    return hashlib.sha256('|'.join(canonical).encode('utf-8')).hexdigest()
+
+
+def _connected_components(nodes: list[str], edges: list[tuple[str, str]]) -> list[list[str]]:
+    """Plain union-find over a small node set; deterministic ordering."""
+    parent = {n: n for n in nodes}
+
+    def find(x: str) -> str:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: str, b: str) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for a, b in edges:
+        if a in parent and b in parent:
+            union(a, b)
+
+    groups: dict[str, list[str]] = defaultdict(list)
+    for n in nodes:
+        groups[find(n)].append(n)
+    return [sorted(g) for g in groups.values() if len(g) >= 2]
+
+
+def _min_pairwise_similarity(
+    members: list[str],
+    sims: dict[tuple[str, str], float],
+) -> tuple[float, float]:
+    """Return (min, max) pairwise similarity across all pairs in the cluster."""
+    values: list[float] = []
+    for a, b in combinations(sorted(members), 2):
+        values.append(sims.get((a, b), 0.0))
+    if not values:
+        return (0.0, 0.0)
+    return (min(values), max(values))
+
+
+def _suggested_winner(members: list[dict[str, Any]]) -> str:
+    """Pick a suggested winner from a cluster.
+
+    Rule: highest ``mention_count``, ties broken by earliest ``first_seen``.
+    """
+    sorted_members = sorted(
+        members,
+        key=lambda m: (-int(m.get('mention_count') or 0), m.get('first_seen') or datetime.max),
+    )
+    return str(sorted_members[0]['id'])
+
+
+async def scan_collapse_clusters(
+    api: 'MemexAPI',
+    *,
+    top_n: int | None = None,
+    scan_cooldown_days: int | None = None,
+    pair_threshold: float | None = None,
+    cluster_min_threshold: float | None = None,
+) -> dict[str, Any]:
+    """Scan top-N active entities, cluster duplicates, emit cluster proposals.
+
+    Returns a summary dict ``{'clusters_emitted': int,
+    'clusters_rejected_cohesion': int, 'rescan_updated': int, 'scanned': int}``.
+
+    Idempotent under rescan: existing pending ``entity_collapse_cluster``
+    findings with the same ``target_id`` are UPDATEd in place rather than
+    duplicated. The partial unique index ``uq_maintenance_proposals_pending``
+    only fires on non-NULL ``vault_id`` rows; our findings carry ``vault_id
+    IS NULL`` (cross-vault by construction), so we enforce the no-duplicate
+    invariant in Python before INSERT.
+    """
+    from memex_core import metrics
+
+    cfg = api.config.server.memory.entity_maintenance
+    top_n = top_n if top_n is not None else cfg.top_n
+    scan_cooldown_days = (
+        scan_cooldown_days if scan_cooldown_days is not None else cfg.scan_cooldown_days
+    )
+    pair_threshold = pair_threshold if pair_threshold is not None else cfg.pair_threshold
+    cluster_min_threshold = (
+        cluster_min_threshold if cluster_min_threshold is not None else cfg.cluster_min_threshold
+    )
+
+    span_cm = (
+        _tracer.start_as_current_span(
+            'memex.entity_maintenance.scan',
+            attributes={
+                'top_n': top_n,
+                'scan_cooldown_days': scan_cooldown_days,
+                'pair_threshold': pair_threshold,
+                'cluster_min_threshold': cluster_min_threshold,
+            },
+        )
+        if _tracer
+        else None
+    )
+    if span_cm is not None:
+        span_cm.__enter__()
+
+    summary = {
+        'clusters_emitted': 0,
+        'clusters_rejected_cohesion': 0,
+        'rescan_updated': 0,
+        'scanned': 0,
+    }
+
+    try:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=scan_cooldown_days)
+        async with api.metastore.session() as session:
+            cand_rows = (
+                (
+                    await session.execute(
+                        text(
+                            """
+                        SELECT id::text AS id,
+                               canonical_name,
+                               phonetic_code,
+                               mention_count,
+                               first_seen,
+                               last_merge_scan_at
+                        FROM entities
+                        WHERE last_merge_scan_at IS NULL
+                           OR last_merge_scan_at < :cutoff
+                        ORDER BY mention_count DESC, first_seen ASC
+                        LIMIT :limit
+                        """
+                        ),
+                        {'cutoff': cutoff, 'limit': top_n},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+            candidates: list[dict[str, Any]] = [dict(r) for r in cand_rows]
+            summary['scanned'] = len(candidates)
+            if len(candidates) < 2:
+                return summary
+
+            ids = [c['id'] for c in candidates]
+            neighbor_rows = (
+                (
+                    await session.execute(
+                        text(
+                            """
+                        WITH combined AS (
+                            SELECT entity_id_1 AS source_id,
+                                   entity_id_2 AS neighbor_id,
+                                   cooccurrence_count
+                            FROM entity_cooccurrences
+                            WHERE entity_id_1 = ANY(CAST(:ids AS uuid[]))
+
+                            UNION ALL
+
+                            SELECT entity_id_2 AS source_id,
+                                   entity_id_1 AS neighbor_id,
+                                   cooccurrence_count
+                            FROM entity_cooccurrences
+                            WHERE entity_id_2 = ANY(CAST(:ids AS uuid[]))
+                        )
+                        SELECT c.source_id::text AS source_id,
+                               e.id::text AS neighbor_id,
+                               e.mention_count AS neighbor_mention_count
+                        FROM combined c
+                        JOIN entities e ON e.id = c.neighbor_id
+                        """
+                        ),
+                        {'ids': ids},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+            neighbors_by_entity: dict[str, dict[str, int]] = defaultdict(dict)
+            for r in neighbor_rows:
+                neighbors_by_entity[r['source_id']][r['neighbor_id']] = int(
+                    r['neighbor_mention_count']
+                )
+
+            # Identify which vaults each candidate appears in via unit_entities
+            vault_rows = (
+                (
+                    await session.execute(
+                        text(
+                            """
+                        SELECT entity_id::text AS entity_id,
+                               vault_id::text AS vault_id
+                        FROM unit_entities
+                        WHERE entity_id = ANY(CAST(:ids AS uuid[]))
+                        GROUP BY entity_id, vault_id
+                        """
+                        ),
+                        {'ids': ids},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+            vaults_by_entity: dict[str, set[str]] = defaultdict(set)
+            for r in vault_rows:
+                vaults_by_entity[r['entity_id']].add(r['vault_id'])
+
+            sims: dict[tuple[str, str], float] = {}
+            edges: list[tuple[str, str]] = []
+            for a, b in combinations(candidates, 2):
+                sim = score_entity_pair(
+                    a['canonical_name'] or '',
+                    b['canonical_name'] or '',
+                    a.get('phonetic_code'),
+                    b.get('phonetic_code'),
+                    neighbors_by_entity.get(a['id'], {}),
+                    neighbors_by_entity.get(b['id'], {}),
+                )
+                key = tuple(sorted([a['id'], b['id']]))
+                sims[key] = sim
+                if sim >= pair_threshold:
+                    edges.append(key)  # type: ignore[arg-type]
+
+            clusters = _connected_components([c['id'] for c in candidates], edges)
+            by_id = {c['id']: c for c in candidates}
+
+            for member_ids in clusters:
+                pair_min, pair_max = _min_pairwise_similarity(member_ids, sims)
+                if pair_min < cluster_min_threshold:
+                    metrics.ENTITY_COLLAPSE_SCAN_EMITTED_TOTAL.labels(
+                        result='rejected_cohesion'
+                    ).inc()
+                    summary['clusters_rejected_cohesion'] += 1
+                    logger.info(
+                        'entity_collapse_scan: rejected_cohesion cluster_id=%s '
+                        'size=%d pair_min=%.3f pair_max=%.3f',
+                        _composition_hash(member_ids),
+                        len(member_ids),
+                        pair_min,
+                        pair_max,
+                    )
+                    continue
+
+                cluster_members = [by_id[m] for m in member_ids]
+                winner_id = _suggested_winner(cluster_members)
+                vaults_affected: set[str] = set()
+                for m in member_ids:
+                    vaults_affected.update(vaults_by_entity.get(m, set()))
+
+                composition_hash = _composition_hash(member_ids)
+                evidence = {
+                    'cluster_members': sorted(member_ids),
+                    'suggested_winner_id': winner_id,
+                    'pair_min_similarity': pair_min,
+                    'pair_max_similarity': pair_max,
+                    'composition_hash': composition_hash,
+                    'vaults_affected': sorted(vaults_affected),
+                    'member_canonical_names': {m: by_id[m]['canonical_name'] for m in member_ids},
+                }
+
+                # Rescan-collision policy: a pending proposal with the same
+                # suggested winner is UPDATEd in place. NULL vault_id is
+                # outside the partial unique index, so we enforce it here.
+                existing_row = (
+                    (
+                        await session.execute(
+                            text(
+                                """
+                            SELECT id::text AS id, evidence
+                            FROM maintenance_proposals
+                            WHERE rule_name = :rule_name
+                              AND target_type = :target_type
+                              AND target_id = :target_id
+                              AND status = 'pending'
+                              AND vault_id IS NULL
+                            ORDER BY created_at ASC
+                            LIMIT 1
+                            """
+                            ),
+                            {
+                                'rule_name': _RULE_NAME,
+                                'target_type': _TARGET_TYPE,
+                                'target_id': winner_id,
+                            },
+                        )
+                    )
+                    .mappings()
+                    .first()
+                )
+
+                if existing_row is not None:
+                    existing_ev = existing_row['evidence'] or {}
+                    # Preserve composition_hash so a dismissed cluster does
+                    # not re-fire on identical membership.
+                    if existing_ev.get('composition_hash'):
+                        evidence['composition_hash'] = existing_ev['composition_hash']
+                    await session.execute(
+                        text(
+                            """
+                            UPDATE maintenance_proposals
+                            SET evidence = CAST(:evidence AS jsonb),
+                                suggested_action = :suggested_action
+                            WHERE id = CAST(:id AS uuid)
+                            """
+                        ),
+                        {
+                            'evidence': json.dumps(evidence),
+                            'suggested_action': _SUGGESTED_ACTION,
+                            'id': existing_row['id'],
+                        },
+                    )
+                    summary['rescan_updated'] += 1
+                    metrics.ENTITY_COLLAPSE_SCAN_EMITTED_TOTAL.labels(result='rescan_updated').inc()
+                    logger.warning(
+                        'entity_collapse_scan: rescan_updated cluster_id=%s size=%d existing_id=%s',
+                        composition_hash,
+                        len(member_ids),
+                        existing_row['id'],
+                    )
+                else:
+                    await session.execute(
+                        text(
+                            """
+                            INSERT INTO maintenance_proposals (
+                                vault_id, lint_type, target_type, target_id,
+                                rule_name, evidence, suggested_action,
+                                status, source
+                            )
+                            VALUES (
+                                NULL,
+                                :lint_type,
+                                :target_type,
+                                :target_id,
+                                :rule_name,
+                                CAST(:evidence AS jsonb),
+                                :suggested_action,
+                                'pending',
+                                'rule'
+                            )
+                            """
+                        ),
+                        {
+                            'lint_type': LintType.QUALITY.value,
+                            'target_type': _TARGET_TYPE,
+                            'target_id': winner_id,
+                            'rule_name': _RULE_NAME,
+                            'evidence': json.dumps(evidence),
+                            'suggested_action': _SUGGESTED_ACTION,
+                        },
+                    )
+                    summary['clusters_emitted'] += 1
+                    metrics.ENTITY_COLLAPSE_SCAN_EMITTED_TOTAL.labels(result='proposed').inc()
+                    logger.info(
+                        'entity_collapse_scan: proposed cluster_id=%s size=%d '
+                        'pair_min=%.3f pair_max=%.3f',
+                        composition_hash,
+                        len(member_ids),
+                        pair_min,
+                        pair_max,
+                    )
+
+            # Mark every scanned entity with the current timestamp so the
+            # cooldown filter excludes them on the next pass.
+            now = datetime.now(timezone.utc)
+            await session.execute(
+                text(
+                    'UPDATE entities SET last_merge_scan_at = :now '
+                    'WHERE id = ANY(CAST(:ids AS uuid[]))'
+                ),
+                {'now': now, 'ids': ids},
+            )
+
+            await session.commit()
+
+        return summary
+    finally:
+        if span_cm is not None:
+            try:
+                span_cm.__exit__(None, None, None)
+            except Exception:  # pragma: no cover
+                pass

--- a/packages/core/src/memex_core/services/entity_maintenance.py
+++ b/packages/core/src/memex_core/services/entity_maintenance.py
@@ -111,7 +111,10 @@ def _suggested_winner(members: list[dict[str, Any]]) -> str:
     """
     sorted_members = sorted(
         members,
-        key=lambda m: (-int(m.get('mention_count') or 0), m.get('first_seen') or datetime.max),
+        key=lambda m: (
+            -int(m.get('mention_count') or 0),
+            m.get('first_seen') or datetime.max.replace(tzinfo=timezone.utc),
+        ),
     )
     return str(sorted_members[0]['id'])
 

--- a/packages/core/src/memex_core/services/entity_maintenance.py
+++ b/packages/core/src/memex_core/services/entity_maintenance.py
@@ -153,6 +153,12 @@ async def scan_collapse_clusters(
         cluster_min_threshold if cluster_min_threshold is not None else cfg.cluster_min_threshold
     )
 
+    if cluster_min_threshold > pair_threshold:
+        raise ValueError(
+            f'cluster_min_threshold ({cluster_min_threshold}) cannot exceed '
+            f'pair_threshold ({pair_threshold})'
+        )
+
     span_cm = (
         _tracer.start_as_current_span(
             'memex.entity_maintenance.scan',

--- a/packages/core/src/memex_core/services/entity_maintenance.py
+++ b/packages/core/src/memex_core/services/entity_maintenance.py
@@ -43,6 +43,14 @@ logger = logging.getLogger('memex.core.services.entity_maintenance')
 
 _RULE_NAME = 'entity_collapse_cluster'
 _TARGET_TYPE = 'entity'
+# Distinct 64-bit advisory-lock key for the cross-batch entity-cluster
+# collapse scan. Held at transaction scope so two concurrent callers
+# (scheduler tick + on-demand HTTP/CLI) cannot race on the
+# composition_hash lookup and emit duplicate findings — the partial
+# unique index on maintenance_proposals does not cover vault_id IS NULL
+# rows, so concurrency control has to live here. Picked to not collide
+# with MEMEX_LEADER_LOCK_ID in scheduler.py.
+_MEMEX_ENTITY_MAINTENANCE_LOCK_ID = 0xE1141E5C
 _SUGGESTED_ACTION = (
     'Cluster of near-duplicate entities detected across batches. '
     'Review the members in evidence.cluster_members and approve via '
@@ -168,6 +176,17 @@ async def scan_collapse_clusters(
     try:
         cutoff = datetime.now(timezone.utc) - timedelta(days=scan_cooldown_days)
         async with api.metastore.session() as session:
+            lock_acquired = (
+                await session.execute(
+                    text('SELECT pg_try_advisory_xact_lock(:lock_id)'),
+                    {'lock_id': _MEMEX_ENTITY_MAINTENANCE_LOCK_ID},
+                )
+            ).scalar()
+            if not lock_acquired:
+                metrics.ENTITY_COLLAPSE_SCAN_EMITTED_TOTAL.labels(result='concurrent_skipped').inc()
+                logger.info('entity_collapse_scan: concurrent scan in progress, skipping')
+                return summary
+
             cand_rows = (
                 (
                     await session.execute(

--- a/packages/core/src/memex_core/services/entity_maintenance.py
+++ b/packages/core/src/memex_core/services/entity_maintenance.py
@@ -121,9 +121,11 @@ async def scan_collapse_clusters(
     Returns a summary dict ``{'clusters_emitted': int,
     'clusters_rejected_cohesion': int, 'rescan_updated': int, 'scanned': int}``.
 
-    Idempotent under rescan: existing pending ``entity_collapse_cluster``
-    findings with the same ``target_id`` are UPDATEd in place rather than
-    duplicated. The partial unique index ``uq_maintenance_proposals_pending``
+    Idempotent under rescan: cluster identity is the order-independent
+    ``composition_hash`` of its members, not the (possibly-shifting) suggested
+    winner. An existing pending ``entity_collapse_cluster`` finding with the
+    same composition_hash is UPDATEd in place; a membership shift writes a
+    new row. The partial unique index ``uq_maintenance_proposals_pending``
     only fires on non-NULL ``vault_id`` rows; our findings carry ``vault_id
     IS NULL`` (cross-vault by construction), so we enforce the no-duplicate
     invariant in Python before INSERT.
@@ -194,6 +196,8 @@ async def scan_collapse_clusters(
             candidates: list[dict[str, Any]] = [dict(r) for r in cand_rows]
             summary['scanned'] = len(candidates)
             if len(candidates) < 2:
+                metrics.ENTITY_COLLAPSE_SCAN_EMITTED_TOTAL.labels(result='no_candidates').inc()
+                logger.info('entity_collapse_scan: no_candidates scanned=%d', len(candidates))
                 return summary
 
             ids = [c['id'] for c in candidates]
@@ -313,9 +317,10 @@ async def scan_collapse_clusters(
                     'member_canonical_names': {m: by_id[m]['canonical_name'] for m in member_ids},
                 }
 
-                # Rescan-collision policy: a pending proposal with the same
-                # suggested winner is UPDATEd in place. NULL vault_id is
-                # outside the partial unique index, so we enforce it here.
+                # Rescan-collision policy: identity is cluster membership, not
+                # the (possibly-shifting) suggested winner. We key on
+                # composition_hash so a winner reorder between scans UPDATEs
+                # the existing row, and a membership change INSERTs a new one.
                 existing_row = (
                     (
                         await session.execute(
@@ -325,9 +330,9 @@ async def scan_collapse_clusters(
                             FROM maintenance_proposals
                             WHERE rule_name = :rule_name
                               AND target_type = :target_type
-                              AND target_id = :target_id
                               AND status = 'pending'
                               AND vault_id IS NULL
+                              AND evidence ->> 'composition_hash' = :composition_hash
                             ORDER BY created_at ASC
                             LIMIT 1
                             """
@@ -335,7 +340,7 @@ async def scan_collapse_clusters(
                             {
                                 'rule_name': _RULE_NAME,
                                 'target_type': _TARGET_TYPE,
-                                'target_id': winner_id,
+                                'composition_hash': composition_hash,
                             },
                         )
                     )
@@ -344,22 +349,19 @@ async def scan_collapse_clusters(
                 )
 
                 if existing_row is not None:
-                    existing_ev = existing_row['evidence'] or {}
-                    # Preserve composition_hash so a dismissed cluster does
-                    # not re-fire on identical membership.
-                    if existing_ev.get('composition_hash'):
-                        evidence['composition_hash'] = existing_ev['composition_hash']
                     await session.execute(
                         text(
                             """
                             UPDATE maintenance_proposals
                             SET evidence = CAST(:evidence AS jsonb),
+                                target_id = :target_id,
                                 suggested_action = :suggested_action
                             WHERE id = CAST(:id AS uuid)
                             """
                         ),
                         {
                             'evidence': json.dumps(evidence),
+                            'target_id': winner_id,
                             'suggested_action': _SUGGESTED_ACTION,
                             'id': existing_row['id'],
                         },

--- a/packages/core/tests/integration/test_entity_collapse_maintenance.py
+++ b/packages/core/tests/integration/test_entity_collapse_maintenance.py
@@ -580,6 +580,173 @@ async def test_collapse_cluster_rejects_invalid_inputs(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_rescan_winner_shift_updates_same_proposal(
+    session: AsyncSession,
+    metastore,
+):
+    """Winner shifts between scans (mention_count reorders) but the cluster
+    membership is unchanged → same composition_hash → existing pending row is
+    UPDATEd in place. No duplicate finding."""
+    suffix = uuid4().hex[:6]
+    a = await _make_entity(
+        session,
+        f'WSHIFT-{suffix}',
+        mention_count=10,
+        first_seen=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    b = await _make_entity(
+        session,
+        f'wshift-{suffix}',
+        mention_count=2,
+        first_seen=datetime(2026, 2, 1, tzinfo=timezone.utc),
+    )
+
+    from memex_core.services.entity_maintenance import scan_collapse_clusters
+
+    api_stub = _make_api_stub(metastore)
+    await scan_collapse_clusters(api_stub, pair_threshold=0.55, cluster_min_threshold=0.4)
+
+    async with metastore.session() as s:
+        before = (
+            await s.execute(
+                text(
+                    'SELECT id::text, target_id::text FROM maintenance_proposals '
+                    "WHERE rule_name = 'entity_collapse_cluster' "
+                    "AND status = 'pending' "
+                    'AND evidence ->> :hash_key IN '
+                    '(SELECT evidence ->> :hash_key FROM maintenance_proposals '
+                    " WHERE target_id = :wid AND status = 'pending')"
+                ),
+                {'wid': str(a.id), 'hash_key': 'composition_hash'},
+            )
+        ).all()
+    assert len(before) == 1, f'expected one proposal pre-flip, got {before}'
+    initial_id = before[0][0]
+    assert before[0][1] == str(a.id)
+
+    async with metastore.session() as s:
+        await s.execute(
+            text('UPDATE entities SET mention_count = :mc WHERE id = :id'),
+            {'mc': 99, 'id': str(b.id)},
+        )
+        await s.execute(
+            text('UPDATE entities SET mention_count = :mc WHERE id = :id'),
+            {'mc': 1, 'id': str(a.id)},
+        )
+        await s.execute(text('UPDATE entities SET last_merge_scan_at = NULL'))
+        await s.commit()
+
+    summary2 = await scan_collapse_clusters(
+        api_stub, pair_threshold=0.55, cluster_min_threshold=0.4
+    )
+    assert summary2['rescan_updated'] >= 1
+
+    async with metastore.session() as s:
+        after = (
+            await s.execute(
+                text(
+                    'SELECT id::text, target_id::text FROM maintenance_proposals '
+                    "WHERE rule_name = 'entity_collapse_cluster' "
+                    "AND status = 'pending' "
+                    'AND id = CAST(:id AS uuid)'
+                ),
+                {'id': initial_id},
+            )
+        ).all()
+    assert len(after) == 1, 'row must survive the rescan (UPDATE not INSERT)'
+    assert after[0][1] == str(b.id), 'target_id must reflect the new winner'
+
+    async with metastore.session() as s:
+        dup_count = (
+            await s.execute(
+                text(
+                    'SELECT count(*) FROM maintenance_proposals '
+                    "WHERE rule_name = 'entity_collapse_cluster' "
+                    "AND status = 'pending' "
+                    'AND target_id IN (:wid_a, :wid_b)'
+                ),
+                {'wid_a': str(a.id), 'wid_b': str(b.id)},
+            )
+        ).scalar()
+    assert dup_count == 1, 'must not split into two pending findings'
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_rescan_membership_shift_creates_new_proposal(
+    session: AsyncSession,
+    metastore,
+):
+    """Cluster gains a member between scans → composition_hash changes →
+    a new row is INSERTed alongside the old one (different identity)."""
+    suffix = uuid4().hex[:6]
+    a = await _make_entity(
+        session,
+        f'MSHIFT-{suffix}',
+        mention_count=10,
+        first_seen=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    _b = await _make_entity(
+        session,
+        f'mshift-{suffix}',
+        mention_count=5,
+        first_seen=datetime(2026, 2, 1, tzinfo=timezone.utc),
+    )
+
+    from memex_core.services.entity_maintenance import scan_collapse_clusters
+
+    api_stub = _make_api_stub(metastore)
+    await scan_collapse_clusters(api_stub, pair_threshold=0.55, cluster_min_threshold=0.4)
+
+    async with metastore.session() as s:
+        first_rows = (
+            await s.execute(
+                text(
+                    "SELECT id::text, evidence ->> 'composition_hash' AS h "
+                    'FROM maintenance_proposals '
+                    "WHERE rule_name = 'entity_collapse_cluster' "
+                    "AND status = 'pending' AND target_id = :wid"
+                ),
+                {'wid': str(a.id)},
+            )
+        ).all()
+    assert len(first_rows) == 1, f'expected one proposal after first scan, got {first_rows}'
+    first_id, first_hash = first_rows[0]
+
+    await _make_entity(
+        session,
+        f'Mshift-{suffix}',
+        mention_count=3,
+        first_seen=datetime(2026, 3, 1, tzinfo=timezone.utc),
+    )
+    async with metastore.session() as s:
+        await s.execute(text('UPDATE entities SET last_merge_scan_at = NULL'))
+        await s.commit()
+
+    await scan_collapse_clusters(api_stub, pair_threshold=0.55, cluster_min_threshold=0.4)
+
+    async with metastore.session() as s:
+        second_rows = (
+            await s.execute(
+                text(
+                    "SELECT id::text, evidence ->> 'composition_hash' AS h "
+                    'FROM maintenance_proposals '
+                    "WHERE rule_name = 'entity_collapse_cluster' "
+                    "AND status = 'pending' AND target_id = :wid"
+                ),
+                {'wid': str(a.id)},
+            )
+        ).all()
+    hashes = {h for _, h in second_rows}
+    assert first_hash in hashes, 'old finding (original membership) must remain'
+    assert len(hashes) >= 2, 'membership change must introduce a new composition_hash'
+    assert any(rid == first_id for rid, _ in second_rows), 'original row must be untouched'
+    new_hashes = hashes - {first_hash}
+    assert all(h for h in new_hashes), 'new composition_hash entries must be non-empty'
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_scan_creates_proposal_with_vaults_affected(
     session: AsyncSession,
     metastore,

--- a/packages/core/tests/integration/test_entity_collapse_maintenance.py
+++ b/packages/core/tests/integration/test_entity_collapse_maintenance.py
@@ -870,3 +870,68 @@ async def test_cooccurrence_merge_preserves_open_ended_intervals(
         'NULL valid_to on either side means "still valid"; merge must NOT '
         f'narrow to a dated value (got {valid_to!r})'
     )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrent_scan_skips_when_lock_held(
+    session: AsyncSession,
+    metastore,
+):
+    """Two concurrent callers must not double-emit findings. The second
+    invocation acquires no lock and returns early without scanning."""
+    from memex_core.services.entity_maintenance import (
+        _MEMEX_ENTITY_MAINTENANCE_LOCK_ID,
+        scan_collapse_clusters,
+    )
+
+    suffix = uuid4().hex[:6]
+    await _make_entity(
+        session,
+        f'LOCKA-{suffix}',
+        mention_count=10,
+        first_seen=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    await _make_entity(
+        session,
+        f'locka-{suffix}',
+        mention_count=5,
+        first_seen=datetime(2026, 2, 1, tzinfo=timezone.utc),
+    )
+
+    api_stub = _make_api_stub(metastore)
+
+    async with metastore.session() as holder:
+        acquired = (
+            await holder.execute(
+                text('SELECT pg_try_advisory_xact_lock(:lock_id)'),
+                {'lock_id': _MEMEX_ENTITY_MAINTENANCE_LOCK_ID},
+            )
+        ).scalar()
+        assert acquired is True, 'holder must acquire the maintenance lock first'
+
+        summary = await scan_collapse_clusters(
+            api_stub, pair_threshold=0.55, cluster_min_threshold=0.4
+        )
+        await holder.rollback()
+
+    assert summary == {
+        'clusters_emitted': 0,
+        'clusters_rejected_cohesion': 0,
+        'rescan_updated': 0,
+        'scanned': 0,
+    }
+
+    async with metastore.session() as s:
+        rows = (
+            await s.execute(
+                text(
+                    'SELECT count(*) FROM maintenance_proposals '
+                    "WHERE rule_name = 'entity_collapse_cluster' "
+                    "AND status = 'pending' "
+                    "AND (evidence -> 'member_canonical_names')::text LIKE :pat"
+                ),
+                {'pat': f'%{suffix}%'},
+            )
+        ).scalar()
+    assert rows == 0, 'no findings should have been emitted under contention'

--- a/packages/core/tests/integration/test_entity_collapse_maintenance.py
+++ b/packages/core/tests/integration/test_entity_collapse_maintenance.py
@@ -1,0 +1,635 @@
+"""Integration tests for cross-batch entity-cluster collapse maintenance.
+
+Exercises the six referential-integrity hazards and the scan/emit/apply
+flow against a real Postgres. All tests are marked ``@pytest.mark.integration``
+and assume the testcontainers fixtures defined in
+``packages/core/tests/integration/conftest.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_common.config import GLOBAL_VAULT_ID
+from memex_core.memory.sql_models import (
+    Entity,
+    EntityAlias,
+    EntityCooccurrence,
+    MemoryLink,
+    MemoryUnit,
+    MentalModel,
+    Note,
+    UnitEntity,
+    Vault,
+)
+from memex_core.services.entities import EntityService
+
+
+def _make_api_stub(metastore):
+    """Construct a minimal MemexAPI surrogate for scan_collapse_clusters.
+
+    The scan needs only ``api.metastore`` and ``api.config``; rather than spin
+    up the full MemexAPI (which initializes models, services, schedulers) we
+    expose just those two attributes.
+    """
+    from memex_common.config import (
+        EntityMaintenanceConfig,
+        MemexConfig,
+    )
+
+    config = MemexConfig()
+    config.server.memory.entity_maintenance = EntityMaintenanceConfig(
+        scan_enabled=True,
+        top_n=100,
+        scan_cooldown_days=0,
+        pair_threshold=0.85,
+        cluster_min_threshold=0.7,
+    )
+    stub = MagicMock()
+    stub.metastore = metastore
+    stub.config = config
+    return stub
+
+
+async def _make_entity(
+    session: AsyncSession,
+    name: str,
+    *,
+    mention_count: int = 5,
+    first_seen: datetime | None = None,
+    phonetic_code: str | None = None,
+) -> Entity:
+    now = datetime.now(timezone.utc)
+    e = Entity(
+        canonical_name=name,
+        phonetic_code=phonetic_code or 'AKM',
+        mention_count=mention_count,
+        first_seen=first_seen or now,
+        last_seen=now,
+    )
+    session.add(e)
+    await session.commit()
+    await session.refresh(e)
+    return e
+
+
+async def _add_unit_entity(
+    session: AsyncSession,
+    *,
+    unit_id: UUID,
+    entity_id: UUID,
+    vault_id: UUID,
+    success: int = 0,
+    failure: int = 0,
+) -> None:
+    session.add(
+        UnitEntity(
+            unit_id=unit_id,
+            entity_id=entity_id,
+            vault_id=vault_id,
+            success_co_count=success,
+            failure_co_count=failure,
+        )
+    )
+    await session.commit()
+
+
+async def _make_unit(session: AsyncSession, vault_id: UUID) -> MemoryUnit:
+    note = Note(id=uuid4(), vault_id=vault_id, content_hash=uuid4().hex)
+    session.add(note)
+    await session.commit()
+    unit = MemoryUnit(
+        id=uuid4(),
+        vault_id=vault_id,
+        note_id=note.id,
+        text=f'unit-{uuid4().hex}',
+        event_date=datetime.now(timezone.utc),
+    )
+    session.add(unit)
+    await session.commit()
+    return unit
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_collapse_cluster_repoints_memory_links_before_delete(
+    session: AsyncSession,
+    metastore,
+    filestore,
+):
+    """Hazard 1: MemoryLink.entity_id MUST be repointed before the entity
+    hard-delete, otherwise the FK CASCADE drops the rows."""
+    e_winner = await _make_entity(session, f'ACME-{uuid4().hex[:6]}')
+    e_loser = await _make_entity(session, f'acme-{uuid4().hex[:6]}')
+
+    unit_a = await _make_unit(session, GLOBAL_VAULT_ID)
+    unit_b = await _make_unit(session, GLOBAL_VAULT_ID)
+
+    link = MemoryLink(
+        from_unit_id=unit_a.id,
+        to_unit_id=unit_b.id,
+        link_type='entity',
+        entity_id=e_loser.id,
+        vault_id=GLOBAL_VAULT_ID,
+    )
+    session.add(link)
+    await session.commit()
+
+    from memex_common.config import MemexConfig
+
+    config = MemexConfig()
+    svc = EntityService(metastore=metastore, filestore=filestore, config=config)
+    summary = await svc.collapse_cluster(
+        winner_id=e_winner.id, loser_ids=[e_loser.id], actor='test'
+    )
+
+    assert summary['links_repointed'] >= 1
+
+    async with metastore.session() as s:
+        result = await s.execute(
+            text(
+                'SELECT entity_id FROM memory_links '
+                'WHERE from_unit_id = :from_id AND to_unit_id = :to_id'
+            ),
+            {'from_id': str(unit_a.id), 'to_id': str(unit_b.id)},
+        )
+        row = result.first()
+    assert row is not None, 'memory_link must survive the collapse'
+    assert UUID(str(row[0])) == e_winner.id
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_collapse_cluster_merges_unit_entity_counters(
+    session: AsyncSession,
+    metastore,
+    filestore,
+):
+    """Hazard 4: UnitEntity collision merged by summing counters."""
+    e_winner = await _make_entity(session, f'win-{uuid4().hex[:6]}')
+    e_loser = await _make_entity(session, f'loss-{uuid4().hex[:6]}')
+
+    unit = await _make_unit(session, GLOBAL_VAULT_ID)
+    await _add_unit_entity(
+        session,
+        unit_id=unit.id,
+        entity_id=e_winner.id,
+        vault_id=GLOBAL_VAULT_ID,
+        success=2,
+        failure=1,
+    )
+    await _add_unit_entity(
+        session,
+        unit_id=unit.id,
+        entity_id=e_loser.id,
+        vault_id=GLOBAL_VAULT_ID,
+        success=3,
+        failure=4,
+    )
+
+    from memex_common.config import MemexConfig
+
+    svc = EntityService(metastore=metastore, filestore=filestore, config=MemexConfig())
+    await svc.collapse_cluster(winner_id=e_winner.id, loser_ids=[e_loser.id], actor='test')
+
+    async with metastore.session() as s:
+        rows = (
+            await s.execute(
+                text(
+                    'SELECT entity_id::text, success_co_count, failure_co_count '
+                    'FROM unit_entities WHERE unit_id = :uid'
+                ),
+                {'uid': str(unit.id)},
+            )
+        ).all()
+
+    assert len(rows) == 1, f'expected one merged row, got {rows}'
+    eid, success, failure = rows[0]
+    assert UUID(eid) == e_winner.id
+    assert success == 5
+    assert failure == 5
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_collapse_cluster_absorbs_aliases(
+    session: AsyncSession,
+    metastore,
+    filestore,
+):
+    """Hazard 3: EntityAlias absorbed with ON CONFLICT DO NOTHING and the
+    loser's canonical_name itself becomes an alias of the winner."""
+    e_winner = await _make_entity(session, f'WinName-{uuid4().hex[:6]}')
+    e_loser = await _make_entity(session, f'LoseName-{uuid4().hex[:6]}')
+
+    session.add(EntityAlias(canonical_id=e_loser.id, name='shared-nickname'))
+    session.add(EntityAlias(canonical_id=e_winner.id, name='shared-nickname'))
+    await session.commit()
+
+    from memex_common.config import MemexConfig
+
+    svc = EntityService(metastore=metastore, filestore=filestore, config=MemexConfig())
+    await svc.collapse_cluster(winner_id=e_winner.id, loser_ids=[e_loser.id], actor='test')
+
+    async with metastore.session() as s:
+        rows = (
+            await s.execute(
+                text('SELECT name FROM entity_aliases WHERE canonical_id = :wid ORDER BY name'),
+                {'wid': str(e_winner.id)},
+            )
+        ).all()
+    names = [r[0] for r in rows]
+    assert 'shared-nickname' in names
+    assert e_loser.canonical_name in names
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_collapse_cluster_reorders_and_sums_cooccurrences(
+    session: AsyncSession,
+    metastore,
+    filestore,
+):
+    """Hazard 2: EntityCooccurrence reordered with canonical (smaller,larger)
+    UUID ordering and counts summed across loser+winner rows."""
+    e_winner = await _make_entity(session, f'WIN-{uuid4().hex[:6]}')
+    e_loser = await _make_entity(session, f'LOSE-{uuid4().hex[:6]}')
+    e_peer = await _make_entity(session, f'PEER-{uuid4().hex[:6]}')
+
+    # winner <-> peer in canonical order
+    e1, e2 = sorted([e_winner.id, e_peer.id], key=str)
+    session.add(
+        EntityCooccurrence(
+            entity_id_1=e1,
+            entity_id_2=e2,
+            vault_id=GLOBAL_VAULT_ID,
+            cooccurrence_count=2,
+        )
+    )
+    # loser <-> peer in canonical order
+    e3, e4 = sorted([e_loser.id, e_peer.id], key=str)
+    session.add(
+        EntityCooccurrence(
+            entity_id_1=e3,
+            entity_id_2=e4,
+            vault_id=GLOBAL_VAULT_ID,
+            cooccurrence_count=3,
+        )
+    )
+    await session.commit()
+
+    from memex_common.config import MemexConfig
+
+    svc = EntityService(metastore=metastore, filestore=filestore, config=MemexConfig())
+    await svc.collapse_cluster(winner_id=e_winner.id, loser_ids=[e_loser.id], actor='test')
+
+    async with metastore.session() as s:
+        rows = (
+            await s.execute(
+                text(
+                    'SELECT entity_id_1::text, entity_id_2::text, cooccurrence_count '
+                    'FROM entity_cooccurrences '
+                    'WHERE :pid IN (entity_id_1, entity_id_2) '
+                    'OR :wid IN (entity_id_1, entity_id_2)'
+                ),
+                {'pid': str(e_peer.id), 'wid': str(e_winner.id)},
+            )
+        ).all()
+    assert len(rows) == 1
+    eid1, eid2, count = rows[0]
+    assert {UUID(eid1), UUID(eid2)} == {e_winner.id, e_peer.id}
+    # The IDs are stored in canonical order
+    assert UUID(eid1) < UUID(eid2)
+    assert count == 5
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_collapse_cluster_merges_mental_models_with_version_bump(
+    session: AsyncSession,
+    metastore,
+    filestore,
+):
+    """Hazard 5: MentalModel per-vault collision → observations merged and
+    ``version = max(winner, loser) + 1``."""
+    e_winner = await _make_entity(session, f'EWIN-{uuid4().hex[:6]}')
+    e_loser = await _make_entity(session, f'ELOSE-{uuid4().hex[:6]}')
+
+    mm_w = MentalModel(
+        vault_id=GLOBAL_VAULT_ID,
+        entity_id=e_winner.id,
+        name='EWIN',
+        observations=[{'fact': 'w1'}],
+        version=4,
+    )
+    mm_l = MentalModel(
+        vault_id=GLOBAL_VAULT_ID,
+        entity_id=e_loser.id,
+        name='ELOSE',
+        observations=[{'fact': 'l1'}, {'fact': 'l2'}],
+        version=7,
+    )
+    session.add(mm_w)
+    session.add(mm_l)
+    await session.commit()
+
+    from memex_common.config import MemexConfig
+
+    svc = EntityService(metastore=metastore, filestore=filestore, config=MemexConfig())
+    await svc.collapse_cluster(winner_id=e_winner.id, loser_ids=[e_loser.id], actor='test')
+
+    async with metastore.session() as s:
+        rows = (
+            await s.execute(
+                text('SELECT version, observations FROM mental_models WHERE entity_id = :wid'),
+                {'wid': str(e_winner.id)},
+            )
+        ).all()
+    assert len(rows) == 1
+    version, observations = rows[0]
+    assert version == 8
+    facts = sorted(o['fact'] for o in observations)
+    assert facts == ['l1', 'l2', 'w1']
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_collapse_cluster_writes_audit_log_with_details_column(
+    session: AsyncSession,
+    metastore,
+    filestore,
+):
+    """Hazard 7: AuditLog row uses the ``details`` column (not ``metadata``)."""
+    e_winner = await _make_entity(session, f'AW-{uuid4().hex[:6]}')
+    e_loser = await _make_entity(session, f'AL-{uuid4().hex[:6]}')
+
+    from memex_common.config import MemexConfig
+
+    svc = EntityService(metastore=metastore, filestore=filestore, config=MemexConfig())
+    await svc.collapse_cluster(winner_id=e_winner.id, loser_ids=[e_loser.id], actor='actor-x')
+
+    async with metastore.session() as s:
+        row = (
+            await s.execute(
+                text(
+                    'SELECT actor, action, resource_id, details FROM audit_logs '
+                    "WHERE action = 'entity.collapse_cluster' "
+                    'ORDER BY timestamp DESC LIMIT 1'
+                )
+            )
+        ).first()
+    assert row is not None, 'audit row must exist'
+    actor, action, resource_id, details = row
+    assert actor == 'actor-x'
+    assert action == 'entity.collapse_cluster'
+    assert UUID(resource_id) == e_winner.id
+    assert details is not None
+    assert details['winner_id'] == str(e_winner.id)
+    assert str(e_loser.id) in details['loser_ids']
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_collapse_cluster_hard_deletes_losers_last(
+    session: AsyncSession,
+    metastore,
+    filestore,
+):
+    """Hazard 6: loser entity rows are gone after collapse."""
+    e_winner = await _make_entity(session, f'KW-{uuid4().hex[:6]}')
+    e_loser = await _make_entity(session, f'KL-{uuid4().hex[:6]}')
+
+    from memex_common.config import MemexConfig
+
+    svc = EntityService(metastore=metastore, filestore=filestore, config=MemexConfig())
+    await svc.collapse_cluster(winner_id=e_winner.id, loser_ids=[e_loser.id], actor='test')
+
+    async with metastore.session() as s:
+        winner_row = (
+            await s.execute(
+                text('SELECT id::text FROM entities WHERE id = :id'),
+                {'id': str(e_winner.id)},
+            )
+        ).first()
+        loser_row = (
+            await s.execute(
+                text('SELECT id::text FROM entities WHERE id = :id'),
+                {'id': str(e_loser.id)},
+            )
+        ).first()
+    assert winner_row is not None
+    assert loser_row is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_scan_emits_cluster_of_three(
+    session: AsyncSession,
+    metastore,
+):
+    """End-to-end: three near-duplicate entities → one cluster proposal."""
+    suffix = uuid4().hex[:6]
+    a = await _make_entity(
+        session,
+        f'ACME-Inc-{suffix}',
+        mention_count=10,
+        first_seen=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    b = await _make_entity(
+        session,
+        f'acme-inc-{suffix}',
+        mention_count=5,
+        first_seen=datetime(2026, 2, 1, tzinfo=timezone.utc),
+    )
+    c = await _make_entity(
+        session,
+        f'Acme-Inc-{suffix}',
+        mention_count=3,
+        first_seen=datetime(2026, 3, 1, tzinfo=timezone.utc),
+    )
+
+    from memex_core.services.entity_maintenance import scan_collapse_clusters
+
+    api_stub = _make_api_stub(metastore)
+    summary = await scan_collapse_clusters(api_stub, pair_threshold=0.55, cluster_min_threshold=0.4)
+    assert summary['clusters_emitted'] >= 1
+
+    async with metastore.session() as s:
+        rows = (
+            await s.execute(
+                text(
+                    'SELECT evidence FROM maintenance_proposals '
+                    "WHERE rule_name = 'entity_collapse_cluster' "
+                    "AND status = 'pending' "
+                    'AND target_id = :wid'
+                ),
+                {'wid': str(a.id)},
+            )
+        ).all()
+    assert rows, 'cluster proposal for the suggested winner must exist'
+    evidence = rows[0][0]
+    members = set(evidence['cluster_members'])
+    assert {str(a.id), str(b.id), str(c.id)}.issubset(members)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_scan_rescan_updates_evidence_in_place(
+    session: AsyncSession,
+    metastore,
+):
+    """Re-scan with same suggested winner UPDATEs the existing pending row
+    rather than inserting a duplicate."""
+    suffix = uuid4().hex[:6]
+    a = await _make_entity(
+        session,
+        f'ZED-{suffix}',
+        mention_count=10,
+        first_seen=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    _b = await _make_entity(
+        session,
+        f'zed-{suffix}',
+        mention_count=2,
+        first_seen=datetime(2026, 2, 1, tzinfo=timezone.utc),
+    )
+
+    from memex_core.services.entity_maintenance import scan_collapse_clusters
+
+    api_stub = _make_api_stub(metastore)
+    await scan_collapse_clusters(api_stub, pair_threshold=0.55, cluster_min_threshold=0.4)
+    # Reset last_merge_scan_at to bypass cooldown for second pass
+    async with metastore.session() as s:
+        await s.execute(text('UPDATE entities SET last_merge_scan_at = NULL'))
+        await s.commit()
+    summary2 = await scan_collapse_clusters(
+        api_stub, pair_threshold=0.55, cluster_min_threshold=0.4
+    )
+    assert summary2['rescan_updated'] >= 1
+
+    async with metastore.session() as s:
+        rows = (
+            await s.execute(
+                text(
+                    'SELECT count(*) FROM maintenance_proposals '
+                    "WHERE rule_name = 'entity_collapse_cluster' "
+                    "AND status = 'pending' AND target_id = :wid"
+                ),
+                {'wid': str(a.id)},
+            )
+        ).all()
+    assert rows[0][0] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_scan_respects_cooldown_window(
+    session: AsyncSession,
+    metastore,
+):
+    """An entity scanned within cooldown_days is skipped on the next pass."""
+    suffix = uuid4().hex[:6]
+    now = datetime.now(timezone.utc)
+    a = await _make_entity(session, f'Q1-{suffix}', mention_count=5)
+    b = await _make_entity(session, f'q1-{suffix}', mention_count=4)
+    # Mark both as just-scanned
+    async with metastore.session() as s:
+        await s.execute(
+            text(
+                'UPDATE entities SET last_merge_scan_at = :now WHERE id = ANY(CAST(:ids AS uuid[]))'
+            ),
+            {'now': now, 'ids': [str(a.id), str(b.id)]},
+        )
+        await s.commit()
+
+    from memex_core.services.entity_maintenance import scan_collapse_clusters
+
+    api_stub = _make_api_stub(metastore)
+    api_stub.config.server.memory.entity_maintenance.scan_cooldown_days = 7
+    summary = await scan_collapse_clusters(api_stub)
+    # Filter to recently created entities only — other test entities may exist
+    # in the same DB; we just assert that ours weren't included.
+    assert summary['scanned'] >= 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_collapse_cluster_rejects_invalid_inputs(
+    session: AsyncSession,
+    metastore,
+    filestore,
+):
+    """winner_id in loser_ids and empty loser_ids both raise ValueError."""
+    e = await _make_entity(session, f'XX-{uuid4().hex[:6]}')
+
+    from memex_common.config import MemexConfig
+
+    svc = EntityService(metastore=metastore, filestore=filestore, config=MemexConfig())
+
+    with pytest.raises(ValueError):
+        await svc.collapse_cluster(winner_id=e.id, loser_ids=[], actor='t')
+    with pytest.raises(ValueError):
+        await svc.collapse_cluster(winner_id=e.id, loser_ids=[e.id], actor='t')
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_scan_creates_proposal_with_vaults_affected(
+    session: AsyncSession,
+    metastore,
+):
+    """Cross-vault: vaults_affected lists every vault the cluster members
+    appear in via unit_entities."""
+    suffix = uuid4().hex[:6]
+    vault_a = Vault(name=f'va-{suffix}')
+    vault_b = Vault(name=f'vb-{suffix}')
+    session.add(vault_a)
+    session.add(vault_b)
+    await session.commit()
+    await session.refresh(vault_a)
+    await session.refresh(vault_b)
+
+    e1 = await _make_entity(
+        session,
+        f'CrossVault-{suffix}',
+        mention_count=10,
+        first_seen=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    e2 = await _make_entity(
+        session,
+        f'crossvault-{suffix}',
+        mention_count=5,
+        first_seen=datetime(2026, 2, 1, tzinfo=timezone.utc),
+    )
+
+    unit_a = await _make_unit(session, vault_a.id)
+    unit_b = await _make_unit(session, vault_b.id)
+    await _add_unit_entity(session, unit_id=unit_a.id, entity_id=e1.id, vault_id=vault_a.id)
+    await _add_unit_entity(session, unit_id=unit_b.id, entity_id=e2.id, vault_id=vault_b.id)
+
+    from memex_core.services.entity_maintenance import scan_collapse_clusters
+
+    api_stub = _make_api_stub(metastore)
+    await scan_collapse_clusters(api_stub, pair_threshold=0.55, cluster_min_threshold=0.4)
+
+    async with metastore.session() as s:
+        rows = (
+            await s.execute(
+                text(
+                    'SELECT evidence FROM maintenance_proposals '
+                    "WHERE rule_name = 'entity_collapse_cluster' "
+                    "AND status = 'pending' AND target_id = :wid"
+                ),
+                {'wid': str(e1.id)},
+            )
+        ).all()
+    assert rows
+    evidence = rows[0][0]
+    vaults_affected = set(evidence['vaults_affected'])
+    assert {str(vault_a.id), str(vault_b.id)}.issubset(vaults_affected)

--- a/packages/core/tests/integration/test_entity_collapse_maintenance.py
+++ b/packages/core/tests/integration/test_entity_collapse_maintenance.py
@@ -360,6 +360,87 @@ async def test_collapse_cluster_merges_mental_models_with_version_bump(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_collapse_cluster_flushes_before_entity_delete(
+    session: AsyncSession,
+    metastore,
+    filestore,
+    monkeypatch,
+):
+    """Step 5 deletes MentalModel rows via the ORM (deferred until flush);
+    Step 6 then issues a raw SQL DELETE on entities. An explicit flush between
+    them makes the ordering invariant — without it, the entity hard-delete
+    could fire while stale MentalModel rows still hold FK references.
+    """
+    e_winner = await _make_entity(session, f'FW-{uuid4().hex[:6]}')
+    e_loser = await _make_entity(session, f'FL-{uuid4().hex[:6]}')
+
+    session.add(
+        MentalModel(
+            vault_id=GLOBAL_VAULT_ID,
+            entity_id=e_winner.id,
+            name='FW',
+            observations=[{'fact': 'w'}],
+            version=1,
+        )
+    )
+    session.add(
+        MentalModel(
+            vault_id=GLOBAL_VAULT_ID,
+            entity_id=e_loser.id,
+            name='FL',
+            observations=[{'fact': 'x'}],
+            version=1,
+        )
+    )
+    await session.commit()
+
+    from sqlmodel.ext.asyncio.session import AsyncSession as _AS
+    from memex_common.config import MemexConfig
+
+    call_log: list[str] = []
+
+    original_delete = _AS.delete
+    original_flush = _AS.flush
+    original_exec = _AS.exec
+
+    async def _track_delete(self, instance):
+        call_log.append(f'delete:{type(instance).__name__}')
+        return await original_delete(self, instance)
+
+    async def _track_flush(self, *args, **kwargs):
+        call_log.append('flush')
+        return await original_flush(self, *args, **kwargs)
+
+    async def _track_exec(self, stmt, *args, **kwargs):
+        raw = str(stmt)
+        if 'DELETE FROM entities' in raw:
+            call_log.append('exec:DELETE_ENTITIES')
+        return await original_exec(self, stmt, *args, **kwargs)
+
+    monkeypatch.setattr(_AS, 'delete', _track_delete)
+    monkeypatch.setattr(_AS, 'flush', _track_flush)
+    monkeypatch.setattr(_AS, 'exec', _track_exec)
+
+    svc = EntityService(metastore=metastore, filestore=filestore, config=MemexConfig())
+    await svc.collapse_cluster(winner_id=e_winner.id, loser_ids=[e_loser.id], actor='test')
+
+    mm_deletes = [i for i, e in enumerate(call_log) if e == 'delete:MentalModel']
+    flushes = [i for i, e in enumerate(call_log) if e == 'flush']
+    entity_deletes = [i for i, e in enumerate(call_log) if e == 'exec:DELETE_ENTITIES']
+
+    assert mm_deletes, 'expected at least one MentalModel ORM delete'
+    assert entity_deletes, 'expected the raw SQL DELETE on entities'
+    last_mm_delete = mm_deletes[-1]
+    first_entity_delete = entity_deletes[0]
+    interposed_flush = [f for f in flushes if last_mm_delete < f < first_entity_delete]
+    assert interposed_flush, (
+        f'expected an explicit session.flush() between MentalModel delete and '
+        f'entity DELETE, got call_log={call_log}'
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_collapse_cluster_writes_audit_log_with_details_column(
     session: AsyncSession,
     metastore,

--- a/packages/core/tests/integration/test_entity_collapse_maintenance.py
+++ b/packages/core/tests/integration/test_entity_collapse_maintenance.py
@@ -800,3 +800,73 @@ async def test_scan_creates_proposal_with_vaults_affected(
     evidence = rows[0][0]
     vaults_affected = set(evidence['vaults_affected'])
     assert {str(vault_a.id), str(vault_b.id)}.issubset(vaults_affected)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_cooccurrence_merge_preserves_open_ended_intervals(
+    session: AsyncSession,
+    metastore,
+    filestore,
+):
+    """A NULL valid_from / valid_to means an open-ended interval; merging a
+    NULL side with a dated side MUST keep NULL — narrowing a dated interval
+    silently loses the "still valid" / "always was" semantics."""
+    e_winner = await _make_entity(session, f'OW-{uuid4().hex[:6]}')
+    e_loser = await _make_entity(session, f'OL-{uuid4().hex[:6]}')
+    e_peer = await _make_entity(session, f'OP-{uuid4().hex[:6]}')
+
+    dated = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    # winner<->peer: dated valid_from, NULL valid_to (still valid).
+    e1, e2 = sorted([e_winner.id, e_peer.id], key=str)
+    session.add(
+        EntityCooccurrence(
+            entity_id_1=e1,
+            entity_id_2=e2,
+            vault_id=GLOBAL_VAULT_ID,
+            cooccurrence_count=1,
+            valid_from=dated,
+            valid_to=None,
+        )
+    )
+    # loser<->peer: NULL valid_from (always was), dated valid_to.
+    e3, e4 = sorted([e_loser.id, e_peer.id], key=str)
+    session.add(
+        EntityCooccurrence(
+            entity_id_1=e3,
+            entity_id_2=e4,
+            vault_id=GLOBAL_VAULT_ID,
+            cooccurrence_count=1,
+            valid_from=None,
+            valid_to=dated,
+        )
+    )
+    await session.commit()
+
+    from memex_common.config import MemexConfig
+
+    svc = EntityService(metastore=metastore, filestore=filestore, config=MemexConfig())
+    await svc.collapse_cluster(winner_id=e_winner.id, loser_ids=[e_loser.id], actor='test')
+
+    async with metastore.session() as s:
+        rows = (
+            await s.execute(
+                text(
+                    'SELECT valid_from, valid_to FROM entity_cooccurrences '
+                    'WHERE :pid IN (entity_id_1, entity_id_2) '
+                    'AND :wid IN (entity_id_1, entity_id_2)'
+                ),
+                {'pid': str(e_peer.id), 'wid': str(e_winner.id)},
+            )
+        ).all()
+    assert len(rows) == 1
+    valid_from, valid_to = rows[0]
+    assert valid_from is None, (
+        'NULL valid_from on either side means "open start"; merge must NOT '
+        f'narrow to a dated value (got {valid_from!r})'
+    )
+    assert valid_to is None, (
+        'NULL valid_to on either side means "still valid"; merge must NOT '
+        f'narrow to a dated value (got {valid_to!r})'
+    )

--- a/packages/core/tests/unit/memory/test_entity_resolver.py
+++ b/packages/core/tests/unit/memory/test_entity_resolver.py
@@ -185,3 +185,90 @@ async def test_persist_resolutions_v2(resolver, mock_session):
     assert final_ids[0] == 'existing-uuid'
     assert final_ids[1] == str(new_id)
     assert mock_session.exec.call_count == 3
+
+
+# -- score_entity_pair (cross-batch pair scorer) --
+
+
+from memex_core.memory.entity_resolver import score_entity_pair  # noqa: E402
+
+
+def test_score_entity_pair_high_similarity():
+    """Case-folded near-identical + matching phonetic + neighbour overlap → score >= 0.8."""
+    score = score_entity_pair(
+        a_name='ACME Corp',
+        b_name='acme corp',
+        a_phonetic='AKM',
+        b_phonetic='AKM',
+        a_neighbors={'ceo': 5, 'product launch': 3},
+        b_neighbors={'ceo': 4, 'investor': 2},
+    )
+    assert score >= 0.8, f'expected >= 0.8, got {score}'
+
+
+def test_score_entity_pair_low_similarity():
+    """Disjoint names + disjoint phonetic + no neighbour overlap → score below threshold."""
+    score = score_entity_pair(
+        a_name='ACME Corp',
+        b_name='Globex Inc',
+        a_phonetic='AKM',
+        b_phonetic='KLPKS',
+        a_neighbors={'ceo': 5},
+        b_neighbors={'investor': 2},
+    )
+    assert score < 0.5, f'expected < 0.5, got {score}'
+
+
+def test_score_entity_pair_phonetic_floor():
+    """Trigram weak but matching phonetic code lifts the name score above floor."""
+    score_no_phonetic = score_entity_pair(
+        a_name='abcdefg',
+        b_name='zyxwvu',
+        a_phonetic=None,
+        b_phonetic=None,
+        a_neighbors={},
+        b_neighbors={},
+    )
+    score_phonetic = score_entity_pair(
+        a_name='abcdefg',
+        b_name='zyxwvu',
+        a_phonetic='PFK',
+        b_phonetic='PFK',
+        a_neighbors={},
+        b_neighbors={},
+    )
+    assert score_phonetic > score_no_phonetic
+
+
+def test_score_entity_pair_neighbor_overlap_contributes():
+    """Shared neighbours lift the score over the no-overlap baseline."""
+    base = score_entity_pair(
+        a_name='Foo Bar',
+        b_name='Foo Baz',
+        a_phonetic=None,
+        b_phonetic=None,
+        a_neighbors={},
+        b_neighbors={},
+    )
+    with_neighbors = score_entity_pair(
+        a_name='Foo Bar',
+        b_name='Foo Baz',
+        a_phonetic=None,
+        b_phonetic=None,
+        a_neighbors={'shared_co': 1},
+        b_neighbors={'shared_co': 1},
+    )
+    assert with_neighbors > base
+
+
+def test_score_entity_pair_identical_names_max():
+    """Identical names + matching phonetic = perfect score."""
+    score = score_entity_pair(
+        a_name='Same Name',
+        b_name='Same Name',
+        a_phonetic='SNM',
+        b_phonetic='SNM',
+        a_neighbors={},
+        b_neighbors={},
+    )
+    assert score >= 0.8

--- a/packages/core/tests/unit/services/test_entity_maintenance.py
+++ b/packages/core/tests/unit/services/test_entity_maintenance.py
@@ -15,11 +15,14 @@ from datetime import datetime, timezone
 
 import pytest
 
+from unittest.mock import MagicMock
+
 from memex_core.services.entity_maintenance import (
     _composition_hash,
     _connected_components,
     _min_pairwise_similarity,
     _suggested_winner,
+    scan_collapse_clusters,
 )
 
 
@@ -133,3 +136,29 @@ def test_suggested_winner_handles_none_first_seen():
         },
     ]
     assert _suggested_winner(members) == 'oldest'
+
+
+@pytest.mark.asyncio
+async def test_scan_collapse_rejects_inverted_thresholds():
+    """Runtime overrides bypass EntityMaintenanceConfig's model_validator, so the
+    scan must independently reject cluster_min_threshold > pair_threshold (which
+    would otherwise reject every cluster as below-cohesion)."""
+    from memex_common.config import EntityMaintenanceConfig, MemexConfig
+
+    config = MemexConfig()
+    config.server.memory.entity_maintenance = EntityMaintenanceConfig(
+        scan_enabled=True,
+        top_n=100,
+        scan_cooldown_days=0,
+        pair_threshold=0.85,
+        cluster_min_threshold=0.7,
+    )
+    api = MagicMock()
+    api.config = config
+
+    with pytest.raises(ValueError, match='cluster_min_threshold'):
+        await scan_collapse_clusters(
+            api,
+            cluster_min_threshold=0.95,
+            pair_threshold=0.7,
+        )

--- a/packages/core/tests/unit/services/test_entity_maintenance.py
+++ b/packages/core/tests/unit/services/test_entity_maintenance.py
@@ -1,0 +1,114 @@
+"""Unit tests for entity_maintenance helpers (clustering, cohesion guard).
+
+These tests exercise the pure-Python helpers in
+``services/entity_maintenance.py`` without touching a DB:
+
+- ``_connected_components`` groups transitive pairs into clusters.
+- ``_min_pairwise_similarity`` returns (min, max) across all pairs.
+- ``_composition_hash`` is stable under member reordering.
+- ``_suggested_winner`` picks by mention_count then first_seen.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from memex_core.services.entity_maintenance import (
+    _composition_hash,
+    _connected_components,
+    _min_pairwise_similarity,
+    _suggested_winner,
+)
+
+
+def test_connected_components_groups_three_pairs_into_one_cluster():
+    nodes = ['A', 'B', 'C', 'D']
+    edges = [('A', 'B'), ('B', 'C')]
+    clusters = _connected_components(nodes, edges)
+    assert len(clusters) == 1
+    assert sorted(clusters[0]) == ['A', 'B', 'C']
+
+
+def test_connected_components_returns_independent_clusters():
+    nodes = ['A', 'B', 'C', 'D']
+    edges = [('A', 'B'), ('C', 'D')]
+    clusters = sorted(_connected_components(nodes, edges), key=lambda c: c[0])
+    assert clusters == [['A', 'B'], ['C', 'D']]
+
+
+def test_connected_components_filters_singletons():
+    nodes = ['A', 'B', 'C']
+    edges = [('A', 'B')]
+    clusters = _connected_components(nodes, edges)
+    assert clusters == [['A', 'B']]
+
+
+def test_composition_hash_stable_under_reorder():
+    h1 = _composition_hash(['A', 'B', 'C'])
+    h2 = _composition_hash(['C', 'A', 'B'])
+    h3 = _composition_hash(['B', 'A', 'C'])
+    assert h1 == h2 == h3
+
+
+def test_composition_hash_differs_by_membership():
+    h1 = _composition_hash(['A', 'B', 'C'])
+    h2 = _composition_hash(['A', 'B', 'D'])
+    assert h1 != h2
+
+
+def test_min_pairwise_similarity_returns_min_max():
+    sims = {
+        ('A', 'B'): 0.9,
+        ('A', 'C'): 0.8,
+        ('B', 'C'): 0.6,
+    }
+    lo, hi = _min_pairwise_similarity(['A', 'B', 'C'], sims)
+    assert lo == pytest.approx(0.6)
+    assert hi == pytest.approx(0.9)
+
+
+def test_min_pairwise_similarity_handles_pair():
+    sims = {('A', 'B'): 0.95}
+    lo, hi = _min_pairwise_similarity(['A', 'B'], sims)
+    assert lo == hi == pytest.approx(0.95)
+
+
+def test_min_pairwise_similarity_rope_drift_detection():
+    """Chain graph with weak bridge: min stays below threshold even though all
+    edges are above pair_threshold individually (the missing pair is what
+    triggers rope-drift rejection)."""
+    sims = {
+        ('A', 'B'): 0.9,
+        ('B', 'C'): 0.9,
+        # A<->C pair missing from edge set; treated as 0.0 in min
+        ('A', 'C'): 0.4,
+    }
+    lo, _ = _min_pairwise_similarity(['A', 'B', 'C'], sims)
+    assert lo == pytest.approx(0.4)
+
+
+def test_suggested_winner_picks_highest_mention_count():
+    members = [
+        {'id': 'a', 'mention_count': 3, 'first_seen': datetime(2026, 1, 1, tzinfo=timezone.utc)},
+        {'id': 'b', 'mention_count': 5, 'first_seen': datetime(2026, 1, 1, tzinfo=timezone.utc)},
+        {'id': 'c', 'mention_count': 1, 'first_seen': datetime(2026, 1, 1, tzinfo=timezone.utc)},
+    ]
+    assert _suggested_winner(members) == 'b'
+
+
+def test_suggested_winner_breaks_ties_by_first_seen():
+    members = [
+        {
+            'id': 'newer',
+            'mention_count': 5,
+            'first_seen': datetime(2026, 5, 1, tzinfo=timezone.utc),
+        },
+        {
+            'id': 'older',
+            'mention_count': 5,
+            'first_seen': datetime(2026, 1, 1, tzinfo=timezone.utc),
+        },
+    ]
+    assert _suggested_winner(members) == 'older'

--- a/packages/core/tests/unit/services/test_entity_maintenance.py
+++ b/packages/core/tests/unit/services/test_entity_maintenance.py
@@ -112,3 +112,24 @@ def test_suggested_winner_breaks_ties_by_first_seen():
         },
     ]
     assert _suggested_winner(members) == 'older'
+
+
+def test_suggested_winner_handles_none_first_seen():
+    members = [
+        {
+            'id': 'no-first-seen',
+            'mention_count': 5,
+            'first_seen': None,
+        },
+        {
+            'id': 'oldest',
+            'mention_count': 5,
+            'first_seen': datetime(2026, 1, 1, tzinfo=timezone.utc),
+        },
+        {
+            'id': 'middle',
+            'mention_count': 5,
+            'first_seen': datetime(2026, 3, 1, tzinfo=timezone.utc),
+        },
+    ]
+    assert _suggested_winner(members) == 'oldest'

--- a/packages/core/tests/unit/test_entities_scan_merges_auth.py
+++ b/packages/core/tests/unit/test_entities_scan_merges_auth.py
@@ -1,0 +1,115 @@
+"""HTTP-level auth gating for POST /api/v1/entities/scan-merges.
+
+The scan endpoint performs cross-vault writes (INSERT/UPDATE on
+``maintenance_proposals`` and ``UPDATE entities SET last_merge_scan_at``),
+so it MUST require the WRITE permission even though the dispatched
+function returns a summary dict. A read-only key — even an
+otherwise-valid one — must be rejected before the service is called.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memex_common.config import Policy, POLICY_PERMISSIONS
+from memex_core.server import app
+from memex_core.server.auth import AuthContext, get_auth_context
+from memex_core.server.common import get_api
+
+
+ALLOWED_VAULT = uuid4()
+
+
+@pytest.fixture
+def mock_api():
+    api = AsyncMock()
+    api.config = SimpleNamespace(server=SimpleNamespace(default_active_vault='vault-a'))
+    api.metastore = SimpleNamespace()
+    return api
+
+
+def _make_client(mock_api, auth: AuthContext | None) -> TestClient:
+    app.dependency_overrides[get_api] = lambda: mock_api
+    app.dependency_overrides[get_auth_context] = lambda: auth
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_overrides():
+    yield
+    app.dependency_overrides = {}
+
+
+def _reader_key() -> AuthContext:
+    return AuthContext(
+        key_prefix='test1234',
+        key_name='scoped-reader',
+        policy=Policy.READER,
+        permissions=POLICY_PERMISSIONS[Policy.READER],
+        vault_ids=[str(ALLOWED_VAULT)],
+        read_vault_ids=None,
+    )
+
+
+def _writer_key() -> AuthContext:
+    return AuthContext(
+        key_prefix='test1234',
+        key_name='writer',
+        policy=Policy.WRITER,
+        permissions=POLICY_PERMISSIONS[Policy.WRITER],
+        vault_ids=None,
+        read_vault_ids=None,
+    )
+
+
+class TestScanMergesAuth:
+    def test_scan_merges_rejects_read_only_key(self, mock_api, monkeypatch):
+        """A reader-policy key must be rejected with 403 before the
+        cross-vault write path runs."""
+        called = {'invoked': False}
+
+        async def _fake_scan(*_args, **_kwargs):
+            called['invoked'] = True
+            return {
+                'clusters_emitted': 0,
+                'clusters_rejected_cohesion': 0,
+                'rescan_updated': 0,
+                'scanned': 0,
+            }
+
+        monkeypatch.setattr(
+            'memex_core.services.entity_maintenance.scan_collapse_clusters',
+            _fake_scan,
+        )
+        client = _make_client(mock_api, _reader_key())
+        resp = client.post('/api/v1/entities/scan-merges')
+        assert resp.status_code == 403, resp.text
+        assert called['invoked'] is False
+
+    def test_scan_merges_accepts_write_key(self, mock_api, monkeypatch):
+        """A writer-policy key passes the permission gate and the
+        underlying scan runs."""
+        called = {'invoked': False}
+
+        async def _fake_scan(*_args, **_kwargs):
+            called['invoked'] = True
+            return {
+                'clusters_emitted': 0,
+                'clusters_rejected_cohesion': 0,
+                'rescan_updated': 0,
+                'scanned': 0,
+            }
+
+        monkeypatch.setattr(
+            'memex_core.services.entity_maintenance.scan_collapse_clusters',
+            _fake_scan,
+        )
+        client = _make_client(mock_api, _writer_key())
+        resp = client.post('/api/v1/entities/scan-merges')
+        assert resp.status_code == 200, resp.text
+        assert called['invoked'] is True

--- a/packages/core/tests/unit/test_lint_vault_access.py
+++ b/packages/core/tests/unit/test_lint_vault_access.py
@@ -252,3 +252,48 @@ class TestLintMutationGlobalFinding:
         mock_api.lint.set_status.assert_awaited_once()
         call = mock_api.lint.set_status.await_args
         assert call.kwargs['vault_id'] is None
+
+
+class TestCollapseClusterEmptyVaultsAffected:
+    """An entity_collapse_cluster finding with an empty ``vaults_affected``
+    list must be rejected (400) at the dispatcher. Cross-vault destructive
+    operations require an explicit scope; fail-open is unacceptable.
+    """
+
+    def _stub_finding(self, mock_api, vaults_affected: list[str]) -> None:
+        mock_api.metastore = AsyncMock()
+        session_cm = AsyncMock()
+
+        async def _execute(stmt, params=None):
+            result = AsyncMock()
+            mappings = AsyncMock()
+            mappings.first = lambda: {
+                'id': str(FINDING_ID),
+                'vault_id': None,
+                'rule_name': 'entity_collapse_cluster',
+                'target_id': str(uuid4()),
+                'evidence': {
+                    'cluster_members': [str(uuid4()), str(uuid4())],
+                    'suggested_winner_id': str(uuid4()),
+                    'vaults_affected': vaults_affected,
+                },
+                'status': 'pending',
+            }
+            result.mappings = lambda: mappings
+            return result
+
+        session_cm.execute = AsyncMock(side_effect=_execute)
+        session_cm.__aenter__ = AsyncMock(return_value=session_cm)
+        session_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_api.metastore.session = lambda: session_cm
+
+    def test_resolve_rejects_empty_vaults_affected(self, mock_api):
+        self._stub_finding(mock_api, vaults_affected=[])
+        client = _make_client(mock_api, _scoped_writer())
+        resp = client.post(
+            f'/api/v1/lint/findings/{FINDING_ID}/resolve',
+            json={'winner_id': str(uuid4())},
+        )
+        assert resp.status_code == 400, resp.text
+        assert 'vaults_affected' in resp.text
+        mock_api.lint.set_status.assert_not_called()

--- a/packages/core/tests/unit/test_lint_vault_access.py
+++ b/packages/core/tests/unit/test_lint_vault_access.py
@@ -45,7 +45,26 @@ def mock_api():
     # Default: finding belongs to ALLOWED_VAULT (tests override per-case).
     api.lint.get_finding_vault_id = AsyncMock(return_value=(True, ALLOWED_VAULT))
     api.lint.set_status = AsyncMock(return_value=True)
-    api.metastore = SimpleNamespace()
+    # ``lint_status?scope=all`` (default) and the resolve dispatcher both query
+    # ``api.metastore.session().execute(...).scalar()/.mappings().first()`` —
+    # stub a session that returns zero scalar and an empty mapping; per-test
+    # overrides may replace ``api.metastore`` with a richer stub.
+    metastore = AsyncMock()
+    session_cm = AsyncMock()
+
+    async def _execute(stmt, params=None):
+        result = AsyncMock()
+        result.scalar = lambda: 0
+        mappings = AsyncMock()
+        mappings.first = lambda: None
+        result.mappings = lambda: mappings
+        return result
+
+    session_cm.execute = AsyncMock(side_effect=_execute)
+    session_cm.__aenter__ = AsyncMock(return_value=session_cm)
+    session_cm.__aexit__ = AsyncMock(return_value=None)
+    metastore.session = lambda: session_cm
+    api.metastore = metastore
     return api
 
 
@@ -187,6 +206,40 @@ def _scoped_writer() -> AuthContext:
 FINDING_ID = uuid4()
 
 
+def _stub_metastore_finding(
+    mock_api,
+    *,
+    rule_name: str = 'duplicate_notes',
+    vault_id: str | None = None,
+    evidence: dict | None = None,
+    status: str = 'pending',
+) -> None:
+    """Stub ``api.metastore.session().execute(...)`` to return a synthetic
+    maintenance_proposals row for the routes that load findings directly.
+    """
+    mock_api.metastore = AsyncMock()
+    session_cm = AsyncMock()
+
+    async def _execute(stmt, params=None):
+        result = AsyncMock()
+        mappings = AsyncMock()
+        mappings.first = lambda: {
+            'id': str(FINDING_ID),
+            'vault_id': vault_id,
+            'rule_name': rule_name,
+            'target_id': str(uuid4()),
+            'evidence': evidence or {},
+            'status': status,
+        }
+        result.mappings = lambda: mappings
+        return result
+
+    session_cm.execute = AsyncMock(side_effect=_execute)
+    session_cm.__aenter__ = AsyncMock(return_value=session_cm)
+    session_cm.__aexit__ = AsyncMock(return_value=None)
+    mock_api.metastore.session = lambda: session_cm
+
+
 class TestLintMutationForbiddenVault:
     def test_dismiss_blocks_when_finding_belongs_to_other_vault(self, mock_api):
         # Finding belongs to FORBIDDEN_VAULT; caller is scoped to ALLOWED_VAULT.
@@ -198,6 +251,7 @@ class TestLintMutationForbiddenVault:
 
     def test_resolve_blocks_when_finding_belongs_to_other_vault(self, mock_api):
         mock_api.lint.get_finding_vault_id = AsyncMock(return_value=(True, FORBIDDEN_VAULT))
+        _stub_metastore_finding(mock_api, vault_id=str(FORBIDDEN_VAULT))
         client = _make_client(mock_api, _scoped_writer())
         resp = client.post(f'/api/v1/lint/findings/{FINDING_ID}/resolve')
         assert resp.status_code == 403, resp.text
@@ -224,6 +278,7 @@ class TestLintMutationAllowedVault:
 
     def test_resolve_allows_in_scope_finding(self, mock_api):
         mock_api.lint.get_finding_vault_id = AsyncMock(return_value=(True, ALLOWED_VAULT))
+        _stub_metastore_finding(mock_api, vault_id=str(ALLOWED_VAULT))
         client = _make_client(mock_api, _scoped_writer())
         resp = client.post(f'/api/v1/lint/findings/{FINDING_ID}/resolve')
         assert resp.status_code == 200, resp.text
@@ -296,4 +351,87 @@ class TestCollapseClusterEmptyVaultsAffected:
         )
         assert resp.status_code == 400, resp.text
         assert 'vaults_affected' in resp.text
+        mock_api.lint.set_status.assert_not_called()
+
+
+class TestCollapseClusterEmptyBody:
+    """A POST with no body to an entity_collapse_cluster finding MUST NOT
+    bypass the rule-keyed dispatcher: the suggested winner should be applied,
+    the empty-``vaults_affected`` guard should still run, and the multi-vault
+    auth check should still gate the mutation.
+    """
+
+    def _stub_finding(
+        self,
+        mock_api,
+        *,
+        vaults_affected: list[str],
+        cluster_members: list[str],
+        suggested_winner_id: str,
+    ) -> None:
+        mock_api.metastore = AsyncMock()
+        session_cm = AsyncMock()
+
+        async def _execute(stmt, params=None):
+            result = AsyncMock()
+            mappings = AsyncMock()
+            mappings.first = lambda: {
+                'id': str(FINDING_ID),
+                'vault_id': None,
+                'rule_name': 'entity_collapse_cluster',
+                'target_id': suggested_winner_id,
+                'evidence': {
+                    'cluster_members': cluster_members,
+                    'suggested_winner_id': suggested_winner_id,
+                    'vaults_affected': vaults_affected,
+                },
+                'status': 'pending',
+            }
+            result.mappings = lambda: mappings
+            return result
+
+        session_cm.execute = AsyncMock(side_effect=_execute)
+        session_cm.__aenter__ = AsyncMock(return_value=session_cm)
+        session_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_api.metastore.session = lambda: session_cm
+
+    def test_resolve_collapse_with_empty_body_applies_suggested_winner(self, mock_api):
+        winner = str(uuid4())
+        loser = str(uuid4())
+        self._stub_finding(
+            mock_api,
+            vaults_affected=[str(ALLOWED_VAULT)],
+            cluster_members=[winner, loser],
+            suggested_winner_id=winner,
+        )
+        mock_api.entities = AsyncMock()
+        mock_api.entities.collapse_cluster = AsyncMock(
+            return_value={'winner_id': winner, 'losers_collapsed': 1}
+        )
+        client = _make_client(mock_api, _scoped_writer())
+        resp = client.post(f'/api/v1/lint/findings/{FINDING_ID}/resolve')
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body['rule_name'] == 'entity_collapse_cluster'
+        assert body['winner_id'] == winner
+        assert body['winner_overridden'] is False
+        mock_api.entities.collapse_cluster.assert_awaited_once()
+        mock_api.lint.set_status.assert_awaited_once()
+
+    def test_resolve_collapse_with_empty_body_still_enforces_empty_vaults_guard(self, mock_api):
+        winner = str(uuid4())
+        loser = str(uuid4())
+        self._stub_finding(
+            mock_api,
+            vaults_affected=[],
+            cluster_members=[winner, loser],
+            suggested_winner_id=winner,
+        )
+        mock_api.entities = AsyncMock()
+        mock_api.entities.collapse_cluster = AsyncMock()
+        client = _make_client(mock_api, _scoped_writer())
+        resp = client.post(f'/api/v1/lint/findings/{FINDING_ID}/resolve')
+        assert resp.status_code == 400, resp.text
+        assert 'vaults_affected' in resp.text
+        mock_api.entities.collapse_cluster.assert_not_called()
         mock_api.lint.set_status.assert_not_called()

--- a/packages/core/tests/unit/test_lint_vault_access.py
+++ b/packages/core/tests/unit/test_lint_vault_access.py
@@ -435,3 +435,83 @@ class TestCollapseClusterEmptyBody:
         assert 'vaults_affected' in resp.text
         mock_api.entities.collapse_cluster.assert_not_called()
         mock_api.lint.set_status.assert_not_called()
+
+
+class TestCollapseClusterWinnerCanonicalNameAmbiguity:
+    """If multiple cluster members share the same canonical_name, the
+    --winner=<name> lookup MUST refuse to silently pick one — the operator
+    sees one name in the CLI and must explicitly disambiguate with a UUID.
+    """
+
+    def _stub_finding_and_ambiguous_winner(
+        self,
+        mock_api,
+        *,
+        cluster_members: list[str],
+        vaults_affected: list[str],
+        winner_name: str,
+        matching_ids: list[str],
+    ) -> None:
+        mock_api.metastore = AsyncMock()
+        session_cm = AsyncMock()
+
+        calls = {'n': 0}
+
+        async def _execute(stmt, params=None):
+            calls['n'] += 1
+            result = AsyncMock()
+            mappings = AsyncMock()
+            stmt_text = str(stmt).lower()
+            if 'maintenance_proposals' in stmt_text:
+                mappings.first = lambda: {
+                    'id': str(FINDING_ID),
+                    'vault_id': None,
+                    'rule_name': 'entity_collapse_cluster',
+                    'target_id': cluster_members[0],
+                    'evidence': {
+                        'cluster_members': cluster_members,
+                        'suggested_winner_id': cluster_members[0],
+                        'vaults_affected': vaults_affected,
+                    },
+                    'status': 'pending',
+                }
+                result.mappings = lambda: mappings
+                return result
+            if 'from entities' in stmt_text and 'canonical_name' in stmt_text:
+                mappings.all = lambda: [{'id': mid} for mid in matching_ids]
+                mappings.first = lambda: ({'id': matching_ids[0]} if matching_ids else None)
+                result.mappings = lambda: mappings
+                return result
+            mappings.first = lambda: None
+            mappings.all = lambda: []
+            result.mappings = lambda: mappings
+            result.scalar = lambda: 0
+            return result
+
+        session_cm.execute = AsyncMock(side_effect=_execute)
+        session_cm.__aenter__ = AsyncMock(return_value=session_cm)
+        session_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_api.metastore.session = lambda: session_cm
+
+    def test_winner_canonical_name_ambiguity_rejected(self, mock_api):
+        winner_a = str(uuid4())
+        winner_b = str(uuid4())
+        third = str(uuid4())
+        self._stub_finding_and_ambiguous_winner(
+            mock_api,
+            cluster_members=[winner_a, winner_b, third],
+            vaults_affected=[str(ALLOWED_VAULT)],
+            winner_name='AcmeCorp',
+            matching_ids=[winner_a, winner_b],
+        )
+        mock_api.entities = AsyncMock()
+        mock_api.entities.collapse_cluster = AsyncMock()
+        client = _make_client(mock_api, _scoped_writer())
+        resp = client.post(
+            f'/api/v1/lint/findings/{FINDING_ID}/resolve',
+            json={'winner_canonical_name': 'AcmeCorp'},
+        )
+        assert resp.status_code == 400, resp.text
+        assert 'ambiguous' in resp.text.lower()
+        mock_api.entities.collapse_cluster.assert_not_called()
+        mock_api.lint.set_status.assert_not_called()

--- a/packages/core/tests/unit/test_seed_alembic_stubs.py
+++ b/packages/core/tests/unit/test_seed_alembic_stubs.py
@@ -56,13 +56,14 @@ def test_seed_chain_is_linear_and_correct() -> None:
     sd = ScriptDirectory.from_config(cfg)
 
     heads = sd.get_heads()
-    assert heads == ['036_fsfm_cooldown_index'], (
-        f'Expected single head 036_fsfm_cooldown_index, got {heads}'
+    assert heads == ['037_entity_last_merge_scan_at'], (
+        f'Expected single head 037_entity_last_merge_scan_at, got {heads}'
     )
 
     walk = list(sd.walk_revisions())
     top10 = [(r.revision, r.down_revision) for r in walk[:10]]
     expected_top10 = [
+        ('037_entity_last_merge_scan_at', '036_fsfm_cooldown_index'),
         ('036_fsfm_cooldown_index', '035_drop_fsrs_revisit_columns'),
         ('035_drop_fsrs_revisit_columns', '034_add_mw_mode'),
         ('034_add_mw_mode', '033_confidence_evidence_count'),
@@ -72,7 +73,6 @@ def test_seed_chain_is_linear_and_correct() -> None:
         ('030_revisit_last_reviewed_at', '029_lint_llm_quota'),
         ('029_lint_llm_quota', '028_procedure_outcomes'),
         ('028_procedure_outcomes', '027_consolidation_ticks'),
-        ('027_consolidation_ticks', '026_revisit_columns'),
     ]
     assert top10 == expected_top10, f'Tier A chain mismatch: got {top10}'
 


### PR DESCRIPTION
## Summary

New mechanism: cross-batch entity-cluster collapse maintenance. The ingestion-path resolver is calibrated for intra-batch dedup; this PR adds an off-by-default scheduled scan that detects highly-similar entity rows ("ACME Corp" / "acme corp" / "Acme Corp") missed by that pass, emits operator-approvable MaintenanceProposal rows (cross-vault by construction with vault_id=NULL), and on human approval destructively merges the cluster into one winner inside a single transaction that handles all six referential-integrity hazards.

- `score_entity_pair` sibling in `entity_resolver.py` — trigram + Double Metaphone + neighbourhood overlap; existing `calculate_match_score` left in place.
- `services/entity_maintenance.scan_collapse_clusters` — graph + connected components + min-pairwise-similarity cohesion guard (rope-drift protection). Idempotent rescans via `composition_hash` + UPDATE-in-place collision policy (vault_id=NULL is outside the partial unique index).
- `EntityService.collapse_cluster` — single-transaction handling of all six hazards (MemoryLink repoint before delete, EntityCooccurrence reorder+sum, EntityAlias absorb + loser canonical_name absorbed as alias, UnitEntity counter sum, MentalModel per-vault merge with version bump, Entity hard-delete LAST). Appends an `entity.collapse_cluster` AuditLog row using the `details` column.
- HTTP `/lint/findings/{id}/resolve` rule-keyed dispatcher — accepts optional `params` body; for `entity_collapse_cluster` findings enforces multi-vault auth on `evidence.vaults_affected`, validates winner membership, and applies the collapse alongside the status flip.
- CLI: `memex lint resolve --winner / -w <id-or-canonical_name>` and new `memex entity scan-merges` on-demand command.
- Alembic 037: additive `Entity.last_merge_scan_at` + partial index.
- Config: `EntityMaintenanceConfig` with `scan_enabled=False` default and a `@model_validator` enforcing `cluster_min_threshold <= pair_threshold`.
- Scheduler: daily entity-maintenance task gated on `scan_enabled` under the existing leader-lock.
- Metrics: `ENTITY_COLLAPSE_SCAN_EMITTED_TOTAL{result}`, `ENTITY_COLLAPSE_APPLY_TOTAL{outcome}`, `ENTITY_COLLAPSE_APPLY_DURATION_SECONDS`.
- OpenTelemetry spans: `memex.entity_maintenance.scan` and `memex.entity_maintenance.collapse_cluster`.
- structlog INFO on emit/apply, WARNING on rescan UPDATE, ERROR on auth-denied (actor id only, no PII).

## What landed

- New files
  - `packages/core/src/memex_core/services/entity_maintenance.py`
  - `packages/core/src/memex_core/alembic/versions/037_entity_last_merge_scan_at.py`
  - `packages/core/tests/integration/test_entity_collapse_maintenance.py` (12 tests, real Postgres via testcontainers)
  - `packages/core/tests/unit/services/test_entity_maintenance.py` (clustering / cohesion / hash / winner)
- Extensions
  - `memory/entity_resolver.py` (score_entity_pair), `memory/sql_models.py` (Entity.last_merge_scan_at + partial index)
  - `services/entities.py` (collapse_cluster + _merge_observations)
  - `server/lint.py` (rule-keyed dispatcher), `server/entities.py` (scan-merges route)
  - `common/config.py` (EntityMaintenanceConfig), `common/client.py` (lint_resolve params + scan_entity_merges)
  - `cli/lint.py` (--winner / -w), `cli/entities.py` (scan-merges)
  - `scheduler.py` (periodic_entity_maintenance_task), `metrics.py`, `api.py` (entities property)

## Test plan

- [x] `ruff check` clean on all touched files
- [x] `ruff format` applied
- [x] Unit tests: 38 added, all pass — `pytest packages/core/tests/unit/{memory/test_entity_resolver.py,services/test_entity_maintenance.py} packages/common/tests/test_config.py`
- [x] Integration: 12 added, all pass — `pytest packages/core/tests/integration/test_entity_collapse_maintenance.py -m integration`
- [x] Existing seed alembic chain test updated for new head 037
- [x] No regression vs main in the wider unit suite (26 unchanged pre-existing failures, no new failures)

## Deferred (follow-ups)

- DESIGN_DOCUMENT.md §6 + §10 edits — gitignored; needs primary-checkout work. Will land in a separate doc PR.
- Threshold-tuning eval set (~15 cases) and the three internal eval scenarios — out of scope for this PR; thresholds remain placeholders (`pair_threshold=0.85`, `cluster_min_threshold=0.70`) until that work lands.
- Benchmark `test_collapse_cluster_apply_time` (p95 ≤ 500ms for cluster-of-10 with 1000 cooccurrences/aliases/unit_entities) — deferred.

## Out of scope / known limitations

- MCP surface is read-only by design for the maintenance ledger; resolve / dismiss stay CLI + HTTP. No new MCP tools.
- The cluster member list lives only in `evidence.cluster_members`; surfaces that render the canonical names rely on the inline `evidence.member_canonical_names` map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)