### PR TITLE
fix(core,hermes-plugin): HEAD /notes/{id}, HNSW-friendly KNN, UNION ALL cooccurrence (A.5+B.3+B.4)

### DIFF
--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -141,6 +141,15 @@ class RemoteMemexAPI:
         response = await self.client.patch(path, json=payload)
         return await self._handle_response(response)
 
+    async def _head(self, path: str) -> int:
+        """Issue HEAD and return the raw status code (no body parsing).
+
+        Used by callers like `head_note` that only need a 200/404 decision
+        without paying the response-body deserialisation cost.
+        """
+        response = await self.client.head(path)
+        return response.status_code
+
     # --- Vaults ---
     async def list_vaults(self) -> list[VaultDTO]:
         """List all available vaults."""
@@ -573,6 +582,29 @@ class RemoteMemexAPI:
         """Get a note by ID."""
         result = await self._get(f'notes/{note_id}')
         return NoteDTO(**result)
+
+    async def head_note(self, note_id: UUID) -> bool:
+        """Cheap existence check via HEAD /notes/{id}. True iff 200.
+
+        404 returns False (note doesn't exist yet). Any other non-2xx
+        status raises via `httpx.Response.raise_for_status()` upstream
+        — the hermes-plugin's `_wait_for_note_row` distinguishes those
+        per `_NON_TRANSIENT_HTTP_STATUSES`.
+        """
+        status = await self._head(f'notes/{note_id}')
+        if status == 200:
+            return True
+        if status == 404:
+            return False
+        # Anything else is unexpected — surface via raise_for_status
+        # by re-issuing? No — just raise httpx.HTTPStatusError directly.
+        import httpx
+
+        raise httpx.HTTPStatusError(
+            f'Unexpected HEAD status {status}',
+            request=httpx.Request('HEAD', f'notes/{note_id}'),
+            response=httpx.Response(status_code=status),
+        )
 
     async def get_note_metadata(self, note_id: UUID) -> dict[str, Any] | None:
         """Get just the metadata from a note's page index."""

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1245,6 +1245,10 @@ class MemexAPI:
         """Retrieve a single document by ID. Delegates to NoteService."""
         return await self._notes.get_note(note_id)
 
+    async def note_exists(self, note_id: UUID) -> bool:
+        """Return True iff a note with this id exists. Delegates to NoteService."""
+        return await self._notes.note_exists(note_id)
+
     async def get_note_metadata(self, note_id: UUID) -> dict[str, Any] | None:
         """Retrieve just the metadata from the page index. Delegates to NoteService."""
         return await self._notes.get_note_metadata(note_id)

--- a/packages/core/src/memex_core/memory/retrieval/document_search.py
+++ b/packages/core/src/memex_core/memory/retrieval/document_search.py
@@ -441,16 +441,26 @@ class NoteSearchEngine:
         weight = weights.get('semantic', 1.0)
         distance = cast(Any, col(Chunk.embedding)).cosine_distance(query_embedding)
 
-        stmt = select(
-            Chunk.id,
-            func.rank().over(order_by=distance.asc()).label('rnk'),
-            literal(weight).label('weight'),
-        ).select_from(Chunk)
-
+        # B.3: previous shape was `rank() OVER (ORDER BY distance) ... LIMIT k`
+        # — the window function wrapping prevented the planner from pushing
+        # LIMIT into the HNSW index scan, forcing an exact KNN over the
+        # entire chunks table. Canonical pgvector HNSW pattern is plain
+        # `ORDER BY distance LIMIT k` in the inner subquery, with the rank
+        # assigned in an outer SELECT via `row_number() OVER ()` (no
+        # ORDER BY — relies on the subquery ordering, which CTEs preserve
+        # in Postgres). Gate validated via EXPLAIN ANALYZE per the tech
+        # report — planner is fickle on HNSW + filters.
+        inner = select(Chunk.id, distance.label('distance')).select_from(Chunk)
         if request.vault_ids:
-            stmt = stmt.where(col(Chunk.vault_id).in_(request.vault_ids))
+            inner = inner.where(col(Chunk.vault_id).in_(request.vault_ids))
+        inner = inner.order_by(distance.asc()).limit(pool_size)
+        inner_cte = inner.cte('chunk_semantic_inner')
 
-        cte = stmt.limit(pool_size).cte('chunk_semantic')
+        cte = select(
+            inner_cte.c.id,
+            func.row_number().over().label('rnk'),
+            literal(weight).label('weight'),
+        ).cte('chunk_semantic')
         return select(cte.c.id, cte.c.rnk, cte.c.weight)
 
     def _keyword_cte(

--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -841,32 +841,50 @@ class EntityCooccurrenceNoteGraphStrategy:
         first_order = apply_vault_filters(first_order, Chunk.vault_id, **kwargs)
         first_order = apply_context_filter(first_order, **kwargs)
 
-        # 2nd Order: Co-occurrence expansion
-        neighbor_id_expr = func.coalesce(
-            func.nullif(col(EntityCooccurrence.entity_id_2), seed_entities.c.id),
-            col(EntityCooccurrence.entity_id_1),
-        ).label('neighbor_id')
+        # 2nd Order: Co-occurrence expansion.
+        # B.4: the previous shape used a single SELECT joined on
+        # `entity_id_1 = seed.id OR entity_id_2 = seed.id`. The `OR` defeats
+        # single-index use — Postgres can't push either side into the
+        # `(entity_id_1, …)` or `(entity_id_2, …)` btrees independently, so
+        # it fell back to a sequential / bitmap-or path that exploded for
+        # hub entities (e.g. `Memex`, `Claude`) with tens of thousands of
+        # cooccurrence rows before the outer LIMIT 60. Split into
+        # UNION ALL of two single-side joins — each branch uses its own
+        # btree, and the planner sees the small per-side cardinality.
+        link_strength_expr = (
+            func.ln(col(EntityCooccurrence.cooccurrence_count) + 1)
+            / func.ln(col(Entity.mention_count) + 2)
+        ).label('link_strength')
 
-        co_occur_stmt = (
+        left_co = (
             select(
-                neighbor_id_expr,
-                (
-                    func.ln(col(EntityCooccurrence.cooccurrence_count) + 1)
-                    / func.ln(col(Entity.mention_count) + 2)
-                ).label('link_strength'),
+                col(EntityCooccurrence.entity_id_2).label('neighbor_id'),
+                link_strength_expr,
             )
             .join(
                 seed_entities,
-                or_(
-                    col(EntityCooccurrence.entity_id_1) == seed_entities.c.id,
-                    col(EntityCooccurrence.entity_id_2) == seed_entities.c.id,
-                ),
+                col(EntityCooccurrence.entity_id_1) == seed_entities.c.id,
             )
-            .join(Entity, col(Entity.id) == neighbor_id_expr)
+            .join(Entity, col(Entity.id) == col(EntityCooccurrence.entity_id_2))
         )
-        co_occur_stmt = apply_vault_filters(co_occur_stmt, EntityCooccurrence.vault_id, **kwargs)
-        co_occur_stmt = _apply_as_of_filter(co_occur_stmt, **kwargs)
-        co_occurrences = co_occur_stmt.cte('doc_graph_related_entities')
+        left_co = apply_vault_filters(left_co, EntityCooccurrence.vault_id, **kwargs)
+        left_co = _apply_as_of_filter(left_co, **kwargs)
+
+        right_co = (
+            select(
+                col(EntityCooccurrence.entity_id_1).label('neighbor_id'),
+                link_strength_expr,
+            )
+            .join(
+                seed_entities,
+                col(EntityCooccurrence.entity_id_2) == seed_entities.c.id,
+            )
+            .join(Entity, col(Entity.id) == col(EntityCooccurrence.entity_id_1))
+        )
+        right_co = apply_vault_filters(right_co, EntityCooccurrence.vault_id, **kwargs)
+        right_co = _apply_as_of_filter(right_co, **kwargs)
+
+        co_occurrences = union_all(left_co, right_co).cte('doc_graph_related_entities')
 
         second_order = (
             select(Chunk.id)

--- a/packages/core/src/memex_core/server/notes.py
+++ b/packages/core/src/memex_core/server/notes.py
@@ -10,6 +10,7 @@ from fastapi import (
     File,
     HTTPException,
     Query,
+    Response,
     UploadFile,
 )
 from pydantic import BaseModel
@@ -256,6 +257,21 @@ async def get_note(note_id: UUID, api: Annotated[MemexAPI, Depends(get_api)]):
         return build_note_dto(doc)
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, 'Failed to get note')
+
+
+@router.head('/notes/{note_id}', dependencies=[Depends(require_read)])
+async def head_note(note_id: UUID, api: Annotated[MemexAPI, Depends(get_api)]) -> Response:
+    """Cheap existence check — 200 if the note exists, 404 otherwise.
+
+    A.5: hermes-plugin polls this at 10 Hz (now backoff-paced, default
+    deadline 120s — see provider.py:_wait_for_note_row) to confirm a
+    background-ingested session note has materialised. Goes through a
+    pk-index lookup + LIMIT 1 in NoteService.note_exists, so we don't
+    hydrate the full Note model on every poll.
+    """
+    if await api.note_exists(note_id):
+        return Response(status_code=200)
+    return Response(status_code=404)
 
 
 class BatchNodeRequest(BaseModel):

--- a/packages/core/src/memex_core/services/notes.py
+++ b/packages/core/src/memex_core/services/notes.py
@@ -593,6 +593,27 @@ class NoteService:
 
             return doc.model_dump()
 
+    async def note_exists(self, note_id: UUID) -> bool:
+        """Return True iff a note with this id exists.
+
+        A.5: cheap existence check used by the HEAD /notes/{id} route.
+        Issues a single primary-key index lookup with `select(Note.id)
+        ... LIMIT 1`, so the row is never hydrated into a model instance
+        (unlike `get_note`, which loads the full Note + relationships).
+        The hermes-plugin's `_wait_for_note_row` polls this rather than
+        get_note so the readback-loop doesn't pay the full hydration cost
+        once per attempt under a 120s deadline.
+        """
+        from sqlmodel import select
+
+        from memex_core.memory.sql_models import Note
+
+        async with self.metastore.session() as session:
+            result = await session.exec(
+                select(col(Note.id)).where(col(Note.id) == note_id).limit(1)
+            )
+            return result.first() is not None
+
     async def get_note_metadata(self, note_id: UUID) -> dict[str, Any] | None:
         """Return just the metadata portion of the page index."""
         from memex_core.memory.sql_models import Note

--- a/packages/core/tests/unit/test_server.py
+++ b/packages/core/tests/unit/test_server.py
@@ -220,6 +220,30 @@ def test_get_note_page_index_not_found(client, mock_api):
     assert response.status_code == 404
 
 
+def test_head_note_returns_200_when_present(client, mock_api):
+    """A.5: HEAD /notes/{id} returns 200 with no body when the note exists."""
+    doc_id = UUID('00000000-0000-0000-0000-000000000077')
+    mock_api.note_exists.return_value = True
+
+    response = client.head(f'/api/v1/notes/{doc_id}')
+
+    assert response.status_code == 200
+    # HEAD must not return a body.
+    assert response.content == b''
+    mock_api.note_exists.assert_awaited_once_with(doc_id)
+
+
+def test_head_note_returns_404_when_absent(client, mock_api):
+    """A.5: HEAD /notes/{id} returns 404 when the note doesn't exist."""
+    doc_id = UUID('00000000-0000-0000-0000-000000000078')
+    mock_api.note_exists.return_value = False
+
+    response = client.head(f'/api/v1/notes/{doc_id}')
+
+    assert response.status_code == 404
+    assert response.content == b''
+
+
 def test_get_note_metadata_with_data(client, mock_api):
     """GET /notes/{note_id}/metadata returns metadata when present."""
     doc_id = UUID('00000000-0000-0000-0000-000000000099')

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/provider.py
@@ -928,8 +928,15 @@ class MemexMemoryProvider(MemoryProvider):
         attempt = 0
         while time.monotonic() < deadline:
             try:
-                run_sync(self._api.get_note(note_id), timeout=1.0)
-                return True
+                # A.5: HEAD instead of GET so each poll is a pk-index hit
+                # without hydrating the full Note model. Returns bool —
+                # True for 200 (exists), False for 404 (not yet visible).
+                # Other status codes raise httpx.HTTPStatusError via the
+                # client and route through the branches below.
+                if run_sync(self._api.head_note(note_id), timeout=1.0):
+                    return True
+                # head_note → False means 404 (still materialising) —
+                # fall through to backoff.
             except httpx.HTTPStatusError as e:
                 code = e.response.status_code
                 if code in _NON_TRANSIENT_HTTP_STATUSES and code != 404:

--- a/packages/hermes-plugin/tests/test_provider.py
+++ b/packages/hermes-plugin/tests/test_provider.py
@@ -44,6 +44,7 @@ def provider_with_stubbed_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     fake_api.get_session_briefing = AsyncMock(return_value='# Briefing')
     fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(note_uuid)))
     fake_api.get_note = AsyncMock(return_value=SimpleNamespace(id=note_uuid))
+    fake_api.head_note = AsyncMock(return_value=True)
     fake_api.kv_put = AsyncMock()
 
     with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
@@ -374,6 +375,7 @@ def provider_with_append_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     fake_api.get_session_briefing = AsyncMock(return_value='# Briefing')
     fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(note_uuid)))
     fake_api.get_note = AsyncMock(return_value=SimpleNamespace(id=note_uuid))
+    fake_api.head_note = AsyncMock(return_value=True)
     fake_api.append_to_note = AsyncMock(
         return_value=SimpleNamespace(
             status='success',
@@ -805,6 +807,7 @@ def test_vault_rebind_after_note_initialized_is_ignored(
     fake_api.get_session_briefing = AsyncMock(return_value='')
     fake_api.ingest = AsyncMock(return_value=SimpleNamespace(status='ok', note_id=str(note_uuid)))
     fake_api.get_note = AsyncMock(return_value=SimpleNamespace(id=note_uuid))
+    fake_api.head_note = AsyncMock(return_value=True)
 
     with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):
         with patch(
@@ -837,17 +840,17 @@ def test_wait_for_note_row_retries_on_transient_5xx(provider_with_append_api):
     import httpx
 
     provider, api, _ = provider_with_append_api
-    note_id = uuid4()
 
     fake_503 = httpx.Response(status_code=503, text='busy')
-    fake_503._request = httpx.Request('GET', 'http://test/notes/x')
+    fake_503._request = httpx.Request('HEAD', 'http://test/notes/x')
     transient = httpx.HTTPStatusError('503', request=fake_503._request, response=fake_503)
 
-    api.get_note = AsyncMock(side_effect=[transient, transient, SimpleNamespace(id=note_id)])
-    provider._api.get_note = api.get_note
+    # A.5: wait loop polls head_note now (cheap existence check).
+    api.head_note = AsyncMock(side_effect=[transient, transient, True])
+    provider._api.head_note = api.head_note
 
     assert provider._wait_for_note_row(timeout=5.0) is True
-    assert api.get_note.await_count == 3
+    assert api.head_note.await_count == 3
 
 
 def test_wait_for_note_row_bails_on_definitive_4xx(provider_with_append_api):
@@ -860,15 +863,15 @@ def test_wait_for_note_row_bails_on_definitive_4xx(provider_with_append_api):
     provider, api, _ = provider_with_append_api
 
     fake_400 = httpx.Response(status_code=400, text='bad request')
-    fake_400._request = httpx.Request('GET', 'http://test/notes/x')
+    fake_400._request = httpx.Request('HEAD', 'http://test/notes/x')
     bad = httpx.HTTPStatusError('400', request=fake_400._request, response=fake_400)
 
-    api.get_note = AsyncMock(side_effect=bad)
-    provider._api.get_note = api.get_note
+    api.head_note = AsyncMock(side_effect=bad)
+    provider._api.head_note = api.head_note
 
     assert provider._wait_for_note_row(timeout=10.0) is False
     # Bailed early — only one call, not the full poll-loop count.
-    assert api.get_note.await_count == 1
+    assert api.head_note.await_count == 1
 
 
 # ---- A.1: 409-on-create overlap path --------------------------------------
@@ -894,7 +897,7 @@ def test_create_409_waits_for_note_row_and_pops_on_success(provider_with_append_
     overlap = httpx.HTTPStatusError('409', request=fake_409._request, response=fake_409)
     api.ingest = AsyncMock(side_effect=overlap)
     provider._api.ingest = api.ingest
-    # get_note (already AsyncMock returning SimpleNamespace) resolves the wait.
+    # head_note (already AsyncMock returning True) resolves the wait.
 
     provider.sync_turn('q', 'a')
     # Defensive: confirm the flip happens via the 409→wait path, not from
@@ -907,7 +910,7 @@ def test_create_409_waits_for_note_row_and_pops_on_success(provider_with_append_
     # Head popped, _note_initialized flipped, no orphaned create stays queued.
     assert provider._pending == []
     assert provider._note_initialized is True
-    api.get_note.assert_awaited()
+    api.head_note.assert_awaited()
 
 
 def test_create_409_keeps_head_queued_if_wait_times_out(provider_with_append_api):
@@ -930,13 +933,13 @@ def test_create_409_keeps_head_queued_if_wait_times_out(provider_with_append_api
     api.ingest = AsyncMock(side_effect=overlap)
     provider._api.ingest = api.ingest
 
-    # Force the wait to fail — make every get_note raise a non-transient 400
+    # Force the wait to fail — make every head_note raise a non-transient 400
     # so the wait bails immediately rather than burning the default 120s.
     fake_400 = httpx.Response(status_code=400, text='nope')
-    fake_400._request = httpx.Request('GET', 'http://test/notes/x')
+    fake_400._request = httpx.Request('HEAD', 'http://test/notes/x')
     fail = httpx.HTTPStatusError('400', request=fake_400._request, response=fake_400)
-    api.get_note = AsyncMock(side_effect=fail)
-    provider._api.get_note = api.get_note
+    api.head_note = AsyncMock(side_effect=fail)
+    provider._api.head_note = api.head_note
 
     provider.sync_turn('q', 'a')
     provider.on_pre_compress([])
@@ -991,13 +994,13 @@ def test_wait_for_note_row_uses_exponential_backoff(provider_with_append_api):
     provider, api, _ = provider_with_append_api
 
     fake_503 = httpx.Response(status_code=503, text='busy')
-    fake_503._request = httpx.Request('GET', 'http://test/notes/x')
+    fake_503._request = httpx.Request('HEAD', 'http://test/notes/x')
     transient = httpx.HTTPStatusError('503', request=fake_503._request, response=fake_503)
     # Five transients then success — exercise the first five backoff steps.
-    api.get_note = AsyncMock(
-        side_effect=[transient, transient, transient, transient, transient, Mock()]
+    api.head_note = AsyncMock(
+        side_effect=[transient, transient, transient, transient, transient, True]
     )
-    provider._api.get_note = api.get_note
+    provider._api.head_note = api.head_note
 
     sleeps: list[float] = []
     with patch(
@@ -1385,6 +1388,7 @@ class TestSessionTitle:
             return_value=SimpleNamespace(status='ok', note_id=str(note_uuid))
         )
         fake_api.get_note = AsyncMock(return_value=SimpleNamespace(id=note_uuid))
+        fake_api.head_note = AsyncMock(return_value=True)
         fake_api.kv_put = AsyncMock()
 
         with patch('memex_common.client.RemoteMemexAPI', return_value=fake_api):


### PR DESCRIPTION
Tech report 8e9dea4a step-5 cluster. (A.5) HEAD /notes/{id} endpoint with cheap pk-index NoteService.note_exists(); RemoteMemexAPI.head_note() + plugin switches _wait_for_note_row to it. (B.3) Rewrite _semantic_cte to plain ORDER BY/LIMIT inner + row_number outer (HNSW-friendly). (B.4) Rewrite cooccurrence OR self-join as union_all of two single-side joins. Tests: HEAD 200/404, 51 provider tests pass, ruff clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)