### PR TITLE
feat(core,cli): inbox router — per-vault note triage

### DIFF
--- a/docs/explanation/inbox-router.md
+++ b/docs/explanation/inbox-router.md
@@ -1,0 +1,114 @@
+# How the inbox router works
+
+The inbox router solves a small but nagging problem: you have something worth
+keeping but you don't want to decide *where* it goes right now. You drop it in
+an `inbox` vault and move on. The router's job is to later look at each inbox
+note and answer "which vault does this belong to?" — confidently enough to move
+it for you, or, when it isn't sure, to hand you a short list to pick from.
+
+## Why a classifier, and why this one
+
+Routing a note to a vault is a classification problem: given a note, which of N
+vaults is the best home? A twelve-iteration proof-of-concept compared several
+approaches (rank fusion à la TEMPR, multinomial logistic regression, several
+Naive Bayes variants). The winner was a **pairwise Gaussian Naive Bayes** model
+over five cheap features, for three reasons:
+
+1. **It runs entirely in Postgres.** No model artifact to load, no Python
+   inference service. Scoring is one SQL query; "training" is arithmetic on
+   running sums.
+2. **It learns online.** Every confirmed route is one conjugate update — a
+   single `UPDATE` of sufficient statistics. The model improves as you use it
+   without a retrain job.
+3. **It degrades gracefully.** Each note is scored against each vault
+   independently as a "does this pair match?" question, so adding or removing a
+   vault needs no retraining.
+
+## The five features
+
+For a (note, vault) pair the router computes:
+
+- `sem_summary_sim` — cosine between the note and the vault's reflected summary.
+- `sem_centroid_sim` — cosine between the note and the mean of the vault's notes.
+- `mm_centroid_sim` — cosine between the note and the vault's mental-model centroid.
+- `entity_jaccard` — overlap between the note's entities and the vault's top-100
+  entities (by mention count — the vault's *core* topics, not every entity it has
+  ever brushed against).
+- `keyword_ts_rank` — Postgres full-text rank of the note's keywords against the
+  vault's text.
+
+Per-vault anchors (centroids, the entity set, the full-text document) are cached
+in `inbox_router_vault_anchors` and refreshed each tick, so scoring never has to
+re-aggregate a whole vault. The note's side is cached in
+`inbox_router_note_cache`.
+
+## How "training" works without training
+
+Gaussian Naive Bayes needs, per feature and per class (match / no-match), a mean
+and a variance. Those are recoverable from three running sums: the count, the
+sum of values, and the sum of squares. The router stores exactly those in
+`inbox_router_nb_stats`, and a view (`inbox_router_nb_params`) derives `(μ, σ²)`
+from them on the fly. Recording an observation is therefore just:
+
+```
+n      ← γ·n      + 1
+Σx     ← γ·Σx     + x
+Σx²    ← γ·Σx²    + x²
+```
+
+The `γ` (default 0.99) is an exponential-decay factor: it lets the model slowly
+forget stale statistics as a vault's character drifts, rather than weighting a
+note from a year ago the same as one from yesterday.
+
+### The cold-start prior
+
+A brand-new install has no confirmed routes. A flat prior here is actively
+harmful: a zero-variance Gaussian makes the likelihood explode and the rankings
+collapse to noise. So the stats table ships **seeded** from the proof-of-concept's
+measured per-feature means and variances, at a deliberately weak weight
+(equivalent to five observations). The router therefore produces sensible
+rankings from the very first tick, and your real decisions quickly outweigh the
+seed.
+
+## From score to action
+
+The per-vault match probabilities are turned into a per-note distribution
+(softmax) so the candidates compete. Then a simple policy decides:
+
+- **Auto-route** when the model is warmed up, the top vault's probability clears
+  a floor, *and* it beats the runner-up by a margin. In the POC, correct routes
+  beat the runner-up by a median margin of 0.81; wrong ones by 0.10 — so the
+  margin gate is what makes hands-off routing safe.
+- **Propose** the top three candidates to the cockpit when it's plausible but not
+  decisive.
+- **No-fit** when nothing clears the floor; the note stays in the inbox and the
+  router backs off (exponentially) before looking again.
+
+Two guards keep auto-routing conservative: a **warm-up gate** (auto-route stays
+off until enough confirmed routes accumulate) and a **per-tick cap** (a
+mis-scoring run can move at most a handful of notes before the rest fall through
+to proposals).
+
+## Why the probabilities are a *score*, not a calibrated confidence
+
+Naive Bayes assumes features are independent; ours aren't (`sem_summary_sim` and
+`sem_centroid_sim` both lean on the note embedding). So a `p_match` of 0.92 does
+not literally mean "92% likely correct" — it's a well-behaved ranking score. That
+is why the auto-route gate leans on the *margin* between candidates and an
+empirically chosen floor rather than treating the probability as ground truth.
+
+## Auditing and reversal
+
+Every auto-route is recorded as a resolved `inbox_vault_route` proposal stamped
+`system:inbox-router`, so there is always a trail. Routing is performed through
+the same reversible `route_note_to_vault` action the cockpit uses, so a route —
+auto or manual — can be undone, moving the note back to where it came from.
+
+## Known limitations
+
+- The router scores against existing vaults; it never invents a new one.
+  Repeated no-fit clusters are a signal you may want a new vault, but creating
+  one is left to you (a future enhancement could suggest it).
+- Probabilities are ranking scores, not calibrated confidences (see above).
+- Auto-routing is intentionally cautious early on; expect to confirm proposals
+  by hand until the model warms up.

--- a/docs/how-to/enable-inbox-router.md
+++ b/docs/how-to/enable-inbox-router.md
@@ -63,7 +63,7 @@ Set any of these (env var form shown) and restart:
 | Confidence floor | `…_AUTO_APPLY_MIN_P_MATCH` | `0.5` | Minimum top-vault probability to auto-route. Raise to route less, more safely. |
 | Margin gate | `…_T_MARGIN` | `0.4` | How far the top vault must beat the runner-up to auto-route. |
 | Warm-up gate | `…_MIN_DECISIONS_BEFORE_AUTO_APPLY` | `50` | Auto-route stays off until this many confirmed routes accumulate. |
-| Per-tick cap | `…_MAX_AUTO_APPLIES_PER_TICK` | `10` | Most notes the router will move in one tick. |
+| Daily cap | `…_MAX_AUTO_APPLIES_PER_DAY` | `10` | Most notes the router will move per vault per day (shared across ticks). |
 | Tick interval | `…_INTERVAL_SECONDS` | `3600` | Seconds between automatic passes. |
 
 ## Turn it off

--- a/docs/how-to/enable-inbox-router.md
+++ b/docs/how-to/enable-inbox-router.md
@@ -1,0 +1,84 @@
+# Enable the inbox router
+
+The inbox router watches a vault named `inbox`, scores each note against your
+other vaults, and either moves a note automatically or files a proposal in the
+maintenance cockpit for you to confirm. It is off by default.
+
+This guide shows you how to turn it on, tune it, and watch it work.
+
+## Turn it on
+
+Set the enable flag and restart the server:
+
+```bash
+export MEMEX_SERVER_MEMORY_INBOX_ROUTER_ENABLED=true
+memex server start
+```
+
+On the first scheduler tick the router creates the `inbox` vault if it does not
+exist. Drop notes into that vault (`memex note add --vault inbox …`, the Firefox
+extension, or the API) and the router takes it from there.
+
+## Trigger a triage pass by hand
+
+The scheduler runs a pass every hour by default. To run one now:
+
+```bash
+memex inbox triage          # live: may move notes and file proposals
+memex inbox triage --dry-run # score and decide only; change nothing
+```
+
+`--dry-run` prints what the router *would* do without touching anything — use it
+to preview behaviour before you trust auto-routing.
+
+## Check status
+
+```bash
+memex inbox status
+```
+
+This shows whether the router is enabled, whether it has warmed up enough to
+auto-route, and how many routing proposals are waiting in the cockpit.
+
+## Resolve proposals
+
+Open the cockpit and work the routing proposals:
+
+```bash
+memex lint review
+```
+
+A `inbox_vault_route` proposal offers one option per candidate vault — pick the
+right one and the note moves there. A `inbox_vault_no_fit` proposal means no
+vault matched; leave the note in the inbox or migrate it yourself with
+`memex note migrate <note> <vault>`.
+
+## Tune it
+
+Set any of these (env var form shown) and restart:
+
+| Setting | Env var | Default | Effect |
+|---|---|---|---|
+| Auto-route on/off | `MEMEX_SERVER_MEMORY_INBOX_ROUTER_AUTO_APPLY_ENABLED` | `true` | When `false` the router only ever proposes. |
+| Confidence floor | `…_AUTO_APPLY_MIN_P_MATCH` | `0.5` | Minimum top-vault probability to auto-route. Raise to route less, more safely. |
+| Margin gate | `…_T_MARGIN` | `0.4` | How far the top vault must beat the runner-up to auto-route. |
+| Warm-up gate | `…_MIN_DECISIONS_BEFORE_AUTO_APPLY` | `50` | Auto-route stays off until this many confirmed routes accumulate. |
+| Per-tick cap | `…_MAX_AUTO_APPLIES_PER_TICK` | `10` | Most notes the router will move in one tick. |
+| Tick interval | `…_INTERVAL_SECONDS` | `3600` | Seconds between automatic passes. |
+
+## Turn it off
+
+```bash
+unset MEMEX_SERVER_MEMORY_INBOX_ROUTER_ENABLED   # or set it to false
+memex server start
+```
+
+The `inbox` vault and any notes in it stay put; the router simply stops running.
+
+## What to expect early on
+
+Out of the box the router proposes but does not auto-route — it waits until it
+has seen `min_decisions_before_auto_apply` confirmed routes (you accepting
+proposals in the cockpit). Until then, treat its suggestions as drafts and
+confirm them yourself. Its rankings are sensible from the first tick; only the
+hands-off auto-move waits for the warm-up.

--- a/packages/cli/src/memex_cli/cockpit/app.py
+++ b/packages/cli/src/memex_cli/cockpit/app.py
@@ -40,6 +40,7 @@ from memex_cli.cockpit.controller import (
     UnitLineage,
     UnitMeta,
     options_for_contradiction,
+    options_for_inbox_route,
     options_for_rule,
 )
 
@@ -689,6 +690,8 @@ class ProposalCockpitApp(App):
     def _populate_actions(self, proposal: CockpitProposal) -> None:
         if proposal.rule_name == 'llm_semantic_contradiction':
             options = options_for_contradiction(proposal)
+        elif proposal.rule_name == 'inbox_vault_route':
+            options = options_for_inbox_route(proposal)
         else:
             options = options_for_rule(proposal.rule_name, proposal.target_type)
         action_list = self.query_one('#action-list', ListView)

--- a/packages/cli/src/memex_cli/cockpit/controller.py
+++ b/packages/cli/src/memex_cli/cockpit/controller.py
@@ -395,19 +395,20 @@ def options_for_inbox_route(proposal: CockpitProposal) -> list[CockpitOption]:
     knows where to migrate the note.
     """
     candidates = proposal.raw_evidence.get('top_candidates') or []
+    valid = [c for c in candidates if isinstance(c, dict) and c.get('vault_id')]
+    all_vault_ids = [str(c['vault_id']) for c in valid]
     options: list[CockpitOption] = []
-    for i, cand in enumerate(candidates):
-        if not isinstance(cand, dict):
-            continue
-        vault_id = cand.get('vault_id')
+    for i, cand in enumerate(valid):
+        vault_id = str(cand['vault_id'])
         vault_name = cand.get('vault_name') or vault_id
         p_match = cand.get('p_match')
-        if not vault_id:
-            continue
         try:
             p_str = f'{float(p_match):.2f}' if p_match is not None else '?'
         except (TypeError, ValueError):
             p_str = '?'
+        # Pass the other candidates so the router can record them as negatives —
+        # a human confirmation is the same learning signal as an auto-route.
+        other_vault_ids = [v for v in all_vault_ids if v != vault_id]
         options.append(
             CockpitOption(
                 action_id='route_note_to_vault',
@@ -416,7 +417,7 @@ def options_for_inbox_route(proposal: CockpitProposal) -> list[CockpitOption]:
                 effect='Moves the note + its units, chunks, and links to the target vault.',
                 reversible=True,
                 recommended=(i == 0),
-                params={'target_vault_id': str(vault_id)},
+                params={'target_vault_id': vault_id, 'other_vault_ids': other_vault_ids},
             )
         )
     options.append(

--- a/packages/cli/src/memex_cli/cockpit/controller.py
+++ b/packages/cli/src/memex_cli/cockpit/controller.py
@@ -123,6 +123,18 @@ _DEFAULT_OPTIONS_BY_RULE: dict[str, list[CockpitOption]] = {
         FLAG_OPTION,
         DISMISS_OPTION,
     ],
+    'inbox_vault_no_fit': [
+        CockpitOption(
+            action_id='no_op',
+            label='Leave in inbox',
+            summary='No vault fits this note; keep it in the inbox for now.',
+            effect='No mutation; the router backs off and re-evaluates later.',
+            reversible=True,
+            recommended=True,
+        ),
+        FLAG_OPTION,
+        DISMISS_OPTION,
+    ],
     'cold_low_mw_unit': [
         CockpitOption(
             action_id='deprioritize_unit',
@@ -369,6 +381,52 @@ def options_for_contradiction(
             effect='No mutation; the contradiction signal persists in audit.',
             reversible=True,
         ),
+    )
+    options.append(FLAG_OPTION)
+    options.append(DISMISS_OPTION)
+    return options
+
+
+def options_for_inbox_route(proposal: CockpitProposal) -> list[CockpitOption]:
+    """Build one route option per candidate vault from ``evidence.top_candidates``.
+
+    The router proposes the top-K vaults; the user picks which (or dismisses).
+    Each option carries ``params.target_vault_id`` so ``route_note_to_vault``
+    knows where to migrate the note.
+    """
+    candidates = proposal.raw_evidence.get('top_candidates') or []
+    options: list[CockpitOption] = []
+    for i, cand in enumerate(candidates):
+        if not isinstance(cand, dict):
+            continue
+        vault_id = cand.get('vault_id')
+        vault_name = cand.get('vault_name') or vault_id
+        p_match = cand.get('p_match')
+        if not vault_id:
+            continue
+        try:
+            p_str = f'{float(p_match):.2f}' if p_match is not None else '?'
+        except (TypeError, ValueError):
+            p_str = '?'
+        options.append(
+            CockpitOption(
+                action_id='route_note_to_vault',
+                label=f'Route to {vault_name} (p={p_str})',
+                summary=f'Migrate this note from the inbox to {vault_name}.',
+                effect='Moves the note + its units, chunks, and links to the target vault.',
+                reversible=True,
+                recommended=(i == 0),
+                params={'target_vault_id': str(vault_id)},
+            )
+        )
+    options.append(
+        CockpitOption(
+            action_id='no_op',
+            label='Leave in inbox',
+            summary='Record review; the note stays in the inbox vault.',
+            effect='No mutation; the router may re-propose at the next tick.',
+            reversible=True,
+        )
     )
     options.append(FLAG_OPTION)
     options.append(DISMISS_OPTION)

--- a/packages/cli/src/memex_cli/inbox.py
+++ b/packages/cli/src/memex_cli/inbox.py
@@ -59,34 +59,8 @@ async def status(
 ):
     """Show inbox-router readiness and pending routing proposals."""
     config: MemexConfig = ctx.obj
-    cfg = config.server.memory.inbox_router
-    from sqlalchemy import text
-
     async with get_api_context(config) as api:
-        async with api.metastore.session() as session:
-            match_n = (
-                await session.execute(
-                    text('SELECT n FROM inbox_router_nb_class_counts WHERE label = 1')
-                )
-            ).scalar()
-            rows = (
-                await session.execute(
-                    text(
-                        'SELECT rule_name, COUNT(*) FROM maintenance_proposals '
-                        "WHERE lint_type = 'routing' AND status = 'pending' GROUP BY rule_name"
-                    )
-                )
-            ).all()
-    pending = {r[0]: int(r[1]) for r in rows}
-    match_count = float(match_n or 0.0)
-    payload = {
-        'enabled': cfg.enabled,
-        'auto_apply_enabled': cfg.auto_apply_enabled,
-        'warmed_up': match_count >= cfg.min_decisions_before_auto_apply,
-        'match_observations': match_count,
-        'pending_route': pending.get('inbox_vault_route', 0),
-        'pending_no_fit': pending.get('inbox_vault_no_fit', 0),
-    }
+        payload = await api.inbox_router.status()
     if json_output:
         console.print_json(json.dumps(payload))
         return

--- a/packages/cli/src/memex_cli/inbox.py
+++ b/packages/cli/src/memex_cli/inbox.py
@@ -1,0 +1,98 @@
+"""Inbox router CLI — trigger triage and inspect router status.
+
+``memex inbox triage [--dry-run]`` runs one triage pass over the inbox vault;
+``memex inbox status`` shows readiness (warmed-up gate) and pending routing
+proposals.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from memex_common.config import MemexConfig
+from memex_cli.utils import async_command, get_api_context
+
+console = Console()
+
+app = typer.Typer(
+    name='inbox',
+    help='Inbox router: triage notes in the inbox vault and route them to vaults.',
+    no_args_is_help=True,
+)
+
+
+@app.command('triage')
+@async_command
+async def triage(
+    ctx: typer.Context,
+    dry_run: Annotated[
+        bool, typer.Option('--dry-run', help='Score + decide without mutating anything.')
+    ] = False,
+    json_output: Annotated[bool, typer.Option('--json', help='Output as JSON.')] = False,
+):
+    """Run one inbox-router triage tick."""
+    config: MemexConfig = ctx.obj
+    async with get_api_context(config) as api:
+        await api.inbox_router.ensure_inbox_vault()
+        result = await api.inbox_router.triage_tick(dry_run=dry_run)
+    payload = {'dry_run': dry_run, **result.as_dict()}
+    if json_output:
+        console.print_json(json.dumps(payload))
+        return
+    verb = 'Would route' if dry_run else 'Routed'
+    console.print(
+        f'[bold]Inbox triage[/bold] ({"dry-run" if dry_run else "live"}): '
+        f'scored={result.scored}  {verb.lower()}/auto={result.auto_routed}  '
+        f'proposed={result.proposed}  no_fit={result.no_fit}  '
+        f'skipped_cap={result.skipped_cap}  errors={result.errors}'
+    )
+
+
+@app.command('status')
+@async_command
+async def status(
+    ctx: typer.Context,
+    json_output: Annotated[bool, typer.Option('--json', help='Output as JSON.')] = False,
+):
+    """Show inbox-router readiness and pending routing proposals."""
+    config: MemexConfig = ctx.obj
+    cfg = config.server.memory.inbox_router
+    from sqlalchemy import text
+
+    async with get_api_context(config) as api:
+        async with api.metastore.session() as session:
+            match_n = (
+                await session.execute(
+                    text('SELECT n FROM inbox_router_nb_class_counts WHERE label = 1')
+                )
+            ).scalar()
+            rows = (
+                await session.execute(
+                    text(
+                        'SELECT rule_name, COUNT(*) FROM maintenance_proposals '
+                        "WHERE lint_type = 'routing' AND status = 'pending' GROUP BY rule_name"
+                    )
+                )
+            ).all()
+    pending = {r[0]: int(r[1]) for r in rows}
+    match_count = float(match_n or 0.0)
+    payload = {
+        'enabled': cfg.enabled,
+        'auto_apply_enabled': cfg.auto_apply_enabled,
+        'warmed_up': match_count >= cfg.min_decisions_before_auto_apply,
+        'match_observations': match_count,
+        'pending_route': pending.get('inbox_vault_route', 0),
+        'pending_no_fit': pending.get('inbox_vault_no_fit', 0),
+    }
+    if json_output:
+        console.print_json(json.dumps(payload))
+        return
+    table = Table(title='Inbox Router Status')
+    table.add_column('Field')
+    table.add_column('Value')
+    for k, v in payload.items():
+        table.add_row(k, str(v))
+    console.print(table)

--- a/packages/cli/src/memex_cli/utils.py
+++ b/packages/cli/src/memex_cli/utils.py
@@ -32,6 +32,7 @@ LAZY_SUBCOMMANDS: dict[str, str] = {
     'note': 'memex_cli.notes:app',
     'kv': 'memex_cli.kv:app',
     'lint': 'memex_cli.lint:app',
+    'inbox': 'memex_cli.inbox:app',
     'system': 'memex_cli.stats:app',
     'config': 'memex_cli.config:app',
     'server': 'memex_cli.server:app',

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -164,6 +164,16 @@ class RemoteMemexAPI:
         result = await self._get('vaults', params={'state': 'active'})
         return VaultDTO(**result[0])
 
+    # --- Inbox router ---
+    async def trigger_inbox_triage(self, dry_run: bool = False) -> dict[str, Any]:
+        """Run one inbox-router triage tick. Returns the per-outcome counts;
+        a dry run additionally returns per-note ``decisions`` without mutating."""
+        return await self._post('inbox/triage', data={}, params={'dry_run': dry_run})
+
+    async def inbox_status(self) -> dict[str, Any]:
+        """Router readiness + pending routing-proposal counts."""
+        return await self._get('inbox/status')
+
     async def get_default_vaults(self) -> DefaultVaultsResponse:
         """Get the active (writer) vault and default reader vaults."""
         result = await self._get('vaults', params={'is_default': True})

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1616,6 +1616,103 @@ class LintConfig(BaseModel):
     )
 
 
+class InboxRouterConfig(BaseModel):
+    """Configuration for the inbox router.
+
+    The router scores notes in the ``inbox`` vault against every other vault
+    using a pairwise Gaussian Naive Bayes model evaluated entirely in Postgres,
+    then either auto-applies a high-confidence route or emits a maintenance
+    proposal for the cockpit. Off by default; opt in via ``enabled``.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description='Enable the periodic inbox-router triage task (opt-in).',
+    )
+    interval_seconds: int = Field(
+        default=3600,
+        ge=60,
+        description='Seconds between inbox-router triage ticks. Default: 1 hour.',
+    )
+    top_k_entities: int = Field(
+        default=100,
+        ge=1,
+        description=(
+            'Per-vault entity-set cap (top-K by mention count) used for the '
+            "entity_jaccard feature. K=100 is the POC sweep's knee."
+        ),
+    )
+    auto_apply_enabled: bool = Field(
+        default=True,
+        description=(
+            'Allow the router to migrate notes automatically when confidence '
+            'clears the gate. When False the router only ever proposes.'
+        ),
+    )
+    auto_apply_min_p_match: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description='Minimum normalised top-1 P(match) required to auto-apply.',
+    )
+    t_margin: float = Field(
+        default=0.4,
+        ge=0.0,
+        le=1.0,
+        description=(
+            'Minimum P(match) margin between the top-1 and top-2 candidate '
+            'required to auto-apply. POC: correct routes had median margin '
+            '0.81, wrong 0.10.'
+        ),
+    )
+    t_low: float = Field(
+        default=0.10,
+        ge=0.0,
+        le=1.0,
+        description=(
+            'Minimum raw P(match) for the top candidate to be proposed at all. '
+            'Below this the note is treated as no-fit.'
+        ),
+    )
+    min_decisions_before_auto_apply: int = Field(
+        default=50,
+        ge=0,
+        description=(
+            'Match-class observation count required before auto-apply is '
+            'eligible. Below this the router proposes only (cold-start gate).'
+        ),
+    )
+    ewma_gamma: float = Field(
+        default=0.99,
+        gt=0.0,
+        le=1.0,
+        description=(
+            'Exponential-decay factor applied to the sufficient statistics on '
+            'each online update. <1 lets the model forget stale vault state as '
+            'vaults drift; 1.0 freezes (never forgets).'
+        ),
+    )
+    backoff_base_days: float = Field(
+        default=1.0,
+        gt=0.0,
+        description='Base retry delay for no-fit proposals (exponential backoff).',
+    )
+    backoff_cap_days: float = Field(
+        default=32.0,
+        gt=0.0,
+        description='Maximum retry delay for no-fit proposals.',
+    )
+    max_auto_applies_per_tick: int = Field(
+        default=10,
+        ge=0,
+        description=(
+            'Safety cap on notes auto-routed per triage tick. Excess notes fall '
+            'through to proposals so a mis-scoring run cannot reshuffle the '
+            'whole inbox at once.'
+        ),
+    )
+
+
 class EntityMaintenanceConfig(BaseModel):
     """Configuration for the cross-batch entity-cluster collapse loop.
 
@@ -1998,6 +2095,14 @@ class MemoryConfig(BaseModel):
     lint_llm: LintLLMConfig = Field(
         default_factory=LintLLMConfig,
         description='Configuration for surprise-gated LLM-assisted lint.',
+    )
+
+    inbox_router: InboxRouterConfig = Field(
+        default_factory=InboxRouterConfig,
+        description=(
+            'Configuration for the inbox router (per-vault note triage). '
+            'Off by default; operators opt in via enabled.'
+        ),
     )
 
     entity_maintenance: EntityMaintenanceConfig = Field(

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1702,13 +1702,21 @@ class InboxRouterConfig(BaseModel):
         gt=0.0,
         description='Maximum retry delay for no-fit proposals.',
     )
-    max_auto_applies_per_tick: int = Field(
+    max_auto_applies_per_day: int = Field(
         default=10,
         ge=0,
         description=(
-            'Safety cap on notes auto-routed per triage tick. Excess notes fall '
-            'through to proposals so a mis-scoring run cannot reshuffle the '
-            'whole inbox at once.'
+            'Safety cap on notes auto-routed per vault per day (counted from '
+            'already-resolved router routes, so it is shared across concurrent '
+            'ticks). Excess notes fall through to proposals so a mis-scoring run '
+            'cannot reshuffle the whole inbox at once.'
+        ),
+    )
+    excluded_vaults: list[str] = Field(
+        default_factory=lambda: ['global'],
+        description=(
+            'Vault names never offered as routing targets, in addition to the '
+            'inbox vault itself. Defaults to the catch-all global vault.'
         ),
     )
 

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1684,12 +1684,14 @@ class InboxRouterConfig(BaseModel):
     )
     ewma_gamma: float = Field(
         default=0.99,
-        gt=0.0,
+        ge=0.5,
         le=1.0,
         description=(
             'Exponential-decay factor applied to the sufficient statistics on '
             'each online update. <1 lets the model forget stale vault state as '
-            'vaults drift; 1.0 freezes (never forgets).'
+            'vaults drift; 1.0 freezes (never forgets). Floored at 0.5 so the '
+            'running count cannot decay below 1 and degrade the variance estimate '
+            '(the params view would otherwise inflate σ² near a zero denominator).'
         ),
     )
     backoff_base_days: float = Field(

--- a/packages/core/src/memex_core/alembic/versions/054_inbox_router.py
+++ b/packages/core/src/memex_core/alembic/versions/054_inbox_router.py
@@ -1,0 +1,156 @@
+"""Inbox router schema: per-vault GaussianNB anchors, note cache, online stats.
+
+Creates the tables and views backing the inbox router (see
+``services/inbox_router/``):
+
+- ``inbox_router_nb_stats`` / ``inbox_router_nb_class_counts`` — sufficient
+  statistics ``(n, Σx, Σx²)`` per (feature, label) and class counts. Online
+  Bayesian conjugate updates land here; the model is "fit" purely in SQL.
+- ``inbox_router_nb_params`` / ``inbox_router_nb_prior`` — VIEWs deriving
+  ``(μ̂, σ̂²)`` and log-priors from the sufficient stats inline.
+- ``inbox_router_vault_anchors`` — per-vault chunk/summary/mental-model
+  centroids, tsvector doc, and top-K entity ids; refreshed each triage tick.
+- ``inbox_router_note_cache`` — per-note features (centroid, tsquery, entity
+  ids) populated on inbox-note ingest.
+
+The stats table is SEEDED from the POC's measured per-feature (μ, σ²) at a
+weak weight (n=5) so the router produces sensible rankings from the first
+tick rather than the uniform-random output a flat prior would give. Online
+updates (with EWMA decay) evolve it toward the live corpus.
+
+Also extends the ``maintenance_proposals`` lint_type CHECK to allow
+``'routing'`` (the router emits ``inbox_vault_route`` / ``inbox_vault_no_fit``
+proposals).
+
+Revision ID: 054_inbox_router
+Revises: 053_merge_heads
+Create Date: 2026-05-29
+"""
+
+from alembic import op
+
+revision: str = '054_inbox_router'
+down_revision: str | None = '053_merge_heads'
+branch_labels: str | list[str] | None = None
+depends_on: str | list[str] | None = None
+
+
+_CREATE = """
+CREATE TABLE inbox_router_nb_stats (
+    feature_name TEXT             NOT NULL,
+    label        SMALLINT         NOT NULL,
+    n            DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    sum_x        DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    sum_x_sq     DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    updated_at   TIMESTAMPTZ      NOT NULL DEFAULT now(),
+    PRIMARY KEY (feature_name, label)
+);
+
+CREATE TABLE inbox_router_nb_class_counts (
+    label      SMALLINT         PRIMARY KEY,
+    n          DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    updated_at TIMESTAMPTZ      NOT NULL DEFAULT now()
+);
+
+-- (μ̂, σ̂²) derived from sufficient stats. Bessel-corrected sample variance
+-- with a floor for numerical safety (avoids a degenerate zero-variance
+-- Gaussian when only the seed prior is present).
+CREATE VIEW inbox_router_nb_params AS
+SELECT feature_name, label,
+       sum_x / NULLIF(n, 0) AS mu,
+       GREATEST(
+           (sum_x_sq - sum_x * sum_x / NULLIF(n, 0)) / NULLIF(GREATEST(n - 1, 1e-6), 0),
+           1e-9
+       ) AS sigma_sq
+FROM inbox_router_nb_stats;
+
+CREATE VIEW inbox_router_nb_prior AS
+SELECT label,
+       ln(GREATEST(n / NULLIF((SELECT SUM(n) FROM inbox_router_nb_class_counts), 0),
+                   1e-12)) AS log_prior
+FROM inbox_router_nb_class_counts;
+
+CREATE TABLE inbox_router_vault_anchors (
+    vault_id          UUID PRIMARY KEY REFERENCES vaults(id) ON DELETE CASCADE,
+    chunk_centroid    vector(384) NOT NULL,
+    summary_embedding vector(384),
+    mm_centroid       vector(384),
+    tsvector_doc      TSVECTOR    NOT NULL DEFAULT ''::tsvector,
+    entity_ids        UUID[]      NOT NULL DEFAULT '{}'::uuid[],
+    n_notes           INTEGER     NOT NULL DEFAULT 0,
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE inbox_router_note_cache (
+    note_id        UUID PRIMARY KEY REFERENCES notes(id) ON DELETE CASCADE,
+    chunk_centroid vector(384),
+    tsq            TSQUERY,
+    entity_ids     UUID[]      NOT NULL DEFAULT '{}'::uuid[],
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_inbox_router_va_tsv
+    ON inbox_router_vault_anchors USING gin(tsvector_doc);
+"""
+
+# Seed sufficient stats from POC v12 empirics at n=5 (weak weight). Derived via
+# sum_x = n*μ, sum_x_sq = σ²*(n-1) + n*μ². Without this, a flat prior yields a
+# near-delta Gaussian likelihood that saturates the logits and produces
+# uniform-random rankings until ~50 user decisions accumulate.
+_SEED_STATS = """
+INSERT INTO inbox_router_nb_stats (feature_name, label, n, sum_x, sum_x_sq) VALUES
+    ('sem_summary_sim',  0, 5.0, 1.159000, 0.319136),
+    ('sem_summary_sim',  1, 5.0, 1.873000, 0.748826),
+    ('sem_centroid_sim', 0, 5.0, 1.693000, 0.635090),
+    ('sem_centroid_sim', 1, 5.0, 3.278500, 2.256592),
+    ('mm_centroid_sim',  0, 5.0, 1.358500, 0.464984),
+    ('mm_centroid_sim',  1, 5.0, 1.970500, 0.979054),
+    ('entity_jaccard',   0, 5.0, 0.054000, 0.001223),
+    ('entity_jaccard',   1, 5.0, 0.307000, 0.024650),
+    ('keyword_ts_rank',  0, 5.0, 4.737500, 4.500701),
+    ('keyword_ts_rank',  1, 5.0, 4.919000, 4.839872);
+"""
+
+# Class prior ~1:6 (match:no_match) — the POC's measured base rate (P(match)≈0.14).
+_SEED_CLASS = """
+INSERT INTO inbox_router_nb_class_counts (label, n) VALUES (1, 1.0), (0, 6.0);
+"""
+
+_DROP = """
+DROP TABLE IF EXISTS inbox_router_note_cache;
+DROP TABLE IF EXISTS inbox_router_vault_anchors;
+DROP VIEW IF EXISTS inbox_router_nb_prior;
+DROP VIEW IF EXISTS inbox_router_nb_params;
+DROP TABLE IF EXISTS inbox_router_nb_class_counts;
+DROP TABLE IF EXISTS inbox_router_nb_stats;
+"""
+
+_CHECK_WITH_ROUTING = (
+    'ALTER TABLE maintenance_proposals '
+    'DROP CONSTRAINT IF EXISTS ck_maintenance_proposals_lint_type; '
+    'ALTER TABLE maintenance_proposals '
+    'ADD CONSTRAINT ck_maintenance_proposals_lint_type '
+    "CHECK (lint_type IN ('structural', 'quality', 'governance', 'schema', 'routing'));"
+)
+
+_CHECK_WITHOUT_ROUTING = (
+    'ALTER TABLE maintenance_proposals '
+    'DROP CONSTRAINT IF EXISTS ck_maintenance_proposals_lint_type; '
+    'ALTER TABLE maintenance_proposals '
+    'ADD CONSTRAINT ck_maintenance_proposals_lint_type '
+    "CHECK (lint_type IN ('structural', 'quality', 'governance', 'schema'));"
+)
+
+
+def upgrade() -> None:
+    op.execute(_CHECK_WITH_ROUTING)
+    op.execute(_CREATE)
+    op.execute(_SEED_STATS)
+    op.execute(_SEED_CLASS)
+
+
+def downgrade() -> None:
+    op.execute(_DROP)
+    # Revert the CHECK; any 'routing' rows must be cleared first to satisfy it.
+    op.execute("DELETE FROM maintenance_proposals WHERE lint_type = 'routing'")
+    op.execute(_CHECK_WITHOUT_ROUTING)

--- a/packages/core/src/memex_core/alembic/versions/055_inbox_router.py
+++ b/packages/core/src/memex_core/alembic/versions/055_inbox_router.py
@@ -22,15 +22,15 @@ Also extends the ``maintenance_proposals`` lint_type CHECK to allow
 ``'routing'`` (the router emits ``inbox_vault_route`` / ``inbox_vault_no_fit``
 proposals).
 
-Revision ID: 054_inbox_router
-Revises: 053_merge_heads
+Revision ID: 055_inbox_router
+Revises: 054_nodes_vault_active
 Create Date: 2026-05-29
 """
 
 from alembic import op
 
-revision: str = '054_inbox_router'
-down_revision: str | None = '053_merge_heads'
+revision: str = '055_inbox_router'
+down_revision: str | None = '054_nodes_vault_active'
 branch_labels: str | list[str] | None = None
 depends_on: str | list[str] | None = None
 

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -76,6 +76,7 @@ from memex_core.services.lint_learning import LintLearningService
 from memex_core.services.lint_optimizer import LintLLMOptimizer
 from memex_core.services.lint_auto_apply import LintAutoApplyService
 from memex_core.services.locks import LocksService
+from memex_core.services.inbox_router import InboxRouterService
 from memex_core.services.notes import NoteService
 from memex_core.services.deprioritize_score import DeprioritizeScorer, ScoreBreakdown
 
@@ -558,6 +559,14 @@ class MemexAPI:
             filestore=self.filestore,
             config=self.config,
         )
+        self._inbox_router = InboxRouterService(
+            metastore=self.metastore,
+            filestore=self.filestore,
+            config=self.config,
+            embedding_model=self.embedding_model,
+            notes=self._notes,
+            vaults=self._vaults,
+        )
         self._lint_learning = LintLearningService(
             metastore=self.metastore,
             filestore=self.filestore,
@@ -652,6 +661,11 @@ class MemexAPI:
     @property
     def lint(self) -> LintService:
         return self._lint
+
+    @property
+    def inbox_router(self) -> InboxRouterService:
+        """Inbox-vault triage / routing service."""
+        return self._inbox_router
 
     @property
     def lint_learning(self) -> LintLearningService:

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -1859,6 +1859,7 @@ class LintType(str, Enum):
     QUALITY = 'quality'
     GOVERNANCE = 'governance'
     SCHEMA = 'schema'
+    ROUTING = 'routing'
 
 
 class LintStatus(str, Enum):
@@ -1954,7 +1955,7 @@ class MaintenanceProposal(SQLModel, table=True):  # type: ignore
 
     __table_args__ = (
         CheckConstraint(
-            "lint_type IN ('structural', 'quality', 'governance', 'schema')",
+            "lint_type IN ('structural', 'quality', 'governance', 'schema', 'routing')",
             name='ck_maintenance_proposals_lint_type',
         ),
         CheckConstraint(

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -9,8 +9,11 @@ from sqlalchemy import (
     Boolean,
     Column,
     Computed,
+    DDL,
+    event,
     ForeignKey,
     Integer,
+    SmallInteger,
     String,
     Text,
     Float,
@@ -21,7 +24,7 @@ from sqlalchemy import (
     ForeignKeyConstraint,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP, ARRAY, TSVECTOR
+from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP, ARRAY, TSQUERY, TSVECTOR
 from sqlalchemy.types import Uuid as SA_UUID
 from sqlmodel import SQLModel, Field, Relationship
 
@@ -2428,3 +2431,178 @@ class LintLLMSignature(SQLModel, table=True):  # type: ignore
             name='ck_lint_llm_signature_superseded_valid',
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Inbox router (per-vault note triage)
+# ---------------------------------------------------------------------------
+
+
+class InboxRouterNbStats(SQLModel, table=True):  # type: ignore
+    """Sufficient statistics ``(n, Σx, Σx²)`` per (feature, label) for the
+    pairwise Gaussian Naive Bayes router model.
+
+    The model is "fit" entirely in SQL: online conjugate updates land here and
+    the ``inbox_router_nb_params`` view derives ``(μ̂, σ̂²)`` from these columns.
+    Seeded from POC empirics at enable-time (see ``InboxRouterService``).
+    """
+
+    __tablename__ = 'inbox_router_nb_stats'
+
+    feature_name: str = Field(sa_column=Column(Text, primary_key=True))
+    label: int = Field(
+        sa_column=Column(SmallInteger, primary_key=True),
+        description='1 = match, 0 = no-match.',
+    )
+    n: float = Field(
+        sa_column=Column(Float, nullable=False, server_default=sql_text('1.0')),
+        description='Effective observation count (EWMA-decayed).',
+    )
+    sum_x: float = Field(
+        sa_column=Column(Float, nullable=False, server_default=sql_text('0.0')),
+    )
+    sum_x_sq: float = Field(
+        sa_column=Column(Float, nullable=False, server_default=sql_text('0.0')),
+    )
+    updated_at: datetime = updated_at_field()
+
+
+class InboxRouterNbClassCounts(SQLModel, table=True):  # type: ignore
+    """Per-class observation counts; the ``inbox_router_nb_prior`` view derives
+    the log-priors from these."""
+
+    __tablename__ = 'inbox_router_nb_class_counts'
+
+    label: int = Field(sa_column=Column(SmallInteger, primary_key=True))
+    n: float = Field(
+        sa_column=Column(Float, nullable=False, server_default=sql_text('1.0')),
+    )
+    updated_at: datetime = updated_at_field()
+
+
+class InboxRouterVaultAnchor(SQLModel, table=True):  # type: ignore
+    """Per-vault scoring anchors, refreshed each triage tick.
+
+    Caches the vault's chunk centroid, reflected-summary embedding, mental-model
+    centroid, full-text document, and top-K entity ids so scoring never has to
+    re-aggregate the whole vault.
+    """
+
+    __tablename__ = 'inbox_router_vault_anchors'
+
+    vault_id: UUID = Field(
+        sa_column=Column(
+            SA_UUID(),
+            ForeignKey('vaults.id', ondelete='CASCADE'),
+            primary_key=True,
+        ),
+    )
+    chunk_centroid: list[float] = Field(
+        sa_column=Column(Vector(EMBEDDING_DIMENSION), nullable=False),
+        description='Mean of the vault notes’ chunk embeddings.',
+    )
+    summary_embedding: list[float] | None = Field(
+        default=None,
+        sa_column=Column(Vector(EMBEDDING_DIMENSION), nullable=True),
+        description='Embedding of the vault’s reflected narrative.',
+    )
+    mm_centroid: list[float] | None = Field(
+        default=None,
+        sa_column=Column(Vector(EMBEDDING_DIMENSION), nullable=True),
+        description='Mean of the vault’s mental-model embeddings.',
+    )
+    tsvector_doc: Any = Field(
+        default=None,
+        sa_column=Column(TSVECTOR, nullable=False, server_default=sql_text("''::tsvector")),
+        description='Full-text document built from the vault’s chunk text.',
+    )
+    entity_ids: list[UUID] = Field(
+        default_factory=list,
+        sa_column=Column(
+            ARRAY(SA_UUID()),
+            nullable=False,
+            server_default=sql_text('ARRAY[]::uuid[]'),
+        ),
+        description='Top-K entity ids by within-vault mention count.',
+    )
+    n_notes: int = Field(
+        default=0,
+        sa_column=Column(Integer, nullable=False, server_default=sql_text('0')),
+    )
+    updated_at: datetime = updated_at_field()
+
+    __table_args__ = (Index('idx_inbox_router_va_tsv', 'tsvector_doc', postgresql_using='gin'),)
+
+
+class InboxRouterNoteCache(SQLModel, table=True):  # type: ignore
+    """Per-note cached features, populated on inbox-note ingest / first triage."""
+
+    __tablename__ = 'inbox_router_note_cache'
+
+    note_id: UUID = Field(
+        sa_column=Column(
+            SA_UUID(),
+            ForeignKey('notes.id', ondelete='CASCADE'),
+            primary_key=True,
+        ),
+    )
+    chunk_centroid: list[float] | None = Field(
+        default=None,
+        sa_column=Column(Vector(EMBEDDING_DIMENSION), nullable=True),
+    )
+    tsq: Any = Field(
+        default=None,
+        sa_column=Column(TSQUERY, nullable=True),
+        description='Top-50 note lexemes OR-joined into a tsquery.',
+    )
+    entity_ids: list[UUID] = Field(
+        default_factory=list,
+        sa_column=Column(
+            ARRAY(SA_UUID()),
+            nullable=False,
+            server_default=sql_text('ARRAY[]::uuid[]'),
+        ),
+    )
+    updated_at: datetime = updated_at_field()
+
+
+# The two derived views can't be SQLModel tables, but they belong to the same
+# schema. Attach their DDL to ``create_all`` / ``drop_all`` so every
+# provisioning path (fresh-server create_all, tests, eval harness) builds them
+# alongside the tables — the same shape migration 055 creates for the upgrade
+# path. ``CREATE OR REPLACE`` keeps re-runs idempotent.
+_INBOX_ROUTER_PARAMS_VIEW = DDL(
+    """
+    CREATE OR REPLACE VIEW inbox_router_nb_params AS
+    SELECT feature_name, label,
+           sum_x / NULLIF(n, 0) AS mu,
+           GREATEST(
+               (sum_x_sq - sum_x * sum_x / NULLIF(n, 0)) / NULLIF(GREATEST(n - 1, 1e-6), 0),
+               1e-9
+           ) AS sigma_sq
+    FROM inbox_router_nb_stats
+    """
+).execute_if(dialect='postgresql')
+
+_INBOX_ROUTER_PRIOR_VIEW = DDL(
+    """
+    CREATE OR REPLACE VIEW inbox_router_nb_prior AS
+    SELECT label,
+           ln(GREATEST(n / NULLIF((SELECT SUM(n) FROM inbox_router_nb_class_counts), 0),
+                       1e-12)) AS log_prior
+    FROM inbox_router_nb_class_counts
+    """
+).execute_if(dialect='postgresql')
+
+event.listen(SQLModel.metadata, 'after_create', _INBOX_ROUTER_PARAMS_VIEW)
+event.listen(SQLModel.metadata, 'after_create', _INBOX_ROUTER_PRIOR_VIEW)
+event.listen(
+    SQLModel.metadata,
+    'before_drop',
+    DDL('DROP VIEW IF EXISTS inbox_router_nb_prior').execute_if(dialect='postgresql'),
+)
+event.listen(
+    SQLModel.metadata,
+    'before_drop',
+    DDL('DROP VIEW IF EXISTS inbox_router_nb_params').execute_if(dialect='postgresql'),
+)

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -374,6 +374,32 @@ async def periodic_consolidation_task(api: 'MemexAPI', units_per_tick: int):
             logger.error(f'Scheduler: Consolidation failed: {e}', exc_info=True)
 
 
+async def periodic_inbox_router_task(api: 'MemexAPI'):
+    """Bootstrap the inbox vault (idempotent) then run one triage tick.
+
+    Runs under MEMEX_LEADER_LOCK_ID (only the leader serves the clock), so the
+    ``ensure_inbox_vault`` create is single-flighted and the
+    ``VaultService.create_vault`` ValueError/IntegrityError race is caught
+    inside the service. Failures are error-logged and never raise.
+    """
+    async with background_session('bg-sched-inbox-router'):
+        try:
+            await api.inbox_router.ensure_inbox_vault()
+            result = await api.inbox_router.triage_tick()
+            if result.scored:
+                logger.info(
+                    'Scheduler: Inbox router scored %d note(s): '
+                    'auto_routed=%d proposed=%d no_fit=%d errors=%d',
+                    result.scored,
+                    result.auto_routed,
+                    result.proposed,
+                    result.no_fit,
+                    result.errors,
+                )
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.error(f'Scheduler: Inbox router tick failed: {e}', exc_info=True)
+
+
 async def periodic_lint_llm_task(api: 'MemexAPI'):
     """Per-vault surprise-gated LLM lint under MEMEX_LEADER_LOCK_ID.
 
@@ -583,6 +609,21 @@ async def run_scheduler_with_leader_election(config: MemexConfig, api: 'MemexAPI
             await periodic_entity_maintenance_task(api)
     else:
         logger.info('Scheduler: Entity-maintenance scan DISABLED (scan_enabled=False).')
+
+    # --- Inbox router ---
+    inbox_router_cfg = config.server.memory.inbox_router
+    if inbox_router_cfg.enabled:
+        logger.info(
+            'Scheduler: Inbox router ENABLED. Interval: %ds. auto_apply=%s.',
+            inbox_router_cfg.interval_seconds,
+            inbox_router_cfg.auto_apply_enabled,
+        )
+
+        @clock.task(trigger=Every(seconds=inbox_router_cfg.interval_seconds))
+        async def run_inbox_router_job():
+            await periodic_inbox_router_task(api)
+    else:
+        logger.info('Scheduler: Inbox router DISABLED (enabled=False).')
 
     # --- Consolidation ---
     consolidation_cfg = config.server.memory.consolidation

--- a/packages/core/src/memex_core/server/__init__.py
+++ b/packages/core/src/memex_core/server/__init__.py
@@ -30,6 +30,7 @@ from memex_core.server.auth import auth_middleware, setup_auth
 from memex_core.server.consolidation import router as consolidation_router
 from memex_core.server.diagnostics import router as diagnostics_router
 from memex_core.server.lint import router as lint_router
+from memex_core.server.inbox import router as inbox_router
 from memex_core.server.rate_limit import setup_rate_limiting
 from memex_core.services.audit import AuditService
 from memex_core.server.kv import router as kv_router
@@ -374,5 +375,6 @@ app.include_router(vault_summary_router)
 app.include_router(session_briefing_router)
 app.include_router(diagnostics_router)
 app.include_router(lint_router)
+app.include_router(inbox_router)
 app.include_router(consolidation_router)
 app.include_router(system_router)

--- a/packages/core/src/memex_core/server/inbox.py
+++ b/packages/core/src/memex_core/server/inbox.py
@@ -15,7 +15,6 @@ import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import text
 
 from memex_core.api import MemexAPI
 from memex_core.server.auth import require_read, require_write
@@ -30,33 +29,7 @@ router = APIRouter(prefix='/api/v1/inbox', tags=['inbox'])
 async def inbox_status(api: Annotated[MemexAPI, Depends(get_api)]) -> dict[str, Any]:
     """Router readiness + pending routing-proposal counts."""
     try:
-        cfg = api.config.server.memory.inbox_router
-        async with api.metastore.session() as session:
-            match_n = (
-                await session.execute(
-                    text('SELECT n FROM inbox_router_nb_class_counts WHERE label = 1')
-                )
-            ).scalar()
-            counts = (
-                await session.execute(
-                    text(
-                        'SELECT rule_name, COUNT(*) FROM maintenance_proposals '
-                        "WHERE lint_type = 'routing' AND status = 'pending' "
-                        'GROUP BY rule_name'
-                    )
-                )
-            ).all()
-        pending = {r[0]: int(r[1]) for r in counts}
-        match_count = float(match_n or 0.0)
-        return {
-            'enabled': cfg.enabled,
-            'auto_apply_enabled': cfg.auto_apply_enabled,
-            'warmed_up': match_count >= cfg.min_decisions_before_auto_apply,
-            'match_observations': match_count,
-            'min_decisions_before_auto_apply': cfg.min_decisions_before_auto_apply,
-            'pending_route': pending.get('inbox_vault_route', 0),
-            'pending_no_fit': pending.get('inbox_vault_no_fit', 0),
-        }
+        return await api.inbox_router.status()
     except Exception as exc:
         raise _handle_error(exc, 'Failed to read inbox-router status')
 

--- a/packages/core/src/memex_core/server/inbox.py
+++ b/packages/core/src/memex_core/server/inbox.py
@@ -1,0 +1,75 @@
+"""Inbox router endpoints.
+
+Routes:
+- GET  /api/v1/inbox/status   — router readiness + pending routing-proposal counts
+- POST /api/v1/inbox/triage   — run one triage tick (``dry_run`` to preview only)
+
+The triage endpoint backs ``memex inbox triage`` (CLI) and the eval suite's
+trigger. With ``dry_run=false`` it can migrate notes (auto-route) and emit
+proposals, so it is a write surface gated by ``require_write``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import text
+
+from memex_core.api import MemexAPI
+from memex_core.server.auth import require_read, require_write
+from memex_core.server.common import _handle_error, get_api
+
+logger = logging.getLogger('memex.core.server.inbox')
+
+router = APIRouter(prefix='/api/v1/inbox', tags=['inbox'])
+
+
+@router.get('/status', dependencies=[Depends(require_read)])
+async def inbox_status(api: Annotated[MemexAPI, Depends(get_api)]) -> dict[str, Any]:
+    """Router readiness + pending routing-proposal counts."""
+    try:
+        cfg = api.config.server.memory.inbox_router
+        async with api.metastore.session() as session:
+            match_n = (
+                await session.execute(
+                    text('SELECT n FROM inbox_router_nb_class_counts WHERE label = 1')
+                )
+            ).scalar()
+            counts = (
+                await session.execute(
+                    text(
+                        'SELECT rule_name, COUNT(*) FROM maintenance_proposals '
+                        "WHERE lint_type = 'routing' AND status = 'pending' "
+                        'GROUP BY rule_name'
+                    )
+                )
+            ).all()
+        pending = {r[0]: int(r[1]) for r in counts}
+        match_count = float(match_n or 0.0)
+        return {
+            'enabled': cfg.enabled,
+            'auto_apply_enabled': cfg.auto_apply_enabled,
+            'warmed_up': match_count >= cfg.min_decisions_before_auto_apply,
+            'match_observations': match_count,
+            'min_decisions_before_auto_apply': cfg.min_decisions_before_auto_apply,
+            'pending_route': pending.get('inbox_vault_route', 0),
+            'pending_no_fit': pending.get('inbox_vault_no_fit', 0),
+        }
+    except Exception as exc:
+        raise _handle_error(exc, 'Failed to read inbox-router status')
+
+
+@router.post('/triage', dependencies=[Depends(require_write)])
+async def inbox_triage(
+    api: Annotated[MemexAPI, Depends(get_api)],
+    dry_run: Annotated[bool, Query(description='Score + decide without mutating.')] = False,
+) -> dict[str, Any]:
+    """Run one inbox triage tick. Returns the per-outcome counts."""
+    try:
+        await api.inbox_router.ensure_inbox_vault()
+        result = await api.inbox_router.triage_tick(dry_run=dry_run)
+        return {'dry_run': dry_run, **result.as_dict()}
+    except Exception as exc:
+        raise _handle_error(exc, 'Failed to run inbox triage')

--- a/packages/core/src/memex_core/services/inbox_router/__init__.py
+++ b/packages/core/src/memex_core/services/inbox_router/__init__.py
@@ -1,0 +1,27 @@
+"""Inbox router service package.
+
+Periodic triage of the ``inbox`` vault: scores each note against every other
+vault with a pairwise GaussianNB model evaluated in Postgres, then auto-routes
+confident notes or emits cockpit proposals. See ``service.InboxRouterService``.
+"""
+
+from memex_core.services.inbox_router.decisions import (
+    CandidateScore,
+    DecisionKind,
+    DecisionThresholds,
+    RouterDecision,
+    RoutingState,
+    decide,
+)
+from memex_core.services.inbox_router.service import InboxRouterService, TriageResult
+
+__all__ = [
+    'CandidateScore',
+    'DecisionKind',
+    'DecisionThresholds',
+    'InboxRouterService',
+    'RouterDecision',
+    'RoutingState',
+    'TriageResult',
+    'decide',
+]

--- a/packages/core/src/memex_core/services/inbox_router/decisions.py
+++ b/packages/core/src/memex_core/services/inbox_router/decisions.py
@@ -94,7 +94,7 @@ def decide(
     margin = top.p_match - (ordered[1].p_match if len(ordered) > 1 else 0.0)
 
     auto_ok = (
-        routing_state is RoutingState.WARMED_UP
+        routing_state == RoutingState.WARMED_UP
         and top.p_match >= thresholds.auto_apply_min_p_match
         and margin >= thresholds.t_margin
     )

--- a/packages/core/src/memex_core/services/inbox_router/decisions.py
+++ b/packages/core/src/memex_core/services/inbox_router/decisions.py
@@ -1,0 +1,109 @@
+"""Pure decision logic for the inbox router.
+
+Given the scored candidates for one note, decide whether to auto-route, propose
+candidates for the cockpit, or mark the note as no-fit. No I/O — trivially
+unit-testable. The thresholds and the warmed-up flag are supplied by the caller
+(from config + the live match-class observation count).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from uuid import UUID
+
+
+class DecisionKind(str, Enum):
+    AUTO_ROUTE = 'auto_route'
+    PROPOSE_CANDIDATES = 'propose_candidates'
+    PROPOSE_NO_FIT = 'propose_no_fit'
+
+
+class RoutingState(str, Enum):
+    #: Auto-apply eligible — counts cleared the cold-start gate.
+    WARMED_UP = 'warmed_up_auto_eligible'
+    #: Still learning — propose only, regardless of confidence.
+    COLD_START = 'cold_start_no_auto'
+    #: Auto-apply disabled by config — always propose.
+    DISABLED = 'disabled'
+
+
+@dataclass(frozen=True)
+class CandidateScore:
+    """One scored (note, vault) pair from ``SCORE_NOTES_SQL``."""
+
+    vault_id: UUID
+    vault_name: str
+    p_match: float  # per-note softmax-normalised P(match)
+    p_match_raw: float  # raw pairwise sigmoid P(match)
+    ci_half_width: float  # delta-method credible-interval half-width
+
+
+@dataclass(frozen=True)
+class DecisionThresholds:
+    auto_apply_enabled: bool
+    auto_apply_min_p_match: float
+    t_margin: float
+    t_low: float
+
+
+@dataclass(frozen=True)
+class RouterDecision:
+    note_id: UUID
+    kind: DecisionKind
+    routing_state: RoutingState
+    candidates: tuple[CandidateScore, ...]  # sorted desc by p_match
+    margin: float  # top1.p_match - top2.p_match (0.0 if a single candidate)
+
+    @property
+    def top(self) -> CandidateScore | None:
+        return self.candidates[0] if self.candidates else None
+
+
+def decide(
+    note_id: UUID,
+    candidates: list[CandidateScore],
+    *,
+    thresholds: DecisionThresholds,
+    warmed_up: bool,
+) -> RouterDecision:
+    """Classify a note's routing outcome from its scored candidates.
+
+    ``candidates`` need not be pre-sorted; this sorts by ``p_match`` descending.
+    """
+    ordered = tuple(sorted(candidates, key=lambda c: c.p_match, reverse=True))
+
+    if not thresholds.auto_apply_enabled:
+        routing_state = RoutingState.DISABLED
+    elif not warmed_up:
+        routing_state = RoutingState.COLD_START
+    else:
+        routing_state = RoutingState.WARMED_UP
+
+    # No candidate clears the floor → the note doesn't fit any vault.
+    top = ordered[0] if ordered else None
+    if top is None or top.p_match_raw < thresholds.t_low:
+        return RouterDecision(
+            note_id=note_id,
+            kind=DecisionKind.PROPOSE_NO_FIT,
+            routing_state=routing_state,
+            candidates=ordered,
+            margin=0.0,
+        )
+
+    margin = top.p_match - (ordered[1].p_match if len(ordered) > 1 else 0.0)
+
+    auto_ok = (
+        routing_state is RoutingState.WARMED_UP
+        and top.p_match >= thresholds.auto_apply_min_p_match
+        and margin >= thresholds.t_margin
+    )
+    kind = DecisionKind.AUTO_ROUTE if auto_ok else DecisionKind.PROPOSE_CANDIDATES
+
+    return RouterDecision(
+        note_id=note_id,
+        kind=kind,
+        routing_state=routing_state,
+        candidates=ordered,
+        margin=margin,
+    )

--- a/packages/core/src/memex_core/services/inbox_router/evidence.py
+++ b/packages/core/src/memex_core/services/inbox_router/evidence.py
@@ -1,0 +1,49 @@
+"""Pydantic models for the ``evidence`` JSONB payload on routing proposals.
+
+The cockpit and any downstream consumer read these shapes off
+``maintenance_proposals.evidence``. Keeping them typed (rather than a bare dict)
+gives one schema both the emitter and the cockpit agree on.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CandidateEvidence(BaseModel):
+    """One scored candidate vault, as surfaced to the cockpit."""
+
+    vault_id: str
+    vault_name: str
+    p_match: float = Field(description='Per-note softmax-normalised P(match).')
+    p_match_raw: float = Field(description='Raw pairwise sigmoid P(match).')
+    ci_half_width: float = Field(description='Credible-interval half-width.')
+
+
+class RouteEvidence(BaseModel):
+    """Evidence for an ``inbox_vault_route`` proposal.
+
+    ``top_candidates`` drives the per-candidate cockpit options. ``routing_state``
+    tells the operator whether the model is warmed up or still cold-starting.
+    """
+
+    kind: str = 'inbox_vault_route'
+    routing_state: str
+    margin: float
+    source_vault_id: str
+    top_candidates: list[CandidateEvidence]
+
+
+class NoFitEvidence(BaseModel):
+    """Evidence for an ``inbox_vault_no_fit`` proposal, including backoff state."""
+
+    kind: str = 'inbox_vault_no_fit'
+    routing_state: str
+    best_p_match_raw: float = Field(
+        description='Highest raw P(match) across vaults — below the t_low floor.'
+    )
+    retry_n: int = Field(default=0, description='Number of no-fit re-evaluations so far.')
+    next_retry_at: str | None = Field(
+        default=None, description='ISO timestamp when this note becomes eligible again.'
+    )
+    last_evaluated_at: str | None = None

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -54,6 +54,9 @@ NO_FIT_RULE = 'inbox_vault_no_fit'
 ROUTER_ACTOR = 'system:inbox-router'
 TOP_CANDIDATES = 3  # surfaced in route-proposal evidence
 MAX_NOTES_PER_TICK = 500  # bound the scoring batch
+# Session-level advisory lock key serialising live triage ticks (distinct from
+# the scheduler leader lock).
+_ROUTER_LOCK_ID = 5432789123456790
 
 
 @dataclass
@@ -259,15 +262,20 @@ class InboxRouterService(BaseService):
                 )
             ).all()
         out: dict[UUID, list[CandidateScore]] = {}
-        for r in rows:
-            note_id = r[0] if isinstance(r[0], UUID) else UUID(str(r[0]))
+        for row in rows:
+            m = row._mapping  # access by column name, not position
+            nid = m['note_id']
+            note_id = nid if isinstance(nid, UUID) else UUID(str(nid))
+            vid = m['vault_id']
             out.setdefault(note_id, []).append(
                 CandidateScore(
-                    vault_id=r[1] if isinstance(r[1], UUID) else UUID(str(r[1])),
-                    vault_name=r[2],
-                    p_match=float(r[3]) if r[3] is not None else 0.0,
-                    p_match_raw=float(r[4]) if r[4] is not None else 0.0,
-                    ci_half_width=float(r[6]) if r[6] is not None else 0.0,
+                    vault_id=vid if isinstance(vid, UUID) else UUID(str(vid)),
+                    vault_name=m['vault_name'],
+                    p_match=float(m['p_match']) if m['p_match'] is not None else 0.0,
+                    p_match_raw=float(m['p_match_raw']) if m['p_match_raw'] is not None else 0.0,
+                    ci_half_width=float(m['ci_half_width'])
+                    if m['ci_half_width'] is not None
+                    else 0.0,
                 )
             )
         return out
@@ -289,7 +297,34 @@ class InboxRouterService(BaseService):
 
     # ------------------------------------------------------------------ tick
     async def triage_tick(self, *, dry_run: bool = False) -> TriageResult:
-        """Run one full triage pass over the inbox vault."""
+        """Run one full triage pass over the inbox vault.
+
+        Live ticks take a session-level advisory lock so a manual
+        ``memex inbox triage`` racing the scheduler can't run concurrently and
+        double the daily auto-apply budget. Dry runs don't mutate, so they skip
+        the lock. If the lock is held, this tick is a no-op.
+        """
+        if dry_run:
+            return await self._run_tick(dry_run=True)
+
+        async with self.metastore.session() as lock_session:
+            got = (
+                await lock_session.execute(
+                    text('SELECT pg_try_advisory_lock(:k)'), {'k': _ROUTER_LOCK_ID}
+                )
+            ).scalar()
+            if not got:
+                logger.info('inbox_router: another triage holds the lock; skipping tick')
+                return TriageResult()
+            try:
+                return await self._run_tick(dry_run=False)
+            finally:
+                await lock_session.execute(
+                    text('SELECT pg_advisory_unlock(:k)'), {'k': _ROUTER_LOCK_ID}
+                )
+                await lock_session.commit()
+
+    async def _run_tick(self, *, dry_run: bool) -> TriageResult:
         result = TriageResult()
         inbox_id = await self._inbox_vault_id()
         if inbox_id is None:
@@ -422,7 +457,9 @@ class InboxRouterService(BaseService):
         if top is None:  # AUTO_ROUTE always has a top; defensive, not assert (-O strips asserts).
             return
         await self._notes.migrate_note(decision.note_id, top.vault_id)
-        evidence = self._route_evidence(inbox_id, decision).model_dump()
+        # Serialize through Pydantic's JSON serializer (consistent with _emit_route)
+        # then graft the resolution block on the parsed dict.
+        evidence = json.loads(self._route_evidence(inbox_id, decision).model_dump_json())
         evidence['resolution'] = {
             'verb': 'auto_route',
             'target_vault_id': str(top.vault_id),

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -68,6 +68,10 @@ class TriageResult:
     no_fit: int = 0
     skipped_cap: int = 0
     errors: int = 0
+    # Populated only on a dry run: one entry per scored note with the would-be
+    # decision + top candidate. Lets callers (e.g. the eval suite) read per-note
+    # predictions without mutating anything.
+    decisions: list[dict[str, Any]] = field(default_factory=list)
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -78,6 +82,7 @@ class TriageResult:
             'no_fit': self.no_fit,
             'skipped_cap': self.skipped_cap,
             'errors': self.errors,
+            'decisions': self.decisions,
         }
 
 
@@ -417,6 +422,19 @@ class InboxRouterService(BaseService):
 
         for nid in note_ids:
             decision = decide(nid, scored.get(nid, []), thresholds=thresholds, warmed_up=warmed_up)
+            if dry_run:
+                top = decision.top
+                result.decisions.append(
+                    {
+                        'note_id': str(nid),
+                        'kind': decision.kind.value,
+                        'routing_state': decision.routing_state.value,
+                        'margin': decision.margin,
+                        'top_vault_id': str(top.vault_id) if top else None,
+                        'top_vault_name': top.vault_name if top else None,
+                        'top_p_match': top.p_match if top else None,
+                    }
+                )
             try:
                 if decision.kind == DecisionKind.AUTO_ROUTE:
                     if dry_run:

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -184,16 +184,25 @@ class InboxRouterService(BaseService):
 
     # ------------------------------------------------------------------ bootstrap
     async def ensure_inbox_vault(self) -> UUID | None:
-        """Create the inbox vault if missing; return its id (None on failure)."""
+        """Create the inbox vault if missing; return its id (None on failure).
+
+        Query-first: only attempt creation when the vault is genuinely absent,
+        so the ValueError/IntegrityError catch is scoped to the create-time race
+        window (another worker created it between our check and ours) rather than
+        masking validation failures.
+        """
         from sqlalchemy.exc import IntegrityError
 
+        existing = await self._inbox_vault_id()
+        if existing is not None:
+            return existing
         try:
             await self._vaults.create_vault(
                 INBOX_VAULT_NAME,
                 description='Holding vault for notes awaiting routing by the inbox router.',
             )
         except (ValueError, IntegrityError):
-            pass  # already exists (non-locking SELECT race or prior creation)
+            pass  # created concurrently between the check above and here
         except Exception:
             logger.exception('inbox_router: failed to bootstrap inbox vault')
         return await self._inbox_vault_id()
@@ -395,26 +404,30 @@ class InboxRouterService(BaseService):
         for nid in note_ids:
             decision = decide(nid, scored.get(nid, []), thresholds=thresholds, warmed_up=warmed_up)
             try:
-                if decision.kind is DecisionKind.AUTO_ROUTE:
+                if decision.kind == DecisionKind.AUTO_ROUTE:
                     if dry_run:
                         result.auto_routed += 1
                     elif remaining_budget <= 0:
                         # Over the daily budget — fall through to a proposal.
-                        await self._emit_route(inbox_vault_id=inbox_id, decision=decision)
                         result.skipped_cap += 1
-                        result.proposed += 1
+                        if await self._emit_route(inbox_vault_id=inbox_id, decision=decision):
+                            result.proposed += 1
                     else:
                         await self._auto_apply(inbox_id, decision)
                         result.auto_routed += 1
                         remaining_budget -= 1
-                elif decision.kind is DecisionKind.PROPOSE_CANDIDATES:
-                    if not dry_run:
-                        await self._emit_route(inbox_vault_id=inbox_id, decision=decision)
-                    result.proposed += 1
+                elif decision.kind == DecisionKind.PROPOSE_CANDIDATES:
+                    # Count only proposals that actually landed (the cooldown guard
+                    # in _EMIT_PENDING_SQL can skip the insert).
+                    if dry_run:
+                        result.proposed += 1
+                    elif await self._emit_route(inbox_vault_id=inbox_id, decision=decision):
+                        result.proposed += 1
                 else:  # PROPOSE_NO_FIT
-                    if not dry_run:
-                        await self._emit_no_fit(inbox_id, decision)
-                    result.no_fit += 1
+                    if dry_run:
+                        result.no_fit += 1
+                    elif await self._emit_no_fit(inbox_id, decision):
+                        result.no_fit += 1
             except Exception:
                 logger.exception('inbox_router: failed to act on note %s', nid)
                 result.errors += 1
@@ -531,13 +544,15 @@ class InboxRouterService(BaseService):
         for cand in decision.candidates[1:TOP_CANDIDATES]:
             await self.record_feedback(decision.note_id, cand.vault_id, 0)
 
-    async def _emit_route(self, *, inbox_vault_id: UUID, decision: RouterDecision) -> None:
+    async def _emit_route(self, *, inbox_vault_id: UUID, decision: RouterDecision) -> bool:
+        """Emit a pending route proposal. Returns True iff a row was inserted
+        (the cooldown guard can skip it)."""
         top = decision.top
         if top is None:
-            return
+            return False
         evidence = self._route_evidence(inbox_vault_id, decision)
         async with self.metastore.session() as session:
-            await session.execute(
+            res = await session.execute(
                 text(_EMIT_PENDING_SQL),
                 {
                     'vault_id': str(inbox_vault_id),
@@ -548,8 +563,10 @@ class InboxRouterService(BaseService):
                 },
             )
             await session.commit()
+        return res.rowcount > 0
 
-    async def _emit_no_fit(self, inbox_id: UUID, decision: RouterDecision) -> None:
+    async def _emit_no_fit(self, inbox_id: UUID, decision: RouterDecision) -> bool:
+        """Emit / refresh a no-fit proposal. Returns True iff a row landed."""
         best = decision.candidates[0].p_match_raw if decision.candidates else 0.0
         now = datetime.now(timezone.utc)
         # Read the existing retry counter and upsert in ONE transaction. The
@@ -600,6 +617,7 @@ class InboxRouterService(BaseService):
                     'inbox_router: no-fit upsert skipped (backoff not due) for note %s',
                     decision.note_id,
                 )
+        return upsert.rowcount > 0
 
     def _route_evidence(self, inbox_id: UUID, decision: RouterDecision) -> RouteEvidence:
         return RouteEvidence(

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -138,7 +138,9 @@ _SELECT_INBOX_NOTES_SQL = """
 SELECT n.id
   FROM notes n
  WHERE n.vault_id = :inbox_id ::uuid
-   AND EXISTS (SELECT 1 FROM chunks c WHERE c.note_id = n.id)
+   -- Require at least one EMBEDDED chunk: a note still awaiting embeddings has
+   -- no centroid to score, and must be deferred rather than scored as no-fit.
+   AND EXISTS (SELECT 1 FROM chunks c WHERE c.note_id = n.id AND c.embedding IS NOT NULL)
    AND NOT EXISTS (
         SELECT 1 FROM maintenance_proposals mp
          WHERE mp.rule_name = :route_rule
@@ -486,30 +488,43 @@ class InboxRouterService(BaseService):
             'margin': decision.margin,
             'applied_at': datetime.now(timezone.utc).isoformat(),
         }
-        async with self.metastore.session() as session:
-            # Dismiss any pending routing proposal for this note — the note has
-            # moved, so a leftover cockpit action would be stale.
-            await session.execute(
-                text(
-                    'UPDATE maintenance_proposals '
-                    "SET status = 'dismissed', resolved_at = now(), resolved_by = :actor "
-                    "WHERE lint_type = 'routing' AND target_type = 'note' "
-                    "AND target_id = :target_id AND status = 'pending'"
-                ),
-                {'target_id': str(decision.note_id), 'actor': ROUTER_ACTOR},
+        # migrate_note has already committed (its own transaction). This audit
+        # write runs in a separate transaction; on failure the note is correctly
+        # moved but the audit row is missing. We log a structured reconciliation
+        # record and re-raise (the tick counts it as an error) rather than losing
+        # it silently. The note is out of the inbox, so it won't be re-triaged.
+        try:
+            async with self.metastore.session() as session:
+                # Dismiss any pending routing proposal for this note — the note has
+                # moved, so a leftover cockpit action would be stale.
+                await session.execute(
+                    text(
+                        'UPDATE maintenance_proposals '
+                        "SET status = 'dismissed', resolved_at = now(), resolved_by = :actor "
+                        "WHERE lint_type = 'routing' AND target_type = 'note' "
+                        "AND target_id = :target_id AND status = 'pending'"
+                    ),
+                    {'target_id': str(decision.note_id), 'actor': ROUTER_ACTOR},
+                )
+                await session.execute(
+                    text(_INSERT_RESOLVED_SQL),
+                    {
+                        'vault_id': str(inbox_id),
+                        'target_id': str(decision.note_id),
+                        'rule_name': ROUTE_RULE,
+                        'evidence': json.dumps(evidence),
+                        'suggested_action': f'Auto-routed to {top.vault_name}',
+                        'actor': ROUTER_ACTOR,
+                    },
+                )
+                await session.commit()
+        except Exception:
+            logger.exception(
+                'auto_route.audit_write_failed: note %s migrated to %s without audit row',
+                decision.note_id,
+                top.vault_id,
             )
-            await session.execute(
-                text(_INSERT_RESOLVED_SQL),
-                {
-                    'vault_id': str(inbox_id),
-                    'target_id': str(decision.note_id),
-                    'rule_name': ROUTE_RULE,
-                    'evidence': json.dumps(evidence),
-                    'suggested_action': f'Auto-routed to {top.vault_name}',
-                    'actor': ROUTER_ACTOR,
-                },
-            )
-            await session.commit()
+            raise
         # Learn: the chosen vault is a positive, the other candidates negatives.
         await self.record_feedback(decision.note_id, top.vault_id, 1)
         for cand in decision.candidates[1:TOP_CANDIDATES]:
@@ -562,7 +577,7 @@ class InboxRouterService(BaseService):
                 next_retry_at=next_retry.isoformat(),
                 last_evaluated_at=now.isoformat(),
             )
-            await session.execute(
+            upsert = await session.execute(
                 text(_UPSERT_NO_FIT_SQL),
                 {
                     'vault_id': str(inbox_id),
@@ -575,6 +590,15 @@ class InboxRouterService(BaseService):
                 },
             )
             await session.commit()
+            if upsert.rowcount == 0 and row is not None:
+                # An existing pending no-fit wasn't due yet, so the UPSERT's WHERE
+                # guard skipped the evidence refresh. Expected only if a manual
+                # tick raced the backoff window (the SELECT guard normally filters
+                # these out); log for visibility rather than silently dropping.
+                logger.debug(
+                    'inbox_router: no-fit upsert skipped (backoff not due) for note %s',
+                    decision.note_id,
+                )
 
     def _route_evidence(self, inbox_id: UUID, decision: RouterDecision) -> RouteEvidence:
         return RouteEvidence(

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -129,13 +129,23 @@ VALUES (:vault_id ::uuid, 'routing', 'note', :target_id, :rule_name,
         now(), :actor)
 """
 
-# Inbox notes due for triage: in the inbox vault, with chunks, and not currently
-# parked behind a not-yet-due no-fit proposal.
+# Inbox notes due for triage: in the inbox vault, with chunks, NOT already
+# awaiting a cockpit decision on a pending route proposal, and not currently
+# parked behind a not-yet-due no-fit backoff window. Skipping notes that already
+# have a pending route proposal avoids re-scoring (and re-proposing with stale
+# evidence) a note the user simply hasn't actioned yet.
 _SELECT_INBOX_NOTES_SQL = """
 SELECT n.id
   FROM notes n
  WHERE n.vault_id = :inbox_id ::uuid
    AND EXISTS (SELECT 1 FROM chunks c WHERE c.note_id = n.id)
+   AND NOT EXISTS (
+        SELECT 1 FROM maintenance_proposals mp
+         WHERE mp.rule_name = :route_rule
+           AND mp.target_type = 'note'
+           AND mp.target_id = n.id::text
+           AND mp.status = 'pending'
+   )
    AND NOT EXISTS (
         SELECT 1 FROM maintenance_proposals mp
          WHERE mp.rule_name = :no_fit_rule
@@ -245,8 +255,17 @@ class InboxRouterService(BaseService):
 
     async def populate_note_cache(self, note_id: UUID) -> None:
         """(Re)compute the cached features for one note. Idempotent upsert."""
+        await self.populate_note_caches([note_id])
+
+    async def populate_note_caches(self, note_ids: list[UUID]) -> None:
+        """(Re)compute cached features for many notes in one statement."""
+        if not note_ids:
+            return
         async with self.metastore.session() as session:
-            await session.execute(text(_sql.POPULATE_NOTE_CACHE_SQL), {'note_id': str(note_id)})
+            await session.execute(
+                text(_sql.POPULATE_NOTE_CACHE_SQL),
+                {'note_ids': [str(n) for n in note_ids]},
+            )
             await session.commit()
 
     # ------------------------------------------------------------------ scoring
@@ -340,6 +359,7 @@ class InboxRouterService(BaseService):
                     text(_SELECT_INBOX_NOTES_SQL),
                     {
                         'inbox_id': str(inbox_id),
+                        'route_rule': ROUTE_RULE,
                         'no_fit_rule': NO_FIT_RULE,
                         'limit': MAX_NOTES_PER_TICK,
                     },
@@ -349,8 +369,7 @@ class InboxRouterService(BaseService):
         if not note_ids:
             return result
 
-        for nid in note_ids:
-            await self.populate_note_cache(nid)
+        await self.populate_note_caches(note_ids)
 
         scored = await self.score_notes(note_ids)
         result.scored = len(scored)
@@ -468,6 +487,17 @@ class InboxRouterService(BaseService):
             'applied_at': datetime.now(timezone.utc).isoformat(),
         }
         async with self.metastore.session() as session:
+            # Dismiss any pending routing proposal for this note — the note has
+            # moved, so a leftover cockpit action would be stale.
+            await session.execute(
+                text(
+                    'UPDATE maintenance_proposals '
+                    "SET status = 'dismissed', resolved_at = now(), resolved_by = :actor "
+                    "WHERE lint_type = 'routing' AND target_type = 'note' "
+                    "AND target_id = :target_id AND status = 'pending'"
+                ),
+                {'target_id': str(decision.note_id), 'actor': ROUTER_ACTOR},
+            )
             await session.execute(
                 text(_INSERT_RESOLVED_SQL),
                 {
@@ -506,31 +536,9 @@ class InboxRouterService(BaseService):
     async def _emit_no_fit(self, inbox_id: UUID, decision: RouterDecision) -> None:
         best = decision.candidates[0].p_match_raw if decision.candidates else 0.0
         now = datetime.now(timezone.utc)
-        retry_n, next_retry = await self._next_backoff(inbox_id, decision.note_id, now)
-        evidence = NoFitEvidence(
-            routing_state=decision.routing_state.value,
-            best_p_match_raw=best,
-            retry_n=retry_n,
-            next_retry_at=next_retry.isoformat(),
-            last_evaluated_at=now.isoformat(),
-        )
-        async with self.metastore.session() as session:
-            await session.execute(
-                text(_UPSERT_NO_FIT_SQL),
-                {
-                    'vault_id': str(inbox_id),
-                    'target_id': str(decision.note_id),
-                    'rule_name': NO_FIT_RULE,
-                    'evidence': evidence.model_dump_json(),
-                    'suggested_action': 'No vault fits this note; leave in inbox or migrate manually.',
-                },
-            )
-            await session.commit()
-
-    async def _next_backoff(
-        self, inbox_id: UUID, note_id: UUID, now: datetime
-    ) -> tuple[int, datetime]:
-        """Compute the next (retry_n, next_retry_at) from any existing no-fit row."""
+        # Read the existing retry counter and upsert in ONE transaction. The
+        # SELECT ... FOR UPDATE locks any existing pending row so a concurrent
+        # writer can't read the same retry_n and clobber the increment.
         async with self.metastore.session() as session:
             row = (
                 await session.execute(
@@ -538,15 +546,35 @@ class InboxRouterService(BaseService):
                         "SELECT (evidence->>'retry_n')::int FROM maintenance_proposals "
                         "WHERE rule_name = :rule AND target_type = 'note' "
                         'AND target_id = :tid AND vault_id = :vid ::uuid '
-                        "AND status = 'pending'"
+                        "AND status = 'pending' FOR UPDATE"
                     ),
-                    {'rule': NO_FIT_RULE, 'tid': str(note_id), 'vid': str(inbox_id)},
+                    {'rule': NO_FIT_RULE, 'tid': str(decision.note_id), 'vid': str(inbox_id)},
                 )
             ).first()
-        prev = int(row[0]) if row and row[0] is not None else -1
-        retry_n = prev + 1
-        delay_days = min(self._cfg.backoff_base_days * (2**retry_n), self._cfg.backoff_cap_days)
-        return retry_n, now + timedelta(days=delay_days)
+            prev = int(row[0]) if row and row[0] is not None else -1
+            retry_n = prev + 1
+            delay_days = min(self._cfg.backoff_base_days * (2**retry_n), self._cfg.backoff_cap_days)
+            next_retry = now + timedelta(days=delay_days)
+            evidence = NoFitEvidence(
+                routing_state=decision.routing_state.value,
+                best_p_match_raw=best,
+                retry_n=retry_n,
+                next_retry_at=next_retry.isoformat(),
+                last_evaluated_at=now.isoformat(),
+            )
+            await session.execute(
+                text(_UPSERT_NO_FIT_SQL),
+                {
+                    'vault_id': str(inbox_id),
+                    'target_id': str(decision.note_id),
+                    'rule_name': NO_FIT_RULE,
+                    'evidence': evidence.model_dump_json(),
+                    'suggested_action': (
+                        'No vault fits this note; leave in inbox or migrate manually.'
+                    ),
+                },
+            )
+            await session.commit()
 
     def _route_evidence(self, inbox_id: UUID, decision: RouterDecision) -> RouteEvidence:
         return RouteEvidence(

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -1,0 +1,479 @@
+"""InboxRouterService — periodic triage of the ``inbox`` vault.
+
+Orchestrates: refresh per-vault anchors → cache per-note features → score all
+inbox notes (pairwise GaussianNB in SQL) → decide → auto-route the confident
+ones (capped) and emit cockpit proposals for the rest. Learns online from
+cockpit/auto decisions via SQL conjugate updates.
+
+The model is "fit" entirely in Postgres; see ``sql.py``. This service is the
+thin Python layer that drives those statements and applies the decision policy
+in ``decisions.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from sqlalchemy import text
+
+from memex_core.services.base import BaseService
+from memex_core.services.inbox_router import sql as _sql
+from memex_core.services.inbox_router.decisions import (
+    CandidateScore,
+    DecisionKind,
+    DecisionThresholds,
+    RouterDecision,
+    decide,
+)
+from memex_core.services.inbox_router.evidence import (
+    CandidateEvidence,
+    NoFitEvidence,
+    RouteEvidence,
+)
+
+if TYPE_CHECKING:
+    from memex_core.config import MemexConfig
+    from memex_core.memory.models.embedding import EmbeddingsModel
+    from memex_core.services.notes import NoteService
+    from memex_core.services.vaults import VaultService
+    from memex_core.storage.filestore import BaseAsyncFileStore
+    from memex_core.storage.metastore import AsyncBaseMetaStoreEngine
+
+logger = logging.getLogger(__name__)
+
+INBOX_VAULT_NAME = 'inbox'
+ROUTE_RULE = 'inbox_vault_route'
+NO_FIT_RULE = 'inbox_vault_no_fit'
+ROUTER_ACTOR = 'system:inbox-router'
+TOP_CANDIDATES = 3  # surfaced in route-proposal evidence
+MAX_NOTES_PER_TICK = 500  # bound the scoring batch
+
+
+@dataclass
+class TriageResult:
+    vault_id: UUID | None = None
+    scored: int = 0
+    auto_routed: int = 0
+    proposed: int = 0
+    no_fit: int = 0
+    skipped_cap: int = 0
+    errors: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            'vault_id': str(self.vault_id) if self.vault_id else None,
+            'scored': self.scored,
+            'auto_routed': self.auto_routed,
+            'proposed': self.proposed,
+            'no_fit': self.no_fit,
+            'skipped_cap': self.skipped_cap,
+            'errors': self.errors,
+        }
+
+
+# Emit a pending proposal, idempotent on the pending tuple AND respecting the
+# 30-day post-resolution/dismissal cooldown (mirrors LintService's guard) so a
+# dismissed route isn't immediately re-proposed.
+_EMIT_PENDING_SQL = """
+INSERT INTO maintenance_proposals
+    (vault_id, lint_type, target_type, target_id, rule_name, evidence,
+     suggested_action, status, source)
+SELECT :vault_id ::uuid, 'routing', 'note', :target_id, :rule_name,
+       CAST(:evidence AS jsonb), :suggested_action, 'pending', 'rule'
+WHERE NOT EXISTS (
+    SELECT 1 FROM maintenance_proposals mp
+     WHERE mp.rule_name = :rule_name
+       AND mp.target_type = 'note'
+       AND mp.target_id = :target_id
+       AND mp.vault_id = :vault_id ::uuid
+       AND mp.status IN ('resolved', 'dismissed')
+       AND mp.resolved_at > now() - interval '30 days'
+)
+ON CONFLICT (rule_name, target_type, target_id, vault_id)
+    WHERE status = 'pending'
+DO NOTHING
+"""
+
+# No-fit backoff: advance the retry counter / next_retry_at on the existing
+# pending row when it is due, otherwise insert a fresh one.
+_UPSERT_NO_FIT_SQL = """
+INSERT INTO maintenance_proposals
+    (vault_id, lint_type, target_type, target_id, rule_name, evidence,
+     suggested_action, status, source)
+VALUES (:vault_id ::uuid, 'routing', 'note', :target_id, :rule_name,
+        CAST(:evidence AS jsonb), :suggested_action, 'pending', 'rule')
+ON CONFLICT (rule_name, target_type, target_id, vault_id)
+    WHERE status = 'pending'
+DO UPDATE SET evidence = CAST(:evidence AS jsonb)
+WHERE (maintenance_proposals.evidence->>'next_retry_at') IS NULL
+   OR (maintenance_proposals.evidence->>'next_retry_at')::timestamptz <= now()
+"""
+
+# Record an auto-applied route as a resolved proposal (audit trail).
+_INSERT_RESOLVED_SQL = """
+INSERT INTO maintenance_proposals
+    (vault_id, lint_type, target_type, target_id, rule_name, evidence,
+     suggested_action, status, source, resolved_at, resolved_by)
+VALUES (:vault_id ::uuid, 'routing', 'note', :target_id, :rule_name,
+        CAST(:evidence AS jsonb), :suggested_action, 'resolved', 'rule',
+        now(), :actor)
+"""
+
+# Inbox notes due for triage: in the inbox vault, with chunks, and not currently
+# parked behind a not-yet-due no-fit proposal.
+_SELECT_INBOX_NOTES_SQL = """
+SELECT n.id
+  FROM notes n
+ WHERE n.vault_id = :inbox_id ::uuid
+   AND EXISTS (SELECT 1 FROM chunks c WHERE c.note_id = n.id)
+   AND NOT EXISTS (
+        SELECT 1 FROM maintenance_proposals mp
+         WHERE mp.rule_name = :no_fit_rule
+           AND mp.target_type = 'note'
+           AND mp.target_id = n.id::text
+           AND mp.status = 'pending'
+           AND (mp.evidence->>'next_retry_at')::timestamptz > now()
+   )
+ LIMIT :limit
+"""
+
+
+class InboxRouterService(BaseService):
+    """Drives inbox-note scoring, auto-routing, and proposal emission."""
+
+    def __init__(
+        self,
+        metastore: AsyncBaseMetaStoreEngine,
+        filestore: BaseAsyncFileStore,
+        config: MemexConfig,
+        *,
+        embedding_model: EmbeddingsModel,
+        notes: NoteService,
+        vaults: VaultService,
+    ) -> None:
+        super().__init__(metastore, filestore, config)
+        self.embedding_model = embedding_model
+        self._notes = notes
+        self._vaults = vaults
+
+    @property
+    def _cfg(self):  # noqa: ANN202 - InboxRouterConfig
+        return self.config.server.memory.inbox_router
+
+    # ------------------------------------------------------------------ bootstrap
+    async def ensure_inbox_vault(self) -> UUID | None:
+        """Create the inbox vault if missing; return its id (None on failure)."""
+        from sqlalchemy.exc import IntegrityError
+
+        try:
+            await self._vaults.create_vault(
+                INBOX_VAULT_NAME,
+                description='Holding vault for notes awaiting routing by the inbox router.',
+            )
+        except (ValueError, IntegrityError):
+            pass  # already exists (non-locking SELECT race or prior creation)
+        except Exception:
+            logger.exception('inbox_router: failed to bootstrap inbox vault')
+        return await self._inbox_vault_id()
+
+    async def _inbox_vault_id(self) -> UUID | None:
+        async with self.metastore.session() as session:
+            row = (
+                await session.execute(
+                    text(
+                        'SELECT id FROM vaults WHERE name = :name AND archived_at IS NULL '
+                        'ORDER BY created_at LIMIT 1'
+                    ),
+                    {'name': INBOX_VAULT_NAME},
+                )
+            ).first()
+        return row[0] if row else None
+
+    # ------------------------------------------------------------------ anchors
+    async def refresh_anchors(self) -> int:
+        """Refresh per-vault anchors for every candidate (non-inbox) vault.
+
+        Embeds each vault's narrative in Python (for ``summary_embedding``); the
+        remaining anchors are computed in SQL. Returns the number refreshed.
+        """
+        excluded = set(self._excluded_vault_names())
+        async with self.metastore.session() as session:
+            rows = (
+                await session.execute(
+                    text(
+                        "SELECT v.id, v.name, COALESCE(vs.narrative, v.description, '') "
+                        'FROM vaults v '
+                        'LEFT JOIN vault_summaries vs ON vs.vault_id = v.id '
+                        'WHERE v.archived_at IS NULL'
+                    )
+                )
+            ).all()
+        targets = [
+            (vid, name, narrative) for (vid, name, narrative) in rows if name not in excluded
+        ]
+        if not targets:
+            return 0
+
+        narratives = [narrative or '(empty)' for (_, _, narrative) in targets]
+        vecs = await asyncio.to_thread(self.embedding_model.encode, narratives)
+
+        refreshed = 0
+        async with self.metastore.session() as session:
+            for (vid, _name, _narr), vec in zip(targets, vecs, strict=True):
+                summary_vec = '[' + ','.join(f'{float(x):.8f}' for x in vec) + ']'
+                await session.execute(
+                    text(_sql.REFRESH_VAULT_ANCHOR_SQL),
+                    {
+                        'vault_id': str(vid),
+                        'summary_embedding': summary_vec,
+                        'top_k': self._cfg.top_k_entities,
+                    },
+                )
+                refreshed += 1
+            await session.commit()
+        return refreshed
+
+    async def populate_note_cache(self, note_id: UUID) -> None:
+        """(Re)compute the cached features for one note. Idempotent upsert."""
+        async with self.metastore.session() as session:
+            await session.execute(text(_sql.POPULATE_NOTE_CACHE_SQL), {'note_id': str(note_id)})
+            await session.commit()
+
+    # ------------------------------------------------------------------ scoring
+    async def score_notes(self, note_ids: list[UUID]) -> dict[UUID, list[CandidateScore]]:
+        if not note_ids:
+            return {}
+        excluded = self._excluded_vault_names()
+        async with self.metastore.session() as session:
+            rows = (
+                await session.execute(
+                    text(_sql.SCORE_NOTES_SQL),
+                    {'note_ids': [str(n) for n in note_ids], 'excluded': excluded},
+                )
+            ).all()
+        out: dict[UUID, list[CandidateScore]] = {}
+        for r in rows:
+            note_id = r[0] if isinstance(r[0], UUID) else UUID(str(r[0]))
+            out.setdefault(note_id, []).append(
+                CandidateScore(
+                    vault_id=r[1] if isinstance(r[1], UUID) else UUID(str(r[1])),
+                    vault_name=r[2],
+                    p_match=float(r[3]) if r[3] is not None else 0.0,
+                    p_match_raw=float(r[4]) if r[4] is not None else 0.0,
+                    ci_half_width=float(r[6]) if r[6] is not None else 0.0,
+                )
+            )
+        return out
+
+    # ------------------------------------------------------------------ feedback
+    async def record_feedback(self, note_id: UUID, vault_id: UUID, label: int) -> None:
+        """Apply one online conjugate update for a (note, vault, match?) pair."""
+        async with self.metastore.session() as session:
+            await session.execute(
+                text(_sql.ONLINE_UPDATE_SQL),
+                {
+                    'note_id': str(note_id),
+                    'vault_id': str(vault_id),
+                    'label': int(label),
+                    'gamma': float(self._cfg.ewma_gamma),
+                },
+            )
+            await session.commit()
+
+    # ------------------------------------------------------------------ tick
+    async def triage_tick(self, *, dry_run: bool = False) -> TriageResult:
+        """Run one full triage pass over the inbox vault."""
+        result = TriageResult()
+        inbox_id = await self._inbox_vault_id()
+        if inbox_id is None:
+            logger.info('inbox_router: no inbox vault; skipping tick')
+            return result
+        result.vault_id = inbox_id
+
+        await self.refresh_anchors()
+
+        async with self.metastore.session() as session:
+            note_rows = (
+                await session.execute(
+                    text(_SELECT_INBOX_NOTES_SQL),
+                    {
+                        'inbox_id': str(inbox_id),
+                        'no_fit_rule': NO_FIT_RULE,
+                        'limit': MAX_NOTES_PER_TICK,
+                    },
+                )
+            ).all()
+        note_ids = [r[0] if isinstance(r[0], UUID) else UUID(str(r[0])) for r in note_rows]
+        if not note_ids:
+            return result
+
+        for nid in note_ids:
+            await self.populate_note_cache(nid)
+
+        scored = await self.score_notes(note_ids)
+        result.scored = len(scored)
+
+        warmed_up = await self._is_warmed_up()
+        thresholds = DecisionThresholds(
+            auto_apply_enabled=self._cfg.auto_apply_enabled,
+            auto_apply_min_p_match=self._cfg.auto_apply_min_p_match,
+            t_margin=self._cfg.t_margin,
+            t_low=self._cfg.t_low,
+        )
+
+        for nid in note_ids:
+            decision = decide(nid, scored.get(nid, []), thresholds=thresholds, warmed_up=warmed_up)
+            try:
+                if decision.kind is DecisionKind.AUTO_ROUTE:
+                    if dry_run:
+                        result.auto_routed += 1
+                    elif result.auto_routed >= self._cfg.max_auto_applies_per_tick:
+                        # Over the per-tick budget — fall through to a proposal.
+                        await self._emit_route(session_vault=inbox_id, decision=decision)
+                        result.skipped_cap += 1
+                        result.proposed += 1
+                    else:
+                        await self._auto_apply(inbox_id, decision)
+                        result.auto_routed += 1
+                elif decision.kind is DecisionKind.PROPOSE_CANDIDATES:
+                    if not dry_run:
+                        await self._emit_route(session_vault=inbox_id, decision=decision)
+                    result.proposed += 1
+                else:  # PROPOSE_NO_FIT
+                    if not dry_run:
+                        await self._emit_no_fit(inbox_id, decision)
+                    result.no_fit += 1
+            except Exception:
+                logger.exception('inbox_router: failed to act on note %s', nid)
+                result.errors += 1
+
+        return result
+
+    # ------------------------------------------------------------------ helpers
+    async def _is_warmed_up(self) -> bool:
+        async with self.metastore.session() as session:
+            n = (
+                await session.execute(
+                    text('SELECT n FROM inbox_router_nb_class_counts WHERE label = 1')
+                )
+            ).scalar()
+        return float(n or 0.0) >= self._cfg.min_decisions_before_auto_apply
+
+    def _excluded_vault_names(self) -> list[str]:
+        # The inbox is the source; 'global' is a catch-all that dilutes routing.
+        return [INBOX_VAULT_NAME, 'global']
+
+    async def _auto_apply(self, inbox_id: UUID, decision: RouterDecision) -> None:
+        top = decision.top
+        assert top is not None
+        await self._notes.migrate_note(decision.note_id, top.vault_id)
+        evidence = self._route_evidence(inbox_id, decision).model_dump()
+        evidence['resolution'] = {
+            'verb': 'auto_route',
+            'target_vault_id': str(top.vault_id),
+            'p_match': top.p_match,
+            'margin': decision.margin,
+            'applied_at': datetime.now(timezone.utc).isoformat(),
+        }
+        async with self.metastore.session() as session:
+            await session.execute(
+                text(_INSERT_RESOLVED_SQL),
+                {
+                    'vault_id': str(inbox_id),
+                    'target_id': str(decision.note_id),
+                    'rule_name': ROUTE_RULE,
+                    'evidence': json.dumps(evidence),
+                    'suggested_action': f'Auto-routed to {top.vault_name}',
+                    'actor': ROUTER_ACTOR,
+                },
+            )
+            await session.commit()
+        # Learn: the chosen vault is a positive, the other candidates negatives.
+        await self.record_feedback(decision.note_id, top.vault_id, 1)
+        for cand in decision.candidates[1:TOP_CANDIDATES]:
+            await self.record_feedback(decision.note_id, cand.vault_id, 0)
+
+    async def _emit_route(self, *, session_vault: UUID, decision: RouterDecision) -> None:
+        top = decision.top
+        assert top is not None
+        evidence = self._route_evidence(session_vault, decision)
+        async with self.metastore.session() as session:
+            await session.execute(
+                text(_EMIT_PENDING_SQL),
+                {
+                    'vault_id': str(session_vault),
+                    'target_id': str(decision.note_id),
+                    'rule_name': ROUTE_RULE,
+                    'evidence': evidence.model_dump_json(),
+                    'suggested_action': f'Route to {top.vault_name}?',
+                },
+            )
+            await session.commit()
+
+    async def _emit_no_fit(self, inbox_id: UUID, decision: RouterDecision) -> None:
+        best = decision.candidates[0].p_match_raw if decision.candidates else 0.0
+        now = datetime.now(timezone.utc)
+        retry_n, next_retry = await self._next_backoff(inbox_id, decision.note_id, now)
+        evidence = NoFitEvidence(
+            routing_state=decision.routing_state.value,
+            best_p_match_raw=best,
+            retry_n=retry_n,
+            next_retry_at=next_retry.isoformat(),
+            last_evaluated_at=now.isoformat(),
+        )
+        async with self.metastore.session() as session:
+            await session.execute(
+                text(_UPSERT_NO_FIT_SQL),
+                {
+                    'vault_id': str(inbox_id),
+                    'target_id': str(decision.note_id),
+                    'rule_name': NO_FIT_RULE,
+                    'evidence': evidence.model_dump_json(),
+                    'suggested_action': 'No vault fits this note; leave in inbox or migrate manually.',
+                },
+            )
+            await session.commit()
+
+    async def _next_backoff(
+        self, inbox_id: UUID, note_id: UUID, now: datetime
+    ) -> tuple[int, datetime]:
+        """Compute the next (retry_n, next_retry_at) from any existing no-fit row."""
+        async with self.metastore.session() as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT (evidence->>'retry_n')::int FROM maintenance_proposals "
+                        "WHERE rule_name = :rule AND target_type = 'note' "
+                        'AND target_id = :tid AND vault_id = :vid ::uuid '
+                        "AND status = 'pending'"
+                    ),
+                    {'rule': NO_FIT_RULE, 'tid': str(note_id), 'vid': str(inbox_id)},
+                )
+            ).first()
+        prev = int(row[0]) if row and row[0] is not None else -1
+        retry_n = prev + 1
+        delay_days = min(self._cfg.backoff_base_days * (2**retry_n), self._cfg.backoff_cap_days)
+        return retry_n, now + timedelta(days=delay_days)
+
+    def _route_evidence(self, inbox_id: UUID, decision: RouterDecision) -> RouteEvidence:
+        return RouteEvidence(
+            routing_state=decision.routing_state.value,
+            margin=decision.margin,
+            source_vault_id=str(inbox_id),
+            top_candidates=[
+                CandidateEvidence(
+                    vault_id=str(c.vault_id),
+                    vault_name=c.vault_name,
+                    p_match=c.p_match,
+                    p_match_raw=c.p_match_raw,
+                    ci_half_width=c.ci_half_width,
+                )
+                for c in decision.candidates[:TOP_CANDIDATES]
+            ],
+        )

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -89,6 +89,11 @@ class TriageResult:
 # Emit a pending proposal, idempotent on the pending tuple AND respecting the
 # 30-day post-resolution/dismissal cooldown (mirrors LintService's guard) so a
 # dismissed route isn't immediately re-proposed.
+# The ON CONFLICT arbiter is the existing partial unique index
+# ``uq_maintenance_proposals_pending`` on
+# (rule_name, target_type, target_id, vault_id) WHERE status='pending'
+# (MaintenanceProposal.__table_args__ in sql_models.py) — shared with the lint
+# system, exercised by the integration tests.
 _EMIT_PENDING_SQL = """
 INSERT INTO maintenance_proposals
     (vault_id, lint_type, target_type, target_id, rule_name, evidence,
@@ -416,9 +421,9 @@ class InboxRouterService(BaseService):
         # already-resolved router routes today so concurrent invocations (a
         # manual `memex inbox triage` racing the scheduler) share one cap rather
         # than each getting a fresh allowance.
-        remaining_budget = self._cfg.max_auto_applies_per_day
-        if not dry_run:
-            remaining_budget = max(0, remaining_budget - await self._auto_applied_today(inbox_id))
+        remaining_budget = max(
+            0, self._cfg.max_auto_applies_per_day - await self._auto_applied_today(inbox_id)
+        )
 
         for nid in note_ids:
             decision = decide(nid, scored.get(nid, []), thresholds=thresholds, warmed_up=warmed_up)
@@ -437,15 +442,17 @@ class InboxRouterService(BaseService):
                 )
             try:
                 if decision.kind == DecisionKind.AUTO_ROUTE:
-                    if dry_run:
-                        result.auto_routed += 1
-                    elif remaining_budget <= 0:
-                        # Over the daily budget — fall through to a proposal.
+                    # The daily cap applies to the count in both modes so a dry run
+                    # previews the same auto/skipped split a live tick would produce.
+                    if remaining_budget <= 0:
                         result.skipped_cap += 1
-                        if await self._emit_route(inbox_vault_id=inbox_id, decision=decision):
+                        if dry_run:
+                            result.proposed += 1
+                        elif await self._emit_route(inbox_vault_id=inbox_id, decision=decision):
                             result.proposed += 1
                     else:
-                        await self._auto_apply(inbox_id, decision)
+                        if not dry_run:
+                            await self._auto_apply(inbox_id, decision)
                         result.auto_routed += 1
                         remaining_budget -= 1
                 elif decision.kind == DecisionKind.PROPOSE_CANDIDATES:
@@ -572,9 +579,24 @@ class InboxRouterService(BaseService):
             )
             raise
         # Learn: the chosen vault is a positive, the other candidates negatives.
-        await self.record_feedback(decision.note_id, top.vault_id, 1)
+        # Best-effort and per-call (matching the cockpit path) — the route is
+        # already applied + audited, so a learning hiccup must not surface as a
+        # routing failure, and one failed update must not drop the rest.
+        await self._record_feedback_safe(decision.note_id, top.vault_id, 1)
         for cand in decision.candidates[1:TOP_CANDIDATES]:
-            await self.record_feedback(decision.note_id, cand.vault_id, 0)
+            await self._record_feedback_safe(decision.note_id, cand.vault_id, 0)
+
+    async def _record_feedback_safe(self, note_id: UUID, vault_id: UUID, label: int) -> None:
+        try:
+            await self.record_feedback(note_id, vault_id, label)
+        except Exception:
+            logger.warning(
+                'inbox_router: record_feedback failed (note=%s vault=%s label=%s)',
+                note_id,
+                vault_id,
+                label,
+                exc_info=True,
+            )
 
     async def _emit_route(self, *, inbox_vault_id: UUID, decision: RouterDecision) -> bool:
         """Emit a pending route proposal. Returns True iff a row was inserted

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -388,7 +388,7 @@ class InboxRouterService(BaseService):
         # already-resolved router routes today so concurrent invocations (a
         # manual `memex inbox triage` racing the scheduler) share one cap rather
         # than each getting a fresh allowance.
-        remaining_budget = self._cfg.max_auto_applies_per_tick
+        remaining_budget = self._cfg.max_auto_applies_per_day
         if not dry_run:
             remaining_budget = max(0, remaining_budget - await self._auto_applied_today(inbox_id))
 
@@ -470,8 +470,9 @@ class InboxRouterService(BaseService):
         return int(n or 0)
 
     def _excluded_vault_names(self) -> list[str]:
-        # The inbox is the source; 'global' is a catch-all that dilutes routing.
-        return [INBOX_VAULT_NAME, 'global']
+        # The inbox is always the source; the rest is operator-configurable
+        # (defaults to the catch-all 'global' vault, which dilutes routing).
+        return [INBOX_VAULT_NAME, *self._cfg.excluded_vaults]
 
     async def _auto_apply(self, inbox_id: UUID, decision: RouterDecision) -> None:
         top = decision.top

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -220,6 +220,19 @@ class InboxRouterService(BaseService):
             ).first()
         return row[0] if row else None
 
+    async def ensure_prior_seeded(self) -> None:
+        """Seed the NB sufficient-statistics prior if absent (idempotent).
+
+        Migration 055 seeds DBs upgraded via Alembic; this covers
+        create_all-provisioned DBs (fresh servers, the eval harness, tests)
+        where the migration body never runs. ``ON CONFLICT DO NOTHING`` makes
+        it a no-op once seeded.
+        """
+        async with self.metastore.session() as session:
+            await session.execute(text(_sql.SEED_NB_STATS_SQL))
+            await session.execute(text(_sql.SEED_NB_CLASS_COUNTS_SQL))
+            await session.commit()
+
     # ------------------------------------------------------------------ anchors
     async def refresh_anchors(self) -> int:
         """Refresh per-vault anchors for every candidate (non-inbox) vault.
@@ -227,6 +240,7 @@ class InboxRouterService(BaseService):
         Embeds each vault's narrative in Python (for ``summary_embedding``); the
         remaining anchors are computed in SQL. Returns the number refreshed.
         """
+        await self.ensure_prior_seeded()
         excluded = set(self._excluded_vault_names())
         async with self.metastore.session() as session:
             rows = (

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -38,6 +38,7 @@ from memex_core.services.inbox_router.evidence import (
 )
 
 if TYPE_CHECKING:
+    from memex_common.config import InboxRouterConfig
     from memex_core.config import MemexConfig
     from memex_core.memory.models.embedding import EmbeddingsModel
     from memex_core.services.notes import NoteService
@@ -163,7 +164,7 @@ class InboxRouterService(BaseService):
         self._vaults = vaults
 
     @property
-    def _cfg(self):  # noqa: ANN202 - InboxRouterConfig
+    def _cfg(self) -> InboxRouterConfig:
         return self.config.server.memory.inbox_router
 
     # ------------------------------------------------------------------ bootstrap
@@ -327,23 +328,32 @@ class InboxRouterService(BaseService):
             t_low=self._cfg.t_low,
         )
 
+        # Auto-apply budget is a per-day-per-vault ceiling, counted from the
+        # already-resolved router routes today so concurrent invocations (a
+        # manual `memex inbox triage` racing the scheduler) share one cap rather
+        # than each getting a fresh allowance.
+        remaining_budget = self._cfg.max_auto_applies_per_tick
+        if not dry_run:
+            remaining_budget = max(0, remaining_budget - await self._auto_applied_today(inbox_id))
+
         for nid in note_ids:
             decision = decide(nid, scored.get(nid, []), thresholds=thresholds, warmed_up=warmed_up)
             try:
                 if decision.kind is DecisionKind.AUTO_ROUTE:
                     if dry_run:
                         result.auto_routed += 1
-                    elif result.auto_routed >= self._cfg.max_auto_applies_per_tick:
-                        # Over the per-tick budget — fall through to a proposal.
-                        await self._emit_route(session_vault=inbox_id, decision=decision)
+                    elif remaining_budget <= 0:
+                        # Over the daily budget — fall through to a proposal.
+                        await self._emit_route(inbox_vault_id=inbox_id, decision=decision)
                         result.skipped_cap += 1
                         result.proposed += 1
                     else:
                         await self._auto_apply(inbox_id, decision)
                         result.auto_routed += 1
+                        remaining_budget -= 1
                 elif decision.kind is DecisionKind.PROPOSE_CANDIDATES:
                     if not dry_run:
-                        await self._emit_route(session_vault=inbox_id, decision=decision)
+                        await self._emit_route(inbox_vault_id=inbox_id, decision=decision)
                     result.proposed += 1
                 else:  # PROPOSE_NO_FIT
                     if not dry_run:
@@ -355,15 +365,53 @@ class InboxRouterService(BaseService):
 
         return result
 
+    # ------------------------------------------------------------------ status
+    async def status(self) -> dict[str, Any]:
+        """Router readiness + pending routing-proposal counts (CLI + HTTP share this)."""
+        match_count = await self._match_count()
+        async with self.metastore.session() as session:
+            rows = (
+                await session.execute(
+                    text(
+                        'SELECT rule_name, COUNT(*) FROM maintenance_proposals '
+                        "WHERE lint_type = 'routing' AND status = 'pending' GROUP BY rule_name"
+                    )
+                )
+            ).all()
+        pending = {r[0]: int(r[1]) for r in rows}
+        return {
+            'enabled': self._cfg.enabled,
+            'auto_apply_enabled': self._cfg.auto_apply_enabled,
+            'warmed_up': match_count >= self._cfg.min_decisions_before_auto_apply,
+            'match_observations': match_count,
+            'min_decisions_before_auto_apply': self._cfg.min_decisions_before_auto_apply,
+            'pending_route': pending.get(ROUTE_RULE, 0),
+            'pending_no_fit': pending.get(NO_FIT_RULE, 0),
+        }
+
     # ------------------------------------------------------------------ helpers
-    async def _is_warmed_up(self) -> bool:
+    async def _match_count(self) -> float:
         async with self.metastore.session() as session:
             n = (
                 await session.execute(
                     text('SELECT n FROM inbox_router_nb_class_counts WHERE label = 1')
                 )
             ).scalar()
-        return float(n or 0.0) >= self._cfg.min_decisions_before_auto_apply
+        return float(n or 0.0)
+
+    async def _is_warmed_up(self) -> bool:
+        return await self._match_count() >= self._cfg.min_decisions_before_auto_apply
+
+    async def _auto_applied_today(self, inbox_id: UUID) -> int:
+        today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        async with self.metastore.session() as session:
+            n = (
+                await session.execute(
+                    text(_sql.COUNT_AUTO_APPLIED_TODAY_SQL),
+                    {'vault_id': str(inbox_id), 'today_start': today_start},
+                )
+            ).scalar()
+        return int(n or 0)
 
     def _excluded_vault_names(self) -> list[str]:
         # The inbox is the source; 'global' is a catch-all that dilutes routing.
@@ -371,7 +419,8 @@ class InboxRouterService(BaseService):
 
     async def _auto_apply(self, inbox_id: UUID, decision: RouterDecision) -> None:
         top = decision.top
-        assert top is not None
+        if top is None:  # AUTO_ROUTE always has a top; defensive, not assert (-O strips asserts).
+            return
         await self._notes.migrate_note(decision.note_id, top.vault_id)
         evidence = self._route_evidence(inbox_id, decision).model_dump()
         evidence['resolution'] = {
@@ -399,15 +448,16 @@ class InboxRouterService(BaseService):
         for cand in decision.candidates[1:TOP_CANDIDATES]:
             await self.record_feedback(decision.note_id, cand.vault_id, 0)
 
-    async def _emit_route(self, *, session_vault: UUID, decision: RouterDecision) -> None:
+    async def _emit_route(self, *, inbox_vault_id: UUID, decision: RouterDecision) -> None:
         top = decision.top
-        assert top is not None
-        evidence = self._route_evidence(session_vault, decision)
+        if top is None:
+            return
+        evidence = self._route_evidence(inbox_vault_id, decision)
         async with self.metastore.session() as session:
             await session.execute(
                 text(_EMIT_PENDING_SQL),
                 {
-                    'vault_id': str(session_vault),
+                    'vault_id': str(inbox_vault_id),
                     'target_id': str(decision.note_id),
                     'rule_name': ROUTE_RULE,
                     'evidence': evidence.model_dump_json(),

--- a/packages/core/src/memex_core/services/inbox_router/sql.py
+++ b/packages/core/src/memex_core/services/inbox_router/sql.py
@@ -65,13 +65,15 @@ ON CONFLICT (vault_id) DO UPDATE SET
 """
 
 
-# Per-note feature cache. tsq = top-50 lexemes of the note's tsvector, OR-joined
-# (robust to long notes that AND-semantics plainto_tsquery would zero out).
+# Per-note feature cache, batched over many notes in one statement (one DB
+# round-trip per tick rather than one per note). tsq = top-50 lexemes of the
+# note's tsvector, OR-joined (robust to long notes that AND-semantics
+# plainto_tsquery would zero out). Pass a single-element array for one note.
 POPULATE_NOTE_CACHE_SQL = """
 INSERT INTO inbox_router_note_cache (note_id, chunk_centroid, tsq, entity_ids, updated_at)
 SELECT
-    :note_id ::uuid,
-    (SELECT AVG(c.embedding) FROM chunks c WHERE c.note_id = :note_id ::uuid),
+    n.id,
+    (SELECT AVG(c.embedding) FROM chunks c WHERE c.note_id = n.id),
     (
         SELECT CASE WHEN q.s IS NULL OR q.s = '' THEN NULL::tsquery
                     ELSE to_tsquery('simple', q.s) END
@@ -81,7 +83,7 @@ SELECT
                   FROM unnest(tsvector_to_array(to_tsvector('english',
                        left(COALESCE(
                            (SELECT string_agg(c.text, ' ')
-                              FROM chunks c WHERE c.note_id = :note_id ::uuid),
+                              FROM chunks c WHERE c.note_id = n.id),
                            ''), 1000000)))) AS lex
                  WHERE lex ~ '^[a-z][a-z0-9_]{1,}$'
                  LIMIT 50
@@ -92,9 +94,10 @@ SELECT
         SELECT array_agg(DISTINCT ue.entity_id)
           FROM memory_units mu
           JOIN unit_entities ue ON ue.unit_id = mu.id
-         WHERE mu.note_id = :note_id ::uuid
+         WHERE mu.note_id = n.id
     ), '{}'::uuid[]),
     now()
+FROM unnest(:note_ids ::uuid[]) AS n(id)
 ON CONFLICT (note_id) DO UPDATE SET
     chunk_centroid = EXCLUDED.chunk_centroid,
     tsq            = EXCLUDED.tsq,

--- a/packages/core/src/memex_core/services/inbox_router/sql.py
+++ b/packages/core/src/memex_core/services/inbox_router/sql.py
@@ -239,9 +239,14 @@ stats_update AS (
      WHERE s.feature_name = nfr.feat AND s.label = :label ::smallint
     RETURNING 1
 )
+-- Only advance the class count when the per-feature stats actually updated
+-- (i.e. the note had a cache row AND the vault had an anchor, so new_feature_rows
+-- was non-empty). Otherwise the class prior would drift relative to the
+-- per-feature stats and skew toward the match class.
 UPDATE inbox_router_nb_class_counts c
    SET n = :gamma ::float8 * c.n + 1, updated_at = now()
  WHERE c.label = :label ::smallint
+   AND EXISTS (SELECT 1 FROM stats_update)
 """
 
 

--- a/packages/core/src/memex_core/services/inbox_router/sql.py
+++ b/packages/core/src/memex_core/services/inbox_router/sql.py
@@ -1,0 +1,254 @@
+"""Raw SQL for the inbox router.
+
+All scoring, fitting, and feature computation runs in Postgres. These are the
+production counterparts of the POC's parametrised query builders (see
+``packages/eval/src/memex_eval/suites/inbox_router/poc/test_perf_v12_online.py``).
+Tables are unqualified (public schema); parameters are SQLAlchemy named binds.
+
+Feature set (per (note, vault) pair), matching the model the prior is seeded
+for: ``sem_summary_sim``, ``sem_centroid_sim``, ``mm_centroid_sim``,
+``entity_jaccard``, ``keyword_ts_rank``.
+"""
+
+from __future__ import annotations
+
+# Per-vault anchor refresh. ``summary_embedding`` is computed in Python (the
+# narrative must be embedded by the model) and passed in; everything else is
+# derived from the DB. Vaults with no chunks produce no row (chunk_centroid is
+# NOT NULL) and simply are not scoring candidates until they have content.
+REFRESH_VAULT_ANCHOR_SQL = """
+INSERT INTO inbox_router_vault_anchors
+    (vault_id, chunk_centroid, summary_embedding, mm_centroid,
+     tsvector_doc, entity_ids, n_notes, updated_at)
+SELECT
+    :vault_id ::uuid,
+    sub.chunk_centroid,
+    CAST(:summary_embedding AS vector),
+    (SELECT AVG(mm.embedding)
+       FROM mental_models mm
+      WHERE mm.vault_id = :vault_id ::uuid
+        AND mm.archived_at IS NULL
+        AND mm.embedding IS NOT NULL),
+    COALESCE(sub.tsvector_doc, ''::tsvector),
+    COALESCE((
+        SELECT array_agg(entity_id) FROM (
+            SELECT ue.entity_id, COUNT(*) AS cnt
+              FROM memory_units mu
+              JOIN unit_entities ue ON ue.unit_id = mu.id
+             WHERE mu.vault_id = :vault_id ::uuid
+             GROUP BY ue.entity_id
+             ORDER BY cnt DESC
+             LIMIT :top_k
+        ) t
+    ), '{}'::uuid[]),
+    sub.n_notes,
+    now()
+FROM (
+    SELECT
+        AVG(c.embedding) AS chunk_centroid,
+        to_tsvector('english', left(COALESCE(string_agg(c.text, ' '), ''), 1000000))
+            AS tsvector_doc,
+        COUNT(DISTINCT c.note_id) AS n_notes
+      FROM chunks c
+      JOIN notes n ON n.id = c.note_id
+     WHERE n.vault_id = :vault_id ::uuid
+) sub
+WHERE sub.chunk_centroid IS NOT NULL
+ON CONFLICT (vault_id) DO UPDATE SET
+    chunk_centroid    = EXCLUDED.chunk_centroid,
+    summary_embedding = EXCLUDED.summary_embedding,
+    mm_centroid       = EXCLUDED.mm_centroid,
+    tsvector_doc      = EXCLUDED.tsvector_doc,
+    entity_ids        = EXCLUDED.entity_ids,
+    n_notes           = EXCLUDED.n_notes,
+    updated_at        = now()
+"""
+
+
+# Per-note feature cache. tsq = top-50 lexemes of the note's tsvector, OR-joined
+# (robust to long notes that AND-semantics plainto_tsquery would zero out).
+POPULATE_NOTE_CACHE_SQL = """
+INSERT INTO inbox_router_note_cache (note_id, chunk_centroid, tsq, entity_ids, updated_at)
+SELECT
+    :note_id ::uuid,
+    (SELECT AVG(c.embedding) FROM chunks c WHERE c.note_id = :note_id ::uuid),
+    (
+        SELECT CASE WHEN q.s IS NULL OR q.s = '' THEN NULL::tsquery
+                    ELSE to_tsquery('simple', q.s) END
+        FROM (
+            SELECT array_to_string(array(
+                SELECT lex
+                  FROM unnest(tsvector_to_array(to_tsvector('english',
+                       left(COALESCE(
+                           (SELECT string_agg(c.text, ' ')
+                              FROM chunks c WHERE c.note_id = :note_id ::uuid),
+                           ''), 1000000)))) AS lex
+                 WHERE lex ~ '^[a-z][a-z0-9_]{1,}$'
+                 LIMIT 50
+            ), ' | ') AS s
+        ) q
+    ),
+    COALESCE((
+        SELECT array_agg(DISTINCT ue.entity_id)
+          FROM memory_units mu
+          JOIN unit_entities ue ON ue.unit_id = mu.id
+         WHERE mu.note_id = :note_id ::uuid
+    ), '{}'::uuid[]),
+    now()
+ON CONFLICT (note_id) DO UPDATE SET
+    chunk_centroid = EXCLUDED.chunk_centroid,
+    tsq            = EXCLUDED.tsq,
+    entity_ids     = EXCLUDED.entity_ids,
+    updated_at     = now()
+"""
+
+
+# Batched pairwise-GaussianNB scoring with per-note softmax + uncertainty.
+# Params: :note_ids (uuid[]), :excluded (text[] of vault names to skip).
+# Returns one row per (note, candidate vault) ordered by (note_id, p_match DESC).
+SCORE_NOTES_SQL = """
+WITH note_data AS (
+    SELECT note_id, chunk_centroid, tsq, entity_ids
+      FROM inbox_router_note_cache
+     WHERE note_id = ANY(:note_ids ::uuid[])
+       AND chunk_centroid IS NOT NULL
+),
+candidates AS (
+    SELECT nd.note_id, v.id AS vault_id, v.name AS vault_name,
+        (1 - (va.summary_embedding <=> nd.chunk_centroid))::float8 AS f_sem_summary_sim,
+        (1 - (va.chunk_centroid    <=> nd.chunk_centroid))::float8 AS f_sem_centroid_sim,
+        COALESCE((1 - (va.mm_centroid <=> nd.chunk_centroid))::float8, 0.0) AS f_mm_centroid_sim,
+        (CASE WHEN cardinality(nd.entity_ids) = 0 AND cardinality(va.entity_ids) = 0 THEN 0.0
+              ELSE ((SELECT COUNT(*) FROM (SELECT unnest(nd.entity_ids) INTERSECT
+                                             SELECT unnest(va.entity_ids)) i)::float8
+                   / NULLIF((SELECT COUNT(*) FROM (SELECT unnest(nd.entity_ids) UNION
+                                                    SELECT unnest(va.entity_ids)) u), 0))
+         END) AS f_entity_jaccard,
+        CASE WHEN nd.tsq IS NULL THEN 0.0
+             ELSE COALESCE(ts_rank_cd(va.tsvector_doc, nd.tsq, 32)::float8, 0.0)
+        END AS f_keyword_ts_rank
+      FROM vaults v
+      JOIN inbox_router_vault_anchors va ON va.vault_id = v.id
+      CROSS JOIN note_data nd
+     WHERE v.name <> ALL(:excluded ::text[])
+       AND v.archived_at IS NULL
+),
+features_long AS (
+    SELECT note_id, vault_id, vault_name, 'sem_summary_sim' AS feat,
+           COALESCE(f_sem_summary_sim, 0.0) AS val FROM candidates
+    UNION ALL SELECT note_id, vault_id, vault_name, 'sem_centroid_sim',
+           COALESCE(f_sem_centroid_sim, 0.0) FROM candidates
+    UNION ALL SELECT note_id, vault_id, vault_name, 'mm_centroid_sim',
+           COALESCE(f_mm_centroid_sim, 0.0)  FROM candidates
+    UNION ALL SELECT note_id, vault_id, vault_name, 'entity_jaccard',
+           COALESCE(f_entity_jaccard, 0.0)   FROM candidates
+    UNION ALL SELECT note_id, vault_id, vault_name, 'keyword_ts_rank',
+           COALESCE(f_keyword_ts_rank, 0.0)  FROM candidates
+),
+per_pair_loglik AS (
+    SELECT fl.note_id, fl.vault_id, fl.vault_name, p.label,
+        SUM(-0.5 * ln(2 * pi() * p.sigma_sq)
+            - power(fl.val - p.mu, 2) / (2 * p.sigma_sq)) AS log_lik
+      FROM features_long fl
+      JOIN inbox_router_nb_params p ON p.feature_name = fl.feat
+     GROUP BY fl.note_id, fl.vault_id, fl.vault_name, p.label
+),
+param_uncertainty AS (
+    SELECT SUM(1.0 / NULLIF(n, 0)) AS u_sum
+      FROM inbox_router_nb_stats WHERE label = 1
+),
+per_pair_posterior AS (
+    SELECT note_id, vault_id, vault_name,
+        MAX(log_lik) FILTER (WHERE label = 1)
+            + (SELECT log_prior FROM inbox_router_nb_prior WHERE label = 1) AS log_post_match,
+        MAX(log_lik) FILTER (WHERE label = 0)
+            + (SELECT log_prior FROM inbox_router_nb_prior WHERE label = 0) AS log_post_no_match
+      FROM per_pair_loglik
+     GROUP BY note_id, vault_id, vault_name
+),
+p_match_raw AS (
+    SELECT note_id, vault_id, vault_name,
+        1.0 / (1.0 + exp(LEAST(GREATEST(log_post_no_match - log_post_match, -700.0), 700.0)))
+            AS p_match_raw,
+        ln(GREATEST(
+            1.0 / (1.0 + exp(LEAST(GREATEST(log_post_no_match - log_post_match, -700.0), 700.0))),
+            1e-12)) AS log_p
+      FROM per_pair_posterior
+),
+note_log_max AS (
+    SELECT note_id, vault_id, vault_name, p_match_raw, log_p,
+        MAX(log_p) OVER (PARTITION BY note_id) AS log_max FROM p_match_raw
+),
+note_exp_sum AS (
+    SELECT note_id, vault_id, vault_name, p_match_raw,
+        exp(log_p - log_max) AS num,
+        SUM(exp(log_p - log_max)) OVER (PARTITION BY note_id) AS denom
+      FROM note_log_max
+)
+SELECT
+    note_id, vault_id, vault_name,
+    (num / NULLIF(denom, 0))::float8 AS p_match,
+    p_match_raw,
+    sqrt((SELECT u_sum FROM param_uncertainty))::float8 AS param_uncertainty,
+    (1.96 * (num / NULLIF(denom, 0)) * (1 - num / NULLIF(denom, 0))
+          * sqrt((SELECT u_sum FROM param_uncertainty)))::float8 AS ci_half_width
+  FROM note_exp_sum
+ ORDER BY note_id, p_match DESC
+"""
+
+
+# Online conjugate update for one (note, vault, label) observation.
+# :gamma is the EWMA decay (1.0 = no decay). Updates the 5 feature stats rows
+# and the class-count row in a single statement.
+ONLINE_UPDATE_SQL = """
+WITH new_features AS (
+    SELECT
+        (1 - (va.summary_embedding <=> nc.chunk_centroid))::float8 AS sem_summary_sim,
+        (1 - (va.chunk_centroid    <=> nc.chunk_centroid))::float8 AS sem_centroid_sim,
+        COALESCE((1 - (va.mm_centroid <=> nc.chunk_centroid))::float8, 0.0) AS mm_centroid_sim,
+        (CASE WHEN cardinality(nc.entity_ids) = 0 AND cardinality(va.entity_ids) = 0 THEN 0.0
+              ELSE ((SELECT COUNT(*) FROM (SELECT unnest(nc.entity_ids) INTERSECT
+                                             SELECT unnest(va.entity_ids)) i)::float8
+                   / NULLIF((SELECT COUNT(*) FROM (SELECT unnest(nc.entity_ids) UNION
+                                                    SELECT unnest(va.entity_ids)) u), 0))
+         END) AS entity_jaccard,
+        CASE WHEN nc.tsq IS NULL THEN 0.0
+             ELSE COALESCE(ts_rank_cd(va.tsvector_doc, nc.tsq, 32)::float8, 0.0)
+        END AS keyword_ts_rank
+      FROM inbox_router_note_cache nc
+      JOIN inbox_router_vault_anchors va ON va.vault_id = :vault_id ::uuid
+     WHERE nc.note_id = :note_id ::uuid
+),
+new_feature_rows AS (
+    SELECT 'sem_summary_sim'  AS feat, sem_summary_sim  AS x FROM new_features
+    UNION ALL SELECT 'sem_centroid_sim', sem_centroid_sim FROM new_features
+    UNION ALL SELECT 'mm_centroid_sim',  mm_centroid_sim  FROM new_features
+    UNION ALL SELECT 'entity_jaccard',   entity_jaccard   FROM new_features
+    UNION ALL SELECT 'keyword_ts_rank',  keyword_ts_rank  FROM new_features
+),
+stats_update AS (
+    UPDATE inbox_router_nb_stats s
+       SET n        = :gamma ::float8 * s.n        + 1,
+           sum_x    = :gamma ::float8 * s.sum_x    + nfr.x,
+           sum_x_sq = :gamma ::float8 * s.sum_x_sq + nfr.x * nfr.x,
+           updated_at = now()
+      FROM new_feature_rows nfr
+     WHERE s.feature_name = nfr.feat AND s.label = :label ::smallint
+    RETURNING 1
+)
+UPDATE inbox_router_nb_class_counts c
+   SET n = :gamma ::float8 * c.n + 1, updated_at = now()
+ WHERE c.label = :label ::smallint
+"""
+
+
+# Count auto-applies recorded today for a (vault, rule) — for the per-tick /
+# daily safety budget. Counts resolved routing proposals stamped by the router.
+COUNT_AUTO_APPLIED_TODAY_SQL = """
+SELECT COUNT(*) FROM maintenance_proposals
+ WHERE rule_name = 'inbox_vault_route'
+   AND vault_id = :vault_id ::uuid
+   AND status = 'resolved'
+   AND resolved_by = 'system:inbox-router'
+   AND resolved_at >= :today_start
+"""

--- a/packages/core/src/memex_core/services/inbox_router/sql.py
+++ b/packages/core/src/memex_core/services/inbox_router/sql.py
@@ -260,3 +260,30 @@ SELECT COUNT(*) FROM maintenance_proposals
    AND resolved_by = 'system:inbox-router'
    AND resolved_at >= :today_start
 """
+
+
+# Idempotent prior seed. Migration 055 seeds existing DBs on upgrade; this seeds
+# create_all-provisioned DBs (fresh servers, the eval harness, tests) where the
+# migration body never runs. ON CONFLICT DO NOTHING makes it a no-op once seeded.
+# Values are the POC v12 per-feature (μ, σ²) at n=5 (sum_x = n·μ,
+# sum_x_sq = σ²·(n-1) + n·μ²) so day-1 rankings are sensible, not uniform-random.
+SEED_NB_STATS_SQL = """
+INSERT INTO inbox_router_nb_stats (feature_name, label, n, sum_x, sum_x_sq) VALUES
+    ('sem_summary_sim',  0, 5.0, 1.159000, 0.319136),
+    ('sem_summary_sim',  1, 5.0, 1.873000, 0.748826),
+    ('sem_centroid_sim', 0, 5.0, 1.693000, 0.635090),
+    ('sem_centroid_sim', 1, 5.0, 3.278500, 2.256592),
+    ('mm_centroid_sim',  0, 5.0, 1.358500, 0.464984),
+    ('mm_centroid_sim',  1, 5.0, 1.970500, 0.979054),
+    ('entity_jaccard',   0, 5.0, 0.054000, 0.001223),
+    ('entity_jaccard',   1, 5.0, 0.307000, 0.024650),
+    ('keyword_ts_rank',  0, 5.0, 4.737500, 4.500701),
+    ('keyword_ts_rank',  1, 5.0, 4.919000, 4.839872)
+ON CONFLICT (feature_name, label) DO NOTHING
+"""
+
+# Class prior ~1:6 (match:no_match) — the POC's measured base rate (P(match)≈0.14).
+SEED_NB_CLASS_COUNTS_SQL = """
+INSERT INTO inbox_router_nb_class_counts (label, n) VALUES (1, 1.0), (0, 6.0)
+ON CONFLICT (label) DO NOTHING
+"""

--- a/packages/core/src/memex_core/services/proposal_actions/__init__.py
+++ b/packages/core/src/memex_core/services/proposal_actions/__init__.py
@@ -24,6 +24,7 @@ from memex_core.services.proposal_actions import (  # noqa: F401  (registration 
     archive_mental_model,
     deprioritize_unit,
     no_op,
+    route_note_to_vault,
 )
 
 __all__ = [

--- a/packages/core/src/memex_core/services/proposal_actions/route_note_to_vault.py
+++ b/packages/core/src/memex_core/services/proposal_actions/route_note_to_vault.py
@@ -110,6 +110,14 @@ class RouteNoteToVaultAction:
                 'cannot reverse route_note_to_vault: prior_state has no source_vault_id.'
             )
         await api.migrate_note(note_id, UUID(str(source_vault_id)))
+        # A reversal is a strong negative: the route we applied was wrong, so
+        # record label=0 for the vault we (incorrectly) routed to. Best-effort.
+        applied_target = applied_state.get('target_vault_id')
+        if applied_target:
+            try:
+                await api.inbox_router.record_feedback(note_id, UUID(str(applied_target)), 0)
+            except Exception:  # noqa: BLE001 - learning is best-effort
+                logger.warning('route_note_to_vault: reverse record_feedback failed', exc_info=True)
         return ReverseResult(
             restored_state={'note_id': str(note_id), 'vault_id': str(source_vault_id)}
         )

--- a/packages/core/src/memex_core/services/proposal_actions/route_note_to_vault.py
+++ b/packages/core/src/memex_core/services/proposal_actions/route_note_to_vault.py
@@ -73,6 +73,10 @@ class RouteNoteToVaultAction:
         # confirmations count toward the warm-up gate.
         try:
             await api.inbox_router.record_feedback(note_id, target_vault_id, 1)
+            # The other candidates the user did NOT pick are negatives — same
+            # learning signal an auto-route records for its runners-up.
+            for other in params.get('other_vault_ids') or []:
+                await api.inbox_router.record_feedback(note_id, UUID(str(other)), 0)
         except Exception:  # noqa: BLE001 - learning is best-effort
             logger.warning('route_note_to_vault: record_feedback failed', exc_info=True)
         source_vault_id = result.get('source_vault_id')

--- a/packages/core/src/memex_core/services/proposal_actions/route_note_to_vault.py
+++ b/packages/core/src/memex_core/services/proposal_actions/route_note_to_vault.py
@@ -73,12 +73,21 @@ class RouteNoteToVaultAction:
         # confirmations count toward the warm-up gate.
         try:
             await api.inbox_router.record_feedback(note_id, target_vault_id, 1)
-            # The other candidates the user did NOT pick are negatives — same
-            # learning signal an auto-route records for its runners-up.
-            for other in params.get('other_vault_ids') or []:
-                await api.inbox_router.record_feedback(note_id, UUID(str(other)), 0)
         except Exception:  # noqa: BLE001 - learning is best-effort
-            logger.warning('route_note_to_vault: record_feedback failed', exc_info=True)
+            logger.warning('route_note_to_vault: positive record_feedback failed', exc_info=True)
+        # The other candidates the user did NOT pick are negatives — same learning
+        # signal an auto-route records for its runners-up. Per-candidate try so a
+        # stale candidate (vault renamed/removed since the proposal was created)
+        # doesn't drop the rest of the negative signal.
+        for other in params.get('other_vault_ids') or []:
+            try:
+                await api.inbox_router.record_feedback(note_id, UUID(str(other)), 0)
+            except Exception:  # noqa: BLE001 - learning is best-effort
+                logger.warning(
+                    'route_note_to_vault: negative record_feedback failed for vault %s',
+                    other,
+                    exc_info=True,
+                )
         source_vault_id = result.get('source_vault_id')
         if source_vault_id is None:
             # migrate_note is a no-op when source == target; nothing to reverse.

--- a/packages/core/src/memex_core/services/proposal_actions/route_note_to_vault.py
+++ b/packages/core/src/memex_core/services/proposal_actions/route_note_to_vault.py
@@ -1,0 +1,113 @@
+"""`route_note_to_vault` — reversible note migration for inbox-router proposals.
+
+Moves a note from its current vault (the inbox) to a target vault via
+``MemexAPI.migrate_note``. The cockpit renders one option per candidate vault
+(from ``evidence.top_candidates``) and supplies ``target_vault_id`` in params.
+Reverse migrates the note back to the vault it came from (captured in
+``prior_state`` from the forward migrate's result).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+from uuid import UUID
+
+from memex_core.services.proposal_actions.base import (
+    ActionValidationError,
+    ExecuteResult,
+    ProposalActionError,
+    ReverseResult,
+    register_action,
+)
+
+if TYPE_CHECKING:
+    from memex_core.api import MemexAPI
+
+
+class RouteNoteToVaultAction:
+    id: ClassVar[str] = 'route_note_to_vault'
+    name: ClassVar[str] = 'Route note to vault'
+    description: ClassVar[str] = (
+        'Migrate this note from the inbox to the chosen vault (params.target_vault_id). '
+        'Reversible: undo migrates it back to the source vault.'
+    )
+    applicable_target_types: ClassVar[tuple[str, ...]] = ('note',)
+    reversible: ClassVar[bool] = True
+
+    def validate(self, params: dict[str, Any], *, target_type: str, target_id: str) -> None:
+        if target_type != 'note':
+            raise ActionValidationError(
+                f'route_note_to_vault applies to note targets, not {target_type!r}.'
+            )
+        try:
+            UUID(target_id)
+        except (ValueError, AttributeError):
+            raise ActionValidationError(f'target_id {target_id!r} is not a valid UUID.')
+        target_vault = params.get('target_vault_id')
+        if not target_vault:
+            raise ActionValidationError('route_note_to_vault requires params.target_vault_id.')
+        try:
+            UUID(str(target_vault))
+        except (ValueError, AttributeError):
+            raise ActionValidationError(f'target_vault_id {target_vault!r} is not a valid UUID.')
+
+    async def execute(
+        self,
+        api: MemexAPI,
+        params: dict[str, Any],
+        *,
+        target_id: str,
+        vault_id: UUID,
+        actor: str,
+    ) -> ExecuteResult:
+        note_id = UUID(target_id)
+        target_vault_id = UUID(str(params['target_vault_id']))
+        result = await api.migrate_note(note_id, target_vault_id)
+        source_vault_id = result.get('source_vault_id')
+        if source_vault_id is None:
+            # migrate_note is a no-op when source == target; nothing to reverse.
+            source_vault_id = str(vault_id)
+        return ExecuteResult(
+            applied_state={
+                'note_id': str(note_id),
+                'target_vault_id': str(target_vault_id),
+                'status': result.get('status'),
+            },
+            prior_state={'note_id': str(note_id), 'source_vault_id': str(source_vault_id)},
+        )
+
+    async def reverse(
+        self,
+        api: MemexAPI,
+        params: dict[str, Any],
+        applied_state: dict[str, Any],
+        prior_state: dict[str, Any],
+        *,
+        target_id: str,
+        vault_id: UUID,
+        actor: str,
+    ) -> ReverseResult:
+        note_id = UUID(str(applied_state.get('note_id') or target_id))
+        source_vault_id = prior_state.get('source_vault_id')
+        if not source_vault_id:
+            raise ProposalActionError(
+                'cannot reverse route_note_to_vault: prior_state has no source_vault_id.'
+            )
+        await api.migrate_note(note_id, UUID(str(source_vault_id)))
+        return ReverseResult(
+            restored_state={'note_id': str(note_id), 'vault_id': str(source_vault_id)}
+        )
+
+    async def preview(
+        self,
+        api: MemexAPI,
+        params: dict[str, Any],
+        *,
+        target_id: str,
+        vault_id: UUID,
+    ) -> str:
+        target_vault = params.get('target_vault_id', '<unspecified>')
+        return f'Will migrate this note to vault {target_vault} (note + units + chunks + links).'
+
+
+register_action(RouteNoteToVaultAction())

--- a/packages/core/src/memex_core/services/proposal_actions/route_note_to_vault.py
+++ b/packages/core/src/memex_core/services/proposal_actions/route_note_to_vault.py
@@ -9,6 +9,7 @@ Reverse migrates the note back to the vault it came from (captured in
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 from uuid import UUID
 
@@ -22,6 +23,8 @@ from memex_core.services.proposal_actions.base import (
 
 if TYPE_CHECKING:
     from memex_core.api import MemexAPI
+
+logger = logging.getLogger(__name__)
 
 
 class RouteNoteToVaultAction:
@@ -63,6 +66,15 @@ class RouteNoteToVaultAction:
         note_id = UUID(target_id)
         target_vault_id = UUID(str(params['target_vault_id']))
         result = await api.migrate_note(note_id, target_vault_id)
+        # Feed the human confirmation back into the router's online model — a
+        # manually-accepted route is a positive (label=1) for the chosen vault,
+        # the same signal an auto-route records. Best-effort: never fail the
+        # migration because learning hiccuped. This is what lets cockpit
+        # confirmations count toward the warm-up gate.
+        try:
+            await api.inbox_router.record_feedback(note_id, target_vault_id, 1)
+        except Exception:  # noqa: BLE001 - learning is best-effort
+            logger.warning('route_note_to_vault: record_feedback failed', exc_info=True)
         source_vault_id = result.get('source_vault_id')
         if source_vault_id is None:
             # migrate_note is a no-op when source == target; nothing to reverse.

--- a/packages/core/tests/integration/test_int_alembic_055.py
+++ b/packages/core/tests/integration/test_int_alembic_055.py
@@ -1,0 +1,153 @@
+"""Migration round-trip test for the inbox-router schema (054).
+
+Verifies via a real ``alembic upgrade`` (not create_all) that:
+- The four router tables + two views are created.
+- The sufficient-stats prior is seeded (10 feature rows + 2 class rows) and the
+  derived params view yields sane (μ, σ²).
+- The ``maintenance_proposals`` lint_type CHECK accepts ``'routing'``.
+- Downgrade drops the router objects and reverts the CHECK.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import NullPool, text
+from sqlalchemy.ext.asyncio import create_async_engine
+from testcontainers.postgres import PostgresContainer
+
+from _alembic_test_helpers import (  # noqa: F401
+    alembic_downgrade as _alembic_downgrade,
+    alembic_upgrade as _alembic_upgrade,
+    make_fresh_db,
+)
+
+pytestmark = [pytest.mark.integration]
+
+_TARGET_BEFORE = '054_nodes_vault_active'
+_TARGET_AFTER = '055_inbox_router'
+
+_ROUTER_TABLES = (
+    'inbox_router_nb_stats',
+    'inbox_router_nb_class_counts',
+    'inbox_router_vault_anchors',
+    'inbox_router_note_cache',
+)
+_ROUTER_VIEWS = ('inbox_router_nb_params', 'inbox_router_nb_prior')
+
+
+@pytest_asyncio.fixture
+async def fresh_db_url(postgres_container: PostgresContainer) -> AsyncGenerator[str, None]:
+    async for url in make_fresh_db(postgres_container, db_prefix='mig054'):
+        yield url
+
+
+async def _relkinds(conn, names: tuple[str, ...]) -> dict[str, str]:
+    rows = (
+        await conn.execute(
+            text(
+                'SELECT relname, relkind FROM pg_class '
+                "WHERE relname = ANY(:names) AND relkind IN ('r', 'v')"
+            ),
+            {'names': list(names)},
+        )
+    ).all()
+    return {r[0]: r[1] for r in rows}
+
+
+@pytest.mark.asyncio
+async def test_upgrade_creates_router_objects_and_seeds_prior(fresh_db_url: str) -> None:
+    await _alembic_upgrade(fresh_db_url, target=_TARGET_BEFORE)
+    await _alembic_upgrade(fresh_db_url, target=_TARGET_AFTER)
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            tables = await _relkinds(conn, _ROUTER_TABLES)
+            assert set(tables) == set(_ROUTER_TABLES), f'missing router tables: {tables}'
+            assert all(k == 'r' for k in tables.values())
+
+            views = await _relkinds(conn, _ROUTER_VIEWS)
+            assert set(views) == set(_ROUTER_VIEWS), f'missing router views: {views}'
+            assert all(k == 'v' for k in views.values())
+
+            # Seeded prior: 10 feature stat rows + 2 class-count rows.
+            n_stats = (
+                await conn.execute(text('SELECT COUNT(*) FROM inbox_router_nb_stats'))
+            ).scalar()
+            assert n_stats == 10
+            n_class = (
+                await conn.execute(text('SELECT COUNT(*) FROM inbox_router_nb_class_counts'))
+            ).scalar()
+            assert n_class == 2
+
+            # The params view yields positive, finite variances and sane means.
+            rows = (
+                await conn.execute(
+                    text(
+                        'SELECT feature_name, label, mu, sigma_sq '
+                        'FROM inbox_router_nb_params ORDER BY feature_name, label'
+                    )
+                )
+            ).all()
+            assert len(rows) == 10
+            for _f, _label, mu, sigma_sq in rows:
+                assert sigma_sq > 0.0
+                assert 0.0 <= mu <= 1.0
+
+            # match-class prior < no-match (1:6 base rate), so log_prior(1) < log_prior(0).
+            lp = dict(
+                (r[0], r[1])
+                for r in (
+                    await conn.execute(text('SELECT label, log_prior FROM inbox_router_nb_prior'))
+                ).all()
+            )
+            assert lp[1] < lp[0]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_routing_lint_type_accepted_after_upgrade(fresh_db_url: str) -> None:
+    await _alembic_upgrade(fresh_db_url, target=_TARGET_AFTER)
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.begin() as conn:
+            vid = (
+                await conn.execute(
+                    text(
+                        'INSERT INTO vaults (id, name) '
+                        "VALUES (gen_random_uuid(), 'inbox-test') RETURNING id"
+                    )
+                )
+            ).scalar()
+            # 'routing' lint_type must satisfy the CHECK.
+            await conn.execute(
+                text(
+                    'INSERT INTO maintenance_proposals '
+                    '(vault_id, lint_type, target_type, target_id, rule_name, '
+                    ' suggested_action, status, source) '
+                    "VALUES (:v, 'routing', 'note', gen_random_uuid()::text, "
+                    "'inbox_vault_route', 'route?', 'pending', 'rule')"
+                ),
+                {'v': vid},
+            )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_downgrade_drops_router_objects(fresh_db_url: str) -> None:
+    await _alembic_upgrade(fresh_db_url, target=_TARGET_AFTER)
+    await _alembic_downgrade(fresh_db_url, _TARGET_BEFORE)
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            tables = await _relkinds(conn, _ROUTER_TABLES)
+            assert tables == {}, f'router tables survived downgrade: {tables}'
+            views = await _relkinds(conn, _ROUTER_VIEWS)
+            assert views == {}, f'router views survived downgrade: {views}'
+    finally:
+        await engine.dispose()

--- a/packages/core/tests/integration/test_int_alembic_055.py
+++ b/packages/core/tests/integration/test_int_alembic_055.py
@@ -1,4 +1,4 @@
-"""Migration round-trip test for the inbox-router schema (054).
+"""Migration round-trip test for the inbox-router schema (055).
 
 Verifies via a real ``alembic upgrade`` (not create_all) that:
 - The four router tables + two views are created.

--- a/packages/core/tests/integration/test_int_inbox_router.py
+++ b/packages/core/tests/integration/test_int_inbox_router.py
@@ -1,0 +1,201 @@
+"""Integration tests for InboxRouterService against real Postgres.
+
+The shared test harness builds schema via ``SQLModel.metadata.create_all``,
+which does not create the router's migration-only tables/views. The
+``router_schema`` fixture below runs the migration's DDL + seed so the service
+has its tables. Distinct per-vault chunk embeddings give a real ranking signal
+(the mock embedding model returns a constant vector for narratives).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from memex_core.memory.sql_models import Chunk, ContentStatus, Note, Vault
+from memex_core.services.inbox_router.service import ROUTE_RULE
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+# Two orthogonal embedding directions so cosine cleanly separates the vaults.
+_VEC_A = [1.0] * 192 + [0.0] * 192
+_VEC_B = [0.0] * 192 + [1.0] * 192
+
+
+def _import_migration_ddl() -> tuple[str, str, str]:
+    import importlib.util
+    import pathlib as plb
+
+    path = (
+        plb.Path(__file__).resolve().parents[2]
+        / 'src/memex_core/alembic/versions/055_inbox_router.py'
+    )
+    spec = importlib.util.spec_from_file_location('mig054_ddl', path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod._CREATE, mod._SEED_STATS, mod._SEED_CLASS
+
+
+@pytest_asyncio.fixture
+async def router_schema(api):
+    """Create + seed the router tables/views (idempotent per test)."""
+    create_sql, seed_stats, seed_class = _import_migration_ddl()
+    drop_sql = (
+        'DROP TABLE IF EXISTS inbox_router_note_cache CASCADE;'
+        'DROP TABLE IF EXISTS inbox_router_vault_anchors CASCADE;'
+        'DROP VIEW IF EXISTS inbox_router_nb_prior CASCADE;'
+        'DROP VIEW IF EXISTS inbox_router_nb_params CASCADE;'
+        'DROP TABLE IF EXISTS inbox_router_nb_class_counts CASCADE;'
+        'DROP TABLE IF EXISTS inbox_router_nb_stats CASCADE;'
+    )
+
+    async def _run_script(session, script: str) -> None:
+        for stmt in (s.strip() for s in script.split(';')):
+            if stmt:
+                await session.execute(text(stmt))
+
+    async with api.metastore.session() as session:
+        await _run_script(session, drop_sql)
+        await _run_script(session, create_sql)
+        await _run_script(session, seed_stats)
+        await _run_script(session, seed_class)
+        await session.commit()
+    yield
+    async with api.metastore.session() as session:
+        await _run_script(session, drop_sql)
+        await session.commit()
+
+
+async def _seed_vault_with_note(session, name: str, embedding: list[float]) -> Vault:
+    vault = Vault(id=uuid4(), name=name, description=f'{name} vault')
+    session.add(vault)
+    note_id = uuid4()
+    session.add(
+        Note(
+            id=note_id,
+            vault_id=vault.id,
+            original_text=f'note {uuid4().hex}',
+            content_hash=uuid4().hex,
+            title=f'{name} note',
+        )
+    )
+    session.add(
+        Chunk(
+            id=uuid4(),
+            vault_id=vault.id,
+            note_id=note_id,
+            text=f'{name} body content alpha beta',
+            content_hash=uuid4().hex,
+            embedding=embedding,
+            chunk_index=0,
+            status=ContentStatus.ACTIVE,
+        )
+    )
+    await session.commit()
+    return vault
+
+
+async def _seed_inbox_note(session, inbox: Vault, embedding: list[float]) -> str:
+    note_id = uuid4()
+    session.add(
+        Note(
+            id=note_id,
+            vault_id=inbox.id,
+            original_text=f'inbox note {uuid4().hex}',
+            content_hash=uuid4().hex,
+            title='inbox note',
+        )
+    )
+    session.add(
+        Chunk(
+            id=uuid4(),
+            vault_id=inbox.id,
+            note_id=note_id,
+            text='inbox body content alpha beta',
+            content_hash=uuid4().hex,
+            embedding=embedding,
+            chunk_index=0,
+            status=ContentStatus.ACTIVE,
+        )
+    )
+    await session.commit()
+    return str(note_id)
+
+
+async def test_score_ranks_topically_closest_vault_first(api, session, router_schema):
+    """An inbox note embedded like vault-a should rank vault-a above vault-b."""
+    inbox = await _seed_vault_with_note(session, 'inbox', _VEC_A)
+    await _seed_vault_with_note(session, 'vault-a', _VEC_A)
+    await _seed_vault_with_note(session, 'vault-b', _VEC_B)
+    note_id = await _seed_inbox_note(session, inbox, _VEC_A)
+
+    await api.inbox_router.refresh_anchors()
+    await api.inbox_router.populate_note_cache(note_id)
+    scored = await api.inbox_router.score_notes([note_id])
+
+    from uuid import UUID
+
+    cands = scored[UUID(note_id)]
+    names = [c.vault_name for c in sorted(cands, key=lambda c: -c.p_match)]
+    assert 'vault-a' in names and 'vault-b' in names
+    # vault-a shares the note's embedding direction; it must outrank vault-b.
+    assert names.index('vault-a') < names.index('vault-b')
+
+
+async def test_triage_tick_emits_routing_proposal(api, session, router_schema):
+    """A full tick scores the inbox note and records a routing proposal."""
+    inbox = await _seed_vault_with_note(session, 'inbox', _VEC_A)
+    await _seed_vault_with_note(session, 'vault-a', _VEC_A)
+    await _seed_vault_with_note(session, 'vault-b', _VEC_B)
+    note_id = await _seed_inbox_note(session, inbox, _VEC_A)
+
+    result = await api.inbox_router.triage_tick()
+    assert result.scored == 1
+    assert result.errors == 0
+
+    async with api.metastore.session() as s:
+        n = (
+            await s.execute(
+                text(
+                    'SELECT COUNT(*) FROM maintenance_proposals '
+                    "WHERE lint_type = 'routing' AND target_id = :tid"
+                ),
+                {'tid': note_id},
+            )
+        ).scalar()
+    # Cold start (seed match-count=1 < 50) → a pending route proposal, not auto-route.
+    assert n >= 1
+
+
+async def test_record_feedback_updates_sufficient_stats(api, session, router_schema):
+    """An online update increments the match class count and a feature's n."""
+    inbox = await _seed_vault_with_note(session, 'inbox', _VEC_A)
+    vault_a = await _seed_vault_with_note(session, 'vault-a', _VEC_A)
+    note_id = await _seed_inbox_note(session, inbox, _VEC_A)
+    await api.inbox_router.refresh_anchors()
+    await api.inbox_router.populate_note_cache(note_id)
+
+    from uuid import UUID
+
+    async with api.metastore.session() as s:
+        before = (
+            await s.execute(text('SELECT n FROM inbox_router_nb_class_counts WHERE label = 1'))
+        ).scalar()
+
+    await api.inbox_router.record_feedback(UUID(note_id), vault_a.id, 1)
+
+    async with api.metastore.session() as s:
+        after = (
+            await s.execute(text('SELECT n FROM inbox_router_nb_class_counts WHERE label = 1'))
+        ).scalar()
+    # With EWMA gamma<1: n_after = gamma*n_before + 1.
+    gamma = api.config.server.memory.inbox_router.ewma_gamma
+    assert after == pytest.approx(gamma * float(before) + 1.0, rel=1e-6)
+
+
+async def test_route_rule_name_constant():
+    assert ROUTE_RULE == 'inbox_vault_route'

--- a/packages/core/tests/integration/test_int_inbox_router.py
+++ b/packages/core/tests/integration/test_int_inbox_router.py
@@ -99,7 +99,7 @@ async def _seed_vault_with_note(session, name: str, embedding: list[float]) -> V
     return vault
 
 
-async def _seed_inbox_note(session, inbox: Vault, embedding: list[float]) -> str:
+async def _seed_inbox_note(session, inbox: Vault, embedding: list[float]) -> UUID:
     note_id = uuid4()
     session.add(
         Note(
@@ -123,7 +123,7 @@ async def _seed_inbox_note(session, inbox: Vault, embedding: list[float]) -> str
         )
     )
     await session.commit()
-    return str(note_id)
+    return note_id
 
 
 async def test_score_ranks_topically_closest_vault_first(api, session, router_schema):
@@ -137,7 +137,7 @@ async def test_score_ranks_topically_closest_vault_first(api, session, router_sc
     await api.inbox_router.populate_note_cache(note_id)
     scored = await api.inbox_router.score_notes([note_id])
 
-    cands = scored[UUID(note_id)]
+    cands = scored[note_id]
     names = [c.vault_name for c in sorted(cands, key=lambda c: -c.p_match)]
     assert 'vault-a' in names and 'vault-b' in names
     # vault-a shares the note's embedding direction; it must outrank vault-b.
@@ -162,7 +162,7 @@ async def test_triage_tick_emits_routing_proposal(api, session, router_schema):
                     'SELECT COUNT(*) FROM maintenance_proposals '
                     "WHERE lint_type = 'routing' AND target_id = :tid"
                 ),
-                {'tid': note_id},
+                {'tid': str(note_id)},
             )
         ).scalar()
     # Cold start (seed match-count=1 < 50) → a pending route proposal, not auto-route.
@@ -182,7 +182,7 @@ async def test_record_feedback_updates_sufficient_stats(api, session, router_sch
             await s.execute(text('SELECT n FROM inbox_router_nb_class_counts WHERE label = 1'))
         ).scalar()
 
-    await api.inbox_router.record_feedback(UUID(note_id), vault_a.id, 1)
+    await api.inbox_router.record_feedback(note_id, vault_a.id, 1)
 
     async with api.metastore.session() as s:
         after = (
@@ -191,6 +191,39 @@ async def test_record_feedback_updates_sufficient_stats(api, session, router_sch
     # With EWMA gamma<1: n_after = gamma*n_before + 1.
     gamma = api.config.server.memory.inbox_router.ewma_gamma
     assert after == pytest.approx(gamma * float(before) + 1.0, rel=1e-6)
+
+
+async def test_ensure_inbox_vault_is_idempotent(api, session):
+    """Calling ensure_inbox_vault twice returns the same vault id."""
+    first = await api.inbox_router.ensure_inbox_vault()
+    second = await api.inbox_router.ensure_inbox_vault()
+    assert first is not None
+    assert first == second
+
+
+async def test_daily_cap_falls_through_to_proposal(api, session, router_schema):
+    """When the daily auto-apply budget is exhausted, an otherwise-auto-routable
+    note falls through to a proposal (skipped_cap increments, not auto_routed)."""
+    inbox = await _seed_vault_with_note(session, 'inbox', _VEC_A)
+    await _seed_vault_with_note(session, 'vault-a', _VEC_A)
+    await _seed_vault_with_note(session, 'vault-b', _VEC_B)
+    await _seed_inbox_note(session, inbox, _VEC_A)
+
+    # Warm up the model and relax the gates so the decision is AUTO_ROUTE...
+    async with api.metastore.session() as s:
+        await s.execute(text('UPDATE inbox_router_nb_class_counts SET n = 100 WHERE label = 1'))
+        await s.commit()
+    cfg = api.config.server.memory.inbox_router
+    cfg.auto_apply_min_p_match = 0.0
+    cfg.t_margin = 0.0
+    cfg.t_low = 0.0
+    # ...but zero the daily budget so nothing may actually auto-route.
+    cfg.max_auto_applies_per_day = 0
+
+    result = await api.inbox_router.triage_tick()
+    assert result.errors == 0
+    assert result.auto_routed == 0
+    assert result.skipped_cap >= 1
 
 
 async def test_route_rule_name_constant():

--- a/packages/core/tests/integration/test_int_inbox_router.py
+++ b/packages/core/tests/integration/test_int_inbox_router.py
@@ -1,10 +1,10 @@
 """Integration tests for InboxRouterService against real Postgres.
 
-The shared test harness builds schema via ``SQLModel.metadata.create_all``,
-which does not create the router's migration-only tables/views. The
-``router_schema`` fixture below runs the migration's DDL + seed so the service
-has its tables. Distinct per-vault chunk embeddings give a real ranking signal
-(the mock embedding model returns a constant vector for narratives).
+The router tables + views are SQLModel models, so the shared ``create_all``
+harness provisions them like any other table; the NB prior is seeded by the
+service (``ensure_prior_seeded`` via ``refresh_anchors``). Distinct per-vault
+chunk embeddings give a real ranking signal (the mock embedding model returns a
+constant vector for narratives).
 """
 
 from __future__ import annotations
@@ -12,7 +12,6 @@ from __future__ import annotations
 from uuid import UUID, uuid4
 
 import pytest
-import pytest_asyncio
 from sqlalchemy import text
 
 from memex_core.memory.sql_models import Chunk, ContentStatus, Note, Vault
@@ -23,51 +22,6 @@ pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 # Two orthogonal embedding directions so cosine cleanly separates the vaults.
 _VEC_A = [1.0] * 192 + [0.0] * 192
 _VEC_B = [0.0] * 192 + [1.0] * 192
-
-
-def _import_migration_ddl() -> tuple[str, str, str]:
-    import importlib.util
-    import pathlib as plb
-
-    path = (
-        plb.Path(__file__).resolve().parents[2]
-        / 'src/memex_core/alembic/versions/055_inbox_router.py'
-    )
-    spec = importlib.util.spec_from_file_location('mig054_ddl', path)
-    assert spec and spec.loader
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod._CREATE, mod._SEED_STATS, mod._SEED_CLASS
-
-
-@pytest_asyncio.fixture
-async def router_schema(api):
-    """Create + seed the router tables/views (idempotent per test)."""
-    create_sql, seed_stats, seed_class = _import_migration_ddl()
-    drop_sql = (
-        'DROP TABLE IF EXISTS inbox_router_note_cache CASCADE;'
-        'DROP TABLE IF EXISTS inbox_router_vault_anchors CASCADE;'
-        'DROP VIEW IF EXISTS inbox_router_nb_prior CASCADE;'
-        'DROP VIEW IF EXISTS inbox_router_nb_params CASCADE;'
-        'DROP TABLE IF EXISTS inbox_router_nb_class_counts CASCADE;'
-        'DROP TABLE IF EXISTS inbox_router_nb_stats CASCADE;'
-    )
-
-    async def _run_script(session, script: str) -> None:
-        for stmt in (s.strip() for s in script.split(';')):
-            if stmt:
-                await session.execute(text(stmt))
-
-    async with api.metastore.session() as session:
-        await _run_script(session, drop_sql)
-        await _run_script(session, create_sql)
-        await _run_script(session, seed_stats)
-        await _run_script(session, seed_class)
-        await session.commit()
-    yield
-    async with api.metastore.session() as session:
-        await _run_script(session, drop_sql)
-        await session.commit()
 
 
 async def _seed_vault_with_note(session, name: str, embedding: list[float]) -> Vault:
@@ -126,7 +80,7 @@ async def _seed_inbox_note(session, inbox: Vault, embedding: list[float]) -> UUI
     return note_id
 
 
-async def test_score_ranks_topically_closest_vault_first(api, session, router_schema):
+async def test_score_ranks_topically_closest_vault_first(api, session):
     """An inbox note embedded like vault-a should rank vault-a above vault-b."""
     inbox = await _seed_vault_with_note(session, 'inbox', _VEC_A)
     await _seed_vault_with_note(session, 'vault-a', _VEC_A)
@@ -144,7 +98,7 @@ async def test_score_ranks_topically_closest_vault_first(api, session, router_sc
     assert names.index('vault-a') < names.index('vault-b')
 
 
-async def test_triage_tick_emits_routing_proposal(api, session, router_schema):
+async def test_triage_tick_emits_routing_proposal(api, session):
     """A full tick scores the inbox note and records a routing proposal."""
     inbox = await _seed_vault_with_note(session, 'inbox', _VEC_A)
     await _seed_vault_with_note(session, 'vault-a', _VEC_A)
@@ -169,7 +123,7 @@ async def test_triage_tick_emits_routing_proposal(api, session, router_schema):
     assert n >= 1
 
 
-async def test_record_feedback_updates_sufficient_stats(api, session, router_schema):
+async def test_record_feedback_updates_sufficient_stats(api, session):
     """An online update increments the match class count and a feature's n."""
     inbox = await _seed_vault_with_note(session, 'inbox', _VEC_A)
     vault_a = await _seed_vault_with_note(session, 'vault-a', _VEC_A)
@@ -201,7 +155,7 @@ async def test_ensure_inbox_vault_is_idempotent(api, session):
     assert first == second
 
 
-async def test_daily_cap_falls_through_to_proposal(api, session, router_schema):
+async def test_daily_cap_falls_through_to_proposal(api, session):
     """When the daily auto-apply budget is exhausted, an otherwise-auto-routable
     note falls through to a proposal (skipped_cap increments, not auto_routed)."""
     inbox = await _seed_vault_with_note(session, 'inbox', _VEC_A)

--- a/packages/core/tests/integration/test_int_inbox_router.py
+++ b/packages/core/tests/integration/test_int_inbox_router.py
@@ -9,7 +9,7 @@ has its tables. Distinct per-vault chunk embeddings give a real ranking signal
 
 from __future__ import annotations
 
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 import pytest_asyncio
@@ -137,8 +137,6 @@ async def test_score_ranks_topically_closest_vault_first(api, session, router_sc
     await api.inbox_router.populate_note_cache(note_id)
     scored = await api.inbox_router.score_notes([note_id])
 
-    from uuid import UUID
-
     cands = scored[UUID(note_id)]
     names = [c.vault_name for c in sorted(cands, key=lambda c: -c.p_match)]
     assert 'vault-a' in names and 'vault-b' in names
@@ -178,8 +176,6 @@ async def test_record_feedback_updates_sufficient_stats(api, session, router_sch
     note_id = await _seed_inbox_note(session, inbox, _VEC_A)
     await api.inbox_router.refresh_anchors()
     await api.inbox_router.populate_note_cache(note_id)
-
-    from uuid import UUID
 
     async with api.metastore.session() as s:
         before = (

--- a/packages/core/tests/unit/services/inbox_router/test_decisions.py
+++ b/packages/core/tests/unit/services/inbox_router/test_decisions.py
@@ -1,0 +1,91 @@
+"""Unit tests for the inbox-router decision policy (pure logic, no DB)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from memex_core.services.inbox_router.decisions import (
+    CandidateScore,
+    DecisionKind,
+    DecisionThresholds,
+    RoutingState,
+    decide,
+)
+
+WARM = DecisionThresholds(
+    auto_apply_enabled=True, auto_apply_min_p_match=0.5, t_margin=0.4, t_low=0.10
+)
+
+
+def _cand(name: str, p: float, raw: float = 0.9, ci: float = 0.02) -> CandidateScore:
+    return CandidateScore(
+        vault_id=uuid4(), vault_name=name, p_match=p, p_match_raw=raw, ci_half_width=ci
+    )
+
+
+def test_auto_route_when_confident_and_warm():
+    cands = [_cand('a', 0.85), _cand('b', 0.10)]
+    d = decide(uuid4(), cands, thresholds=WARM, warmed_up=True)
+    assert d.kind is DecisionKind.AUTO_ROUTE
+    assert d.routing_state is RoutingState.WARMED_UP
+    assert d.top.vault_name == 'a'
+    assert d.margin == pytest.approx(0.75)
+
+
+def test_cold_start_never_auto_routes_even_if_confident():
+    cands = [_cand('a', 0.95), _cand('b', 0.02)]
+    d = decide(uuid4(), cands, thresholds=WARM, warmed_up=False)
+    assert d.kind is DecisionKind.PROPOSE_CANDIDATES
+    assert d.routing_state is RoutingState.COLD_START
+
+
+def test_disabled_auto_apply_proposes_only():
+    th = DecisionThresholds(
+        auto_apply_enabled=False, auto_apply_min_p_match=0.5, t_margin=0.4, t_low=0.10
+    )
+    d = decide(uuid4(), [_cand('a', 0.99), _cand('b', 0.0)], thresholds=th, warmed_up=True)
+    assert d.kind is DecisionKind.PROPOSE_CANDIDATES
+    assert d.routing_state is RoutingState.DISABLED
+
+
+def test_low_margin_proposes_not_auto():
+    # Top-1 clears p_match floor but top-2 is close → ambiguous → propose.
+    cands = [_cand('a', 0.55), _cand('b', 0.45)]
+    d = decide(uuid4(), cands, thresholds=WARM, warmed_up=True)
+    assert d.kind is DecisionKind.PROPOSE_CANDIDATES
+    assert d.margin == pytest.approx(0.10)
+
+
+def test_below_p_match_floor_proposes_not_auto():
+    # Margin is wide but the absolute p_match is below the auto floor.
+    cands = [_cand('a', 0.45), _cand('b', 0.01)]
+    d = decide(uuid4(), cands, thresholds=WARM, warmed_up=True)
+    assert d.kind is DecisionKind.PROPOSE_CANDIDATES
+
+
+def test_no_fit_when_best_raw_below_t_low():
+    cands = [_cand('a', 0.9, raw=0.05), _cand('b', 0.1, raw=0.02)]
+    d = decide(uuid4(), cands, thresholds=WARM, warmed_up=True)
+    assert d.kind is DecisionKind.PROPOSE_NO_FIT
+
+
+def test_no_candidates_is_no_fit():
+    d = decide(uuid4(), [], thresholds=WARM, warmed_up=True)
+    assert d.kind is DecisionKind.PROPOSE_NO_FIT
+    assert d.top is None
+    assert d.margin == 0.0
+
+
+def test_single_candidate_margin_is_full_p_match():
+    d = decide(uuid4(), [_cand('a', 0.8)], thresholds=WARM, warmed_up=True)
+    assert d.margin == pytest.approx(0.8)
+    assert d.kind is DecisionKind.AUTO_ROUTE
+
+
+def test_candidates_are_sorted_descending():
+    cands = [_cand('low', 0.2), _cand('high', 0.7), _cand('mid', 0.4)]
+    d = decide(uuid4(), cands, thresholds=WARM, warmed_up=True)
+    names = [c.vault_name for c in d.candidates]
+    assert names == ['high', 'mid', 'low']

--- a/packages/core/tests/unit/services/inbox_router/test_evidence_and_migration.py
+++ b/packages/core/tests/unit/services/inbox_router/test_evidence_and_migration.py
@@ -1,0 +1,86 @@
+"""Unit tests: evidence model shapes + static checks on migration 054 (no DB)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib as plb
+
+from memex_core.services.inbox_router.evidence import (
+    CandidateEvidence,
+    NoFitEvidence,
+    RouteEvidence,
+)
+
+_MIGRATION = (
+    plb.Path(__file__).resolve().parents[4] / 'src/memex_core/alembic/versions/055_inbox_router.py'
+)
+
+
+def test_route_evidence_round_trips():
+    ev = RouteEvidence(
+        routing_state='warmed_up_auto_eligible',
+        margin=0.6,
+        source_vault_id='11111111-1111-1111-1111-111111111111',
+        top_candidates=[
+            CandidateEvidence(
+                vault_id='22222222-2222-2222-2222-222222222222',
+                vault_name='memex',
+                p_match=0.8,
+                p_match_raw=0.9,
+                ci_half_width=0.02,
+            )
+        ],
+    )
+    payload = json.loads(ev.model_dump_json())
+    assert payload['kind'] == 'inbox_vault_route'
+    assert payload['top_candidates'][0]['vault_name'] == 'memex'
+    # Re-parse to confirm the shape is stable.
+    assert RouteEvidence.model_validate(payload).margin == 0.6
+
+
+def test_no_fit_evidence_defaults():
+    ev = NoFitEvidence(routing_state='cold_start_no_auto', best_p_match_raw=0.03)
+    payload = json.loads(ev.model_dump_json())
+    assert payload['kind'] == 'inbox_vault_no_fit'
+    assert payload['retry_n'] == 0
+    assert payload['next_retry_at'] is None
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location('mig054', _MIGRATION)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_migration_revision_chain():
+    mod = _load_migration()
+    assert mod.revision == '055_inbox_router'
+    assert mod.down_revision == '054_nodes_vault_active'
+
+
+def test_migration_extends_lint_type_check_with_routing():
+    text = _MIGRATION.read_text()
+    assert "'routing'" in text
+    # Upgrade adds routing; downgrade removes it.
+    assert 'ADD CONSTRAINT ck_maintenance_proposals_lint_type' in text
+    assert 'inbox_router_nb_stats' in text
+    assert 'inbox_router_vault_anchors' in text
+    assert 'inbox_router_note_cache' in text
+    assert 'CREATE VIEW inbox_router_nb_params' in text
+
+
+def test_migration_seeds_prior():
+    text = _MIGRATION.read_text()
+    # All five features seeded for both labels (10 rows) + class counts.
+    for feat in (
+        'sem_summary_sim',
+        'sem_centroid_sim',
+        'mm_centroid_sim',
+        'entity_jaccard',
+        'keyword_ts_rank',
+    ):
+        assert feat in text
+    assert 'inbox_router_nb_class_counts' in text

--- a/packages/core/tests/unit/services/inbox_router/test_route_action.py
+++ b/packages/core/tests/unit/services/inbox_router/test_route_action.py
@@ -45,23 +45,25 @@ def test_validate_accepts_well_formed():
 
 
 @pytest.mark.asyncio
-async def test_execute_migrates_and_records_feedback():
-    note_id, target_vault, source_vault = uuid4(), uuid4(), uuid4()
+async def test_execute_migrates_and_records_positive_and_negative_feedback():
+    note_id, target_vault, source_vault, other = uuid4(), uuid4(), uuid4(), uuid4()
     api = MagicMock()
     api.migrate_note = AsyncMock(return_value={'source_vault_id': str(source_vault)})
     api.inbox_router.record_feedback = AsyncMock()
 
     res = await ACTION.execute(
         api,
-        {'target_vault_id': str(target_vault)},
+        {'target_vault_id': str(target_vault), 'other_vault_ids': [str(other)]},
         target_id=str(note_id),
         vault_id=source_vault,
         actor='tester',
     )
 
     api.migrate_note.assert_awaited_once_with(note_id, target_vault)
-    # Manual confirmation feeds the model as a positive for the chosen vault.
-    api.inbox_router.record_feedback.assert_awaited_once_with(note_id, target_vault, 1)
+    # Chosen vault is a positive; the unchosen candidate is a negative.
+    calls = api.inbox_router.record_feedback.await_args_list
+    assert (note_id, target_vault, 1) in [c.args for c in calls]
+    assert (note_id, other, 0) in [c.args for c in calls]
     assert res.prior_state['source_vault_id'] == str(source_vault)
     assert res.applied_state['target_vault_id'] == str(target_vault)
 

--- a/packages/core/tests/unit/services/inbox_router/test_route_action.py
+++ b/packages/core/tests/unit/services/inbox_router/test_route_action.py
@@ -1,0 +1,116 @@
+"""Unit tests for the route_note_to_vault proposal action (mocked api, no DB)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from memex_core.services.proposal_actions.base import (
+    ActionValidationError,
+    ProposalActionError,
+)
+from memex_core.services.proposal_actions.route_note_to_vault import RouteNoteToVaultAction
+
+ACTION = RouteNoteToVaultAction()
+
+
+def test_validate_rejects_wrong_target_type():
+    with pytest.raises(ActionValidationError):
+        ACTION.validate(
+            {'target_vault_id': str(uuid4())}, target_type='memory_unit', target_id=str(uuid4())
+        )
+
+
+def test_validate_rejects_bad_target_id():
+    with pytest.raises(ActionValidationError):
+        ACTION.validate(
+            {'target_vault_id': str(uuid4())}, target_type='note', target_id='not-a-uuid'
+        )
+
+
+def test_validate_requires_target_vault_id():
+    with pytest.raises(ActionValidationError):
+        ACTION.validate({}, target_type='note', target_id=str(uuid4()))
+
+
+def test_validate_rejects_bad_target_vault_id():
+    with pytest.raises(ActionValidationError):
+        ACTION.validate({'target_vault_id': 'nope'}, target_type='note', target_id=str(uuid4()))
+
+
+def test_validate_accepts_well_formed():
+    ACTION.validate({'target_vault_id': str(uuid4())}, target_type='note', target_id=str(uuid4()))
+
+
+@pytest.mark.asyncio
+async def test_execute_migrates_and_records_feedback():
+    note_id, target_vault, source_vault = uuid4(), uuid4(), uuid4()
+    api = MagicMock()
+    api.migrate_note = AsyncMock(return_value={'source_vault_id': str(source_vault)})
+    api.inbox_router.record_feedback = AsyncMock()
+
+    res = await ACTION.execute(
+        api,
+        {'target_vault_id': str(target_vault)},
+        target_id=str(note_id),
+        vault_id=source_vault,
+        actor='tester',
+    )
+
+    api.migrate_note.assert_awaited_once_with(note_id, target_vault)
+    # Manual confirmation feeds the model as a positive for the chosen vault.
+    api.inbox_router.record_feedback.assert_awaited_once_with(note_id, target_vault, 1)
+    assert res.prior_state['source_vault_id'] == str(source_vault)
+    assert res.applied_state['target_vault_id'] == str(target_vault)
+
+
+@pytest.mark.asyncio
+async def test_execute_survives_feedback_failure():
+    note_id, target_vault = uuid4(), uuid4()
+    api = MagicMock()
+    api.migrate_note = AsyncMock(return_value={'source_vault_id': str(uuid4())})
+    api.inbox_router.record_feedback = AsyncMock(side_effect=RuntimeError('boom'))
+    # Learning failure must not break the migration.
+    res = await ACTION.execute(
+        api,
+        {'target_vault_id': str(target_vault)},
+        target_id=str(note_id),
+        vault_id=uuid4(),
+        actor='tester',
+    )
+    assert res.applied_state['target_vault_id'] == str(target_vault)
+
+
+@pytest.mark.asyncio
+async def test_reverse_migrates_back_to_source():
+    note_id, source_vault = uuid4(), uuid4()
+    api = MagicMock()
+    api.migrate_note = AsyncMock(return_value={})
+    res = await ACTION.reverse(
+        api,
+        {},
+        {'note_id': str(note_id)},
+        {'source_vault_id': str(source_vault)},
+        target_id=str(note_id),
+        vault_id=uuid4(),
+        actor='tester',
+    )
+    api.migrate_note.assert_awaited_once_with(note_id, source_vault)
+    assert res.restored_state['vault_id'] == str(source_vault)
+
+
+@pytest.mark.asyncio
+async def test_reverse_without_source_raises():
+    api = MagicMock()
+    with pytest.raises(ProposalActionError):
+        await ACTION.reverse(
+            api,
+            {},
+            {'note_id': str(uuid4())},
+            {},
+            target_id=str(uuid4()),
+            vault_id=uuid4(),
+            actor='tester',
+        )

--- a/packages/eval/src/memex_eval/suites/inbox_router/README.md
+++ b/packages/eval/src/memex_eval/suites/inbox_router/README.md
@@ -1,0 +1,42 @@
+# inbox_router suite
+
+Gates the **inbox router's routing accuracy**: given notes dropped in the
+`inbox` vault, does the router route each to the topically-correct vault?
+
+## What it does
+
+The `seed_inbox_router_corpus` setup action (in `_setup_actions.py`):
+
+1. Creates two topically-distinct target vaults (`eval-router-cooking`,
+   `eval-router-gardening`) and ingests a few on-topic notes into each.
+2. Ingests a set of **labelled** notes into the `inbox` vault — each note
+   clearly belongs to one target vault.
+3. Waits for extraction in every vault (chunks, embeddings, entities).
+4. Triggers a **dry-run** triage (`POST /api/v1/inbox/triage?dry_run=true`),
+   which scores + decides without mutating, and returns per-note predictions.
+5. Publishes `{predictions, expected}` (keyed by note UUID) into the scenario
+   context.
+
+The `inbox_route_accuracy` outcome compares the router's top-1 candidate per
+note to the label and passes when accuracy ≥ `min_accuracy` (default 0.75).
+
+## Scope
+
+- **In scope:** end-to-end routing accuracy over the live server — anchor
+  refresh, per-note feature cache, pairwise GaussianNB scoring, and the decision
+  policy. The NB prior is seeded by the service, so this measures the seeded
+  model (no warm-up), which is the day-1 behaviour an operator sees.
+- **Out of scope:** auto-apply gating, the cockpit proposal lifecycle, online
+  learning over many decisions, and no-fit backoff — those are covered by the
+  unit + integration tests (`packages/core/tests/.../inbox_router`).
+
+## Running
+
+```bash
+memex-eval suite run inbox_router
+```
+
+Requires a running server + Postgres (the runner provisions both). The corpus is
+deliberately small and topically unambiguous, so a correctly-wired router should
+clear the accuracy bar comfortably; a regression in scoring, anchors, or the
+decision policy drops it.

--- a/packages/eval/src/memex_eval/suites/inbox_router/__init__.py
+++ b/packages/eval/src/memex_eval/suites/inbox_router/__init__.py
@@ -1,0 +1,62 @@
+"""Inbox-router suite — auto-routing accuracy gate.
+
+Seeds two topically-distinct vaults plus a set of labelled notes in the inbox
+vault, triggers a dry-run triage, and checks the router's top-1 routing accuracy
+against the labels. Exercises the full path: per-vault anchor refresh →
+per-note feature cache → pairwise GaussianNB scoring → decision policy — over
+the live HTTP server (``POST /api/v1/inbox/triage``).
+
+The corpus and labels live in ``_setup_actions.py`` (the action ingests them
+into multiple vaults itself; the runner's single-vault source ingestion doesn't
+fit a routing scenario). Import order matters: ``_outcomes`` / ``_setup_actions``
+import FIRST so their decorators register before ``suite.register`` references
+them.
+"""
+
+from pathlib import Path
+
+from memex_eval.suite import SuiteMetadata
+from memex_eval.suite.base import SetupAction
+from memex_eval.suite.decorator import Suite
+
+# Side-effect imports: register the outcome + setup action before use.
+from memex_eval.suites.inbox_router._outcomes import InboxRouteAccuracy
+from memex_eval.suites.inbox_router import _setup_actions  # noqa: F401
+
+_ROOT = Path(__file__).parent
+
+METADATA = SuiteMetadata(
+    name='inbox_router',
+    schema_version='1',
+    suite_version='1.0.0',
+    description=(
+        'Inbox-router auto-routing accuracy: labelled notes in the inbox vault '
+        'must be routed (top-1) to the topically-correct vault by the pairwise '
+        'GaussianNB router evaluated in Postgres.'
+    ),
+    tags=['inbox-router', 'routing', 'classification'],
+    primary_metrics=['suite.pass_rate'],
+    components_under_test=[
+        'services.inbox_router',
+        'services.inbox_router.decisions',
+    ],
+    knobs=[
+        'server.memory.inbox_router.t_low',
+        'server.memory.inbox_router.top_k_entities',
+    ],
+    requires_llm_judge=False,
+)
+
+suite = Suite(metadata=METADATA, readme_path=_ROOT / 'README.md')
+
+suite.register(
+    id='inbox_router_top1_accuracy',
+    description='Labelled inbox notes route to the topically-correct vault (top-1).',
+    # The setup action does all the work and publishes predictions vs labels into
+    # context; the query is a no-op placeholder (the outcome ignores the answer).
+    query='inbox router routing accuracy',
+    setup_actions=[SetupAction(kind='seed_inbox_router_corpus')],
+    expected=InboxRouteAccuracy(type='inbox_route_accuracy', min_accuracy=0.75),
+)
+
+SUITE = suite.build()

--- a/packages/eval/src/memex_eval/suites/inbox_router/_outcomes.py
+++ b/packages/eval/src/memex_eval/suites/inbox_router/_outcomes.py
@@ -1,0 +1,54 @@
+"""Suite-private outcome for ``inbox_router``: routing top-1 accuracy."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from memex_eval.suite.base import ExpectedOutcomeBase, register_outcome
+
+
+@register_outcome('inbox_route_accuracy')
+class InboxRouteAccuracy(ExpectedOutcomeBase):
+    """Score the router's top-1 routing accuracy against ground-truth labels.
+
+    Reads the predictions + expected mapping the ``seed_inbox_router_corpus``
+    setup action published into the scenario context (auto-prefixed with the
+    handler name). For each labelled inbox note, a hit is the router's top
+    candidate matching the expected vault. ``pass`` when accuracy ≥ ``min_accuracy``.
+    """
+
+    type: Literal['inbox_route_accuracy']
+    min_accuracy: float = 0.75
+    predictions_key: str = 'seed_inbox_router_corpus.predictions'
+    expected_key: str = 'seed_inbox_router_corpus.expected'
+
+    def metric_keys(self, top_k: int | None = None) -> list[str]:
+        return ['pass', 'accuracy', 'n_notes', 'n_correct']
+
+    def score(
+        self,
+        answer: Any,
+        scenario: Any,
+        *,
+        context: dict[str, Any] | None = None,
+        **_kw: Any,
+    ) -> dict[str, float]:
+        ctx = context or {}
+        predictions: dict[str, Any] = ctx.get(self.predictions_key) or {}
+        expected: dict[str, Any] = ctx.get(self.expected_key) or {}
+
+        total = len(expected)
+        if total == 0:
+            # No labelled notes resolved — treat as an error, not a silent pass.
+            return {'pass': 0.0, 'accuracy': 0.0, 'n_notes': 0.0, 'n_correct': 0.0}
+
+        correct = sum(
+            1 for note_id, exp_vault in expected.items() if predictions.get(note_id) == exp_vault
+        )
+        accuracy = correct / total
+        return {
+            'pass': 1.0 if accuracy >= self.min_accuracy else 0.0,
+            'accuracy': accuracy,
+            'n_notes': float(total),
+            'n_correct': float(correct),
+        }

--- a/packages/eval/src/memex_eval/suites/inbox_router/_setup_actions.py
+++ b/packages/eval/src/memex_eval/suites/inbox_router/_setup_actions.py
@@ -1,0 +1,174 @@
+"""Suite-private setup action for ``inbox_router``.
+
+``seed_inbox_router_corpus`` builds a tiny labelled routing scenario end-to-end
+against a live server, then triggers a dry-run triage and returns the router's
+per-note predictions alongside the ground-truth labels for the outcome to score.
+
+Flow:
+1. Create two topically-distinct target vaults and ingest a few on-topic notes
+   into each (real embeddings via the ingest pipeline).
+2. Ensure the inbox vault exists and ingest the labelled notes-to-route.
+3. Wait for extraction in every vault so chunks/embeddings/entities are ready.
+4. Resolve each inbox note's real UUID (``find_notes_by_title``) — the ingest
+   response returns an idempotency hash, not ``notes.id``.
+5. Trigger a DRY-RUN triage (``RemoteMemexAPI.trigger_inbox_triage``) so nothing
+   is mutated; read the per-note top-candidate predictions.
+6. Publish ``{predictions, expected}`` (keyed by note UUID) into the scenario
+   context for ``inbox_route_accuracy``.
+
+The handler talks to the server over the HTTP client (the documented setup-action
+surface); the router tables are SQLModel models, so the server's create_all DB
+already has them and no direct DDL is needed.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar
+from uuid import UUID
+
+from memex_common.schemas import NoteCreateDTO
+from memex_eval.helpers import wait_for_extraction
+from memex_eval.suite.setup_actions import SetupActionHandler, register_setup_action
+
+if TYPE_CHECKING:
+    from memex_common.client import RemoteMemexAPI
+
+logger = logging.getLogger('memex_eval.suites.inbox_router.setup_actions')
+
+# Two clearly-separable topics. Target vaults are prefixed so they don't collide
+# with a real operator vault and are easy to clean up.
+_COOKING = 'eval-router-cooking'
+_GARDENING = 'eval-router-gardening'
+
+_TARGET_CORPUS: dict[str, list[str]] = {
+    _COOKING: [
+        'Fresh pasta dough: combine 00 flour and eggs, knead ten minutes, rest, '
+        'then roll thin and cut into tagliatelle. Salt the boiling water well.',
+        'A proper risotto needs warm stock added one ladle at a time, constant '
+        'stirring to release the rice starch, and a final beat of butter and parmesan.',
+        'To temper chocolate, melt to 45C, cool to 27C over a cold bowl, then warm '
+        'back to 31C so it sets glossy and snaps cleanly.',
+    ],
+    _GARDENING: [
+        'Start tomato seeds indoors six weeks before the last frost; harden the '
+        'seedlings off gradually before transplanting into rich, well-drained soil.',
+        'Prune fruit trees in late winter while dormant: remove crossing branches '
+        'and open the canopy so light and air reach the inner growth.',
+        'Compost needs a balance of green nitrogen (kitchen scraps) and brown carbon '
+        '(dry leaves), turned regularly to keep the pile aerobic and hot.',
+    ],
+}
+
+# (note_key, body, expected_vault) — each clearly belongs to one target vault.
+_INBOX_CORPUS: list[tuple[str, str, str]] = [
+    (
+        'route-carbonara',
+        'How do I make a silky carbonara? Whisk egg yolks with pecorino, toss off the '
+        'heat with the hot guanciale fat and a little pasta water so it does not scramble.',
+        _COOKING,
+    ),
+    (
+        'route-sourdough',
+        'My sourdough starter doubles in four hours now. Best hydration and bulk-'
+        'fermentation time for an open crumb when baking in a dutch oven?',
+        _COOKING,
+    ),
+    (
+        'route-raised-beds',
+        'Planning raised beds for next spring. Companion planting for tomatoes, basil '
+        'and marigolds, and how deep the soil should be for good root growth.',
+        _GARDENING,
+    ),
+    (
+        'route-pruning',
+        'When should I prune my apple tree, and how much of the canopy can I safely '
+        'remove in one dormant season without stressing the tree?',
+        _GARDENING,
+    ),
+]
+
+_INBOX_VAULT = 'inbox'
+
+
+def _b64(text: str) -> bytes:
+    return base64.b64encode(text.encode('utf-8'))
+
+
+@register_setup_action('seed_inbox_router_corpus')
+class _SeedInboxRouterCorpus(SetupActionHandler):
+    # A seed failure must error the scenario, not be soft-logged.
+    required: ClassVar[bool] = True
+    # Ingestion + triage are stateful side effects; re-running against a reused
+    # vault would double-ingest and bias the predictions.
+    reusable_under_reuse_vault: ClassVar[bool] = False
+
+    async def run(
+        self,
+        api: 'RemoteMemexAPI',
+        vault_id: UUID,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        # 1. Target vaults + on-topic content.
+        for vname, bodies in _TARGET_CORPUS.items():
+            await self._ensure_vault(api, vname, f'Inbox-router eval target: {vname}')
+            for i, body in enumerate(bodies):
+                await self._ingest(api, vname, f'{vname}-{i}', body)
+
+        # 2. Inbox vault + labelled notes to route.
+        await self._ensure_vault(api, _INBOX_VAULT, 'Inbox-router eval: notes to route')
+        for note_key, body, _expected in _INBOX_CORPUS:
+            await self._ingest(api, _INBOX_VAULT, note_key, body)
+
+        # 3. Wait for extraction so chunks/embeddings/entities are ready.
+        vault_names = [*_TARGET_CORPUS.keys(), _INBOX_VAULT]
+        for vname in vault_names:
+            vid = await api.resolve_vault_identifier(vname)
+            await wait_for_extraction(api, vid, poll_timeout=180.0)
+
+        # 4. Resolve each inbox note's real UUID (ingest returns an idempotency
+        #    hash, not notes.id) so predictions and labels share one key space.
+        inbox_id = await api.resolve_vault_identifier(_INBOX_VAULT)
+        expected: dict[str, str] = {}
+        for note_key, _body, expected_vault in _INBOX_CORPUS:
+            matches = await api.find_notes_by_title(note_key, vault_ids=[inbox_id], limit=3)
+            if not matches:
+                raise RuntimeError(f'seed_inbox_router_corpus: inbox note {note_key!r} not found')
+            expected[str(matches[0].note_id)] = expected_vault
+
+        # 5. Dry-run triage — score + decide, mutate nothing.
+        triage = await api.trigger_inbox_triage(dry_run=True)
+        predictions: dict[str, str] = {}
+        for d in triage.get('decisions', []):
+            note_id = d.get('note_id')
+            if note_id is not None:
+                predictions[str(note_id)] = d.get('top_vault_name')
+
+        return {'predictions': predictions, 'expected': expected}
+
+    @staticmethod
+    async def _ensure_vault(api: 'RemoteMemexAPI', name: str, description: str) -> UUID:
+        try:
+            return await api.resolve_vault_identifier(name)
+        except Exception:  # noqa: BLE001 - not found; fall through to create
+            pass
+        try:
+            v = await api.create_vault(name, description)
+            return v.id
+        except Exception:  # noqa: BLE001 - created concurrently; resolve again
+            return await api.resolve_vault_identifier(name)
+
+    @staticmethod
+    async def _ingest(api: 'RemoteMemexAPI', vault_name: str, note_key: str, body: str) -> None:
+        vid = await api.resolve_vault_identifier(vault_name)
+        dto = NoteCreateDTO(
+            name=note_key,
+            note_key=f'eval-inbox-router-{note_key}',
+            description=f'Inbox-router eval note: {note_key}',
+            content=_b64(body),
+            files=[],
+            tags=[],
+            vault_id=str(vid),
+        )
+        await api.ingest(dto)

--- a/scripts/rebuild_entity_cooccurrences.py
+++ b/scripts/rebuild_entity_cooccurrences.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""Rebuild ``entity_cooccurrences`` per-vault from ground truth.
+
+Migration ``052_entity_cooccurrence_vault_pk`` changed the cooccurrence grain
+to ``(entity_id_1, entity_id_2, vault_id)`` and rebuilds the table on upgrade.
+This is the standalone operational equivalent: an operator can re-derive the
+table from the source of truth (``unit_entities`` ⋈ ``memory_units``) at any
+time — e.g. after a bulk import, a suspected drift, or to repair a DB that
+carried the old cross-vault-summed rows — without running a full Alembic cycle.
+
+The cooccurrence count for a pair in a vault is the number of distinct units in
+that vault that co-mention both entities (the ingest-time semantics). Canonical
+ordering ``entity_id_1 < entity_id_2`` is enforced by the self-join, matching
+the table CHECK constraint.
+
+Defaults to a DRY RUN (reports current vs rebuilt row counts, writes nothing).
+Pass ``--apply`` to perform the rebuild inside a single transaction (TRUNCATE +
+repopulate; rolls back atomically on error). On a large corpus the self-join is
+heavy and takes an ACCESS EXCLUSIVE lock for its duration — run in a maintenance
+window.
+
+Usage:
+    uv run python scripts/rebuild_entity_cooccurrences.py            # dry run
+    uv run python scripts/rebuild_entity_cooccurrences.py --apply
+    uv run python scripts/rebuild_entity_cooccurrences.py --dsn postgresql://... --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+import asyncpg
+from sqlalchemy.engine.url import make_url
+
+# Per-vault rebuild SELECT — identical semantics to migration 052's
+# _REBUILD_PER_VAULT (count = distinct units in the vault co-mentioning the pair).
+_REBUILD_SELECT = """
+SELECT a.entity_id, b.entity_id, mu.vault_id,
+       COUNT(DISTINCT a.unit_id), now(), MIN(mu.event_date)
+FROM unit_entities a
+JOIN unit_entities b ON a.unit_id = b.unit_id AND a.entity_id < b.entity_id
+JOIN memory_units mu ON mu.id = a.unit_id
+GROUP BY a.entity_id, b.entity_id, mu.vault_id
+"""
+
+_REBUILD_SQL = (
+    'INSERT INTO entity_cooccurrences '
+    '(entity_id_1, entity_id_2, vault_id, cooccurrence_count, last_cooccurred, valid_from)\n'
+    + _REBUILD_SELECT
+)
+
+_COUNT_REBUILD_SQL = f'SELECT COUNT(*) FROM ({_REBUILD_SELECT}) t'
+
+
+def _resolve_dsn(explicit: str | None) -> str:
+    """Return a plain ``postgresql://`` DSN (asyncpg wants no +driver suffix)."""
+    if explicit:
+        raw = explicit
+    else:
+        # Reuse the same config the server resolves (YAML + env).
+        from memex_common.config import MemexConfig
+
+        raw = MemexConfig().server.meta_store.instance.connection_string
+    return make_url(raw).set(drivername='postgresql').render_as_string(hide_password=False)
+
+
+async def _run(dsn: str, apply: bool) -> int:
+    conn = await asyncpg.connect(dsn)
+    try:
+        current = await conn.fetchval('SELECT COUNT(*) FROM entity_cooccurrences')
+        rebuilt = await conn.fetchval(_COUNT_REBUILD_SQL)
+        print(f'entity_cooccurrences: current rows = {current:,}; rebuilt rows = {rebuilt:,}')
+
+        if not apply:
+            delta = rebuilt - current
+            print(
+                f'DRY RUN — no changes made. Rebuild would result in {rebuilt:,} rows '
+                f'({delta:+,} vs current). Re-run with --apply to perform it.'
+            )
+            return 0
+
+        print('Applying rebuild (TRUNCATE + repopulate) in a single transaction...')
+        async with conn.transaction():
+            await conn.execute('TRUNCATE entity_cooccurrences')
+            await conn.execute(_REBUILD_SQL)
+            final = await conn.fetchval('SELECT COUNT(*) FROM entity_cooccurrences')
+        print(f'Done. entity_cooccurrences now has {final:,} rows.')
+        return 0
+    finally:
+        await conn.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--dsn',
+        default=None,
+        help='Postgres DSN. Defaults to the server config (YAML + env).',
+    )
+    parser.add_argument(
+        '--apply',
+        action='store_true',
+        help='Perform the rebuild. Without this flag the script only reports (dry run).',
+    )
+    args = parser.parse_args()
+
+    try:
+        dsn = _resolve_dsn(args.dsn)
+    except Exception as exc:  # noqa: BLE001 - surface config errors plainly
+        print(f'Failed to resolve DSN: {exc}', file=sys.stderr)
+        return 2
+
+    return asyncio.run(_run(dsn, apply=args.apply))
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Opt-in **inbox router**: scores notes in the `inbox` vault against every other vault with a pairwise Gaussian Naive Bayes model evaluated **entirely in Postgres**, then auto-routes confident notes (capped) or emits cockpit proposals for the rest. Architecture settled by a 12-iteration POC (MLflow experiment 11). Off by default (`server.memory.inbox_router.enabled`).

## Engine
- **`InboxRouterConfig`** — `enabled=False`, `top_k_entities=100`, `auto_apply_min_p_match=0.5`, `t_margin=0.4`, `t_low=0.10`, `min_decisions_before_auto_apply=50` (cold-start gate), `ewma_gamma=0.99` (drift decay), `max_auto_applies_per_tick=10`.
- **Migration 054** — `inbox_router_nb_stats` / `inbox_router_nb_class_counts` (sufficient stats `n, Σx, Σx²`); `inbox_router_nb_params` / `inbox_router_nb_prior` VIEWs deriving `(μ̂, σ̂²)` + log-priors; `inbox_router_vault_anchors` + `inbox_router_note_cache`. Seeds the prior from POC empirics (n=5) so day-1 rankings are sensible (a flat prior gives uniform-random output). Extends `maintenance_proposals` lint_type CHECK to `'routing'`.
- **`services/inbox_router/`** — `sql.py` (anchor refresh, note-cache, batched scoring + per-note softmax + credible-interval, online conjugate update), `decisions.py` (pure auto-route / propose / no-fit policy), `evidence.py` (proposal JSONB models), `service.py` (triage orchestration + online learning from auto/cockpit decisions).

## Wiring
- `api.inbox_router`; leader-gated `run_inbox_router_job` + idempotent inbox-vault bootstrap; `route_note_to_vault` reversible `ProposalAction`; `POST /inbox/triage` + `GET /inbox/status`; `memex inbox triage|status`; cockpit per-candidate route options + no-fit options.

## Design decisions (from adversarial review of the plan)
- **Prior seeded from POC empirics**, not flat — avoids cold-start uniform-random rankings.
- **EWMA γ=0.99 default** so the model forgets stale vault state as vaults drift.
- **Cold-start gate** (`min_decisions`) controls *auto-apply* only; proposals are sensible from tick 1.
- **Per-tick auto-apply cap** so a mis-scoring run can't reshuffle the whole inbox.

## Tests / docs
Unit + integration tests and the eval suite + docs land in follow-up commits on this branch (in progress). Migration verified single-head locally; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)