### PR TITLE
feat(hermes-plugin): transcript preprocessing pipeline for session notes

### DIFF
--- a/.github/workflows/hermes-review.yaml
+++ b/.github/workflows/hermes-review.yaml
@@ -68,6 +68,7 @@ jobs:
           api_key: ${{ secrets.OLLAMA_API_KEY }}
           max_iterations: '12'
           quiet_mode: 'false'
+          uv_version: '0.11.x'
 
       - name: Post review comment
         env:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/config.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/config.py
@@ -58,6 +58,15 @@ class RetainConfig(BaseModel):
     # ``memex_add_note(name=..., note_key=<session_note_key>)`` directly.
     session_title_template: str = 'Hermes session [{agent_identity}@{platform}] — {date}'
 
+    # Transcript preprocessing — quality gate
+    min_capture_turns: int = 1
+    min_capture_chars: int = 50
+
+    # Transcript preprocessing — content stripping
+    strip_system_prompts: bool = True
+    strip_html_content: bool = True
+    html_content_threshold: int = 500
+
 
 class HermesMemexConfig(BaseModel):
     """Plugin configuration resolved from file + env + MemexConfig fallback."""

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/config.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/config.py
@@ -64,6 +64,7 @@ class RetainConfig(BaseModel):
 
     # Transcript preprocessing — content stripping
     strip_system_prompts: bool = True
+    strip_system_metadata: bool = True
     strip_html_content: bool = True
     html_content_threshold: int = 500
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -36,6 +36,7 @@ from .session import make_session_note_key
 from .templates import HERMES_SESSION_TEMPLATE
 from .tools import ALL_SCHEMAS, TOOLS_MODE_SCHEMAS, dispatch
 from .transcript import (
+    _render_pairs,
     content_chars,
     format_transcript,
     passes_quality_gate,
@@ -459,20 +460,20 @@ class MemexMemoryProvider(MemoryProvider):
             # Degenerate case: ``sync_turn`` was never called this session
             # (some Hermes deployments only fire on_session_end). Trust
             # Hermes' history as the fallback source.
-            retain = self._config.retain
+            retain = self._config.retain if self._config else None
             cleaned = preprocess_turns(
                 messages,
-                strip_system_prompts=retain.strip_system_prompts,
-                strip_system_metadata=retain.strip_system_metadata,
-                strip_html_content=retain.strip_html_content,
-                html_content_threshold=retain.html_content_threshold,
+                strip_system_prompts=retain.strip_system_prompts if retain else True,
+                strip_system_metadata=retain.strip_system_metadata if retain else True,
+                strip_html_content=retain.strip_html_content if retain else True,
+                html_content_threshold=retain.html_content_threshold if retain else 500,
             )
             if passes_quality_gate(
                 cleaned,
-                min_turns=retain.min_capture_turns,
-                min_capture_chars=retain.min_capture_chars,
+                min_turns=retain.min_capture_turns if retain else 1,
+                min_capture_chars=retain.min_capture_chars if retain else 50,
             ):
-                chunk = format_transcript(cleaned)
+                chunk = _render_pairs(cleaned)
             else:
                 chunk = ''
         if chunk:
@@ -655,7 +656,7 @@ class MemexMemoryProvider(MemoryProvider):
             with self._state_lock:
                 self._flushed_index = end_index
             return ''
-        formatted = format_transcript(cleaned)
+        formatted = _render_pairs(cleaned)
         if not formatted.strip():
             with self._state_lock:
                 self._flushed_index = end_index

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -29,7 +29,7 @@ from memex_common.note_utils import derive_note_uuid_from_key
 
 from .async_bridge import run_sync
 from .briefing import BriefingCache, format_briefing_block
-from .config import HermesMemexConfig, load_config, save_config
+from .config import HermesMemexConfig, RetainConfig, load_config, save_config
 from .prefetch import PrefetchCache
 from .project import derive_project_id, resolve_vault
 from .session import make_session_note_key
@@ -460,18 +460,18 @@ class MemexMemoryProvider(MemoryProvider):
             # Degenerate case: ``sync_turn`` was never called this session
             # (some Hermes deployments only fire on_session_end). Trust
             # Hermes' history as the fallback source.
-            retain = self._config.retain if self._config else None
+            retain = self._config.retain if self._config else RetainConfig()
             cleaned = preprocess_turns(
                 messages,
-                strip_system_prompts=retain.strip_system_prompts if retain else True,
-                strip_system_metadata=retain.strip_system_metadata if retain else True,
-                strip_html_content=retain.strip_html_content if retain else True,
-                html_content_threshold=retain.html_content_threshold if retain else 500,
+                strip_system_prompts=retain.strip_system_prompts,
+                strip_system_metadata=retain.strip_system_metadata,
+                strip_html_content=retain.strip_html_content,
+                html_content_threshold=retain.html_content_threshold,
             )
             if passes_quality_gate(
                 cleaned,
-                min_turns=retain.min_capture_turns if retain else 1,
-                min_capture_chars=retain.min_capture_chars if retain else 50,
+                min_turns=retain.min_capture_turns,
+                min_capture_chars=retain.min_capture_chars,
             ):
                 chunk = render_pairs(cleaned)
             else:
@@ -634,19 +634,19 @@ class MemexMemoryProvider(MemoryProvider):
             # Pin the watermark target to the snapshot range so concurrent
             # sync_turn appends are not silently skipped.
             end_index = self._flushed_index + len(snapshot)
-            retain = self._config.retain if self._config else None
+            retain = self._config.retain if self._config else RetainConfig()
 
         cleaned = preprocess_turns(
             snapshot,
-            strip_system_prompts=retain.strip_system_prompts if retain else True,
-            strip_system_metadata=retain.strip_system_metadata if retain else True,
-            strip_html_content=retain.strip_html_content if retain else True,
-            html_content_threshold=retain.html_content_threshold if retain else 500,
+            strip_system_prompts=retain.strip_system_prompts,
+            strip_system_metadata=retain.strip_system_metadata,
+            strip_html_content=retain.strip_html_content,
+            html_content_threshold=retain.html_content_threshold,
         )
         if not passes_quality_gate(
             cleaned,
-            min_turns=retain.min_capture_turns if retain else 1,
-            min_capture_chars=retain.min_capture_chars if retain else 50,
+            min_turns=retain.min_capture_turns,
+            min_capture_chars=retain.min_capture_chars,
         ):
             logger.info(
                 'Transcript quality gate rejected session (%d turns, %d content chars)',

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -36,7 +36,7 @@ from .session import make_session_note_key
 from .templates import HERMES_SESSION_TEMPLATE
 from .tools import ALL_SCHEMAS, TOOLS_MODE_SCHEMAS, dispatch
 from .transcript import (
-    _render_pairs,
+    render_pairs,
     content_chars,
     format_transcript,
     passes_quality_gate,
@@ -473,7 +473,7 @@ class MemexMemoryProvider(MemoryProvider):
                 min_turns=retain.min_capture_turns if retain else 1,
                 min_capture_chars=retain.min_capture_chars if retain else 50,
             ):
-                chunk = _render_pairs(cleaned)
+                chunk = render_pairs(cleaned)
             else:
                 chunk = ''
         if chunk:
@@ -654,15 +654,15 @@ class MemexMemoryProvider(MemoryProvider):
                 content_chars(cleaned),
             )
             with self._state_lock:
-                self._flushed_index = end_index
+                self._flushed_index = max(self._flushed_index, end_index)
             return ''
-        formatted = _render_pairs(cleaned)
+        formatted = render_pairs(cleaned)
         if not formatted.strip():
             with self._state_lock:
-                self._flushed_index = end_index
+                self._flushed_index = max(self._flushed_index, end_index)
             return ''
         with self._state_lock:
-            self._flushed_index = end_index
+            self._flushed_index = max(self._flushed_index, end_index)
         return formatted
 
     def _enqueue_chunk(self, content: str, *, title: str) -> None:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -35,7 +35,12 @@ from .project import derive_project_id, resolve_vault
 from .session import make_session_note_key
 from .templates import HERMES_SESSION_TEMPLATE
 from .tools import ALL_SCHEMAS, TOOLS_MODE_SCHEMAS, dispatch
-from .transcript import format_transcript, passes_quality_gate, preprocess_turns
+from .transcript import (
+    _content_chars,
+    format_transcript,
+    passes_quality_gate,
+    preprocess_turns,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -458,6 +463,7 @@ class MemexMemoryProvider(MemoryProvider):
             cleaned = preprocess_turns(
                 messages,
                 strip_system_prompts=retain.strip_system_prompts,
+                strip_system_metadata=retain.strip_system_metadata,
                 strip_html_content=retain.strip_html_content,
                 html_content_threshold=retain.html_content_threshold,
             )
@@ -627,6 +633,7 @@ class MemexMemoryProvider(MemoryProvider):
             cleaned = preprocess_turns(
                 unflushed,
                 strip_system_prompts=retain.strip_system_prompts if retain else True,
+                strip_system_metadata=retain.strip_system_metadata if retain else True,
                 strip_html_content=retain.strip_html_content if retain else True,
                 html_content_threshold=retain.html_content_threshold if retain else 500,
             )
@@ -636,9 +643,9 @@ class MemexMemoryProvider(MemoryProvider):
                 min_content_chars=retain.min_capture_chars if retain else 50,
             ):
                 logger.info(
-                    'Transcript quality gate rejected session (%d turns, %d chars)',
+                    'Transcript quality gate rejected session (%d turns, %d content chars)',
                     len(cleaned),
-                    sum(len(t.get('user', '')) + len(t.get('assistant', '')) for t in cleaned),
+                    _content_chars(cleaned),
                 )
                 self._flushed_index = len(self._turn_buffer)
                 return ''

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -662,7 +662,9 @@ class MemexMemoryProvider(MemoryProvider):
                 self._flushed_index = max(self._flushed_index, end_index)
             return ''
         with self._state_lock:
-            self._flushed_index = max(self._flushed_index, end_index)
+            if self._flushed_index >= end_index:
+                return ''
+            self._flushed_index = end_index
         return formatted
 
     def _enqueue_chunk(self, content: str, *, title: str) -> None:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -36,7 +36,7 @@ from .session import make_session_note_key
 from .templates import HERMES_SESSION_TEMPLATE
 from .tools import ALL_SCHEMAS, TOOLS_MODE_SCHEMAS, dispatch
 from .transcript import (
-    _content_chars,
+    content_chars,
     format_transcript,
     passes_quality_gate,
     preprocess_turns,
@@ -470,7 +470,7 @@ class MemexMemoryProvider(MemoryProvider):
             if passes_quality_gate(
                 cleaned,
                 min_turns=retain.min_capture_turns,
-                min_content_chars=retain.min_capture_chars,
+                min_capture_chars=retain.min_capture_chars,
             ):
                 chunk = format_transcript(cleaned)
             else:
@@ -629,29 +629,35 @@ class MemexMemoryProvider(MemoryProvider):
             unflushed = self._turn_buffer[self._flushed_index :]
             if not unflushed:
                 return ''
+            snapshot = list(unflushed)
             retain = self._config.retain if self._config else None
-            cleaned = preprocess_turns(
-                unflushed,
-                strip_system_prompts=retain.strip_system_prompts if retain else True,
-                strip_system_metadata=retain.strip_system_metadata if retain else True,
-                strip_html_content=retain.strip_html_content if retain else True,
-                html_content_threshold=retain.html_content_threshold if retain else 500,
+
+        cleaned = preprocess_turns(
+            snapshot,
+            strip_system_prompts=retain.strip_system_prompts if retain else True,
+            strip_system_metadata=retain.strip_system_metadata if retain else True,
+            strip_html_content=retain.strip_html_content if retain else True,
+            html_content_threshold=retain.html_content_threshold if retain else 500,
+        )
+        if not passes_quality_gate(
+            cleaned,
+            min_turns=retain.min_capture_turns if retain else 1,
+            min_capture_chars=retain.min_capture_chars if retain else 50,
+        ):
+            logger.info(
+                'Transcript quality gate rejected session (%d turns, %d content chars)',
+                len(cleaned),
+                content_chars(cleaned),
             )
-            if not passes_quality_gate(
-                cleaned,
-                min_turns=retain.min_capture_turns if retain else 1,
-                min_content_chars=retain.min_capture_chars if retain else 50,
-            ):
-                logger.info(
-                    'Transcript quality gate rejected session (%d turns, %d content chars)',
-                    len(cleaned),
-                    _content_chars(cleaned),
-                )
+            with self._state_lock:
                 self._flushed_index = len(self._turn_buffer)
-                return ''
-            formatted = format_transcript(cleaned)
-            if not formatted.strip():
-                return ''
+            return ''
+        formatted = format_transcript(cleaned)
+        if not formatted.strip():
+            with self._state_lock:
+                self._flushed_index = len(self._turn_buffer)
+            return ''
+        with self._state_lock:
             self._flushed_index = len(self._turn_buffer)
         return formatted
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -35,6 +35,7 @@ from .project import derive_project_id, resolve_vault
 from .session import make_session_note_key
 from .templates import HERMES_SESSION_TEMPLATE
 from .tools import ALL_SCHEMAS, TOOLS_MODE_SCHEMAS, dispatch
+from .transcript import format_transcript, passes_quality_gate, preprocess_turns
 
 logger = logging.getLogger(__name__)
 
@@ -453,7 +454,21 @@ class MemexMemoryProvider(MemoryProvider):
             # Degenerate case: ``sync_turn`` was never called this session
             # (some Hermes deployments only fire on_session_end). Trust
             # Hermes' history as the fallback source.
-            chunk = _format_transcript(messages)
+            retain = self._config.retain
+            cleaned = preprocess_turns(
+                messages,
+                strip_system_prompts=retain.strip_system_prompts,
+                strip_html_content=retain.strip_html_content,
+                html_content_threshold=retain.html_content_threshold,
+            )
+            if passes_quality_gate(
+                cleaned,
+                min_turns=retain.min_capture_turns,
+                min_content_chars=retain.min_capture_chars,
+            ):
+                chunk = format_transcript(cleaned)
+            else:
+                chunk = ''
         if chunk:
             self._enqueue_chunk(chunk, title=self._format_session_title())
         with self._state_lock:
@@ -600,12 +615,34 @@ class MemexMemoryProvider(MemoryProvider):
         watermark moves on capture, not on successful flush — the pending
         queue handles retries via stable ``append_id``s, so we never need to
         reread the same buffer slice twice.
+
+        The raw turns are preprocessed (system-prompt stripping, HTML
+        sanitization) and quality-gated before formatting.
         """
         with self._state_lock:
             unflushed = self._turn_buffer[self._flushed_index :]
             if not unflushed:
                 return ''
-            formatted = _format_transcript(unflushed)
+            retain = self._config.retain if self._config else None
+            cleaned = preprocess_turns(
+                unflushed,
+                strip_system_prompts=retain.strip_system_prompts if retain else True,
+                strip_html_content=retain.strip_html_content if retain else True,
+                html_content_threshold=retain.html_content_threshold if retain else 500,
+            )
+            if not passes_quality_gate(
+                cleaned,
+                min_turns=retain.min_capture_turns if retain else 1,
+                min_content_chars=retain.min_capture_chars if retain else 50,
+            ):
+                logger.info(
+                    'Transcript quality gate rejected session (%d turns, %d chars)',
+                    len(cleaned),
+                    sum(len(t.get('user', '')) + len(t.get('assistant', '')) for t in cleaned),
+                )
+                self._flushed_index = len(self._turn_buffer)
+                return ''
+            formatted = format_transcript(cleaned)
             if not formatted.strip():
                 return ''
             self._flushed_index = len(self._turn_buffer)
@@ -808,29 +845,11 @@ class MemexMemoryProvider(MemoryProvider):
 
 
 def _format_transcript(messages: list[dict[str, Any]]) -> str:
-    """Render a list of turn dicts as a flat markdown transcript.
+    """Render a list of turn dicts as a structured markdown transcript.
 
-    Accepts both ``{user, assistant}`` pairs (our sync_turn buffer format) and
-    Hermes' own ``{role, content}`` message objects.
+    Delegates to ``transcript.format_transcript``.
     """
-    lines: list[str] = []
-    for m in messages:
-        if 'user' in m or 'assistant' in m:
-            if m.get('user'):
-                lines.append(f'**User:** {m["user"]}')
-            if m.get('assistant'):
-                lines.append(f'**Assistant:** {m["assistant"]}')
-        else:
-            role = str(m.get('role', 'user')).strip() or 'user'
-            content = m.get('content', '')
-            if isinstance(content, list):
-                content = '\n'.join(
-                    c.get('text', '') if isinstance(c, dict) else str(c) for c in content
-                )
-            if content:
-                lines.append(f'**{role.capitalize()}:** {content}')
-        lines.append('')
-    return '\n'.join(lines).strip()
+    return format_transcript(messages)
 
 
 __all__ = ['MemexMemoryProvider']

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -630,6 +630,9 @@ class MemexMemoryProvider(MemoryProvider):
             if not unflushed:
                 return ''
             snapshot = list(unflushed)
+            # Pin the watermark target to the snapshot range so concurrent
+            # sync_turn appends are not silently skipped.
+            end_index = self._flushed_index + len(snapshot)
             retain = self._config.retain if self._config else None
 
         cleaned = preprocess_turns(
@@ -650,15 +653,15 @@ class MemexMemoryProvider(MemoryProvider):
                 content_chars(cleaned),
             )
             with self._state_lock:
-                self._flushed_index = len(self._turn_buffer)
+                self._flushed_index = end_index
             return ''
         formatted = format_transcript(cleaned)
         if not formatted.strip():
             with self._state_lock:
-                self._flushed_index = len(self._turn_buffer)
+                self._flushed_index = end_index
             return ''
         with self._state_lock:
-            self._flushed_index = len(self._turn_buffer)
+            self._flushed_index = end_index
         return formatted
 
     def _enqueue_chunk(self, content: str, *, title: str) -> None:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
@@ -47,6 +47,7 @@ def is_system_prompt(text: str) -> bool:
 # B. System-metadata detector
 # ---------------------------------------------------------------------------
 
+# Single-line only: no DOTALL (would let .+ span newlines) or MULTILINE.
 _SYSTEM_METADATA_RE = re.compile(
     r'^\s*\[(?:Note|System)\s*[:]\s*.+\]\s*$',
 )
@@ -78,7 +79,8 @@ _HTML_INDICATORS: tuple[str, ...] = (
     "style='",
 )
 
-_HTML_PLACEHOLDER = '[HTML content removed]'
+HTML_PLACEHOLDER = '[HTML content removed]'
+SYSTEM_PROMPT_PLACEHOLDER = '[system prompt omitted]'
 
 
 def sanitize_html_content(text: str, threshold: int = 500) -> str:
@@ -93,12 +95,12 @@ def sanitize_html_content(text: str, threshold: int = 500) -> str:
     """
     tag_chars = sum(len(m.group()) for m in _HTML_TAG_RE.finditer(text))
     if tag_chars > threshold:
-        return _HTML_PLACEHOLDER
+        return HTML_PLACEHOLDER
 
     lower = text.lower()
     indicator_hits = sum(1 for ind in _HTML_INDICATORS if ind in lower)
     if indicator_hits >= 3 and len(text) > threshold:
-        return _HTML_PLACEHOLDER
+        return HTML_PLACEHOLDER
 
     return text
 
@@ -174,7 +176,7 @@ def preprocess_turns(
 
         if strip_system_prompts and user and is_system_prompt(user):
             logger.debug('Stripped system prompt from turn %d (%d chars)', i, len(user))
-            user = '[system prompt omitted]'
+            user = SYSTEM_PROMPT_PLACEHOLDER
 
         if strip_system_metadata and user and is_system_metadata(user):
             logger.debug('Stripped system metadata from turn %d', i)
@@ -197,13 +199,13 @@ def preprocess_turns(
 
 _PLACEHOLDER_STRINGS = frozenset(
     {
-        '[system prompt omitted]',
-        _HTML_PLACEHOLDER,
+        SYSTEM_PROMPT_PLACEHOLDER,
+        HTML_PLACEHOLDER,
     }
 )
 
 
-def _content_chars(turns: list[dict[str, str]]) -> int:
+def content_chars(turns: list[dict[str, str]]) -> int:
     """Sum of non-placeholder content characters across all turns."""
     total = 0
     for turn in turns:
@@ -218,7 +220,7 @@ def passes_quality_gate(
     turns: list[dict[str, str]],
     *,
     min_turns: int = 1,
-    min_content_chars: int = 50,
+    min_capture_chars: int = 50,
 ) -> bool:
     """Return False when the preprocessed transcript is too thin to capture."""
     substantive_turns = sum(
@@ -229,7 +231,7 @@ def passes_quality_gate(
     if substantive_turns < min_turns:
         return False
 
-    if _content_chars(turns) < min_content_chars:
+    if content_chars(turns) < min_capture_chars:
         return False
 
     return True
@@ -267,6 +269,9 @@ def format_transcript(messages: list[dict[str, Any]]) -> str:
 
 
 __all__ = [
+    'HTML_PLACEHOLDER',
+    'SYSTEM_PROMPT_PLACEHOLDER',
+    'content_chars',
     'format_transcript',
     'is_system_metadata',
     'is_system_prompt',

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
@@ -136,6 +136,8 @@ def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
                 for c in content
                 if not isinstance(c, dict) or c.get('type', 'text') == 'text'
             )
+        elif not isinstance(content, str):
+            content = str(content)
 
         if role == 'tool':
             continue
@@ -242,17 +244,10 @@ def passes_quality_gate(
 # ---------------------------------------------------------------------------
 
 
-def format_transcript(messages: list[dict[str, Any]]) -> str:
-    """Render turn dicts as a structured markdown transcript.
-
-    Accepts both ``{user, assistant}`` pairs and ``{role, content}`` messages.
-    Produces ``### Role`` headers with content on separate lines and ``---``
-    horizontal rules between turns.
-    """
-    normalized = _normalize_messages(messages)
+def _render_pairs(pairs: list[dict[str, str]]) -> str:
+    """Render already-normalized ``{user, assistant}`` pairs as markdown."""
     blocks: list[str] = []
-
-    for turn in normalized:
+    for turn in pairs:
         parts: list[str] = []
         user = turn.get('user', '').strip()
         assistant = turn.get('assistant', '').strip()
@@ -266,6 +261,16 @@ def format_transcript(messages: list[dict[str, Any]]) -> str:
             blocks.append('\n\n'.join(parts))
 
     return '\n\n---\n\n'.join(blocks)
+
+
+def format_transcript(messages: list[dict[str, Any]]) -> str:
+    """Render turn dicts as a structured markdown transcript.
+
+    Accepts both ``{user, assistant}`` pairs and ``{role, content}`` messages.
+    Produces ``### Role`` headers with content on separate lines and ``---``
+    horizontal rules between turns.
+    """
+    return _render_pairs(_normalize_messages(messages))
 
 
 __all__ = [

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
@@ -139,10 +139,10 @@ def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
         elif not isinstance(content, str):
             content = str(content)
 
-        if role == 'tool':
+        if role in ('tool', 'system'):
             continue
 
-        if role in ('user', 'system'):
+        if role == 'user':
             if pending_user is not None:
                 pairs.append({'user': pending_user, 'assistant': ''})
             pending_user = content

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
@@ -142,7 +142,7 @@ def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
         if role == 'tool':
             continue
 
-        if role == 'user':
+        if role in ('user', 'system'):
             if pending_user is not None:
                 pairs.append({'user': pending_user, 'assistant': ''})
             pending_user = content
@@ -244,7 +244,7 @@ def passes_quality_gate(
 # ---------------------------------------------------------------------------
 
 
-def _render_pairs(pairs: list[dict[str, str]]) -> str:
+def render_pairs(pairs: list[dict[str, str]]) -> str:
     """Render already-normalized ``{user, assistant}`` pairs as markdown."""
     blocks: list[str] = []
     for turn in pairs:
@@ -270,7 +270,7 @@ def format_transcript(messages: list[dict[str, Any]]) -> str:
     Produces ``### Role`` headers with content on separate lines and ``---``
     horizontal rules between turns.
     """
-    return _render_pairs(_normalize_messages(messages))
+    return render_pairs(_normalize_messages(messages))
 
 
 __all__ = [
@@ -278,6 +278,7 @@ __all__ = [
     'SYSTEM_PROMPT_PLACEHOLDER',
     'content_chars',
     'format_transcript',
+    'render_pairs',
     'is_system_metadata',
     'is_system_prompt',
     'passes_quality_gate',

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
@@ -49,7 +49,7 @@ def is_system_prompt(text: str) -> bool:
 
 # Single-line only: no DOTALL (would let .+ span newlines) or MULTILINE.
 _SYSTEM_METADATA_RE = re.compile(
-    r'^\s*\[(?:Note|System)\s*[:]\s*.+\]\s*$',
+    r'^\s*\[(?:Note|System)\s*:\s*.+\]\s*$',
 )
 
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
@@ -1,0 +1,268 @@
+"""Transcript preprocessing pipeline for Hermes session-note capture.
+
+Cleans, filters, and reformats raw turn buffers before they are ingested
+as Memex notes.  All functions are pure (no I/O, no side-effects) so they
+can be tested in isolation.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# A. System-prompt detector
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT_ANCHORS: tuple[str, ...] = (
+    'update the skill library',
+    'consider saving to memory',
+    'you can only call memory and skill management tools',
+    'other tools will be denied at runtime',
+    'do not attempt them',
+    'nothing to save',
+)
+
+_SYSTEM_PROMPT_MIN_LENGTH = 200
+_SYSTEM_PROMPT_MIN_ANCHORS = 2
+
+
+def is_system_prompt(text: str) -> bool:
+    """Detect injected system prompts using anchor-phrase matching.
+
+    Robust to moderate rewording: requires *multiple* short structural
+    anchors to match, not a single exact sentence.
+    """
+    if len(text) < _SYSTEM_PROMPT_MIN_LENGTH:
+        return False
+    lower = text.lower()
+    hits = sum(1 for anchor in _SYSTEM_PROMPT_ANCHORS if anchor in lower)
+    return hits >= _SYSTEM_PROMPT_MIN_ANCHORS
+
+
+# ---------------------------------------------------------------------------
+# B. System-metadata detector
+# ---------------------------------------------------------------------------
+
+_SYSTEM_METADATA_RE = re.compile(
+    r'^\s*\[(?:Note|System)\s*[:]\s*.+\]\s*$',
+    re.DOTALL,
+)
+
+
+def is_system_metadata(text: str) -> bool:
+    """Detect bracketed system-injected metadata lines."""
+    return bool(_SYSTEM_METADATA_RE.match(text.strip()))
+
+
+# ---------------------------------------------------------------------------
+# C. HTML content detector / sanitizer
+# ---------------------------------------------------------------------------
+
+_HTML_TAG_RE = re.compile(r'<[^>]+>')
+
+_HTML_INDICATORS: tuple[str, ...] = (
+    '<!doctype',
+    '<html',
+    '<head',
+    '<body',
+    '<div',
+    '<style',
+    '<script',
+    '<span',
+    'class="',
+    "class='",
+    'style="',
+    "style='",
+)
+
+_HTML_PLACEHOLDER = '[HTML content removed]'
+
+
+def sanitize_html_content(text: str, threshold: int = 500) -> str:
+    """Replace HTML-heavy content with a placeholder.
+
+    Detection works in two modes:
+    1. Tagged HTML — total chars inside ``<...>`` tags exceeds *threshold*.
+    2. LLM-generated HTML — 3+ distinct HTML indicator patterns AND total
+       text length > *threshold*.
+
+    Returns the original text unchanged when neither mode triggers.
+    """
+    tag_chars = sum(len(m.group()) for m in _HTML_TAG_RE.finditer(text))
+    if tag_chars > threshold:
+        return _HTML_PLACEHOLDER
+
+    lower = text.lower()
+    indicator_hits = sum(1 for ind in _HTML_INDICATORS if ind in lower)
+    if indicator_hits >= 3 and len(text) > threshold:
+        return _HTML_PLACEHOLDER
+
+    return text
+
+
+# ---------------------------------------------------------------------------
+# D. Turn preprocessor
+# ---------------------------------------------------------------------------
+
+
+def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Convert Hermes ``{role, content}`` messages into ``{user, assistant}`` pairs."""
+    pairs: list[dict[str, str]] = []
+    pending_user: str | None = None
+
+    for m in messages:
+        if 'user' in m or 'assistant' in m:
+            pairs.append(
+                {
+                    'user': m.get('user', ''),
+                    'assistant': m.get('assistant', ''),
+                }
+            )
+            continue
+
+        role = str(m.get('role', '')).strip().lower()
+        content = m.get('content', '')
+        if isinstance(content, list):
+            content = '\n'.join(
+                c.get('text', '') if isinstance(c, dict) else str(c) for c in content
+            )
+
+        if role == 'user':
+            if pending_user is not None:
+                pairs.append({'user': pending_user, 'assistant': ''})
+            pending_user = content
+        elif role == 'assistant':
+            pairs.append({'user': pending_user or '', 'assistant': content})
+            pending_user = None
+
+    if pending_user is not None:
+        pairs.append({'user': pending_user, 'assistant': ''})
+
+    return pairs
+
+
+def preprocess_turns(
+    turns: list[dict[str, Any]],
+    *,
+    strip_system_prompts: bool = True,
+    strip_html_content: bool = True,
+    html_content_threshold: int = 500,
+) -> list[dict[str, str]]:
+    """Clean raw turn dicts before formatting.
+
+    Accepts both ``{user, assistant}`` pairs and ``{role, content}`` messages.
+    Returns a new list of ``{user, assistant}`` dicts (never mutates input).
+    """
+    normalized = _normalize_messages(turns)
+    cleaned: list[dict[str, str]] = []
+
+    for i, turn in enumerate(normalized):
+        user = turn.get('user', '')
+        assistant = turn.get('assistant', '')
+
+        if strip_system_prompts and user and is_system_prompt(user):
+            logger.debug('Stripped system prompt from turn %d (%d chars)', i, len(user))
+            user = '[system prompt omitted]'
+
+        if user and is_system_metadata(user):
+            logger.debug('Stripped system metadata from turn %d', i)
+            user = ''
+
+        if strip_html_content:
+            if user:
+                user = sanitize_html_content(user, threshold=html_content_threshold)
+            if assistant:
+                assistant = sanitize_html_content(assistant, threshold=html_content_threshold)
+
+        cleaned.append({'user': user, 'assistant': assistant})
+
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# E. Quality gate
+# ---------------------------------------------------------------------------
+
+_PLACEHOLDER_STRINGS = frozenset(
+    {
+        '[system prompt omitted]',
+        _HTML_PLACEHOLDER,
+    }
+)
+
+
+def _content_chars(turns: list[dict[str, str]]) -> int:
+    """Sum of non-placeholder content characters across all turns."""
+    total = 0
+    for turn in turns:
+        for field in ('user', 'assistant'):
+            text = turn.get(field, '').strip()
+            if text and text not in _PLACEHOLDER_STRINGS:
+                total += len(text)
+    return total
+
+
+def passes_quality_gate(
+    turns: list[dict[str, str]],
+    *,
+    min_turns: int = 1,
+    min_content_chars: int = 50,
+) -> bool:
+    """Return False when the preprocessed transcript is too thin to capture."""
+    substantive_turns = sum(
+        1
+        for t in turns
+        if t.get('assistant', '').strip() and t['assistant'].strip() not in _PLACEHOLDER_STRINGS
+    )
+    if substantive_turns < min_turns:
+        return False
+
+    if _content_chars(turns) < min_content_chars:
+        return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# F. Improved formatter
+# ---------------------------------------------------------------------------
+
+
+def format_transcript(messages: list[dict[str, Any]]) -> str:
+    """Render turn dicts as a structured markdown transcript.
+
+    Accepts both ``{user, assistant}`` pairs and ``{role, content}`` messages.
+    Produces ``### Role`` headers with content on separate lines and ``---``
+    horizontal rules between turns.
+    """
+    normalized = _normalize_messages(messages)
+    blocks: list[str] = []
+
+    for turn in normalized:
+        parts: list[str] = []
+        user = turn.get('user', '').strip()
+        assistant = turn.get('assistant', '').strip()
+
+        if user:
+            parts.append(f'### User\n\n{user}')
+        if assistant:
+            parts.append(f'### Assistant\n\n{assistant}')
+
+        if parts:
+            blocks.append('\n\n'.join(parts))
+
+    return '\n\n---\n\n'.join(blocks)
+
+
+__all__ = [
+    'format_transcript',
+    'is_system_metadata',
+    'is_system_prompt',
+    'passes_quality_gate',
+    'preprocess_turns',
+    'sanitize_html_content',
+]

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
@@ -49,7 +49,6 @@ def is_system_prompt(text: str) -> bool:
 
 _SYSTEM_METADATA_RE = re.compile(
     r'^\s*\[(?:Note|System)\s*[:]\s*.+\]\s*$',
-    re.DOTALL,
 )
 
 
@@ -116,6 +115,9 @@ def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
 
     for m in messages:
         if 'user' in m or 'assistant' in m:
+            if pending_user is not None:
+                pairs.append({'user': pending_user, 'assistant': ''})
+                pending_user = None
             pairs.append(
                 {
                     'user': m.get('user', ''),
@@ -124,7 +126,7 @@ def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
             )
             continue
 
-        role = str(m.get('role', '')).strip().lower()
+        role = str(m.get('role', 'user')).strip().lower() or 'user'
         content = m.get('content', '')
         if isinstance(content, list):
             content = '\n'.join(
@@ -154,6 +156,7 @@ def preprocess_turns(
     turns: list[dict[str, Any]],
     *,
     strip_system_prompts: bool = True,
+    strip_system_metadata: bool = True,
     strip_html_content: bool = True,
     html_content_threshold: int = 500,
 ) -> list[dict[str, str]]:
@@ -173,7 +176,7 @@ def preprocess_turns(
             logger.debug('Stripped system prompt from turn %d (%d chars)', i, len(user))
             user = '[system prompt omitted]'
 
-        if user and is_system_metadata(user):
+        if strip_system_metadata and user and is_system_metadata(user):
             logger.debug('Stripped system metadata from turn %d', i)
             user = ''
 

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/transcript.py
@@ -128,8 +128,13 @@ def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
         content = m.get('content', '')
         if isinstance(content, list):
             content = '\n'.join(
-                c.get('text', '') if isinstance(c, dict) else str(c) for c in content
+                c.get('text', '') if isinstance(c, dict) else str(c)
+                for c in content
+                if not isinstance(c, dict) or c.get('type', 'text') == 'text'
             )
+
+        if role == 'tool':
+            continue
 
         if role == 'user':
             if pending_user is not None:

--- a/packages/hermes-plugin/tests/integration/conftest.py
+++ b/packages/hermes-plugin/tests/integration/conftest.py
@@ -339,15 +339,7 @@ def server_url_env(memex_server_url: str, monkeypatch: pytest.MonkeyPatch) -> st
 
 @pytest.fixture(scope='session')
 def hermes_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    home = tmp_path_factory.mktemp('hermes-home')
-    import json
-
-    cfg_dir = home / 'memex'
-    cfg_dir.mkdir(parents=True, exist_ok=True)
-    (cfg_dir / 'config.json').write_text(
-        json.dumps({'retain': {'min_capture_turns': 0, 'min_capture_chars': 0}})
-    )
-    return home
+    return tmp_path_factory.mktemp('hermes-home')
 
 
 @pytest.fixture(scope='session')
@@ -367,9 +359,26 @@ def installed_plugin(hermes_home: Path) -> Path:
     return plugin_dir
 
 
+def _ensure_quality_gate_disabled(hermes_home: Path) -> None:
+    """Write or merge quality-gate-off config so short test turns pass."""
+    import json
+
+    cfg_path = hermes_home / 'memex' / 'config.json'
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = json.loads(cfg_path.read_text()) if cfg_path.exists() else {}
+    existing.setdefault('retain', {}).update(
+        {
+            'min_capture_turns': 0,
+            'min_capture_chars': 0,
+        }
+    )
+    cfg_path.write_text(json.dumps(existing))
+
+
 @pytest.fixture(autouse=True)
 def _hermes_env(hermes_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv('HERMES_HOME', str(hermes_home))
+    _ensure_quality_gate_disabled(hermes_home)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/hermes-plugin/tests/integration/conftest.py
+++ b/packages/hermes-plugin/tests/integration/conftest.py
@@ -339,7 +339,15 @@ def server_url_env(memex_server_url: str, monkeypatch: pytest.MonkeyPatch) -> st
 
 @pytest.fixture(scope='session')
 def hermes_home(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    return tmp_path_factory.mktemp('hermes-home')
+    home = tmp_path_factory.mktemp('hermes-home')
+    import json
+
+    cfg_dir = home / 'memex'
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / 'config.json').write_text(
+        json.dumps({'retain': {'min_capture_turns': 0, 'min_capture_chars': 0}})
+    )
+    return home
 
 
 @pytest.fixture(scope='session')

--- a/packages/hermes-plugin/tests/integration/test_live_hermes.py
+++ b/packages/hermes-plugin/tests/integration/test_live_hermes.py
@@ -437,13 +437,15 @@ def test_session_title_uses_template_against_real_server(
 
     cfg_dir = hermes_home / 'memex'
     cfg_dir.mkdir(parents=True, exist_ok=True)
-    (cfg_dir / 'memex' / 'config.json' if False else cfg_dir / 'config.json').write_text(
+    (cfg_dir / 'config.json').write_text(
         json.dumps(
             {
                 'server_url': memex_server_url,
                 'vault_id': vault_name,
                 'retain': {
                     'session_title_template': ('IntegrationTitle [{agent_identity}@{platform}]'),
+                    'min_capture_turns': 0,
+                    'min_capture_chars': 0,
                 },
             }
         )

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -13,11 +14,27 @@ import pytest
 from memex_hermes_plugin.memex.provider import MemexMemoryProvider
 
 
+def _write_test_config(tmp_path: Path) -> None:
+    """Write a config that disables the quality gate so short test turns pass."""
+    cfg_dir = tmp_path / 'memex'
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg = cfg_dir / 'config.json'
+    existing = json.loads(cfg.read_text()) if cfg.exists() else {}
+    existing.setdefault('retain', {}).update(
+        {
+            'min_capture_turns': 0,
+            'min_capture_chars': 0,
+        }
+    )
+    cfg.write_text(json.dumps(existing))
+
+
 @pytest.fixture
 def provider_with_stubbed_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv('HERMES_HOME', str(tmp_path))
     monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
     monkeypatch.setenv('MEMEX_VAULT', 'test-vault')
+    _write_test_config(tmp_path)
 
     fake_api = Mock()
     vault_uuid = uuid4()
@@ -347,6 +364,7 @@ def provider_with_append_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv('HERMES_HOME', str(tmp_path))
     monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
     monkeypatch.setenv('MEMEX_VAULT', 'test-vault')
+    _write_test_config(tmp_path)
 
     fake_api = Mock()
     vault_uuid = uuid4()
@@ -769,7 +787,14 @@ def test_vault_rebind_after_note_initialized_is_ignored(
 
     cfg_dir = tmp_path / 'memex'
     cfg_dir.mkdir(parents=True, exist_ok=True)
-    (cfg_dir / 'config.json').write_text(json.dumps({'briefing_refresh_cadence': 1}))
+    (cfg_dir / 'config.json').write_text(
+        json.dumps(
+            {
+                'briefing_refresh_cadence': 1,
+                'retain': {'min_capture_turns': 0, 'min_capture_chars': 0},
+            }
+        )
+    )
 
     fake_api = Mock()
     vault_a = uuid4()
@@ -865,7 +890,14 @@ def test_vault_rebind_with_pending_create_is_ignored(
 
     cfg_dir = tmp_path / 'memex'
     cfg_dir.mkdir(parents=True, exist_ok=True)
-    (cfg_dir / 'config.json').write_text(json.dumps({'briefing_refresh_cadence': 1}))
+    (cfg_dir / 'config.json').write_text(
+        json.dumps(
+            {
+                'briefing_refresh_cadence': 1,
+                'retain': {'min_capture_turns': 0, 'min_capture_chars': 0},
+            }
+        )
+    )
 
     fake_api = Mock()
     vault_a = uuid4()
@@ -919,7 +951,14 @@ def test_vault_rebind_toctou_reverify_under_lock(tmp_path: Path, monkeypatch: py
 
     cfg_dir = tmp_path / 'memex'
     cfg_dir.mkdir(parents=True, exist_ok=True)
-    (cfg_dir / 'config.json').write_text(json.dumps({'briefing_refresh_cadence': 1}))
+    (cfg_dir / 'config.json').write_text(
+        json.dumps(
+            {
+                'briefing_refresh_cadence': 1,
+                'retain': {'min_capture_turns': 0, 'min_capture_chars': 0},
+            }
+        )
+    )
 
     fake_api = Mock()
     vault_a = uuid4()
@@ -1024,7 +1063,14 @@ def test_vault_rebind_reresolves_on_cadence(tmp_path: Path, monkeypatch: pytest.
 
     cfg_dir = tmp_path / 'memex'
     cfg_dir.mkdir(parents=True, exist_ok=True)
-    (cfg_dir / 'config.json').write_text(json.dumps({'briefing_refresh_cadence': 2}))
+    (cfg_dir / 'config.json').write_text(
+        json.dumps(
+            {
+                'briefing_refresh_cadence': 2,
+                'retain': {'min_capture_turns': 0, 'min_capture_chars': 0},
+            }
+        )
+    )
 
     fake_api = Mock()
     vault_a = uuid4()
@@ -1119,14 +1165,15 @@ class TestSessionTitle:
         monkeypatch.setenv('MEMEX_SERVER_URL', 'http://test:8000')
         monkeypatch.setenv('MEMEX_VAULT', 'v')
 
+        retain: dict[str, Any] = {
+            'min_capture_turns': 0,
+            'min_capture_chars': 0,
+        }
         if template is not None:
-            import json
-
-            cfg_dir = tmp_path / 'memex'
-            cfg_dir.mkdir(parents=True, exist_ok=True)
-            (cfg_dir / 'config.json').write_text(
-                json.dumps({'retain': {'session_title_template': template}})
-            )
+            retain['session_title_template'] = template
+        cfg_dir = tmp_path / 'memex'
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        (cfg_dir / 'config.json').write_text(json.dumps({'retain': retain}))
 
         fake_api = Mock()
         note_uuid = uuid4()

--- a/packages/hermes-plugin/tests/test_transcript.py
+++ b/packages/hermes-plugin/tests/test_transcript.py
@@ -375,9 +375,9 @@ class TestPassesQualityGate:
 
     def test_custom_thresholds(self) -> None:
         turns = [{'user': 'x', 'assistant': 'y'}]
-        assert passes_quality_gate(turns, min_turns=1, min_content_chars=1) is True
-        assert passes_quality_gate(turns, min_turns=1, min_content_chars=100) is False
-        assert passes_quality_gate(turns, min_turns=2, min_content_chars=1) is False
+        assert passes_quality_gate(turns, min_turns=1, min_capture_chars=1) is True
+        assert passes_quality_gate(turns, min_turns=1, min_capture_chars=100) is False
+        assert passes_quality_gate(turns, min_turns=2, min_capture_chars=1) is False
 
     def test_placeholder_strings_not_counted(self) -> None:
         turns = [{'user': '[system prompt omitted]', 'assistant': '[HTML content removed]'}]
@@ -385,7 +385,7 @@ class TestPassesQualityGate:
 
     def test_zero_thresholds_pass_everything(self) -> None:
         turns = [{'user': '', 'assistant': 'x'}]
-        assert passes_quality_gate(turns, min_turns=0, min_content_chars=0) is True
+        assert passes_quality_gate(turns, min_turns=0, min_capture_chars=0) is True
 
 
 # ===================================================================

--- a/packages/hermes-plugin/tests/test_transcript.py
+++ b/packages/hermes-plugin/tests/test_transcript.py
@@ -154,6 +154,15 @@ class TestIsSystemMetadata:
         text = '  [Note: something happened]  '
         assert is_system_metadata(text) is True
 
+    def test_does_not_flag_multiline_content(self) -> None:
+        """Multi-line user content starting with [Note: must not false-positive."""
+        text = (
+            '[Note: here is my analysis\n'
+            'of the deployment pipeline.\n'
+            'It covers many topics and ends with a summary]'
+        )
+        assert is_system_metadata(text) is False
+
 
 # ===================================================================
 # C. sanitize_html_content
@@ -285,6 +294,38 @@ class TestPreprocessTurns:
         turns = [{'user': 'Make it', 'assistant': html}]
         result = preprocess_turns(turns, strip_html_content=False)
         assert result[0]['assistant'] == html
+
+    def test_strip_system_metadata_toggle_off(self) -> None:
+        turns = [
+            {
+                'user': '[Note: model was just switched from X to Y]',
+                'assistant': 'Hello!',
+            }
+        ]
+        result = preprocess_turns(turns, strip_system_metadata=False)
+        assert result[0]['user'] == '[Note: model was just switched from X to Y]'
+
+    def test_missing_role_defaults_to_user(self) -> None:
+        """Messages with no 'role' key should be treated as user turns."""
+        messages: list[dict[str, Any]] = [
+            {'content': 'orphaned text'},
+            {'role': 'assistant', 'content': 'response'},
+        ]
+        result = preprocess_turns(messages)
+        assert result[0]['user'] == 'orphaned text'
+        assert result[0]['assistant'] == 'response'
+
+    def test_pending_user_flushed_before_pair_dict(self) -> None:
+        """A pending {role:'user'} must be flushed before a {user,assistant} dict."""
+        messages: list[dict[str, Any]] = [
+            {'role': 'user', 'content': 'Q1'},
+            {'user': 'Q2', 'assistant': 'A2'},
+        ]
+        result = preprocess_turns(messages)
+        assert result[0]['user'] == 'Q1'
+        assert result[0]['assistant'] == ''
+        assert result[1]['user'] == 'Q2'
+        assert result[1]['assistant'] == 'A2'
 
     def test_empty_turns(self) -> None:
         assert preprocess_turns([]) == []

--- a/packages/hermes-plugin/tests/test_transcript.py
+++ b/packages/hermes-plugin/tests/test_transcript.py
@@ -1,0 +1,402 @@
+"""Tests for the transcript preprocessing pipeline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from memex_hermes_plugin.memex.transcript import (
+    format_transcript,
+    is_system_metadata,
+    is_system_prompt,
+    passes_quality_gate,
+    preprocess_turns,
+    sanitize_html_content,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — reusable prompt fragments
+# ---------------------------------------------------------------------------
+
+SKILL_REVIEW_PROMPT = (
+    'Review the conversation above and update the skill library. '
+    'Be ACTIVE — most sessions produce at least one skill update, even if small. '
+    'A pass that does nothing is a missed learning opportunity, not a neutral outcome.\n\n'
+    'Target shape of the library: CLASS-LEVEL skills, each with a rich SKILL.md '
+    'and a `references/` directory for session-specific detail. Not a long flat list '
+    'of narrow one-session-one-skill entries. This shapes HOW you update, not WHETHER '
+    'you update.\n\n'
+    'Signals to look for (any one of these warrants action):\n'
+    '  • User corrected your style, tone, format, legibility, or verbosity.\n'
+    '  • User corrected your workflow, approach, or sequence of steps.\n'
+    '  • Non-trivial technique, fix, workaround, debugging path emerged.\n'
+    '  • A skill that got loaded or consulted this session turned out to be wrong.\n\n'
+    "'Nothing to save.' is a real option but should NOT be the default. "
+    'If the session ran smoothly with no corrections and produced no new technique, '
+    "just say 'Nothing to save.' and stop. Otherwise, act.\n\n"
+    'You can only call memory and skill management tools. Other tools will be denied '
+    'at runtime — do not attempt them.'
+)
+
+MEMORY_REVIEW_PROMPT = (
+    'Review the conversation above and consider saving to memory if appropriate.\n\n'
+    'Focus on:\n'
+    '1. Has the user revealed things about themselves?\n'
+    '2. Has the user expressed expectations about how you should behave?\n\n'
+    "If nothing is worth saving, just say 'Nothing to save.' and stop.\n\n"
+    'You can only call memory and skill management tools. Other tools will be denied '
+    'at runtime — do not attempt them.'
+)
+
+
+# ===================================================================
+# A. is_system_prompt
+# ===================================================================
+
+
+class TestIsSystemPrompt:
+    def test_detects_skill_review_prompt(self) -> None:
+        assert is_system_prompt(SKILL_REVIEW_PROMPT) is True
+
+    def test_detects_memory_review_prompt(self) -> None:
+        assert is_system_prompt(MEMORY_REVIEW_PROMPT) is True
+
+    def test_detects_reworded_prompt(self) -> None:
+        """Minor rewording should still be detected (2+ anchors survive)."""
+        reworded = (
+            'Look at the conversation and refresh the skill library. '
+            'Be proactive — most conversations yield at least one improvement.\n\n'
+            'Signals to watch for:\n'
+            '  • Style corrections\n'
+            '  • Workflow corrections\n\n'
+            "'Nothing to save.' is fine if nothing changed.\n\n"
+            'You can only call memory and skill management tools. Other tools '
+            'will be denied at runtime — do not attempt them.'
+        )
+        assert is_system_prompt(reworded) is True
+
+    def test_detects_prompt_with_extra_paragraphs(self) -> None:
+        extended = SKILL_REVIEW_PROMPT + '\n\nAdditional paragraph about new guidelines.\n' * 5
+        assert is_system_prompt(extended) is True
+
+    def test_does_not_flag_organic_conversation(self) -> None:
+        organic = (
+            'Hey, I was thinking about the architecture of the retrieval pipeline. '
+            'Can you explain how the TEMPR strategies work together? I want to '
+            'understand the ranking fusion approach and how MMR diversity is applied. '
+            'Also, what happens when the circuit breaker trips during an LLM call? '
+            'Does the system fall back to keyword-only search?'
+        )
+        assert is_system_prompt(organic) is False
+
+    def test_does_not_flag_long_organic_text(self) -> None:
+        """Long organic text should not trigger even if it exceeds the length threshold."""
+        long_text = 'This is a detailed technical discussion. ' * 50
+        assert len(long_text) > 500
+        assert is_system_prompt(long_text) is False
+
+    def test_does_not_flag_short_text_with_one_anchor(self) -> None:
+        short = 'Nothing to save.'
+        assert is_system_prompt(short) is False
+
+    def test_empty_string(self) -> None:
+        assert is_system_prompt('') is False
+
+    def test_single_anchor_in_long_text(self) -> None:
+        """One anchor in a long text is not enough — needs >= 2."""
+        text = 'a ' * 150 + 'update the skill library' + ' a' * 50
+        assert len(text) > 200
+        assert is_system_prompt(text) is False
+
+    def test_two_anchors_in_long_text(self) -> None:
+        text = (
+            'a ' * 150
+            + 'update the skill library. '
+            + 'You can only call memory and skill management tools.'
+            + ' a' * 50
+        )
+        assert len(text) > 200
+        assert is_system_prompt(text) is True
+
+    def test_anchor_removal_still_detects(self) -> None:
+        """Removing one anchor from the real prompt should still detect (others remain)."""
+        modified = SKILL_REVIEW_PROMPT.replace("'Nothing to save.'", "'No updates needed.'")
+        assert is_system_prompt(modified) is True
+
+
+# ===================================================================
+# B. is_system_metadata
+# ===================================================================
+
+
+class TestIsSystemMetadata:
+    def test_detects_model_switch_note(self) -> None:
+        text = (
+            '[Note: model was just switched from gemma4:31b-cloud to glm-5.1 '
+            'via Ollama Cloud. Adjust your self-identification accordingly.]'
+        )
+        assert is_system_metadata(text) is True
+
+    def test_detects_system_prefix(self) -> None:
+        text = '[System: session resumed after network interruption]'
+        assert is_system_metadata(text) is True
+
+    def test_does_not_flag_footnotes(self) -> None:
+        assert is_system_metadata('[1]') is False
+        assert is_system_metadata('[citation needed]') is False
+
+    def test_does_not_flag_normal_brackets(self) -> None:
+        assert is_system_metadata('Use [this approach] for the fix') is False
+
+    def test_does_not_flag_empty(self) -> None:
+        assert is_system_metadata('') is False
+
+    def test_handles_leading_trailing_whitespace(self) -> None:
+        text = '  [Note: something happened]  '
+        assert is_system_metadata(text) is True
+
+
+# ===================================================================
+# C. sanitize_html_content
+# ===================================================================
+
+
+class TestSanitizeHtmlContent:
+    def test_replaces_full_html_page(self) -> None:
+        html = (
+            '<!DOCTYPE html>\n<html lang="en">\n<head>\n'
+            '<meta charset="UTF-8">\n<title>Test</title>\n'
+            '<style>body { color: white; background: #020617; }</style>\n</head>\n'
+            '<body>\n<div class="container">\n<h1>Title</h1>\n'
+            + '<p class="text">Content paragraph.</p>\n<div class="card"><span>Item</span></div>\n'
+            * 10
+            + '</div>\n</body>\n</html>'
+        )
+        assert sanitize_html_content(html) == '[HTML content removed]'
+
+    def test_replaces_llm_generated_html_without_doctype(self) -> None:
+        """LLM-generated HTML without <!DOCTYPE> but with dense tag patterns."""
+        html = (
+            '<div class="card" style="background: #020617;">\n'
+            '<span class="title">Architecture</span>\n'
+            '<div class="body"><p>Some content</p></div>\n'
+            '<style>.card { border: 1px solid; }</style>\n'
+            '</div>\n' * 5
+        )
+        assert len(html) > 500
+        assert sanitize_html_content(html) == '[HTML content removed]'
+
+    def test_does_not_flag_inline_formatting(self) -> None:
+        text = 'Use <b>bold</b> and <i>italic</i> for emphasis.'
+        assert sanitize_html_content(text) == text
+
+    def test_threshold_respected(self) -> None:
+        html = '<div>x</div>' * 10
+        assert sanitize_html_content(html, threshold=5000) == html
+        assert sanitize_html_content(html, threshold=10) == '[HTML content removed]'
+
+    def test_mixed_markdown_and_small_html(self) -> None:
+        text = '## Heading\n\nSome text with <code>inline</code> code.\n\n- Item 1\n- Item 2'
+        assert sanitize_html_content(text) == text
+
+    def test_placeholder_text(self) -> None:
+        html = '<html><body>' + '<div>x</div>' * 100 + '</body></html>'
+        result = sanitize_html_content(html)
+        assert result == '[HTML content removed]'
+
+    def test_empty_string(self) -> None:
+        assert sanitize_html_content('') == ''
+
+
+# ===================================================================
+# D. preprocess_turns
+# ===================================================================
+
+
+class TestPreprocessTurns:
+    def test_strips_system_prompt_keeps_assistant(self) -> None:
+        turns = [{'user': SKILL_REVIEW_PROMPT, 'assistant': 'Updated sorting-hat skill.'}]
+        result = preprocess_turns(turns)
+        assert result[0]['user'] == '[system prompt omitted]'
+        assert result[0]['assistant'] == 'Updated sorting-hat skill.'
+
+    def test_strips_system_metadata(self) -> None:
+        turns = [
+            {
+                'user': '[Note: model was just switched from X to Y]',
+                'assistant': 'Hello!',
+            }
+        ]
+        result = preprocess_turns(turns)
+        assert result[0]['user'] == ''
+        assert result[0]['assistant'] == 'Hello!'
+
+    def test_sanitizes_html_in_assistant(self) -> None:
+        html = (
+            '<html><head><style>body{}</style></head><body>'
+            + '<div>x</div>' * 100
+            + '</body></html>'
+        )
+        turns = [{'user': 'Make a diagram', 'assistant': html}]
+        result = preprocess_turns(turns)
+        assert result[0]['user'] == 'Make a diagram'
+        assert result[0]['assistant'] == '[HTML content removed]'
+
+    def test_normal_turns_unchanged(self) -> None:
+        turns = [
+            {'user': 'What is the weather?', 'assistant': 'It is sunny.'},
+            {'user': 'Thanks!', 'assistant': 'You are welcome.'},
+        ]
+        result = preprocess_turns(turns)
+        assert result == turns
+
+    def test_does_not_mutate_input(self) -> None:
+        original = [{'user': SKILL_REVIEW_PROMPT, 'assistant': 'Updated.'}]
+        original_copy = [dict(t) for t in original]
+        preprocess_turns(original)
+        assert original == original_copy
+
+    def test_handles_role_content_format(self) -> None:
+        messages = [
+            {'role': 'user', 'content': 'Hello'},
+            {'role': 'assistant', 'content': 'Hi there!'},
+        ]
+        result = preprocess_turns(messages)
+        assert result[0]['user'] == 'Hello'
+        assert result[0]['assistant'] == 'Hi there!'
+
+    def test_multiple_issues_in_session(self) -> None:
+        html = '<html><body>' + '<div class="x" style="y">z</div>' * 50 + '</body></html>'
+        turns = [
+            {'user': 'Make a diagram', 'assistant': html},
+            {'user': SKILL_REVIEW_PROMPT, 'assistant': 'Nothing to save.'},
+        ]
+        result = preprocess_turns(turns)
+        assert result[0]['assistant'] == '[HTML content removed]'
+        assert result[1]['user'] == '[system prompt omitted]'
+        assert result[1]['assistant'] == 'Nothing to save.'
+
+    def test_strip_system_prompts_toggle_off(self) -> None:
+        turns = [{'user': SKILL_REVIEW_PROMPT, 'assistant': 'Updated.'}]
+        result = preprocess_turns(turns, strip_system_prompts=False)
+        assert result[0]['user'] == SKILL_REVIEW_PROMPT
+
+    def test_strip_html_toggle_off(self) -> None:
+        html = '<html><body>' + '<div>x</div>' * 100 + '</body></html>'
+        turns = [{'user': 'Make it', 'assistant': html}]
+        result = preprocess_turns(turns, strip_html_content=False)
+        assert result[0]['assistant'] == html
+
+    def test_empty_turns(self) -> None:
+        assert preprocess_turns([]) == []
+
+
+# ===================================================================
+# E. passes_quality_gate
+# ===================================================================
+
+
+class TestPassesQualityGate:
+    def test_rejects_nothing_to_save(self) -> None:
+        turns = [{'user': '[system prompt omitted]', 'assistant': 'Nothing to save.'}]
+        assert passes_quality_gate(turns) is False
+
+    def test_accepts_substantive_response(self) -> None:
+        turns = [
+            {
+                'user': '[system prompt omitted]',
+                'assistant': (
+                    'Updated sorting-hat skill to add CLI commands for vault listing '
+                    'and note enumeration.'
+                ),
+            }
+        ]
+        assert passes_quality_gate(turns) is True
+
+    def test_rejects_trivial_greeting(self) -> None:
+        turns = [{'user': 'Hello', 'assistant': 'Hi!'}]
+        assert passes_quality_gate(turns) is False
+
+    def test_accepts_multi_turn_conversation(self) -> None:
+        turns = [
+            {
+                'user': 'How does vault routing work?',
+                'assistant': 'Vault routing uses a hierarchy of resolution...',
+            },
+            {
+                'user': 'Can you show me an example?',
+                'assistant': 'Sure, here is how you configure it...',
+            },
+        ]
+        assert passes_quality_gate(turns) is True
+
+    def test_rejects_empty_list(self) -> None:
+        assert passes_quality_gate([]) is False
+
+    def test_custom_thresholds(self) -> None:
+        turns = [{'user': 'x', 'assistant': 'y'}]
+        assert passes_quality_gate(turns, min_turns=1, min_content_chars=1) is True
+        assert passes_quality_gate(turns, min_turns=1, min_content_chars=100) is False
+        assert passes_quality_gate(turns, min_turns=2, min_content_chars=1) is False
+
+    def test_placeholder_strings_not_counted(self) -> None:
+        turns = [{'user': '[system prompt omitted]', 'assistant': '[HTML content removed]'}]
+        assert passes_quality_gate(turns) is False
+
+    def test_zero_thresholds_pass_everything(self) -> None:
+        turns = [{'user': '', 'assistant': 'x'}]
+        assert passes_quality_gate(turns, min_turns=0, min_content_chars=0) is True
+
+
+# ===================================================================
+# F. format_transcript
+# ===================================================================
+
+
+class TestFormatTranscript:
+    def test_basic_format(self) -> None:
+        turns = [{'user': 'Hello', 'assistant': 'Hi there!'}]
+        result = format_transcript(turns)
+        assert '### User\n\nHello' in result
+        assert '### Assistant\n\nHi there!' in result
+
+    def test_horizontal_rules_between_turns(self) -> None:
+        turns = [
+            {'user': 'First', 'assistant': 'Response 1'},
+            {'user': 'Second', 'assistant': 'Response 2'},
+        ]
+        result = format_transcript(turns)
+        assert '\n\n---\n\n' in result
+
+    def test_no_rule_for_single_turn(self) -> None:
+        turns = [{'user': 'Only', 'assistant': 'Turn'}]
+        result = format_transcript(turns)
+        assert '---' not in result
+
+    def test_handles_role_content_format(self) -> None:
+        messages = [
+            {'role': 'user', 'content': 'Query'},
+            {'role': 'assistant', 'content': 'Answer'},
+        ]
+        result = format_transcript(messages)
+        assert '### User\n\nQuery' in result
+        assert '### Assistant\n\nAnswer' in result
+
+    def test_skips_empty_content(self) -> None:
+        turns = [{'user': '', 'assistant': 'Only assistant spoke'}]
+        result = format_transcript(turns)
+        assert '### User' not in result
+        assert '### Assistant\n\nOnly assistant spoke' in result
+
+    def test_empty_turns(self) -> None:
+        assert format_transcript([]) == ''
+
+    def test_content_list_format(self) -> None:
+        messages: list[dict[str, Any]] = [
+            {
+                'role': 'user',
+                'content': [{'type': 'text', 'text': 'From a list'}],
+            },
+            {'role': 'assistant', 'content': 'Plain text'},
+        ]
+        result = format_transcript(messages)
+        assert 'From a list' in result


### PR DESCRIPTION
## Summary

- Adds a transcript preprocessing pipeline (`transcript.py`) that cleans, filters, and reformats Hermes session notes before Memex ingest
- Strips system-prompt boilerplate from cron sessions (skill-review / memory-review prompts) using anchor-phrase matching robust to prompt rewording
- Sanitizes HTML artifacts (both tagged HTML and LLM-generated HTML), strips system metadata injections (`[Note: ...]`), and gates on quality (min content chars / turns)
- Replaces flat `**Role:** text` formatting with structured `### Role` headers and `---` turn separators

## Context

Analysis of 45 recent Hermes session notes revealed that cron sessions were dominated by ~1500-word system-prompt boilerplate (80-90% of note content), causing the extraction pipeline to produce generic descriptions like "AI Skill Maintenance and Documentation Protocols". The assistant's actual useful output (e.g., "patched sorting-hat skill to add CLI commands") was buried. Additionally, HTML pages, system metadata, and trivial greeting sessions were captured without any filtering.

## Test plan

- [x] 49 new unit tests in `test_transcript.py` across 6 test classes
- [x] System-prompt detection tested with exact prompts, reworded prompts, extra paragraphs, and single-anchor-removed variants
- [x] All 44 existing `test_provider.py` tests pass (quality gate disabled in test config)
- [x] All 511 hermes-plugin unit tests pass
- [x] `just prek` clean (ruff + ruff-format + mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)