### PR TITLE
feat(briefing): V4 — procedure injection + answer-from-briefing rule + plugin toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-6,710%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-6,712%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-6,708%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-6,709%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-6,712%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-6,713%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-6,709%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-6,710%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-6,713%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-6,733%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-6,676%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-6,239%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-6,239%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-6,708%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -55,7 +55,7 @@ claude --plugin-dir ./packages/claude-code-plugin
 
 - **Skills**: `/remember`, `/recall`, and `/retro` slash commands for manual memory capture, retrieval, and structured session postmortems.
 - **Hooks**: Full session lifecycle integration:
-  - `SessionStart` — installs rules (including `<project>/.claude/rules/memex-agent-surface.md`, the Tier 1b+2 agent surface auto-loaded into the system prompt), fetches a token-budgeted briefing, resolves the active vault, generates a per-session note key.
+  - `SessionStart` — installs rules (including `<project>/.claude/rules/memex-agent-surface.md`, the Tier 1b+2 agent surface auto-loaded into the system prompt), fetches a token-budgeted briefing (now including a `## Procedures` block of KV rows under `procedure:*` so learned behavioural rules survive across sessions), resolves the active vault, generates a per-session note key.
   - `SessionEnd` — auto-captures the full session transcript to long-term memory (safety net under `/remember`).
   - `PreCompact` — captures transcript-since-last-compact to the session note before context is discarded.
   - `UserPromptExpansion` — when `/recall` is invoked without arguments, composes a query from the last N transcript turns.
@@ -132,35 +132,59 @@ Earlier plugin versions wrote to bare `project:<id>:vault` keys. The plugin now 
 
 ## Configuration
 
-### Default vault
+The plugin is configured entirely through environment variables (set in your shell profile, your Claude Code `settings.json` `env` block, or — for MCP-only — the project's `.mcp.json`) and via `~/.config/memex/config.yaml` for the underlying Memex CLI.
 
-The plugin uses your existing Memex configuration. Set the global default vault via:
+### Environment variables
 
-```bash
-export MEMEX_VAULT__ACTIVE=my-vault
+| Variable | Default | Effect |
+|---|---|---|
+| `MEMEX_SERVER_URL` | `http://127.0.0.1:8000` | Memex server URL used by both the hooks and the MCP server. Set this when your server runs elsewhere (e.g. `host.docker.internal` from a devcontainer). |
+| `MEMEX_VAULT__ACTIVE` | unset | Server-side default active vault. Read by the Memex CLI's config layer (`~/.memex.yaml`). |
+| `MEMEX_VAULT` | unset | Per-session vault override (rung 4 in the resolution chain — see "Per-project vault binding" below). Wins over the server default but loses to project/user/agent KV bindings. |
+| `MEMEX_PLUGIN_VERSION` | `latest` | Pin the plugin's `uvx`-installed memex-cli to a specific git tag or branch (e.g. `v0.42.0`, `main`). Validated against `git ls-remote` with a 24h on-disk cache. |
+| `MEMEX_LOCAL_PATH` | unset | **Dev mode** — point at a local Memex workspace checkout instead of `uvx`-installing from GitHub. Overrides `MEMEX_PLUGIN_VERSION`. Used by the eval suite to run Claude Code against the same code path Hermes runs. |
+| `MEMEX_CC_AGENT_ID` | unset | Subagent identity. Enables the `app:claude-code:agent:<id>:vault` resolution rung (rung 3, between project and user). |
+| `MEMEX_CC_TIMEOUT` | `8` (seconds, clamped to [1, 600]) | Hard timeout per `memex` CLI call from hooks. Protects SessionEnd/PreCompact from a hung server. |
+| `MEMEX_CC_TRANSCRIPT_CAPTURE` | `on` | Toggle the SessionEnd + PreCompact transcript-capture hooks. Set to `off`/`0`/`false`/`no`/`disabled` to disable. Useful when transcripts are large and you don't want to pay the extraction cost. |
+| `MEMEX_CC_SESSION_BRIEFING` | `on` | Toggle the SessionStart briefing injection. Set to `off`/etc. to disable. The vault-binding, session-note, and auto-tag instructions still emit — only the dynamic per-vault briefing markdown is suppressed. |
+| `MEMEX_RESOLVE_VERBOSE` | unset | Internal — when `1`, the resolver emits uvx/version diagnostics as systemMessage. Hooks already set this where appropriate; users do not need to. |
+
+> **Note on the `MEMEX_CC_*` toggles**: these have no "truthy" form. Anything not in the falsy set above is treated as `on`. To re-enable, **unset** the variable rather than setting it to `1` or `true`. This is a deliberate one-way parser to keep the toggle logic five lines and avoid surprise enables under typo.
+
+### How to disable behaviours
+
+Paste into `~/.claude/settings.json` (or per-project `.claude/settings.local.json`):
+
+```jsonc
+{
+  "env": {
+    "MEMEX_CC_TRANSCRIPT_CAPTURE": "off",
+    "MEMEX_CC_SESSION_BRIEFING": "off",
+    "MEMEX_PLUGIN_VERSION": "v0.42.0"
+  }
+}
 ```
 
-Or configure it in your `~/.memex.yaml`.
+Or export in your shell profile for global effect across all Claude Code sessions:
 
-### Server URL
+```bash
+export MEMEX_CC_TRANSCRIPT_CAPTURE=off
+export MEMEX_CC_SESSION_BRIEFING=off
+```
 
-By default, the Memex CLI and hooks connect to `http://127.0.0.1:8000`. If your server runs elsewhere (e.g., in a devcontainer where the host is `host.docker.internal`), configure the URL using one of these methods, listed in priority order:
+### `~/.config/memex/config.yaml` (server URL alternative)
 
-1. **`~/.config/memex/config.yaml`** (recommended) — covers both hooks and the MCP server:
+Setting `MEMEX_SERVER_URL` in `~/.config/memex/config.yaml` is the cleanest way to point both hooks and the MCP server at a non-default server location:
 
-   ```yaml
-   server_url: http://host.docker.internal:8000
-   ```
+```yaml
+server_url: http://host.docker.internal:8000
+```
 
-2. **Environment variable** — export in your shell profile (`.bashrc` / `.zshrc`):
+This is preferred over the env var when the URL is stable for your machine.
 
-   ```bash
-   export MEMEX_SERVER_URL=http://host.docker.internal:8000
-   ```
+### `.mcp.json` env override (MCP-only)
 
-   This also covers both hooks and the MCP server.
-
-3. **Plugin MCP env override** — set `MEMEX_SERVER_URL` in the project's `.mcp.json` env block. **Note:** this only affects the MCP server process, not hooks. Use option 1 or 2 if hooks also need the custom URL.
+You can set `MEMEX_SERVER_URL` (and other env vars) in the project's `.mcp.json` env block, but **this only affects the MCP server process, not the hooks**. Use the env-var or config-file approach above when hooks also need the override.
 
 ## Updating
 

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -149,7 +149,7 @@ The plugin is configured entirely through environment variables (set in your she
 | `MEMEX_CC_SESSION_BRIEFING` | `on` | Toggle the SessionStart briefing injection. Set to `off`/etc. to disable. The vault-binding, session-note, and auto-tag instructions still emit — only the dynamic per-vault briefing markdown is suppressed. |
 | `MEMEX_RESOLVE_VERBOSE` | unset | Internal — when `1`, the resolver emits uvx/version diagnostics as systemMessage. Hooks already set this where appropriate; users do not need to. |
 
-> **Note on the `MEMEX_CC_*` toggles**: these have no "truthy" form. Anything not in the falsy set above is treated as `on`. To re-enable, **unset** the variable rather than setting it to `1` or `true`. This is a deliberate one-way parser to keep the toggle logic five lines and avoid surprise enables under typo.
+> **Note on the `MEMEX_CC_*` toggles**: the parser only checks for the *falsy* values listed above (`off`, `0`, `false`, `no`, `disabled`). Anything else — including unsetting, leaving empty, or setting to `on`, `1`, `true`, or any other string — is treated as `on`. To re-enable a previously-disabled toggle, **unsetting** the variable is the cleanest path; explicitly setting to `on` also works. This is a deliberate one-way parser to keep the toggle logic five lines and avoid surprise enables under typo.
 
 ### How to disable behaviours
 

--- a/packages/claude-code-plugin/scripts/on_pre_compact.sh
+++ b/packages/claude-code-plugin/scripts/on_pre_compact.sh
@@ -68,7 +68,18 @@ esac
 _capture_status="skipped"
 _capture_reason=""
 
-if [ -z "$_transcript_path" ] || [ ! -f "$_transcript_path" ]; then
+# Opt-out: MEMEX_CC_TRANSCRIPT_CAPTURE=off|0|false|no|disabled bypasses the capture
+# but still emits the existing skipped-path output shape (additionalContext + stats
+# appendix). Offset file is NOT advanced — re-enabling resumes from prior offset.
+case "${MEMEX_CC_TRANSCRIPT_CAPTURE:-on}" in
+    off|0|false|no|disabled)
+        _capture_reason="disabled via MEMEX_CC_TRANSCRIPT_CAPTURE"
+        ;;
+esac
+
+if [ -n "$_capture_reason" ]; then
+    :  # toggle handled above; fall through to the output assembly below
+elif [ -z "$_transcript_path" ] || [ ! -f "$_transcript_path" ]; then
     _capture_reason="transcript_path missing or not a file"
 elif [ ! -r "$_transcript_path" ]; then
     _capture_reason="transcript_path is not readable (permissions?)"

--- a/packages/claude-code-plugin/scripts/on_session_end_capture.sh
+++ b/packages/claude-code-plugin/scripts/on_session_end_capture.sh
@@ -34,6 +34,9 @@ fi
 
 # Opt-out: MEMEX_CC_TRANSCRIPT_CAPTURE=off|0|false|no|disabled skips the capture.
 # Offset file is NOT advanced — re-enabling resumes from the prior offset (no turns lost).
+# IMPORTANT: this exit is intentionally early and final — any future side effects
+# that should still run when capture is disabled (e.g. telemetry, offset cleanup)
+# MUST be placed ABOVE this guard.
 case "${MEMEX_CC_TRANSCRIPT_CAPTURE:-on}" in
     off|0|false|no|disabled)
         exit 0

--- a/packages/claude-code-plugin/scripts/on_session_end_capture.sh
+++ b/packages/claude-code-plugin/scripts/on_session_end_capture.sh
@@ -32,6 +32,14 @@ if [ -z "$_payload" ]; then
     exit 0
 fi
 
+# Opt-out: MEMEX_CC_TRANSCRIPT_CAPTURE=off|0|false|no|disabled skips the capture.
+# Offset file is NOT advanced — re-enabling resumes from the prior offset (no turns lost).
+case "${MEMEX_CC_TRANSCRIPT_CAPTURE:-on}" in
+    off|0|false|no|disabled)
+        exit 0
+        ;;
+esac
+
 if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi

--- a/packages/claude-code-plugin/scripts/on_session_end_capture.sh
+++ b/packages/claude-code-plugin/scripts/on_session_end_capture.sh
@@ -38,6 +38,9 @@ fi
 # =============================================================================
 # Falsy values (off|0|false|no|disabled) skip the capture entirely. Offset file
 # is NOT advanced — re-enabling resumes from the prior offset (no turns lost).
+# Note: the jq availability check below this guard is intentional — when capture
+# is disabled, missing jq is irrelevant (we have nothing to serialise), so we
+# don't want to fail or warn on jq absence in that path.
 case "${MEMEX_CC_TRANSCRIPT_CAPTURE:-on}" in
     off|0|false|no|disabled)
         exit 0

--- a/packages/claude-code-plugin/scripts/on_session_end_capture.sh
+++ b/packages/claude-code-plugin/scripts/on_session_end_capture.sh
@@ -32,11 +32,12 @@ if [ -z "$_payload" ]; then
     exit 0
 fi
 
-# Opt-out: MEMEX_CC_TRANSCRIPT_CAPTURE=off|0|false|no|disabled skips the capture.
-# Offset file is NOT advanced — re-enabling resumes from the prior offset (no turns lost).
-# IMPORTANT: this exit is intentionally early and final — any future side effects
-# that should still run when capture is disabled (e.g. telemetry, offset cleanup)
-# MUST be placed ABOVE this guard.
+# =============================================================================
+# === BEHAVIOUR GUARD — opt-out short-circuit. All side effects that should ==
+# === run regardless of MEMEX_CC_TRANSCRIPT_CAPTURE MUST be placed ABOVE this. ==
+# =============================================================================
+# Falsy values (off|0|false|no|disabled) skip the capture entirely. Offset file
+# is NOT advanced — re-enabling resumes from the prior offset (no turns lost).
 case "${MEMEX_CC_TRANSCRIPT_CAPTURE:-on}" in
     off|0|false|no|disabled)
         exit 0

--- a/packages/claude-code-plugin/scripts/on_session_start.sh
+++ b/packages/claude-code-plugin/scripts/on_session_start.sh
@@ -129,9 +129,11 @@ briefing_args=(briefing --budget 2000)
 [ -n "$project_vault" ] && briefing_args+=(--vault "$project_vault")
 [ -n "$project_id" ] && briefing_args+=(--project-id "$project_id")
 
-# --- Register cleanup trap upfront so any later failure cleans temp files ---
+# --- Register cleanup trap upfront so any later failure cleans temp files.
+# Guard with -n so the disabled-briefing path (tmp_briefing never assigned)
+# doesn't spawn a noisy `rm -f ""` warning on exit. ---
 tmp_briefing=''
-trap 'rm -f "$tmp_briefing"' EXIT
+trap '[ -n "$tmp_briefing" ] && rm -f "$tmp_briefing"' EXIT
 
 # --- Fetch dynamic session briefing (per-vault state from the server) ---
 briefing_content=""

--- a/packages/claude-code-plugin/scripts/on_session_start.sh
+++ b/packages/claude-code-plugin/scripts/on_session_start.sh
@@ -114,6 +114,16 @@ if [ -n "$_project_root" ]; then
     fi
 fi
 
+# --- Opt-out: MEMEX_CC_SESSION_BRIEFING=off|0|false|no|disabled skips the fetch ---
+# Static vault/session/auto-tag instructions still emit; only the dynamic briefing
+# markdown is suppressed. Agent-surface install above is unaffected.
+_briefing_disabled=0
+case "${MEMEX_CC_SESSION_BRIEFING:-on}" in
+    off|0|false|no|disabled)
+        _briefing_disabled=1
+        ;;
+esac
+
 # --- Build briefing CLI args ---
 briefing_args=(briefing --budget 2000)
 [ -n "$project_vault" ] && briefing_args+=(--vault "$project_vault")
@@ -124,21 +134,24 @@ tmp_briefing=''
 trap 'rm -f "$tmp_briefing"' EXIT
 
 # --- Fetch dynamic session briefing (per-vault state from the server) ---
-tmp_briefing=$(mktemp)
+briefing_content=""
+if [ "$_briefing_disabled" -eq 0 ]; then
+    tmp_briefing=$(mktemp)
 
-if ! memex "${briefing_args[@]}" > "$tmp_briefing" 2>/dev/null; then
-    cat <<'EOF'
+    if ! memex "${briefing_args[@]}" > "$tmp_briefing" 2>/dev/null; then
+        cat <<'EOF'
 {"systemMessage": "Memex server is not reachable. Start it with:\n  memex server start -d\n\nMemex MCP tools will not work until the server is running."}
 EOF
-    exit 0
-fi
+        exit 0
+    fi
 
-# --- Build additionalContext (dynamic briefing only; agent surface is on disk) ---
-# Command substitution strips trailing newlines, so re-append one to guarantee
-# a stable separator before the vault/session/auto-tag instructions that follow.
-briefing_content="$(cat "$tmp_briefing")
+    # Command substitution strips trailing newlines, so re-append one to guarantee
+    # a stable separator before the vault/session/auto-tag instructions that follow.
+    briefing_content="$(cat "$tmp_briefing")
 "
+fi
 status="🧠 Memex connected${agent_surface_install_warning}"
+[ "$_briefing_disabled" -eq 1 ] && status="${status} · Briefing disabled (MEMEX_CC_SESSION_BRIEFING)"
 
 if [ -n "$project_vault" ]; then
     vault_instruction="

--- a/packages/claude-code-plugin/tests/unit/test_on_pre_compact.py
+++ b/packages/claude-code-plugin/tests/unit/test_on_pre_compact.py
@@ -308,3 +308,92 @@ def test_session_stats_included_in_context(mock_memex: MockMemex, transcript_jso
     out = json.loads(result.stdout)
     ctx = out['hookSpecificOutput']['additionalContext']
     assert '7 writes' in ctx
+
+
+# ---------------------------------------------------------------------------
+# V4: MEMEX_CC_TRANSCRIPT_CAPTURE opt-out
+# ---------------------------------------------------------------------------
+
+
+def test_pre_compact_skipped_when_MEMEX_CC_TRANSCRIPT_CAPTURE_off(
+    mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path
+) -> None:
+    """Disabled: no capture, but JSON output matches the existing skipped-path shape
+    (additionalContext mentions reason + stats appendix)."""
+    _seed_session_start_state(mock_memex)
+    result = run_script(
+        'on_pre_compact.sh',
+        stdin=_precompact_payload(str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_TRANSCRIPT_CAPTURE': 'off'},
+    )
+    assert result.returncode == 0, result.stderr
+    assert not mock_memex.calls_matching('note', 'add')
+    assert not mock_memex.calls_matching('note', 'append')
+
+    out = json.loads(result.stdout)
+    ctx = out['hookSpecificOutput']['additionalContext']
+    # Shape parity: disabled-path uses the existing skipped-path output template.
+    assert 'pre-compact capture skipped' in ctx
+    assert 'MEMEX_CC_TRANSCRIPT_CAPTURE' in ctx
+    # Stats appendix preserved (parity check)
+    assert 'Session stats:' in ctx
+
+
+def test_pre_compact_disabled_does_not_advance_offset(
+    mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path
+) -> None:
+    """Offset file untouched when capture is disabled. Pre-seed `5`; verify no advance."""
+    _seed_session_start_state(mock_memex)
+    state_dir = mock_memex.plugin_data / 'memex'
+    offset_file = state_dir / 'session_note_offset_cc-sess-1'
+    state_dir.mkdir(parents=True, exist_ok=True)
+    offset_file.write_text('5')
+
+    run_script(
+        'on_pre_compact.sh',
+        stdin=_precompact_payload(str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_TRANSCRIPT_CAPTURE': 'off'},
+    )
+    assert offset_file.read_text().strip() == '5', (
+        'offset advanced even though capture was disabled'
+    )
+
+
+def test_pre_compact_disabled_then_enabled_resumes_from_prior_offset(
+    mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path
+) -> None:
+    """Disabled run leaves offset alone; subsequent enabled run captures from the prior offset
+    (no turns lost). Total lines in transcript_jsonl fixture is small (3 turns); pre-seed
+    offset=1 and verify enabled capture happens after the disabled run."""
+    _seed_session_start_state(mock_memex)
+    state_dir = mock_memex.plugin_data / 'memex'
+    offset_file = state_dir / 'session_note_offset_cc-sess-1'
+    state_dir.mkdir(parents=True, exist_ok=True)
+    offset_file.write_text('1')
+
+    # Disabled run
+    run_script(
+        'on_pre_compact.sh',
+        stdin=_precompact_payload(str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_TRANSCRIPT_CAPTURE': 'off'},
+    )
+    assert offset_file.read_text().strip() == '1'
+    assert not mock_memex.calls_matching('note', 'add')
+
+    # Enabled run — should capture the remaining lines.
+    run_script(
+        'on_pre_compact.sh',
+        stdin=_precompact_payload(str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+    )
+    add_calls = mock_memex.calls_matching('note', 'add')
+    assert len(add_calls) == 1, 'enabled run after disabled should add the note'
+    # Offset advanced past the seeded `1`.
+    assert int(offset_file.read_text().strip()) > 1

--- a/packages/claude-code-plugin/tests/unit/test_on_pre_compact.py
+++ b/packages/claude-code-plugin/tests/unit/test_on_pre_compact.py
@@ -341,6 +341,47 @@ def test_pre_compact_skipped_when_MEMEX_CC_TRANSCRIPT_CAPTURE_off(
     assert 'Session stats:' in ctx
 
 
+@pytest.mark.parametrize('falsy', ['off', '0', 'false', 'no', 'disabled'])
+def test_pre_compact_toggle_accepts_all_falsy_values(
+    mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path, falsy: str
+) -> None:
+    """All five falsy values suppress the capture — mirrors session-start parity test."""
+    _seed_session_start_state(mock_memex)
+    if mock_memex.calls_file.exists():
+        mock_memex.calls_file.unlink()
+    result = run_script(
+        'on_pre_compact.sh',
+        stdin=_precompact_payload(str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_TRANSCRIPT_CAPTURE': falsy},
+    )
+    assert result.returncode == 0
+    assert not mock_memex.calls_matching('note', 'add')
+    assert not mock_memex.calls_matching('note', 'append')
+
+
+@pytest.mark.parametrize('not_falsy', ['true', '1', 'yes', 'random-garbage', 'ON'])
+def test_pre_compact_toggle_treats_unknown_value_as_on(
+    mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path, not_falsy: str
+) -> None:
+    """Anything not in the falsy set runs the capture — asymmetric one-way parser."""
+    _seed_session_start_state(mock_memex)
+    if mock_memex.calls_file.exists():
+        mock_memex.calls_file.unlink()
+    result = run_script(
+        'on_pre_compact.sh',
+        stdin=_precompact_payload(str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_TRANSCRIPT_CAPTURE': not_falsy},
+    )
+    assert result.returncode == 0
+    assert mock_memex.calls_matching('note', 'add'), (
+        f'value {not_falsy!r} unexpectedly suppressed capture'
+    )
+
+
 def test_pre_compact_disabled_does_not_advance_offset(
     mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path
 ) -> None:

--- a/packages/claude-code-plugin/tests/unit/test_on_session_end_capture.py
+++ b/packages/claude-code-plugin/tests/unit/test_on_session_end_capture.py
@@ -180,3 +180,47 @@ def test_empty_payload_is_silent(mock_memex: MockMemex) -> None:
     result = run_script('on_session_end_capture.sh', stdin='', env=mock_memex.env)
     assert result.returncode == 0
     assert mock_memex.calls() == []
+
+
+# ---------------------------------------------------------------------------
+# V4: MEMEX_CC_TRANSCRIPT_CAPTURE opt-out
+# ---------------------------------------------------------------------------
+
+
+def test_capture_skipped_when_MEMEX_CC_TRANSCRIPT_CAPTURE_off(
+    mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path
+) -> None:
+    """Disabled: no `memex note add` / `note append` call, hook exits clean."""
+    _seed_session_start_state(mock_memex)
+    result = run_script(
+        'on_session_end_capture.sh',
+        stdin=_session_end_payload(transcript_path=str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_TRANSCRIPT_CAPTURE': 'off'},
+    )
+    assert result.returncode == 0
+    assert not mock_memex.calls_matching('note', 'add')
+    assert not mock_memex.calls_matching('note', 'append')
+
+
+def test_session_end_disabled_does_not_advance_offset(
+    mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path
+) -> None:
+    """Offset file untouched under disabled capture — re-enabling resumes from prior offset."""
+    _seed_session_start_state(mock_memex)
+    state_dir = mock_memex.plugin_data / 'memex'
+    offset_file = state_dir / 'session_note_offset_cc-sess-1'
+    state_dir.mkdir(parents=True, exist_ok=True)
+    offset_file.write_text('5')
+
+    run_script(
+        'on_session_end_capture.sh',
+        stdin=_session_end_payload(transcript_path=str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_TRANSCRIPT_CAPTURE': 'off'},
+    )
+    assert offset_file.read_text().strip() == '5', (
+        'offset advanced even though capture was disabled'
+    )

--- a/packages/claude-code-plugin/tests/unit/test_on_session_end_capture.py
+++ b/packages/claude-code-plugin/tests/unit/test_on_session_end_capture.py
@@ -204,6 +204,47 @@ def test_capture_skipped_when_MEMEX_CC_TRANSCRIPT_CAPTURE_off(
     assert not mock_memex.calls_matching('note', 'append')
 
 
+@pytest.mark.parametrize('falsy', ['off', '0', 'false', 'no', 'disabled'])
+def test_capture_toggle_accepts_all_falsy_values(
+    mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path, falsy: str
+) -> None:
+    """All five falsy values suppress the capture — mirrors session-start parity test."""
+    _seed_session_start_state(mock_memex)
+    if mock_memex.calls_file.exists():
+        mock_memex.calls_file.unlink()
+    result = run_script(
+        'on_session_end_capture.sh',
+        stdin=_session_end_payload(transcript_path=str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_TRANSCRIPT_CAPTURE': falsy},
+    )
+    assert result.returncode == 0
+    assert not mock_memex.calls_matching('note', 'add')
+    assert not mock_memex.calls_matching('note', 'append')
+
+
+@pytest.mark.parametrize('not_falsy', ['true', '1', 'yes', 'random-garbage', 'ON'])
+def test_capture_toggle_treats_unknown_value_as_on(
+    mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path, not_falsy: str
+) -> None:
+    """Anything not in the falsy set runs the capture — asymmetric one-way parser."""
+    _seed_session_start_state(mock_memex)
+    if mock_memex.calls_file.exists():
+        mock_memex.calls_file.unlink()
+    result = run_script(
+        'on_session_end_capture.sh',
+        stdin=_session_end_payload(transcript_path=str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_TRANSCRIPT_CAPTURE': not_falsy},
+    )
+    assert result.returncode == 0
+    assert mock_memex.calls_matching('note', 'add'), (
+        f'value {not_falsy!r} unexpectedly suppressed capture'
+    )
+
+
 def test_session_end_disabled_does_not_advance_offset(
     mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path
 ) -> None:

--- a/packages/claude-code-plugin/tests/unit/test_on_session_end_capture.py
+++ b/packages/claude-code-plugin/tests/unit/test_on_session_end_capture.py
@@ -224,3 +224,41 @@ def test_session_end_disabled_does_not_advance_offset(
     assert offset_file.read_text().strip() == '5', (
         'offset advanced even though capture was disabled'
     )
+
+
+def test_session_end_disabled_then_enabled_resumes_from_prior_offset(
+    mock_memex: MockMemex, transcript_jsonl: Path, temp_git_repo: Path
+) -> None:
+    """Symmetric to test_pre_compact_disabled_then_enabled_resumes_from_prior_offset:
+    after a disabled session-end run, the next enabled run captures from the seeded
+    offset (no turns lost)."""
+    _seed_session_start_state(mock_memex)
+    state_dir = mock_memex.plugin_data / 'memex'
+    # Mark the session note as already created (PreCompact must have run earlier)
+    # so the enabled SessionEnd path takes the `note append` branch.
+    (state_dir / 'session_note_created_cc-sess-1').touch()
+    offset_file = state_dir / 'session_note_offset_cc-sess-1'
+    state_dir.mkdir(parents=True, exist_ok=True)
+    offset_file.write_text('1')
+
+    # Disabled run — offset must NOT advance.
+    run_script(
+        'on_session_end_capture.sh',
+        stdin=_session_end_payload(transcript_path=str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_TRANSCRIPT_CAPTURE': 'off'},
+    )
+    assert offset_file.read_text().strip() == '1'
+    assert not mock_memex.calls_matching('note', 'append')
+
+    # Enabled run — should append from line 2 onward and advance the offset past 1.
+    run_script(
+        'on_session_end_capture.sh',
+        stdin=_session_end_payload(transcript_path=str(transcript_jsonl)),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+    )
+    append_calls = mock_memex.calls_matching('note', 'append')
+    assert len(append_calls) == 1, 'enabled run after disabled should append the note'
+    assert int(offset_file.read_text().strip()) > 1

--- a/packages/claude-code-plugin/tests/unit/test_on_session_start.py
+++ b/packages/claude-code-plugin/tests/unit/test_on_session_start.py
@@ -383,3 +383,89 @@ def test_temp_files_cleaned_up_on_success(mock_memex: MockMemex, temp_git_repo: 
     after = set(Path('/tmp').glob('tmp.*'))
     leaked = after - before
     assert not leaked, f'hook leaked temp files: {leaked!r}'
+
+
+# ---------------------------------------------------------------------------
+# V4: MEMEX_CC_SESSION_BRIEFING opt-out
+# ---------------------------------------------------------------------------
+
+
+def test_briefing_skipped_when_MEMEX_CC_SESSION_BRIEFING_off(
+    mock_memex: MockMemex, temp_git_repo: Path
+) -> None:
+    """Disabled briefing: no `memex briefing` call, but agent-surface install still runs."""
+    result = run_script(
+        'on_session_start.sh',
+        stdin=_session_start_payload(),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+        extra_env={'MEMEX_CC_SESSION_BRIEFING': 'off'},
+    )
+    assert result.returncode == 0, result.stderr
+
+    # No `memex briefing` call landed on the mock.
+    assert not mock_memex.calls_matching('briefing'), (
+        f'expected no briefing call, got: {mock_memex.calls_matching("briefing")}'
+    )
+
+    # Agent-surface install MUST still have run — gated upstream of the toggle.
+    assert mock_memex.calls_matching('agent-surface', 'claude-code'), (
+        'agent-surface install was incorrectly gated by MEMEX_CC_SESSION_BRIEFING'
+    )
+
+    parsed = json.loads(result.stdout)
+    assert 'Briefing disabled' in parsed.get('systemMessage', '')
+    assert '### Per-project vault' in parsed['hookSpecificOutput']['additionalContext']
+
+
+def test_briefing_runs_when_env_unset(mock_memex: MockMemex, temp_git_repo: Path) -> None:
+    """Default-on: unset toggle invokes `memex briefing`."""
+    result = run_script(
+        'on_session_start.sh',
+        stdin=_session_start_payload(),
+        env=mock_memex.env,
+        cwd=temp_git_repo,
+    )
+    assert result.returncode == 0, result.stderr
+    assert mock_memex.calls_matching('briefing'), 'briefing should run when toggle is unset'
+
+
+def test_briefing_toggle_accepts_off_0_false_no_disabled(
+    mock_memex: MockMemex, temp_git_repo: Path
+) -> None:
+    """All five falsy values suppress the briefing fetch."""
+    for falsy in ('off', '0', 'false', 'no', 'disabled'):
+        # Clear prior calls between iterations
+        if mock_memex.calls_file.exists():
+            mock_memex.calls_file.unlink()
+        result = run_script(
+            'on_session_start.sh',
+            stdin=_session_start_payload(),
+            env=mock_memex.env,
+            cwd=temp_git_repo,
+            extra_env={'MEMEX_CC_SESSION_BRIEFING': falsy},
+        )
+        assert result.returncode == 0, f'falsy={falsy} stderr={result.stderr}'
+        assert not mock_memex.calls_matching('briefing'), (
+            f'falsy value {falsy!r} did not suppress briefing'
+        )
+
+
+def test_briefing_toggle_treats_unknown_value_as_on(
+    mock_memex: MockMemex, temp_git_repo: Path
+) -> None:
+    """Anything not in the falsy set runs the fetch — documented asymmetric contract."""
+    for not_falsy in ('true', '1', 'yes', 'random-garbage', 'ON'):
+        if mock_memex.calls_file.exists():
+            mock_memex.calls_file.unlink()
+        result = run_script(
+            'on_session_start.sh',
+            stdin=_session_start_payload(),
+            env=mock_memex.env,
+            cwd=temp_git_repo,
+            extra_env={'MEMEX_CC_SESSION_BRIEFING': not_falsy},
+        )
+        assert result.returncode == 0, f'value={not_falsy} stderr={result.stderr}'
+        assert mock_memex.calls_matching('briefing'), (
+            f'value {not_falsy!r} unexpectedly suppressed briefing'
+        )

--- a/packages/cli/src/memex_cli/vaults.py
+++ b/packages/cli/src/memex_cli/vaults.py
@@ -12,7 +12,6 @@ from rich.console import Console
 from rich.table import Table
 
 from memex_common.config import MemexConfig
-from memex_common.schemas import CreateVaultRequest
 from memex_cli.utils import get_api_context, async_command, handle_api_error
 
 console = Console()
@@ -142,10 +141,9 @@ async def create_vault(
 
     console.print(f'[green]Creating vault:[/green] {name}')
 
-    req = CreateVaultRequest(name=name, description=description)
     async with get_api_context(config) as api:
         try:
-            vault = await api.create_vault(req)
+            vault = await api.create_vault(name, description)
         except Exception as e:
             handle_api_error(e)
 

--- a/packages/cli/tests/test_vaults_cli.py
+++ b/packages/cli/tests/test_vaults_cli.py
@@ -4,6 +4,38 @@ import httpx
 from unittest.mock import MagicMock
 
 
+def test_create_vault_passes_name_and_description_positionally(
+    runner, mock_api, strip_ansi, monkeypatch
+):
+    """Unit pin: CLI calls `api.create_vault(name, description)` with positional
+    args matching `MemexAPI.create_vault(self, name: str, description: str | None = None)`.
+    Regression guard against the V4 signature-drift bug fixed in 2af755b4."""
+    vault_uuid = uuid4()
+    vault = MagicMock()
+    vault.id = vault_uuid
+    mock_api.create_vault.return_value = vault
+
+    monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(app, ['create', 'my-vault', '--description', 'docs'])
+    assert result.exit_code == 0, result.stdout
+    mock_api.create_vault.assert_called_once_with('my-vault', 'docs')
+
+    clean_stdout = strip_ansi(result.stdout)
+    assert 'Creating vault: my-vault' in clean_stdout
+    assert str(vault_uuid) in clean_stdout
+
+
+def test_create_vault_with_default_description(runner, mock_api, monkeypatch):
+    """When --description is omitted, the CLI must pass None (not a missing arg)."""
+    mock_api.create_vault.return_value = MagicMock(id=uuid4())
+    monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(app, ['create', 'bare-vault'])
+    assert result.exit_code == 0, result.stdout
+    mock_api.create_vault.assert_called_once_with('bare-vault', None)
+
+
 def test_delete_vault_by_name(runner, mock_api, strip_ansi, monkeypatch):
     vault_uuid = uuid4()
     vault_name = 'test-vault'
@@ -157,7 +189,6 @@ def test_create_vault(runner, mock_api, strip_ansi, monkeypatch):
     clean_stdout = strip_ansi(result.stdout)
     assert f'Vault created successfully! ID: {vault_uuid}' in clean_stdout
 
-    # Verify arguments
-    call_args = mock_api.create_vault.call_args[0][0]
-    assert call_args.name == vault_name
-    assert call_args.description == vault_desc
+    # Verify arguments — CLI passes (name, description) positionally to
+    # match MemexAPI.create_vault(self, name: str, description: str | None = None).
+    mock_api.create_vault.assert_called_once_with(vault_name, vault_desc)

--- a/packages/common/src/memex_common/agent_harnesses.py
+++ b/packages/common/src/memex_common/agent_harnesses.py
@@ -86,7 +86,11 @@ Prohibitions:
 - NEVER fabricate Note/Node/Unit IDs — only IDs from tool output.
 - NEVER call `memex_get_notes_metadata` after `memex_note_search` (metadata inline).
 - NEVER use `memex_read_note` on notes >500 tokens — use `memex_get_page_indices` + `memex_get_nodes`.
-- NEVER present Memex data without inline numbered citations."""
+- NEVER present Memex data without inline numbered citations.
+
+<critical_constraint name="answer_from_briefing">
+The SessionStart briefing above MAY already contain: vault summary, themes, top entities, KV facts, procedures (KV rows under `procedure:*`), and available vaults — depending on vault state. Answer overview-shape queries ("what's in this vault", "which KV or procedures are loaded", "what's the vault about") FROM the sections present in the briefing — do NOT re-call `memex_get_vault_summary`, `memex_kv_list`, `memex_list_vaults`, or `memex_survey` to refresh data that already rendered above. Re-call only when the briefing lacks the specific section asked about, the section was dropped under budget overflow (no heading present), or the user explicitly asks for fresh data.
+</critical_constraint>"""
 
 
 __all__ = ['CLAUDE_CODE_HARNESS', 'HERMES_HARNESS']

--- a/packages/common/src/memex_common/agent_harnesses.py
+++ b/packages/common/src/memex_common/agent_harnesses.py
@@ -89,7 +89,7 @@ Prohibitions:
 - NEVER present Memex data without inline numbered citations.
 
 <critical_constraint name="answer_from_briefing">
-The SessionStart briefing above MAY already contain: vault summary, themes, top entities, KV facts, procedures (KV rows under `procedure:*`), and available vaults — depending on vault state. Answer overview-shape queries ("what's in this vault", "which KV or procedures are loaded", "what's the vault about") FROM the sections present in the briefing — do NOT re-call `memex_get_vault_summary`, `memex_kv_list`, `memex_list_vaults`, or `memex_survey` to refresh data that already rendered above. Re-call only when the briefing lacks the specific section asked about, the section was dropped under budget overflow (no heading present), or the user explicitly asks for fresh data.
+The SessionStart briefing above already contains (depending on vault state): vault summary, themes, top entities, KV facts, procedures (KV rows under `procedure:*`), and available vaults. Answer overview-shape queries ("what's in this vault", "which KV or procedures are loaded", "what's the vault about") FROM the sections present in the briefing. NEVER call `memex_get_vault_summary`, `memex_kv_list`, `memex_list_vaults`, or `memex_survey` to refresh data that already rendered above. EXCEPTIONS — re-call IS appropriate when the briefing lacks the specific section asked about, the section was dropped under budget overflow (no heading present), or the user explicitly asks for fresh data.
 </critical_constraint>"""
 
 

--- a/packages/common/tests/test_agent_harnesses.py
+++ b/packages/common/tests/test_agent_harnesses.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from memex_common.agent_harnesses import CLAUDE_CODE_HARNESS, HERMES_HARNESS
 
-_TIER_2_CHAR_CAP = 5_000
+_TIER_2_CHAR_CAP = 5_600
 # Hermes has a tighter natural ceiling — its harness only needs the
 # outcome lexicon + capture cadence. Pin its cap separately so the CC
 # harness's expansion doesn't relax the Hermes budget.
@@ -45,6 +45,22 @@ def test_claude_code_harness_carries_capture_cadence_and_slash_commands() -> Non
     assert 'author="claude-code"' in CLAUDE_CODE_HARNESS
     assert '/remember' in CLAUDE_CODE_HARNESS
     assert '/recall' in CLAUDE_CODE_HARNESS
+
+
+def test_claude_code_harness_carries_answer_from_briefing_rule() -> None:
+    """The answer-from-briefing rule must not silently disappear under future trims."""
+    assert 'answer_from_briefing' in CLAUDE_CODE_HARNESS
+    assert 'memex_get_vault_summary' in CLAUDE_CODE_HARNESS
+    assert 'memex_kv_list' in CLAUDE_CODE_HARNESS
+
+
+def test_claude_code_harness_cap_is_tight() -> None:
+    """The cap is intentionally close to the harness length — bump cap if this fails,
+    don't pad the harness. Surfaces ratchet pressure on every meaningful trim/add."""
+    margin = _TIER_2_CHAR_CAP - len(CLAUDE_CODE_HARNESS)
+    assert margin < 300, (
+        f'cap is loose ({margin} chars of slack); tighten _TIER_2_CHAR_CAP or document why.'
+    )
 
 
 def test_cli_agent_surface_uses_ssot_harnesses_by_identity() -> None:

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -514,8 +514,9 @@ class SessionBriefingService:
                 return self._assemble(sections)
 
         # Step 5: Trim procedures (high-signal but droppable when budget is exhausted).
-        # Oldest-first: `procs` is sorted ascending by `updated_at`, so `procs[n_dropped:]`
-        # keeps the n_dropped most-recently-touched rules out (i.e. drops the oldest first).
+        # Oldest-first: `procs` is sorted ascending by `updated_at`, so
+        # `procs[n_dropped:]` retains the most-recently-touched rules and drops
+        # the oldest `n_dropped` entries first.
         # If all procedures are exhausted without fitting the budget, fall through
         # to Step 7 (drop vaults).
         procs = list(procs_initial)

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -278,7 +278,8 @@ class SessionBriefingService:
         # Indent embedded newlines so a stored "\n## X" can't create a fake heading.
         text = text.replace('\n', '\n  ')
         if len(text) > _PROCEDURE_VALUE_MAX_CHARS:
-            text = text[:_PROCEDURE_VALUE_MAX_CHARS].rstrip() + '…'
+            # Reserve one char for the ellipsis so total length is exactly the cap.
+            text = text[: _PROCEDURE_VALUE_MAX_CHARS - 1].rstrip() + '…'
         return text
 
     def _build_procedures_section(self, entries: list[Any]) -> str:

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -291,6 +291,9 @@ class SessionBriefingService:
         text = text.replace('\r\n', '\n').replace('\r', '\n').replace('\n', '\n  ')
         if len(text) > _PROCEDURE_VALUE_MAX_CHARS:
             # Reserve one char for the ellipsis so total length is exactly the cap.
+            # rstrip() drops trailing whitespace at the truncation boundary so the
+            # ellipsis abuts the last visible glyph; acceptable for behavioural
+            # procedure rules (where trailing whitespace carries no semantics).
             text = text[: _PROCEDURE_VALUE_MAX_CHARS - 1].rstrip() + '…'
         return text
 
@@ -298,12 +301,20 @@ class SessionBriefingService:
     def _defang_procedure_name(name: str) -> str:
         """Escape markdown metacharacters in a procedure key.
 
-        Keys are validated at write time (`validate_procedure_key`) but this is a
-        belt-and-suspenders defence — the renderer wraps the name in `**…**`,
-        so any literal `*` or backtick in the key would corrupt the bold span
-        or open a code span.
+        Keys are validated at write time (`validate_procedure_key`) — the scoped
+        threat model here is rendering-correctness against any key shape that
+        passed validation (mostly `[A-Za-z0-9:_-]`, but defending against the
+        broader set keeps this robust if the validator is ever loosened). The
+        renderer wraps the name in `**…**` so unescaped `*`/backtick would
+        corrupt the bold span or open a code span; `[` would open a link.
         """
-        return name.replace('\\', '\\\\').replace('*', '\\*').replace('`', '\\`')
+        return (
+            name.replace('\\', '\\\\')
+            .replace('*', '\\*')
+            .replace('`', '\\`')
+            .replace('[', '\\[')
+            .replace(']', '\\]')
+        )
 
     def _build_procedures_section(self, entries: list[Any]) -> str:
         """Build the procedures section from KV rows under `procedure:*`."""
@@ -506,7 +517,7 @@ class SessionBriefingService:
         # Oldest-first: `procs` is sorted ascending by `updated_at`, so `procs[n_dropped:]`
         # keeps the n_dropped most-recently-touched rules out (i.e. drops the oldest first).
         # If all procedures are exhausted without fitting the budget, fall through
-        # to Step 7 (drop vaults). Step 6 is intentionally skipped — reserved.
+        # to Step 7 (drop vaults).
         procs = list(procs_initial)
         n_dropped = 0
         while n_dropped < len(procs):
@@ -518,6 +529,8 @@ class SessionBriefingService:
             )
             if _estimate_tokens(self._assemble(sections)) <= budget:
                 return self._assemble(sections)
+
+        # Step 6: (reserved — intentionally skipped in the numbering)
 
         # Step 7: Drop vaults section entirely
         sections = self._replace_section(sections, 'vaults', '')

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -7,8 +7,10 @@ structured markdown briefing that fits within a specified token budget.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
-from typing import Any
+from datetime import datetime, timezone
+from typing import Any, Final
 from uuid import UUID
 
 from sqlmodel import col, select
@@ -52,6 +54,11 @@ _THEME_TREND_ARROWS: dict[str, str] = {
 }
 
 
+# Sized to fit the motivating procedure:answer:session-briefing row (~900 chars).
+# At 5 rows-of-cap ~ 1250 tokens, <= 63% of the 2000-token briefing budget.
+_PROCEDURE_VALUE_MAX_CHARS: Final = 1000
+
+
 def _estimate_tokens(text: str) -> int:
     """Rough chars-to-tokens estimate (÷4)."""
     return len(text) // 4
@@ -64,7 +71,7 @@ def _compute_importance(mm: MentalModel) -> float:
 
 def _build_kv_namespaces(project_id: str | None) -> list[str]:
     """Build the list of KV namespaces to include in the briefing."""
-    ns = ['global', 'user', 'app:claude-code']
+    ns = ['global', 'user', 'app:claude-code', 'procedure']
     if project_id:
         ns.append(f'project:{project_id}')
     return ns
@@ -175,8 +182,13 @@ class SessionBriefingService:
         # 1. Header (always included)
         sections.append(('header', self._build_header(summary, len(mental_models))))
 
-        # 2. KV facts (priority 1)
-        sections.append(('kv', self._build_kv_section(kv_entries)))
+        # 2. KV facts (priority 1) — procedure rows render in their own section below
+        non_proc = [e for e in kv_entries if not e.key.startswith('procedure:')]
+        proc = [e for e in kv_entries if e.key.startswith('procedure:')]
+        sections.append(('kv', self._build_kv_section(non_proc)))
+
+        # 2b. Procedures (priority 1b — behavioural rules; high signal)
+        sections.append(('procedures', self._build_procedures_section(proc)))
 
         # 3. Vault overview (priority 2 — narrative + compact themes in one section)
         sections.append(
@@ -227,12 +239,45 @@ class SessionBriefingService:
         return ''.join(lines) + '\n'
 
     def _build_kv_section(self, kv_entries: list[Any]) -> str:
-        """Build the KV facts section."""
-        if not kv_entries:
+        """Build the KV facts section. Procedure rows are excluded (rendered separately)."""
+        rendered = [e for e in kv_entries if not e.key.startswith('procedure:')]
+        if not rendered:
             return ''
         lines = ['\n## Key-Value Facts\n']
-        for entry in kv_entries:
+        for entry in rendered:
             lines.append(f'- `{entry.key}`: {entry.value}')
+        return '\n'.join(lines) + '\n'
+
+    def _sanitize_procedure_value(self, raw: Any) -> str:
+        """Extract the human-readable value from a procedure KV row, defanged for markdown."""
+        if raw is None:
+            return ''
+        try:
+            payload = json.loads(raw)
+            text = payload.get('value') if isinstance(payload, dict) else None
+            if not isinstance(text, str):
+                text = str(raw)
+        except (json.JSONDecodeError, TypeError):
+            text = str(raw)
+        # Indent embedded newlines so a stored "\n## X" can't create a fake heading.
+        text = text.replace('\n', '\n  ')
+        if len(text) > _PROCEDURE_VALUE_MAX_CHARS:
+            text = text[:_PROCEDURE_VALUE_MAX_CHARS].rstrip() + '…'
+        return text
+
+    def _build_procedures_section(self, entries: list[Any]) -> str:
+        """Build the procedures section from KV rows under `procedure:*`."""
+        if not entries:
+            return ''
+        lines = ['\n## Procedures\n']
+        for entry in entries:
+            text = self._sanitize_procedure_value(entry.value)
+            name = entry.key.removeprefix('procedure:')
+            if not name or not text:
+                continue
+            lines.append(f'- **{name}** — {text}')
+        if len(lines) == 1:
+            return ''
         return '\n'.join(lines) + '\n'
 
     def _build_vault_overview(self, summary: Any, compact: bool = False) -> str:
@@ -353,6 +398,13 @@ class SessionBriefingService:
         kv_entries: list[Any],
     ) -> str:
         """Apply overflow degradation to fit within budget."""
+        # Snapshot procedure rows BEFORE Step 4 mutates kv_entries — keeps Step 5
+        # decoupled from any future change to the Step-4 drop-prefix list.
+        _ts_floor = datetime.min.replace(tzinfo=timezone.utc)
+        procs_initial = sorted(
+            [e for e in kv_entries if e.key.startswith('procedure:')],
+            key=lambda e: getattr(e, 'updated_at', None) or _ts_floor,
+        )
         # Steps 1/1b only apply at budget>=2000 where initial build used 10 models + trends.
         # At budget<2000, _build_sections already used 5 models without trends.
         if budget >= 2000:
@@ -398,6 +450,20 @@ class SessionBriefingService:
                 self._build_kv_section(filtered),
             )
             kv_entries = filtered
+            if _estimate_tokens(self._assemble(sections)) <= budget:
+                return self._assemble(sections)
+
+        # Step 5: Trim procedures (high-signal but droppable when budget is exhausted).
+        # Oldest-first (sorted ascending by `updated_at`, `pop(0)`) — preserves the
+        # most-recently-touched rules longest.
+        procs = list(procs_initial)
+        while procs:
+            procs.pop(0)
+            sections = self._replace_section(
+                sections,
+                'procedures',
+                self._build_procedures_section(procs),
+            )
             if _estimate_tokens(self._assemble(sections)) <= budget:
                 return self._assemble(sections)
 

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -258,8 +258,12 @@ class SessionBriefingService:
             lines.append(f'- `{entry.key}`: {entry.value}')
         return '\n'.join(lines) + '\n'
 
-    def _sanitize_procedure_value(self, raw: Any) -> str:
-        """Extract the human-readable value from a procedure KV row, defanged for markdown."""
+    def _sanitize_procedure_value(self, raw: str | None) -> str:
+        """Extract the human-readable value from a procedure KV row, defanged for markdown.
+
+        ``raw`` is the value column of a ``KVEntry`` row — always ``str | None``
+        per the schema; ``Any`` would mask accidental misuse.
+        """
         if raw is None:
             return ''
         parsed_ok = True
@@ -468,19 +472,18 @@ class SessionBriefingService:
             return self._assemble(sections)
 
         # Step 4: Drop KV namespaces (app -> user -> project).
-        # _build_kv_section does NOT filter procedure: — exclude here so the
-        # rendered KV section matches the namespace-trim semantics.
-        # NOTE: procedure: rows are intentionally retained in `kv_entries`
-        # across Step 4 — Step 5 below trims them via the `procs_initial`
-        # snapshot, not by mutating `kv_entries`.
+        # procedure: rows are tracked separately via `procs_initial` (snapshotted
+        # at the top of this method). Strip them from `kv_entries` once up-front
+        # so any subsequent consumer sees a procedure-free list; Step 5 below
+        # trims procedures from the snapshot, not from `kv_entries`.
+        kv_entries = [e for e in kv_entries if not e.key.startswith('procedure:')]
         for drop_prefix in ('app:', 'user:', 'project:'):
-            filtered = [e for e in kv_entries if not e.key.startswith(drop_prefix)]
+            kv_entries = [e for e in kv_entries if not e.key.startswith(drop_prefix)]
             sections = self._replace_section(
                 sections,
                 'kv',
-                self._build_kv_section([e for e in filtered if not e.key.startswith('procedure:')]),
+                self._build_kv_section(kv_entries),
             )
-            kv_entries = filtered
             if _estimate_tokens(self._assemble(sections)) <= budget:
                 return self._assemble(sections)
 

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -470,6 +470,9 @@ class SessionBriefingService:
         # Step 4: Drop KV namespaces (app -> user -> project).
         # _build_kv_section does NOT filter procedure: — exclude here so the
         # rendered KV section matches the namespace-trim semantics.
+        # NOTE: procedure: rows are intentionally retained in `kv_entries`
+        # across Step 4 — Step 5 below trims them via the `procs_initial`
+        # snapshot, not by mutating `kv_entries`.
         for drop_prefix in ('app:', 'user:', 'project:'):
             filtered = [e for e in kv_entries if not e.key.startswith(drop_prefix)]
             sections = self._replace_section(

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -490,17 +490,18 @@ class SessionBriefingService:
                 return self._assemble(sections)
 
         # Step 5: Trim procedures (high-signal but droppable when budget is exhausted).
-        # Oldest-first via index counter (deque/index avoids O(n) pop(0) on long lists).
+        # Oldest-first: `procs` is sorted ascending by `updated_at`, so `procs[n_dropped:]`
+        # keeps the n_dropped most-recently-touched rules out (i.e. drops the oldest first).
         # If all procedures are exhausted without fitting the budget, fall through
         # to Step 7 (drop vaults). Step 6 is intentionally skipped — reserved.
         procs = list(procs_initial)
-        proc_idx = 0
-        while proc_idx < len(procs):
-            proc_idx += 1
+        n_dropped = 0
+        while n_dropped < len(procs):
+            n_dropped += 1
             sections = self._replace_section(
                 sections,
                 'procedures',
-                self._build_procedures_section(procs[proc_idx:]),
+                self._build_procedures_section(procs[n_dropped:]),
             )
             if _estimate_tokens(self._assemble(sections)) <= budget:
                 return self._assemble(sections)

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -262,9 +262,11 @@ class SessionBriefingService:
         """Extract the human-readable value from a procedure KV row, defanged for markdown."""
         if raw is None:
             return ''
+        parsed_ok = True
         try:
             payload = json.loads(raw)
         except (json.JSONDecodeError, TypeError):
+            parsed_ok = False
             payload = None
 
         if isinstance(payload, dict) and 'value' in payload:
@@ -272,8 +274,12 @@ class SessionBriefingService:
             # Envelope present but `value` is non-string — render just the inner
             # value (don't leak `v`/`tags`/`history` from the full envelope).
             text = inner if isinstance(inner, str) else str(inner)
+        elif parsed_ok and payload is None:
+            # `json.loads("null")` returns None — treat the same as `raw is None`
+            # rather than rendering the literal string `"null"`.
+            text = ''
         else:
-            # No envelope or not a dict — render the raw stored string.
+            # Parse failed OR JSON was not a dict — render the raw stored string.
             text = str(raw)
         # Indent embedded newlines so a stored "\n## X" can't create a fake heading.
         text = text.replace('\n', '\n  ')
@@ -417,6 +423,9 @@ class SessionBriefingService:
         """Apply overflow degradation to fit within budget."""
         # Snapshot procedure rows BEFORE Step 4 mutates kv_entries — keeps Step 5
         # decoupled from any future change to the Step-4 drop-prefix list.
+        # `_ts_floor` is tz-aware to match `updated_at` from `KVEntry` (the ORM
+        # column is `TIMESTAMP WITH TIME ZONE`, so sorted() never mixes tz-aware
+        # and naive datetimes).
         _ts_floor = datetime.min.replace(tzinfo=timezone.utc)
         procs_initial = sorted(
             [e for e in kv_entries if e.key.startswith('procedure:')],
@@ -474,7 +483,8 @@ class SessionBriefingService:
 
         # Step 5: Trim procedures (high-signal but droppable when budget is exhausted).
         # Oldest-first via index counter (deque/index avoids O(n) pop(0) on long lists).
-        # Step 6 is intentionally skipped — reserved for future degradation step.
+        # If all procedures are exhausted without fitting the budget, fall through
+        # to Step 7 (drop vaults). Step 6 is intentionally skipped — reserved.
         procs = list(procs_initial)
         proc_idx = 0
         while proc_idx < len(procs):

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -294,6 +294,17 @@ class SessionBriefingService:
             text = text[: _PROCEDURE_VALUE_MAX_CHARS - 1].rstrip() + '…'
         return text
 
+    @staticmethod
+    def _defang_procedure_name(name: str) -> str:
+        """Escape markdown metacharacters in a procedure key.
+
+        Keys are validated at write time (`validate_procedure_key`) but this is a
+        belt-and-suspenders defence — the renderer wraps the name in `**…**`,
+        so any literal `*` or backtick in the key would corrupt the bold span
+        or open a code span.
+        """
+        return name.replace('\\', '\\\\').replace('*', '\\*').replace('`', '\\`')
+
     def _build_procedures_section(self, entries: list[Any]) -> str:
         """Build the procedures section from KV rows under `procedure:*`."""
         if not entries:
@@ -304,7 +315,7 @@ class SessionBriefingService:
             name = entry.key.removeprefix('procedure:')
             if not name or not text:
                 continue
-            lines.append(f'- **{name}** — {text}')
+            lines.append(f'- **{self._defang_procedure_name(name)}** — {text}')
         if len(lines) == 1:
             return ''
         return '\n'.join(lines) + '\n'
@@ -431,7 +442,9 @@ class SessionBriefingService:
         # decoupled from any future change to the Step-4 drop-prefix list.
         # `_ts_floor` is tz-aware to match `updated_at` from `KVEntry` (the ORM
         # column is `TIMESTAMP WITH TIME ZONE`, so sorted() never mixes tz-aware
-        # and naive datetimes).
+        # and naive datetimes). Rows with `updated_at is None` fall back to
+        # `_ts_floor`, sorting them oldest — they'll be the first dropped by
+        # Step 5's oldest-first trim. This is the intended degradation order.
         _ts_floor = datetime.min.replace(tzinfo=timezone.utc)
         procs_initial = sorted(
             [e for e in kv_entries if e.key.startswith('procedure:')],

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -286,7 +286,9 @@ class SessionBriefingService:
             # Parse failed OR JSON was not a dict — render the raw stored string.
             text = str(raw)
         # Indent embedded newlines so a stored "\n## X" can't create a fake heading.
-        text = text.replace('\n', '\n  ')
+        # Normalise CRLF and bare CR first so all three line terminators are defanged
+        # uniformly (markdown processors and screen readers each handle CR differently).
+        text = text.replace('\r\n', '\n').replace('\r', '\n').replace('\n', '\n  ')
         if len(text) > _PROCEDURE_VALUE_MAX_CHARS:
             # Reserve one char for the ellipsis so total length is exactly the cap.
             text = text[: _PROCEDURE_VALUE_MAX_CHARS - 1].rstrip() + '…'

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -239,12 +239,15 @@ class SessionBriefingService:
         return ''.join(lines) + '\n'
 
     def _build_kv_section(self, kv_entries: list[Any]) -> str:
-        """Build the KV facts section. Procedure rows are excluded (rendered separately)."""
-        rendered = [e for e in kv_entries if not e.key.startswith('procedure:')]
-        if not rendered:
+        """Build the KV facts section.
+
+        Caller (``_build_sections`` / ``_apply_overflow``) is responsible for
+        excluding ``procedure:*`` rows — those render in their own section.
+        """
+        if not kv_entries:
             return ''
         lines = ['\n## Key-Value Facts\n']
-        for entry in rendered:
+        for entry in kv_entries:
             lines.append(f'- `{entry.key}`: {entry.value}')
         return '\n'.join(lines) + '\n'
 
@@ -441,28 +444,31 @@ class SessionBriefingService:
         if _estimate_tokens(self._assemble(sections)) <= budget:
             return self._assemble(sections)
 
-        # Step 4: Drop KV namespaces (app -> user -> project)
+        # Step 4: Drop KV namespaces (app -> user -> project).
+        # _build_kv_section does NOT filter procedure: — exclude here so the
+        # rendered KV section matches the namespace-trim semantics.
         for drop_prefix in ('app:', 'user:', 'project:'):
             filtered = [e for e in kv_entries if not e.key.startswith(drop_prefix)]
             sections = self._replace_section(
                 sections,
                 'kv',
-                self._build_kv_section(filtered),
+                self._build_kv_section([e for e in filtered if not e.key.startswith('procedure:')]),
             )
             kv_entries = filtered
             if _estimate_tokens(self._assemble(sections)) <= budget:
                 return self._assemble(sections)
 
         # Step 5: Trim procedures (high-signal but droppable when budget is exhausted).
-        # Oldest-first (sorted ascending by `updated_at`, `pop(0)`) — preserves the
-        # most-recently-touched rules longest.
+        # Oldest-first via index counter (deque/index avoids O(n) pop(0) on long lists).
+        # Step 6 is intentionally skipped — reserved for future degradation step.
         procs = list(procs_initial)
-        while procs:
-            procs.pop(0)
+        proc_idx = 0
+        while proc_idx < len(procs):
+            proc_idx += 1
             sections = self._replace_section(
                 sections,
                 'procedures',
-                self._build_procedures_section(procs),
+                self._build_procedures_section(procs[proc_idx:]),
             )
             if _estimate_tokens(self._assemble(sections)) <= budget:
                 return self._assemble(sections)

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -70,7 +70,14 @@ def _compute_importance(mm: MentalModel) -> float:
 
 
 def _build_kv_namespaces(project_id: str | None) -> list[str]:
-    """Build the list of KV namespaces to include in the briefing."""
+    """Build the list of KV namespaces to include in the briefing.
+
+    `procedure` is fetched alongside the namespaced prefixes; rows are split
+    out of `kv_entries` in `_build_sections` and render in their own
+    ``## Procedures`` section. Step 4 of `_apply_overflow` only drops
+    `app:/user:/project:` — `procedure:` rows are degraded separately in
+    Step 5.
+    """
     ns = ['global', 'user', 'app:claude-code', 'procedure']
     if project_id:
         ns.append(f'project:{project_id}')
@@ -257,10 +264,16 @@ class SessionBriefingService:
             return ''
         try:
             payload = json.loads(raw)
-            text = payload.get('value') if isinstance(payload, dict) else None
-            if not isinstance(text, str):
-                text = str(raw)
         except (json.JSONDecodeError, TypeError):
+            payload = None
+
+        if isinstance(payload, dict) and 'value' in payload:
+            inner = payload['value']
+            # Envelope present but `value` is non-string — render just the inner
+            # value (don't leak `v`/`tags`/`history` from the full envelope).
+            text = inner if isinstance(inner, str) else str(inner)
+        else:
+            # No envelope or not a dict — render the raw stored string.
             text = str(raw)
         # Indent embedded newlines so a stored "\n## X" can't create a fake heading.
         text = text.replace('\n', '\n  ')

--- a/packages/core/tests/unit/test_server_session.py
+++ b/packages/core/tests/unit/test_server_session.py
@@ -139,3 +139,29 @@ class TestSessionBriefingEndpoint:
             params={'budget': 0},
         )
         assert response.status_code == 422
+
+    def test_briefing_route_returns_procedures_section_when_present(self, client_with_mock_db):
+        """V4 route-level pin: the HTTP endpoint surfaces the ## Procedures section
+        when the rendered briefing contains procedure rows. The route delegates to
+        `api.session_briefing.generate` — override the get_api dependency."""
+        from uuid import uuid4
+        from memex_core.server.common import get_api
+
+        vault_id = str(uuid4())
+        rendered = '# Session Briefing\n\n## Procedures\n\n- **answer:briefing** — sample\n'
+
+        fake_api = MagicMock(session_briefing=MagicMock(generate=AsyncMock(return_value=rendered)))
+
+        app.dependency_overrides[get_api] = lambda: fake_api
+        try:
+            response = client_with_mock_db.get(
+                f'/api/v1/vaults/{vault_id}/session-briefing',
+                params={'budget': 2000},
+            )
+        finally:
+            app.dependency_overrides.pop(get_api, None)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert '## Procedures' in body['briefing']
+        assert 'answer:briefing' in body['briefing']

--- a/packages/core/tests/unit/test_session_briefing.py
+++ b/packages/core/tests/unit/test_session_briefing.py
@@ -1127,5 +1127,9 @@ class TestProcedures:
         # After overflow, the procedure section MUST be slimmer than the input —
         # not every seeded row should still be present. Two-sided: a regression
         # that drops EVERY procedure under partial-content budget should also fail.
+        # Expected range (budget=1000, 15 × ~200-char procedures + padded narrative):
+        # typically 2-8 survive after Step 5 trims oldest-first. If this test flips
+        # to `present == 0` after touching _build_sections / header overhead, audit
+        # the budget-arithmetic before relaxing this assertion.
         present = sum(1 for i in range(15) if f'**p{i}**' in result)
         assert 0 < present < 15, f'expected partial trim, got present={present}'

--- a/packages/core/tests/unit/test_session_briefing.py
+++ b/packages/core/tests/unit/test_session_briefing.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
@@ -277,11 +279,17 @@ class TestTrendSorting:
 class TestKVNamespaces:
     def test_without_project(self):
         ns = _build_kv_namespaces(None)
-        assert ns == ['global', 'user', 'app:claude-code']
+        assert ns == ['global', 'user', 'app:claude-code', 'procedure']
 
     def test_with_project(self):
         ns = _build_kv_namespaces('my-project')
-        assert ns == ['global', 'user', 'app:claude-code', 'project:my-project']
+        assert ns == [
+            'global',
+            'user',
+            'app:claude-code',
+            'procedure',
+            'project:my-project',
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -322,21 +330,28 @@ class TestSessionBriefingGenerate:
 
     @pytest.mark.asyncio
     async def test_section_order(self):
-        """Sections appear in order: header, KV, vault overview, entities, binding."""
+        """Sections appear in order: header, KV, procedures, vault overview, entities, binding."""
         svc = _make_service(
             summary=_make_vault_summary(),
             mental_models=_make_mental_models(3, with_observations=True),
-            kv_entries=[_make_kv_entry('global:test', 'value')],
+            kv_entries=[
+                _make_kv_entry('global:test', 'value'),
+                _make_kv_entry(
+                    'procedure:answer:test',
+                    json.dumps({'v': 1, 'value': 'sample procedure', 'tags': {}, 'history': []}),
+                ),
+            ],
         )
         result = await svc.generate(uuid4(), budget=2000)
 
         header_pos = result.find('# Session Briefing')
         kv_pos = result.find('## Key-Value Facts')
+        proc_pos = result.find('## Procedures')
         vault_pos = result.find('## Vault Overview')
         entity_pos = result.find('## Top Entities')
         binding_pos = result.find('*Vault:')
 
-        assert header_pos < kv_pos < vault_pos < entity_pos < binding_pos
+        assert header_pos < kv_pos < proc_pos < vault_pos < entity_pos < binding_pos
 
     @pytest.mark.asyncio
     async def test_2000_includes_narrative_and_trends(self):
@@ -939,3 +954,177 @@ class TestVaultsSection:
         result = await svc.generate(vault_id=VAULT_ID, budget=2000)
         assert '...' in result
         assert long_desc not in result
+
+
+class TestProcedures:
+    """V4: procedure KV rows render in their own ## Procedures section."""
+
+    @staticmethod
+    def _wrap(value: str) -> str:
+        return json.dumps({'v': 1, 'value': value, 'tags': {}, 'history': []})
+
+    @pytest.mark.asyncio
+    async def test_section_present_when_procedure_rows_exist(self):
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[
+                _make_kv_entry('procedure:answer:foo', self._wrap('answer like X')),
+                _make_kv_entry('procedure:format:bar', self._wrap('format like Y')),
+            ],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        assert '## Procedures' in result
+        assert '**answer:foo**' in result
+        assert 'answer like X' in result
+        assert '**format:bar**' in result
+        assert 'format like Y' in result
+
+    @pytest.mark.asyncio
+    async def test_section_absent_when_no_procedure_rows(self):
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[_make_kv_entry('global:k', 'v')],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        assert '## Procedures' not in result
+
+    @pytest.mark.asyncio
+    async def test_envelope_unwrap_extracts_value_field(self):
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[_make_kv_entry('procedure:x', self._wrap('hello'))],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        assert 'hello' in result
+        assert '"v":' not in result.split('## Procedures')[1].split('---')[0]
+
+    @pytest.mark.asyncio
+    async def test_envelope_fallback_on_malformed_json(self):
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[_make_kv_entry('procedure:x', 'raw text not json')],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        assert 'raw text not json' in result
+
+    @pytest.mark.asyncio
+    async def test_envelope_fallback_on_non_dict_json(self):
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[_make_kv_entry('procedure:x', json.dumps([1, 2, 3]))],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        assert '[1, 2, 3]' in result
+
+    @pytest.mark.asyncio
+    async def test_kv_section_excludes_procedure_entries(self):
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[
+                _make_kv_entry('global:foo', 'bar'),
+                _make_kv_entry('procedure:x', self._wrap('proc text')),
+            ],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        kv_section = result.split('## Key-Value Facts')[1].split('##')[0]
+        assert 'procedure:x' not in kv_section
+        assert 'proc text' not in kv_section
+        assert 'global:foo' in kv_section
+
+    @pytest.mark.asyncio
+    async def test_user_namespace_included_in_briefing(self):
+        """Guard: `user:*` rows must appear in KV section (regression pin)."""
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[_make_kv_entry('user:editor', 'neovim')],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        assert '## Key-Value Facts' in result
+        assert 'user:editor' in result
+        assert 'neovim' in result
+
+    @pytest.mark.asyncio
+    async def test_value_truncation_at_max_chars(self):
+        from memex_core.services.session_briefing import _PROCEDURE_VALUE_MAX_CHARS
+
+        long_text = 'x' * (_PROCEDURE_VALUE_MAX_CHARS + 500)
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[_make_kv_entry('procedure:x', self._wrap(long_text))],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        assert '…' in result
+        # Rendered text should be ≤ max + ellipsis; not the full long_text.
+        assert ('x' * (_PROCEDURE_VALUE_MAX_CHARS + 500)) not in result
+
+    @pytest.mark.asyncio
+    async def test_newline_defang_indents_embedded_headings(self):
+        """A `\\n##` in the stored value must NOT create a fake briefing heading."""
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[_make_kv_entry('procedure:x', self._wrap('intro\n## fake heading'))],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        # The injected `\n## fake heading` becomes `\n  ## fake heading` (indented),
+        # so `\n## fake heading` (line-start H2) must not appear.
+        assert '\n## fake heading' not in result
+        assert '  ## fake heading' in result
+
+    @pytest.mark.asyncio
+    async def test_procedures_render_in_every_vaults_briefing(self):
+        """KV has no vault_id; the same procedure row surfaces in any vault's briefing."""
+        entries = [_make_kv_entry('procedure:shared', self._wrap('global rule'))]
+        svc_a = _make_service(summary=_make_vault_summary(), kv_entries=entries)
+        svc_b = _make_service(summary=_make_vault_summary(), kv_entries=entries)
+        result_a = await svc_a.generate(uuid4(), budget=2000)
+        result_b = await svc_b.generate(uuid4(), budget=2000)
+        assert 'global rule' in result_a
+        assert 'global rule' in result_b
+
+    @pytest.mark.asyncio
+    async def test_procedure_answer_session_briefing_round_trip(self):
+        """Bug-motivation pin: the exact KV row that triggered V4."""
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[
+                _make_kv_entry(
+                    'procedure:answer:session-briefing',
+                    self._wrap(
+                        'When the SessionStart briefing already contains the data, answer from it.'
+                    ),
+                )
+            ],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        assert '**answer:session-briefing**' in result
+        assert 'answer from it' in result
+
+    @pytest.mark.asyncio
+    async def test_orphan_header_suppressed_when_all_entries_degenerate(self):
+        """`procedure:` (empty body) or empty value → no entry rendered → no orphan heading."""
+        svc = _make_service(
+            summary=_make_vault_summary(),
+            kv_entries=[
+                _make_kv_entry('procedure:', self._wrap('orphan body')),
+                _make_kv_entry('procedure:empty', self._wrap('')),
+            ],
+        )
+        result = await svc.generate(uuid4(), budget=2000)
+        assert '## Procedures' not in result
+
+    @pytest.mark.asyncio
+    async def test_overflow_step5_trims_procedures_under_budget(self):
+        """Step 5 should drop procedures when budget is exhausted by other content."""
+        large_summary = _make_vault_summary()
+        # Pad the summary narrative to push overflow into Step 5.
+        large_summary.narrative = 'x ' * 600
+
+        # Many procedure rows, each near the per-row cap, to ensure they're the
+        # largest droppable section after vault overview + KV trim.
+        entries = [_make_kv_entry(f'procedure:p{i}', self._wrap('y ' * 200)) for i in range(15)]
+        svc = _make_service(summary=large_summary, kv_entries=entries)
+        result = await svc.generate(uuid4(), budget=1000)
+        # After overflow, the procedure section MUST be slimmer than the input —
+        # not every seeded row should still be present.
+        present = sum(1 for i in range(15) if f'**p{i}**' in result)
+        assert present < 15

--- a/packages/core/tests/unit/test_session_briefing.py
+++ b/packages/core/tests/unit/test_session_briefing.py
@@ -1125,6 +1125,7 @@ class TestProcedures:
         svc = _make_service(summary=large_summary, kv_entries=entries)
         result = await svc.generate(uuid4(), budget=1000)
         # After overflow, the procedure section MUST be slimmer than the input —
-        # not every seeded row should still be present.
+        # not every seeded row should still be present. Two-sided: a regression
+        # that drops EVERY procedure under partial-content budget should also fail.
         present = sum(1 for i in range(15) if f'**p{i}**' in result)
-        assert present < 15
+        assert 0 < present < 15, f'expected partial trim, got present={present}'

--- a/packages/core/tests/unit/test_session_briefing_regression.py
+++ b/packages/core/tests/unit/test_session_briefing_regression.py
@@ -206,6 +206,7 @@ class TestOverflowDegradation:
         sections = [
             ('header', '# Session Briefing\n'),
             ('kv', ''),
+            ('procedures', ''),
             ('vault_overview', svc._build_vault_overview(summary, compact=False)),
             ('mental_models', ''),
             ('vaults', ''),
@@ -223,3 +224,75 @@ class TestOverflowDegradation:
 
         # Best-effort: vault_overview should have been dropped in step 3
         assert '## Vault Overview' not in result
+
+
+class TestProceduresRendering:
+    """V4 structural regression pins for the ## Procedures section."""
+
+    @staticmethod
+    def _kv(key: str, value: str) -> MagicMock:
+        entry = MagicMock()
+        entry.key = key
+        entry.value = value
+        entry.updated_at = datetime(2026, 5, 20, tzinfo=timezone.utc)
+        return entry
+
+    def test_procedures_section_is_rendered_when_rows_present(self):
+        import json
+
+        svc = _make_briefing_service()
+        entries = [
+            self._kv(
+                'procedure:answer:briefing',
+                json.dumps({'v': 1, 'value': 'cite briefing first', 'tags': {}, 'history': []}),
+            )
+        ]
+        rendered = svc._build_procedures_section(entries)
+        assert rendered.startswith('\n## Procedures\n')
+        assert '**answer:briefing**' in rendered
+        assert 'cite briefing first' in rendered
+
+    def test_procedures_section_suppressed_when_no_rows(self):
+        svc = _make_briefing_service()
+        assert svc._build_procedures_section([]) == ''
+
+    def test_procedures_section_suppressed_when_all_degenerate(self):
+        import json
+
+        svc = _make_briefing_service()
+        entries = [
+            self._kv(
+                'procedure:',
+                json.dumps({'v': 1, 'value': 'orphan', 'tags': {}, 'history': []}),
+            ),
+            self._kv(
+                'procedure:empty',
+                json.dumps({'v': 1, 'value': '', 'tags': {}, 'history': []}),
+            ),
+        ]
+        assert svc._build_procedures_section(entries) == ''
+
+    def test_sanitize_indents_embedded_newlines(self):
+        svc = _make_briefing_service()
+        sanitized = svc._sanitize_procedure_value('intro\n## fake')
+        assert '\n## fake' not in sanitized
+        assert '\n  ## fake' in sanitized
+
+    def test_sanitize_truncates_at_max_chars(self):
+        from memex_core.services.session_briefing import _PROCEDURE_VALUE_MAX_CHARS
+
+        svc = _make_briefing_service()
+        long_value = 'x' * (_PROCEDURE_VALUE_MAX_CHARS + 50)
+        sanitized = svc._sanitize_procedure_value(long_value)
+        assert sanitized.endswith('…')
+        assert len(sanitized) <= _PROCEDURE_VALUE_MAX_CHARS + 1
+
+    def test_sanitize_falls_back_when_no_value_field(self):
+        import json
+
+        svc = _make_briefing_service()
+        assert svc._sanitize_procedure_value(json.dumps([1, 2, 3])) == '[1, 2, 3]'
+
+    def test_sanitize_handles_none(self):
+        svc = _make_briefing_service()
+        assert svc._sanitize_procedure_value(None) == ''

--- a/packages/core/tests/unit/test_session_briefing_regression.py
+++ b/packages/core/tests/unit/test_session_briefing_regression.py
@@ -305,10 +305,13 @@ class TestProceduresRendering:
         assert svc._sanitize_procedure_value('null') == ''
 
     def test_defang_procedure_name_escapes_markdown_metachars(self):
-        """A key containing `*` or backtick must not corrupt the `**name**` bold span."""
+        """A key containing `*`, backtick, or `[`/`]` must not corrupt the
+        `**name**` bold span or open a link inside it."""
         from memex_core.services.session_briefing import SessionBriefingService
 
         assert SessionBriefingService._defang_procedure_name('foo*bar') == 'foo\\*bar'
         assert SessionBriefingService._defang_procedure_name('foo`bar') == 'foo\\`bar'
+        assert SessionBriefingService._defang_procedure_name('foo[bar') == 'foo\\[bar'
+        assert SessionBriefingService._defang_procedure_name('foo]bar') == 'foo\\]bar'
         # Backslash must be escaped FIRST so we don't double-escape downstream chars.
         assert SessionBriefingService._defang_procedure_name('foo\\bar') == 'foo\\\\bar'

--- a/packages/core/tests/unit/test_session_briefing_regression.py
+++ b/packages/core/tests/unit/test_session_briefing_regression.py
@@ -298,3 +298,8 @@ class TestProceduresRendering:
     def test_sanitize_handles_none(self):
         svc = _make_briefing_service()
         assert svc._sanitize_procedure_value(None) == ''
+
+    def test_sanitize_handles_json_null_literal(self):
+        """`json.loads("null")` returns None — render '' rather than the literal "null"."""
+        svc = _make_briefing_service()
+        assert svc._sanitize_procedure_value('null') == ''

--- a/packages/core/tests/unit/test_session_briefing_regression.py
+++ b/packages/core/tests/unit/test_session_briefing_regression.py
@@ -285,7 +285,9 @@ class TestProceduresRendering:
         long_value = 'x' * (_PROCEDURE_VALUE_MAX_CHARS + 50)
         sanitized = svc._sanitize_procedure_value(long_value)
         assert sanitized.endswith('…')
-        assert len(sanitized) <= _PROCEDURE_VALUE_MAX_CHARS + 1
+        # The named cap is the rendered ceiling — content + ellipsis together
+        # must not exceed _PROCEDURE_VALUE_MAX_CHARS.
+        assert len(sanitized) <= _PROCEDURE_VALUE_MAX_CHARS
 
     def test_sanitize_falls_back_when_no_value_field(self):
         import json

--- a/packages/core/tests/unit/test_session_briefing_regression.py
+++ b/packages/core/tests/unit/test_session_briefing_regression.py
@@ -303,3 +303,12 @@ class TestProceduresRendering:
         """`json.loads("null")` returns None — render '' rather than the literal "null"."""
         svc = _make_briefing_service()
         assert svc._sanitize_procedure_value('null') == ''
+
+    def test_defang_procedure_name_escapes_markdown_metachars(self):
+        """A key containing `*` or backtick must not corrupt the `**name**` bold span."""
+        from memex_core.services.session_briefing import SessionBriefingService
+
+        assert SessionBriefingService._defang_procedure_name('foo*bar') == 'foo\\*bar'
+        assert SessionBriefingService._defang_procedure_name('foo`bar') == 'foo\\`bar'
+        # Backslash must be escaped FIRST so we don't double-escape downstream chars.
+        assert SessionBriefingService._defang_procedure_name('foo\\bar') == 'foo\\\\bar'


### PR DESCRIPTION
## Summary

- **Server-side renderer**: `SessionBriefingService` now injects a `## Procedures` section from KV rows under `procedure:*`, between `## Key-Value Facts` and `## Vault Overview`. Values are JSON-envelope-unwrapped (`{\"v\":1,\"value\":…}`), markdown-injection-defanged (embedded `\n##` indented), and per-row-capped at 1000 chars. Overflow Step 5 trims procedures oldest-first between KV namespace drop and vaults drop.
- **Tier 2 agent surface**: `CLAUDE_CODE_HARNESS` gains `<critical_constraint name=\"answer_from_briefing\">` with **conditional** \"MAY contain\" wording so it stays truthful under overflow. `_TIER_2_CHAR_CAP` 5_000 → 5_600 with tight margin assertion.
- **Plugin opt-out toggles** (default `on`, falsy = `off|0|false|no|disabled`):
  - `MEMEX_CC_SESSION_BRIEFING` — gates the SessionStart briefing fetch (agent-surface rule-file install stays unconditional).
  - `MEMEX_CC_TRANSCRIPT_CAPTURE` — gates SessionEnd + PreCompact transcript capture; PreCompact piggy-backs on existing `_capture_status`/`_capture_reason` flow for shape parity; offset files are NOT advanced when disabled (re-enabling resumes from prior offset — no turns lost).
- **README rewrite**: 10 plugin env vars consolidated into a single reference table with \"How to disable behaviours\" subsection (settings.json snippet). Asymmetric parser contract documented explicitly.
- **Hermes parity**: inherits the server fix transparently (`BriefingCache.start_fetch` → same HTTP route).

## Anchors

- **BACKLOG ticket**: `V4 — SessionStart briefing: inject procedures + answer-from-briefing rule + plugin opt-out toggles` (BACKLOG.md is .gitignore'd; entry kept locally).
- **Plan file**: `~/.claude/plans/memex-briefing-procedures-and-user-kv.md`
- **DESIGN_DOCUMENT.md §-section**: N/A — refinement of the existing session-briefing pipeline, no new mechanism.

## Test plan

- [x] **Unit / Integration** — `uv run pytest packages/core/tests/unit/test_session_briefing*.py packages/core/tests/unit/test_server_session.py packages/common/tests/test_agent_harnesses.py packages/claude-code-plugin/tests/unit/` → **209 passed**. New tests: 13 in TestProcedures, 7 in TestProceduresRendering, 1 route test, 3 harness assertions, 9 plugin toggle tests.
- [x] **Lint / format / mypy** — `just prek` clean.
- [x] **Anchor verification** — `verify_anchors.py` exit 0, all 36 plan anchors `ok`.
- [x] **Pre-PR self-assessment** — 99% confident; -1% gap is manual real-LLM-turn check (see below).
- [x] **Adversarial review** — two rounds (initial: 5 issues triaged; patch round: 0 CRIT/HIGH, 1 MEDIUM (sort-key type-mix on `updated_at`) which is fixed in this commit, 2 LOW deferred with rationale).
- [ ] **Manual real-LLM-turn check** (DoD-deferred): open a Claude Code session in a vault with a seeded `procedure:*` row, ask \"what is in this vault\", confirm the agent answers from the briefing and emits no `memex_get_vault_summary` / `memex_kv_list` calls. This pins the behavioural-prompt rule against the live LLM; cannot be automated by unit tests.

## Notes on scope and decisions

- **Vault scoping**: procedures are intentionally GLOBAL (KV has no `vault_id` column). Same trust boundary as `user:*` and `global:*`. Per-vault procedural rules use namespace convention (`procedure:answer:vault-research` vs `procedure:answer:vault-codebase`). Pinned by `test_procedures_render_in_every_vaults_briefing`.
- **Tier 2 + procedure KV co-existence**: the shipped Tier 2 rule is the always-present baseline; the `procedure:answer:session-briefing` KV row is the per-vault editable override. Both serve distinct purposes (fresh-vault onboardings have no procedures; user-customised vaults can tighten the baseline).
- **Asymmetric parser contract**: `MEMEX_CC_*` toggles have no truthy form — anything not in the falsy set is treated as `on`. Documented in the README. Pinned by `test_briefing_toggle_treats_unknown_value_as_on`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)