### PR TITLE
fix(core): align trgm seed-entity queries to functional lower() GIN index (B.1)

### DIFF
--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -63,6 +63,18 @@ def _warn_mental_model_filters_skipped(intent_class: str | None, risk_class: str
 _MAX_DECAY_EXPONENT = -996
 
 
+def _escape_like_pattern(s: str) -> str:
+    """Escape `%`, `_`, and `\\` so `s` matches as a literal in ILIKE.
+
+    NER outputs are nominally proper nouns, but the query-side fallback
+    accepts raw user input. Without this, an input like `Al_ce` would
+    match `Alice` (`_` = "any single char"); `%` would widen the match
+    arbitrarily. Pair with `ilike(pattern, escape='\\\\')` at the call site
+    so the backslash itself is treated literally.
+    """
+    return s.replace('\\', '\\\\').replace('%', r'\%').replace('_', r'\_')
+
+
 def apply_date_filters(statement: Select, date_column: Any, **kwargs: Any) -> Select:
     """Applies start_date and end_date filters to a SQLAlchemy statement."""
     start_date = kwargs.get('start_date')
@@ -372,7 +384,10 @@ def _build_ner_seeds(
         if include_ilike:
             for name in extracted_names:
                 lowered = name.lower()
-                conds_canonical.append(func.lower(col(Entity.canonical_name)).ilike(f'%{lowered}%'))
+                escaped = _escape_like_pattern(lowered)
+                conds_canonical.append(
+                    func.lower(col(Entity.canonical_name)).ilike(f'%{escaped}%', escape='\\')
+                )
                 conds_canonical.append(
                     func.similarity(func.lower(col(Entity.canonical_name)), lowered)
                     > similarity_threshold
@@ -386,7 +401,10 @@ def _build_ner_seeds(
         if include_ilike:
             for name in extracted_names:
                 lowered = name.lower()
-                conds_alias.append(func.lower(col(EntityAlias.name)).ilike(f'%{lowered}%'))
+                escaped = _escape_like_pattern(lowered)
+                conds_alias.append(
+                    func.lower(col(EntityAlias.name)).ilike(f'%{escaped}%', escape='\\')
+                )
                 conds_alias.append(
                     func.similarity(func.lower(col(EntityAlias.name)), lowered)
                     > similarity_threshold
@@ -395,18 +413,20 @@ def _build_ner_seeds(
         seed_from_alias = select(col(EntityAlias.canonical_id).label('id')).where(or_(*conds_alias))
     else:
         logger.info('No entities found by NER. Using fallback similarity search.')
-        # Same B.1 fix on the no-NER fallback path.
+        # Same B.1 fix on the no-NER fallback path. Escape LIKE wildcards
+        # because `query` is user-supplied free text.
         query_lower = query.lower()
+        query_escaped = _escape_like_pattern(query_lower)
         seed_from_canonical = select(col(Entity.id).label('id')).where(
             or_(
-                func.lower(col(Entity.canonical_name)).ilike(f'%{query_lower}%'),
+                func.lower(col(Entity.canonical_name)).ilike(f'%{query_escaped}%', escape='\\'),
                 func.similarity(func.lower(col(Entity.canonical_name)), query_lower)
                 > similarity_threshold,
             )
         )
         seed_from_alias = select(col(EntityAlias.canonical_id).label('id')).where(
             or_(
-                func.lower(col(EntityAlias.name)).ilike(f'%{query_lower}%'),
+                func.lower(col(EntityAlias.name)).ilike(f'%{query_escaped}%', escape='\\'),
                 func.similarity(func.lower(col(EntityAlias.name)), query_lower)
                 > similarity_threshold,
             )

--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -357,14 +357,25 @@ def _build_ner_seeds(
     if extracted_names:
         logger.info(f'NER found entities: {extracted_names}')
 
+        # B.1: align trgm-fuzzy queries to the existing functional GIN-trgm
+        # indexes on `lower(canonical_name)` and `lower(name)` (see
+        # sql_models.py:_GIN_TRGM_CANONICAL_NAME / _GIN_TRGM_ALIAS_NAME).
+        # Without the `func.lower()` wrapper Postgres cannot match the query
+        # expression to the indexed expression and falls back to a seqscan
+        # over `entities` + `entity_aliases` per NER token — the root cause
+        # of the ~18s `statement_timeout` documented in the 2026-05-29 tech
+        # report. RHS is lowered once at the Python level so the planner
+        # doesn't have to call lower() per row.
         conds_canonical: list[Any] = [col(Entity.canonical_name).in_(extracted_names)]
         if extracted_phonetics:
             conds_canonical.append(col(Entity.phonetic_code).in_(extracted_phonetics))
         if include_ilike:
             for name in extracted_names:
-                conds_canonical.append(col(Entity.canonical_name).ilike(f'%{name}%'))
+                lowered = name.lower()
+                conds_canonical.append(func.lower(col(Entity.canonical_name)).ilike(f'%{lowered}%'))
                 conds_canonical.append(
-                    func.similarity(col(Entity.canonical_name), name) > similarity_threshold
+                    func.similarity(func.lower(col(Entity.canonical_name)), lowered)
+                    > similarity_threshold
                 )
 
         seed_from_canonical = select(col(Entity.id).label('id')).where(or_(*conds_canonical))
@@ -374,24 +385,30 @@ def _build_ner_seeds(
             conds_alias.append(col(EntityAlias.phonetic_code).in_(extracted_phonetics))
         if include_ilike:
             for name in extracted_names:
-                conds_alias.append(col(EntityAlias.name).ilike(f'%{name}%'))
+                lowered = name.lower()
+                conds_alias.append(func.lower(col(EntityAlias.name)).ilike(f'%{lowered}%'))
                 conds_alias.append(
-                    func.similarity(col(EntityAlias.name), name) > similarity_threshold
+                    func.similarity(func.lower(col(EntityAlias.name)), lowered)
+                    > similarity_threshold
                 )
 
         seed_from_alias = select(col(EntityAlias.canonical_id).label('id')).where(or_(*conds_alias))
     else:
         logger.info('No entities found by NER. Using fallback similarity search.')
+        # Same B.1 fix on the no-NER fallback path.
+        query_lower = query.lower()
         seed_from_canonical = select(col(Entity.id).label('id')).where(
             or_(
-                col(Entity.canonical_name).ilike(f'%{query}%'),
-                func.similarity(col(Entity.canonical_name), query) > similarity_threshold,
+                func.lower(col(Entity.canonical_name)).ilike(f'%{query_lower}%'),
+                func.similarity(func.lower(col(Entity.canonical_name)), query_lower)
+                > similarity_threshold,
             )
         )
         seed_from_alias = select(col(EntityAlias.canonical_id).label('id')).where(
             or_(
-                col(EntityAlias.name).ilike(f'%{query}%'),
-                func.similarity(col(EntityAlias.name), query) > similarity_threshold,
+                func.lower(col(EntityAlias.name)).ilike(f'%{query_lower}%'),
+                func.similarity(func.lower(col(EntityAlias.name)), query_lower)
+                > similarity_threshold,
             )
         )
 

--- a/packages/core/tests/unit/memory/retrieval/test_graph_factory.py
+++ b/packages/core/tests/unit/memory/retrieval/test_graph_factory.py
@@ -141,6 +141,71 @@ class TestBuildSeedEntityCte:
         sql = str(cte.compile())
         assert 'similarity' in sql or 'LIKE' in sql
 
+    def test_trgm_queries_wrap_columns_in_lower(self) -> None:
+        """B.1 regression: trgm-fuzzy queries (`ilike` + `similarity`) must
+        wrap the indexed columns in `lower(...)` to match the functional GIN
+        indexes (`gin (lower(canonical_name) gin_trgm_ops)` on entities,
+        `gin (lower(name) gin_trgm_ops)` on entity_aliases). Without the
+        wrapper Postgres can't use the index and falls back to a seq scan
+        per NER token — the ~18s statement_timeout from the 2026-05-29
+        tech report.
+        """
+
+        # NER path
+        class MockNER:
+            def predict(self, text: str) -> list[dict[str, str]]:
+                return [{'word': 'Alice'}]
+
+        cte = build_seed_entity_cte(
+            'Tell me about Alice',
+            ner_model=MockNER(),  # type: ignore[arg-type]
+            include_ilike=True,
+        )
+        sql = str(cte.compile())
+        assert 'lower(entities.canonical_name)' in sql, (
+            f'Expected `lower(entities.canonical_name)` in NER-path SQL, got: {sql}'
+        )
+        assert 'lower(entity_aliases.name)' in sql, (
+            f'Expected `lower(entity_aliases.name)` in NER-path SQL, got: {sql}'
+        )
+
+    def test_fallback_path_also_wraps_columns_in_lower(self) -> None:
+        """Same B.1 wrap on the no-NER fallback. Without the wrapper the
+        fallback similarity search misses the GIN-trgm index too.
+        """
+        cte = build_seed_entity_cte('chimera', ner_model=None)
+        sql = str(cte.compile())
+        assert 'lower(entities.canonical_name)' in sql
+        assert 'lower(entity_aliases.name)' in sql
+
+    def test_trgm_rhs_lowered_at_python_level(self) -> None:
+        """The parameter side of similarity / ilike is pre-lowered in
+        Python (passed to SQLAlchemy as the bound value), not via SQL's
+        `lower()` on the param — that would force Postgres to call lower()
+        once per row pair, defeating the index alignment.
+        """
+
+        class MockNER:
+            def predict(self, text: str) -> list[dict[str, str]]:
+                # Title-Case so we can tell pre-lowering from post-lowering.
+                return [{'word': 'AliceWonder'}]
+
+        cte = build_seed_entity_cte(
+            'q',
+            ner_model=MockNER(),  # type: ignore[arg-type]
+            include_ilike=True,
+        )
+        params = cte.compile().params
+        # Bound parameters should be lowercase; no Title-Case leaks through.
+        bound_values = [v for v in params.values() if isinstance(v, str)]
+        for v in bound_values:
+            if 'alicewonder' in v.lower():
+                # Either the bare lowercase or the %lower% pattern, never the
+                # original Title-Case spelling.
+                assert 'AliceWonder' not in v, (
+                    f'Bound parameter still contains Title-Case spelling: {v!r}'
+                )
+
 
 # ---------------------------------------------------------------------------
 # Default behavior unchanged

--- a/packages/core/tests/unit/memory/retrieval/test_graph_factory.py
+++ b/packages/core/tests/unit/memory/retrieval/test_graph_factory.py
@@ -178,6 +178,32 @@ class TestBuildSeedEntityCte:
         assert 'lower(entities.canonical_name)' in sql
         assert 'lower(entity_aliases.name)' in sql
 
+    def test_like_wildcards_in_input_are_escaped(self) -> None:
+        """Wildcard chars in NER / query inputs must not widen the match.
+        `Al_ce` should be treated literally, not as `Al<any-char>ce`.
+        """
+        from memex_core.memory.retrieval.strategies import _escape_like_pattern
+
+        assert _escape_like_pattern('Al_ce') == 'Al\\_ce'
+        assert _escape_like_pattern('100%') == '100\\%'
+        assert _escape_like_pattern('a\\b') == 'a\\\\b'
+        assert _escape_like_pattern('clean') == 'clean'
+
+        # End-to-end: compiled SQL params contain the escaped form.
+        class MockNER:
+            def predict(self, text: str) -> list[dict[str, str]]:
+                return [{'word': 'Al_ce'}]
+
+        cte = build_seed_entity_cte(
+            'find Al_ce',
+            ner_model=MockNER(),  # type: ignore[arg-type]
+            include_ilike=True,
+        )
+        params = cte.compile().params
+        assert any('al\\_ce' in v for v in params.values() if isinstance(v, str)), (
+            f'Expected escaped al\\_ce in params: {params}'
+        )
+
     def test_trgm_rhs_lowered_at_python_level(self) -> None:
         """The parameter side of similarity / ilike is pre-lowered in
         Python (passed to SQLAlchemy as the bound value), not via SQL's


### PR DESCRIPTION
Bug B item B.1 from tech report 8e9dea4a. Wraps trgm-fuzzy queries in func.lower() to match the functional GIN-trgm indexes on entities + entity_aliases. Expected impact: search latency from ~18s to sub-second. Tests assert lower() appears in compiled SQL on NER and fallback paths, and bound params are pre-lowered. 29/29 graph_factory tests pass; 1477 pass in broader memory suite (1 pre-existing failure unrelated). 🤖 Generated with [Claude Code](https://claude.com/claude-code)