### PR TITLE
fix(hermes-plugin): wait on 409 overlap, exponential backoff, propagate cancellation (A.1/A.2/A.6)

### DIFF
--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -12,8 +12,10 @@ All async calls are marshalled onto the shared event loop in ``async_bridge``.
 
 from __future__ import annotations
 
+import asyncio
 import atexit
 import base64
+import concurrent.futures
 import logging
 import os
 import threading
@@ -51,7 +53,58 @@ _PENDING_MAX = 256
 # Non-transient HTTP statuses. The append/create will never succeed if
 # resent verbatim, so we drop the failing entry and continue draining the
 # rest of the queue. 5xx, 408, 429, and network errors are transient.
+#
+# Asymmetry on 409:
+# - 409 on CREATE is the server's overlap detector signalling an in-flight
+#   ingest of the same note_key. The note row WILL materialise once that
+#   job completes, so `_drain_pending` special-cases this branch and waits
+#   on `_wait_for_note_row` instead of dropping.
+# - 409 on APPEND has different semantics (note status / id conflict) and
+#   is final — drop and let the next append carry on. Append idempotency
+#   is keyed on `append_id`; re-POSTing the same body without a new id
+#   would only re-trigger the same 409.
 _NON_TRANSIENT_HTTP_STATUSES: frozenset[int] = frozenset({400, 404, 409, 410, 422})
+
+# Exceptions that must NEVER be silently swallowed by the drain loop:
+# - KeyboardInterrupt / SystemExit — shell-level cooperative shutdown.
+# - asyncio.CancelledError — direct asyncio cancellation (would surface
+#   here only if code is refactored to await directly).
+# - concurrent.futures.CancelledError — `run_sync` translates cancellation
+#   of the bridged asyncio Task into this on the calling thread (via
+#   `_chain_future` recognising the asyncio Task entered cancelled state).
+#   Importantly: concurrent.futures.CancelledError inherits from Exception
+#   (NOT BaseException), so a bare `except Exception` clause would absorb
+#   it and turn cooperative cancellation into "warn + retry on next flush"
+#   — exactly the swallow A.6 is meant to prevent.
+_PROPAGATE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    KeyboardInterrupt,
+    SystemExit,
+    asyncio.CancelledError,
+    concurrent.futures.CancelledError,
+)
+
+# Default deadline for _wait_for_note_row — sized for the p99 of
+# background ingest (LLM extraction) on resource-constrained hardware
+# (e.g. Jetson Orin Nano). The previous 10s deadline expired before
+# extraction completed on most session notes, which combined with the
+# overlap-409 drop produced the orphaned-session-note storm documented
+# in the 2026-05-29 tech report.
+_WAIT_FOR_NOTE_ROW_DEFAULT_TIMEOUT = 120.0
+
+# Exponential backoff schedule for _wait_for_note_row attempts (seconds
+# between attempts). After the schedule is exhausted, attempts space at
+# _WAIT_FOR_NOTE_ROW_BACKOFF_PLATEAU until the deadline. Keeps the early
+# cycles snappy (fast happy-path return) while bounding poll volume for
+# multi-minute extractions.
+_WAIT_FOR_NOTE_ROW_BACKOFF: tuple[float, ...] = (0.1, 0.2, 0.5, 1.0, 2.0, 5.0)
+_WAIT_FOR_NOTE_ROW_BACKOFF_PLATEAU = 10.0
+
+
+def _backoff_delay(attempt: int) -> float:
+    """Return the delay (seconds) to sleep before the next poll attempt."""
+    if attempt < len(_WAIT_FOR_NOTE_ROW_BACKOFF):
+        return _WAIT_FOR_NOTE_ROW_BACKOFF[attempt]
+    return _WAIT_FOR_NOTE_ROW_BACKOFF_PLATEAU
 
 
 def _resolve_hermes_home(kwargs: dict[str, Any]) -> Path:
@@ -755,11 +808,39 @@ class MemexMemoryProvider(MemoryProvider):
                             if self._pending and self._pending[0] is head:
                                 self._pending.pop(0)
                 except httpx.HTTPStatusError as e:
-                    if e.response.status_code in _NON_TRANSIENT_HTTP_STATUSES:
+                    code = e.response.status_code
+                    # A.1: 409 on create means the server's overlap detector
+                    # found an in-flight ingest for the same note_key (see
+                    # packages/core/.../processing/batch.py overlap probe).
+                    # The note row WILL materialise once the in-flight job
+                    # finishes — wait for it rather than dropping the head
+                    # (which would orphan the session note and break every
+                    # subsequent append). The Location header on 409 points
+                    # to the job; we poll the note row instead (deterministic
+                    # id from note_key) since that's the materialisation
+                    # signal we actually need.
+                    if head['kind'] == 'create' and code == 409:
+                        logger.info(
+                            'Session note create returned 409 (overlap); '
+                            'waiting for in-flight job at %s',
+                            e.response.headers.get('Location', '<unknown>'),
+                        )
+                        if self._wait_for_note_row():
+                            with self._state_lock:
+                                self._note_initialized = True
+                                if self._pending and self._pending[0] is head:
+                                    self._pending.pop(0)
+                            continue
+                        logger.warning(
+                            'Session note create overlap did not resolve '
+                            'before deadline; will retry on next flush.',
+                        )
+                        return
+                    if code in _NON_TRANSIENT_HTTP_STATUSES:
                         logger.error(
                             'Session note %s rejected (HTTP %d); dropping entry: %s',
                             head['kind'],
-                            e.response.status_code,
+                            code,
                             e,
                         )
                         with self._state_lock:
@@ -769,10 +850,13 @@ class MemexMemoryProvider(MemoryProvider):
                     logger.warning(
                         'Session note %s transient error (HTTP %d); will retry: %s',
                         head['kind'],
-                        e.response.status_code,
+                        code,
                         e,
                     )
                     return
+                except _PROPAGATE_EXCEPTIONS:
+                    # A.6: see _PROPAGATE_EXCEPTIONS docstring for rationale.
+                    raise
                 except Exception as e:
                     logger.warning(
                         'Session note %s failed; will retry on next flush: %s',
@@ -806,7 +890,7 @@ class MemexMemoryProvider(MemoryProvider):
         )
         run_sync(self._api.ingest(dto, background=True), timeout=30.0)
 
-    def _wait_for_note_row(self, *, timeout: float = 10.0) -> bool:
+    def _wait_for_note_row(self, *, timeout: float = _WAIT_FOR_NOTE_ROW_DEFAULT_TIMEOUT) -> bool:
         """Poll for the session note row to appear server-side.
 
         Returns True if the row is visible, False on timeout. The id is
@@ -820,25 +904,40 @@ class MemexMemoryProvider(MemoryProvider):
           won't change the outcome.
         - Everything else (5xx, 408, 429, network errors) is transient —
           retry within the deadline.
+
+        A.2: exponential backoff between attempts (`_backoff_delay`). The
+        previous flat 0.1s sleep produced 100 polls per 10s window, which
+        was both too aggressive (burning CPU on tight loops) and too short
+        (LLM extraction p99 well above 10s on resource-constrained hosts).
+        New default timeout is 120s; backoff plateaus at 10s/attempt for
+        the long tail.
         """
         if self._api is None:
             return False
         note_id = derive_note_uuid_from_key(self._session_note_key)
         deadline = time.monotonic() + timeout
+        attempt = 0
         while time.monotonic() < deadline:
             try:
                 run_sync(self._api.get_note(note_id), timeout=1.0)
                 return True
             except httpx.HTTPStatusError as e:
                 code = e.response.status_code
-                if code == 404:
-                    time.sleep(0.1)
-                    continue
-                if code in _NON_TRANSIENT_HTTP_STATUSES:
+                if code in _NON_TRANSIENT_HTTP_STATUSES and code != 404:
                     return False
-                time.sleep(0.1)  # transient
+                # 404 = not yet visible; other codes (5xx, 408, 429, etc.)
+                # = transient — both fall through to backoff.
+            except _PROPAGATE_EXCEPTIONS:
+                # A.6: cancellation/shutdown — propagate, don't retry.
+                raise
             except Exception:
-                time.sleep(0.1)
+                pass  # transient — back off and retry
+            # Bound the sleep so we don't overrun the deadline.
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(_backoff_delay(attempt), remaining))
+            attempt += 1
         return False
 
     def _do_append(self, content: str, *, append_id: UUID, vault_id: str | None) -> None:

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -770,6 +770,15 @@ class MemexMemoryProvider(MemoryProvider):
         place for retry; non-transient failures (4xx HTTP statuses)
         drop the failing entry so a poisoned item can't block the rest of
         the queue.
+
+        Latency profile (A.2 trade-off): the 409-on-create branch waits
+        up to ``_WAIT_FOR_NOTE_ROW_DEFAULT_TIMEOUT`` (120s) for the
+        in-flight ingest to materialise. Callers on latency-sensitive
+        paths (UI threads, outer timeouts) should be aware that
+        ``on_pre_compress`` / ``on_session_end`` / ``shutdown`` can
+        therefore block for up to 2 minutes when the overlap branch
+        fires. The previous 10s ceiling was the root cause of the
+        404+409 storm — see tech report Bug A for the trade-off.
         """
         if self._api is None or self._config is None:
             return

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -930,8 +930,13 @@ class MemexMemoryProvider(MemoryProvider):
             except _PROPAGATE_EXCEPTIONS:
                 # A.6: cancellation/shutdown — propagate, don't retry.
                 raise
-            except Exception:
-                pass  # transient — back off and retry
+            except Exception as poll_exc:
+                # Treat as transient and back off. Log at DEBUG so a hidden
+                # programming error (e.g. AttributeError from a refactor of
+                # the API client) is visible to ops who flip the level —
+                # the previous bare-pass made these invisible for the
+                # full 120s poll window.
+                logger.debug('Note-row poll attempt %d failed: %s', attempt, poll_exc)
             # Bound the sleep so we don't overrun the deadline.
             remaining = deadline - time.monotonic()
             if remaining <= 0:

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -897,6 +897,11 @@ def test_create_409_waits_for_note_row_and_pops_on_success(provider_with_append_
     # get_note (already AsyncMock returning SimpleNamespace) resolves the wait.
 
     provider.sync_turn('q', 'a')
+    # Defensive: confirm the flip happens via the 409→wait path, not from
+    # leaked fixture state. Fixtures are function-scoped so this should be
+    # impossible today, but a future refactor that shares state across
+    # tests would silently turn this assertion into a no-op.
+    assert provider._note_initialized is False
     provider.on_pre_compress([])
 
     # Head popped, _note_initialized flipped, no orphaned create stays queued.

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -871,6 +871,197 @@ def test_wait_for_note_row_bails_on_definitive_4xx(provider_with_append_api):
     assert api.get_note.await_count == 1
 
 
+# ---- A.1: 409-on-create overlap path --------------------------------------
+
+
+def test_create_409_waits_for_note_row_and_pops_on_success(provider_with_append_api):
+    """A.1: 409 on create means an in-flight ingest of the same note_key is
+    already running on the server (overlap detector). The note row will
+    materialise once that job finishes — wait for it rather than dropping
+    the head and orphaning every subsequent append.
+    """
+    import httpx
+
+    provider, api, _ = provider_with_append_api
+
+    # First ingest raises 409 + Location, second poll resolves.
+    fake_409 = httpx.Response(
+        status_code=409,
+        text='overlap',
+        headers={'Location': '/api/v1/ingestions/in-flight-id'},
+    )
+    fake_409._request = httpx.Request('POST', 'http://test/ingest')
+    overlap = httpx.HTTPStatusError('409', request=fake_409._request, response=fake_409)
+    api.ingest = AsyncMock(side_effect=overlap)
+    provider._api.ingest = api.ingest
+    # get_note (already AsyncMock returning SimpleNamespace) resolves the wait.
+
+    provider.sync_turn('q', 'a')
+    provider.on_pre_compress([])
+
+    # Head popped, _note_initialized flipped, no orphaned create stays queued.
+    assert provider._pending == []
+    assert provider._note_initialized is True
+    api.get_note.assert_awaited()
+
+
+def test_create_409_keeps_head_queued_if_wait_times_out(provider_with_append_api):
+    """A.1: if the in-flight ingest never materialises before the
+    _wait_for_note_row deadline, leave the head in the queue. The next
+    flush will retry — the alternative (dropping silently) is exactly the
+    bug that caused the orphaned-session-note storm.
+    """
+    import httpx
+
+    provider, api, _ = provider_with_append_api
+
+    fake_409 = httpx.Response(
+        status_code=409,
+        text='overlap',
+        headers={'Location': '/api/v1/ingestions/in-flight-id'},
+    )
+    fake_409._request = httpx.Request('POST', 'http://test/ingest')
+    overlap = httpx.HTTPStatusError('409', request=fake_409._request, response=fake_409)
+    api.ingest = AsyncMock(side_effect=overlap)
+    provider._api.ingest = api.ingest
+
+    # Force the wait to fail — make every get_note raise a non-transient 400
+    # so the wait bails immediately rather than burning the default 120s.
+    fake_400 = httpx.Response(status_code=400, text='nope')
+    fake_400._request = httpx.Request('GET', 'http://test/notes/x')
+    fail = httpx.HTTPStatusError('400', request=fake_400._request, response=fake_400)
+    api.get_note = AsyncMock(side_effect=fail)
+    provider._api.get_note = api.get_note
+
+    provider.sync_turn('q', 'a')
+    provider.on_pre_compress([])
+
+    # Head MUST stay; _note_initialized must NOT flip.
+    assert len(provider._pending) == 1
+    assert provider._pending[0]['kind'] == 'create'
+    assert provider._note_initialized is False
+
+
+def test_append_409_still_drops(provider_with_append_api):
+    """A.1's special-case is scoped to create. A 409 on append is still
+    non-transient (an append should be idempotent on append_id; if the
+    server rejects with 409 it won't accept a literal replay), so the
+    drop-and-continue path is preserved.
+    """
+    import httpx
+
+    provider, api, _ = provider_with_append_api
+
+    # First flush succeeds (create).
+    provider.sync_turn('q1', 'a1')
+    provider.on_pre_compress([])
+    api.ingest.assert_awaited_once()
+
+    # Next append: 409.
+    fake_409 = httpx.Response(status_code=409, text='append conflict')
+    fake_409._request = httpx.Request('POST', 'http://test/append')
+    conflict = httpx.HTTPStatusError('409', request=fake_409._request, response=fake_409)
+    api.append_to_note = AsyncMock(side_effect=conflict)
+    provider._api.append_to_note = api.append_to_note
+
+    provider.sync_turn('q2', 'a2')
+    provider.on_pre_compress([])
+
+    # Append entry dropped (current contract — not the 409-create special case).
+    assert provider._pending == []
+
+
+# ---- A.2: exponential backoff in _wait_for_note_row -----------------------
+
+
+def test_wait_for_note_row_uses_exponential_backoff(provider_with_append_api):
+    """A.2: poll attempts space out per the backoff schedule (0.1, 0.2, 0.5,
+    1.0, 2.0, 5.0) and then plateau at 10s. Previously a flat 0.1s sleep
+    burned CPU + bounded the wait to 10s of attempts; new schedule keeps
+    the early cycles snappy while bounding poll volume for multi-minute
+    background extractions.
+    """
+    import httpx
+
+    provider, api, _ = provider_with_append_api
+
+    fake_503 = httpx.Response(status_code=503, text='busy')
+    fake_503._request = httpx.Request('GET', 'http://test/notes/x')
+    transient = httpx.HTTPStatusError('503', request=fake_503._request, response=fake_503)
+    # Five transients then success — exercise the first five backoff steps.
+    api.get_note = AsyncMock(
+        side_effect=[transient, transient, transient, transient, transient, Mock()]
+    )
+    provider._api.get_note = api.get_note
+
+    sleeps: list[float] = []
+    with patch(
+        'memex_hermes_plugin.memex.provider.time.sleep',
+        side_effect=lambda s: sleeps.append(s),
+    ):
+        assert provider._wait_for_note_row(timeout=60.0) is True
+
+    # Schedule: 0.1, 0.2, 0.5, 1.0, 2.0 — verify the prefix.
+    assert sleeps[:5] == [0.1, 0.2, 0.5, 1.0, 2.0]
+
+
+def test_backoff_delay_plateaus_after_schedule():
+    """_backoff_delay returns the schedule values then plateaus."""
+    from memex_hermes_plugin.memex.provider import (
+        _WAIT_FOR_NOTE_ROW_BACKOFF,
+        _WAIT_FOR_NOTE_ROW_BACKOFF_PLATEAU,
+        _backoff_delay,
+    )
+
+    for i, expected in enumerate(_WAIT_FOR_NOTE_ROW_BACKOFF):
+        assert _backoff_delay(i) == expected
+    # Past the schedule end, return plateau.
+    assert _backoff_delay(len(_WAIT_FOR_NOTE_ROW_BACKOFF)) == _WAIT_FOR_NOTE_ROW_BACKOFF_PLATEAU
+    assert _backoff_delay(len(_WAIT_FOR_NOTE_ROW_BACKOFF) + 100) == (
+        _WAIT_FOR_NOTE_ROW_BACKOFF_PLATEAU
+    )
+
+
+def test_wait_for_note_row_default_timeout_is_extended():
+    """A.2: the default _wait_for_note_row deadline must comfortably exceed
+    LLM-extraction p99 on the target hardware (Jetson Orin Nano, ~60s).
+    """
+    from memex_hermes_plugin.memex.provider import _WAIT_FOR_NOTE_ROW_DEFAULT_TIMEOUT
+
+    assert _WAIT_FOR_NOTE_ROW_DEFAULT_TIMEOUT >= 60.0
+
+
+# ---- A.6: CancelledError propagates ---------------------------------------
+
+
+def test_drain_pending_propagates_cancelled_error(provider_with_append_api):
+    """A.6: cooperative cancellation must not be swallowed.
+
+    Gotcha: `run_sync` uses `asyncio.run_coroutine_threadsafe`, which
+    translates `asyncio.CancelledError` raised inside the bridged
+    coroutine into `concurrent.futures.CancelledError` on the calling
+    thread (via `_chain_future` recognising the asyncio Task entered the
+    cancelled state). `concurrent.futures.CancelledError` inherits from
+    `Exception`, so the bare `except Exception` clause would swallow it
+    without the explicit re-raise added by A.6.
+    """
+    import asyncio
+    import concurrent.futures
+
+    provider, api, _ = provider_with_append_api
+    api.ingest = AsyncMock(side_effect=asyncio.CancelledError())
+    provider._api.ingest = api.ingest
+
+    provider.sync_turn('q', 'a')
+    # run_sync surfaces concurrent.futures.CancelledError on the caller
+    # thread, which is what _drain_pending must propagate.
+    with pytest.raises(concurrent.futures.CancelledError):
+        provider.on_pre_compress([])
+    # Head still queued; future flush can retry once cancellation is handled.
+    assert len(provider._pending) == 1
+    assert provider._pending[0]['kind'] == 'create'
+
+
 def test_vault_rebind_with_pending_create_is_ignored(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -1053,9 +1053,14 @@ def test_drain_pending_propagates_cancelled_error(provider_with_append_api):
     provider._api.ingest = api.ingest
 
     provider.sync_turn('q', 'a')
-    # run_sync surfaces concurrent.futures.CancelledError on the caller
-    # thread, which is what _drain_pending must propagate.
-    with pytest.raises(concurrent.futures.CancelledError):
+    # Empirically run_sync surfaces concurrent.futures.CancelledError on the
+    # caller thread (verified via a standalone repro: an asyncio Task whose
+    # coroutine raises CancelledError enters the cancelled state, and
+    # `_chain_future` translates that into concurrent.Future cancellation,
+    # whose .result() raises concurrent.futures.CancelledError). The tuple
+    # below admits the asyncio variant too — defensive against future
+    # Python changes that unify the two classes, at zero cost.
+    with pytest.raises((concurrent.futures.CancelledError, asyncio.CancelledError)):
         provider.on_pre_compress([])
     # Head still queued; future flush can retry once cancellation is handled.
     assert len(provider._pending) == 1


### PR DESCRIPTION
## Summary

Implements Bug A items A.1, A.2, A.6 from the [Memex error storm tech report](https://github.com/JasperHG90/memex) (saved note id `8e9dea4a-080d-3fd0-e243-a1d68b2d6138`). With PR #186 already merged (A.3 + A.4 server log demotion), this is the second piece of the remediation slate.

## What broke

Hermes plugin POSTs `/api/v1/ingestions?background=true`, gets 202, then polls `get_note(derive_note_uuid_from_key(key))` at 10 Hz for 10s. LLM extraction on resource-constrained hosts routinely takes > 10s. When the readback times out, the plugin returns False without popping the head; the next flush re-POSTs the same payload; the server's overlap detector returns `HTTP 409 + Location: /api/v1/ingestions/<existing_id>`; the plugin's `_NON_TRANSIENT_HTTP_STATUSES` includes 409 → drops the entry → `_note_initialized` never flips → every subsequent append orphans.

## What changes

### A.1 — overlap-aware 409 handling for create
`_drain_pending` special-cases `head['kind']=='create' AND status==409`: calls `_wait_for_note_row` with the extended deadline and pops only on success. 409 on append still drops (different conflict semantics).

### A.2 — exponential backoff + extended deadline
`_wait_for_note_row` default timeout 10s → 120s. Flat 0.1s sleep → schedule `(0.1, 0.2, 0.5, 1.0, 2.0, 5.0)` then plateau at 10s/attempt. Module helper `_backoff_delay(attempt)` plus constants make the schedule tunable in one place.

### A.6 — propagate cancellation through the drain loop
Both `_drain_pending` and `_wait_for_note_row` now catch a single `_PROPAGATE_EXCEPTIONS` tuple (`KeyboardInterrupt`, `SystemExit`, `asyncio.CancelledError`, `concurrent.futures.CancelledError`) and re-raise before the generic `except Exception`. **The concurrent.futures one is load-bearing**: `run_sync` (via `asyncio.run_coroutine_threadsafe` + `_chain_future`) translates cancellation of the bridged asyncio task into `concurrent.futures.CancelledError` on the calling thread, and that class inherits from `Exception` (NOT `BaseException`). The bare `except Exception` would otherwise turn cooperative cancellation into a generic "failed; retry on next flush" log.

## Tests (7 new)

| Test | Verifies |
|---|---|
| `test_create_409_waits_for_note_row_and_pops_on_success` | A.1 happy path |
| `test_create_409_keeps_head_queued_if_wait_times_out` | A.1 head stays on timeout (no orphan) |
| `test_append_409_still_drops` | A.1 scope — append unchanged |
| `test_wait_for_note_row_uses_exponential_backoff` | A.2 sleep sequence prefix matches schedule |
| `test_backoff_delay_plateaus_after_schedule` | A.2 plateau behavior |
| `test_wait_for_note_row_default_timeout_is_extended` | A.2 default ≥ 60s |
| `test_drain_pending_propagates_cancelled_error` | A.6 concurrent.futures.CancelledError surfaces |

All 51 provider tests pass.

## Test plan

- [x] Targeted: `uv run pytest packages/hermes-plugin/tests/test_provider.py` — 51 pass
- [x] Broader: `uv run pytest packages/hermes-plugin/tests/ --ignore=integration` — only pre-existing `test_kv_namespace_parity::test_project_procedure_pattern_documented` fails (unrelated, confirmed via `git stash` reproduction)
- [x] Linting: ruff + ruff-format clean
- [x] Pre-commit hooks (ruff, mypy, ruff-format, AST checks) all pass

## Refs

- Tech report note `8e9dea4a-080d-3fd0-e243-a1d68b2d6138`, Bug A items A.1, A.2, A.6
- Landing-order step 2 (post-PR #186, before B.1/B.2/A.5/B.3/B.4/C.1)
- Follow-up (out of scope): a future PR could poll the in-flight job's status via the `Location` header to detect failed extractions faster than waiting the full 120s for a row that won't materialise

🤖 Generated with [Claude Code](https://claude.com/claude-code)