### PR TITLE
chore(memex): cleanup from PR #188/#191/#192 Hermes round-2 findings

### DIFF
--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -141,14 +141,15 @@ class RemoteMemexAPI:
         response = await self.client.patch(path, json=payload)
         return await self._handle_response(response)
 
-    async def _head(self, path: str) -> int:
-        """Issue HEAD and return the raw status code (no body parsing).
+    async def _head(self, path: str) -> httpx.Response:
+        """Issue HEAD and return the response (no body parsing).
 
-        Used by callers like `head_note` that only need a 200/404 decision
-        without paying the response-body deserialisation cost.
+        Returns the full ``httpx.Response`` so callers raising
+        ``HTTPStatusError`` from an unexpected code can pass the real
+        response object (with proper headers/request/stream internals)
+        rather than a fabricated one.
         """
-        response = await self.client.head(path)
-        return response.status_code
+        return await self.client.head(path)
 
     # --- Vaults ---
     async def list_vaults(self) -> list[VaultDTO]:
@@ -587,24 +588,25 @@ class RemoteMemexAPI:
         """Cheap existence check via HEAD /notes/{id}. True iff 200.
 
         404 returns False (note doesn't exist yet). Any other non-2xx
-        status raises via `httpx.Response.raise_for_status()` upstream
-        — the hermes-plugin's `_wait_for_note_row` distinguishes those
-        per `_NON_TRANSIENT_HTTP_STATUSES`.
+        status raises ``httpx.HTTPStatusError`` carrying the real response
+        and request — the hermes-plugin's ``_wait_for_note_row``
+        distinguishes those per ``_NON_TRANSIENT_HTTP_STATUSES``.
         """
-        status = await self._head(f'notes/{note_id}')
-        if status == 200:
+        response = await self._head(f'notes/{note_id}')
+        if response.status_code == 200:
             return True
-        if status == 404:
+        if response.status_code == 404:
             return False
-        # Anything else is unexpected — surface via raise_for_status
-        # by re-issuing? No — just raise httpx.HTTPStatusError directly.
-        import httpx
-
-        raise httpx.HTTPStatusError(
-            f'Unexpected HEAD status {status}',
-            request=httpx.Request('HEAD', f'notes/{note_id}'),
-            response=httpx.Response(status_code=status),
-        )
+        # Use the real response so downstream callers that read .headers
+        # / .text / .reason_phrase get the actual server values, not
+        # synthesised stand-ins. raise_for_status() raises HTTPStatusError
+        # for any 4xx/5xx; we know it's non-2xx here because 200 was
+        # already handled above.
+        response.raise_for_status()
+        # raise_for_status only raises on 4xx/5xx; an unexpected 3xx /
+        # 1xx ends up here. Treat as not-exists to keep the contract
+        # ``bool``.
+        return False
 
     async def get_note_metadata(self, note_id: UUID) -> dict[str, Any] | None:
         """Get just the metadata from a note's page index."""

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1,5 +1,6 @@
 """Configuration for Memex based on Persona library"""
 
+import json
 import logging
 import math
 from enum import Enum
@@ -2426,13 +2427,23 @@ class VaultConfig(BaseModel):
     def _coerce_csv_search(cls, v: Any) -> Any:
         """Accept `MEMEX_VAULT__SEARCH=a,b,c` as shorthand for `[a, b, c]`.
 
-        Pydantic-settings already supports JSON list env values
-        (`["a","b"]`) and index-suffixed env vars (`__SEARCH__0=a`), but
-        CSV is what operators reach for in HCL / Dockerfile env_passthrough
-        lists. Empty entries are dropped so trailing commas and whitespace
-        don't leak in.
+        Try JSON first so a kwarg / YAML value like `'["a","b"]'`
+        survives unchanged — the CSV fallback would otherwise mangle a
+        JSON-list string to `['["a"', '"b"]']`. Empty CSV entries are
+        dropped so trailing commas and whitespace don't leak in.
+
+        Env values may also arrive here as already-parsed lists from
+        pydantic-settings (which JSON-decodes complex types upstream);
+        the bare ``isinstance(v, str)`` guard punts those to the default
+        path.
         """
         if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+            except (json.JSONDecodeError, ValueError):
+                parsed = None
+            if isinstance(parsed, list):
+                return parsed
             return [s.strip() for s in v.split(',') if s.strip()]
         return v
 

--- a/packages/common/tests/test_client_head_note.py
+++ b/packages/common/tests/test_client_head_note.py
@@ -1,0 +1,115 @@
+"""Tests for RemoteMemexAPI.head_note — A.5 cheap existence check.
+
+Covers the three response branches: 200 → True, 404 → False, and any
+other non-2xx (5xx/4xx) → ``httpx.HTTPStatusError`` raised from the real
+response (NOT a fabricated one — that was the High finding from
+Hermes' round-2 review on PR #191).
+"""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from memex_common.client import RemoteMemexAPI
+
+
+@pytest.fixture
+def mock_client():
+    return AsyncMock(spec=httpx.AsyncClient)
+
+
+@pytest.fixture
+def api(mock_client: AsyncMock) -> RemoteMemexAPI:
+    """RemoteMemexAPI with the HTTP client swapped for a mock."""
+    api = RemoteMemexAPI.__new__(RemoteMemexAPI)
+    api.client = mock_client
+    return api
+
+
+def _make_response(status_code: int, url: str = 'http://test/notes/x') -> httpx.Response:
+    """A real httpx.Response with a real request attached."""
+    return httpx.Response(
+        status_code=status_code,
+        headers={'content-type': 'application/json'},
+        request=httpx.Request('HEAD', url),
+    )
+
+
+@pytest.mark.asyncio
+async def test_head_note_returns_true_on_200(api: RemoteMemexAPI, mock_client: AsyncMock) -> None:
+    note_id = uuid4()
+    mock_client.head.return_value = _make_response(200)
+
+    assert await api.head_note(note_id) is True
+    mock_client.head.assert_awaited_once_with(f'notes/{note_id}')
+
+
+@pytest.mark.asyncio
+async def test_head_note_returns_false_on_404(api: RemoteMemexAPI, mock_client: AsyncMock) -> None:
+    note_id = uuid4()
+    mock_client.head.return_value = _make_response(404)
+
+    assert await api.head_note(note_id) is False
+
+
+@pytest.mark.asyncio
+async def test_head_note_raises_httpstatus_error_on_5xx(
+    api: RemoteMemexAPI, mock_client: AsyncMock
+) -> None:
+    """5xx surfaces as a real ``httpx.HTTPStatusError`` carrying the
+    actual response (with headers, request, status_code). This is the
+    regression for Hermes' High on PR #191 — the previous implementation
+    constructed a fabricated response missing headers/request/stream
+    internals.
+    """
+    note_id = uuid4()
+    response = _make_response(503)
+    mock_client.head.return_value = response
+
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await api.head_note(note_id)
+
+    # The exception carries the REAL response — accessing .headers and
+    # .request would have crashed with the previous fabricated shape.
+    assert excinfo.value.response is response
+    assert excinfo.value.response.status_code == 503
+    assert excinfo.value.response.headers['content-type'] == 'application/json'
+    assert excinfo.value.response.request is not None
+    assert excinfo.value.response.request.method == 'HEAD'
+
+
+@pytest.mark.asyncio
+async def test_head_note_raises_httpstatus_error_on_4xx_other_than_404(
+    api: RemoteMemexAPI, mock_client: AsyncMock
+) -> None:
+    """4xx other than 404 (e.g. 401, 403, 422) still surfaces as
+    ``httpx.HTTPStatusError`` rather than getting confused for "not
+    found"."""
+    note_id = uuid4()
+    response = _make_response(401)
+    mock_client.head.return_value = response
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await api.head_note(note_id)
+
+
+@pytest.mark.asyncio
+async def test_head_note_uses_module_level_httpx(
+    api: RemoteMemexAPI, mock_client: AsyncMock
+) -> None:
+    """Followup to PR #191 Medium: ``httpx`` must be imported at module
+    level (already was on the import block at the top of client.py).
+    Locked in by checking that head_note doesn't redundantly re-import.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    src = textwrap.dedent(inspect.getsource(RemoteMemexAPI.head_note))
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names = ', '.join(alias.name for alias in node.names)
+            pytest.fail(f'head_note has an inline import: {names}')

--- a/packages/common/tests/test_config.py
+++ b/packages/common/tests/test_config.py
@@ -207,18 +207,22 @@ class TestVaultBareStringCoercion:
         cfg = MemexConfig(vault=VaultConfig(search=['x', 'y']))
         assert cfg.vault.search == ['x', 'y']
 
-    def test_nested_env_wins_over_bare_string_when_both_set(self):
+    def test_bare_and_nested_env_both_set_resolves_to_one(self):
         """If somehow both MEMEX_VAULT and MEMEX_VAULT__ACTIVE are set,
-        pydantic-settings resolves the nested form last → it wins."""
+        ONE of them resolves and the loader does not raise.
+
+        Pydantic-settings v2 currently resolves the nested form after
+        the bare form, so `nested` wins empirically — but that priority
+        is undocumented and could flip on a minor bump. Asserting the
+        looser invariant keeps the test useful while not pinning us to
+        an upstream implementation detail.
+        """
         with patch.dict(
             os.environ,
             {'MEMEX_VAULT': 'bare', 'MEMEX_VAULT__ACTIVE': 'nested'},
         ):
             cfg = MemexConfig()
-        # The nested form is more explicit; document whichever wins.
-        # Empirically pydantic-settings v2 resolves __ACTIVE after the
-        # bare form, so 'nested' should be the resolved value.
-        assert cfg.vault.active == 'nested'
+        assert cfg.vault.active in ('bare', 'nested')
 
     def test_full_resolution_chain(self):
         """vault.search > vault.active > server defaults."""

--- a/packages/core/src/memex_core/memory/retrieval/document_search.py
+++ b/packages/core/src/memex_core/memory/retrieval/document_search.py
@@ -447,9 +447,12 @@ class NoteSearchEngine:
         # entire chunks table. Canonical pgvector HNSW pattern is plain
         # `ORDER BY distance LIMIT k` in the inner subquery, with the rank
         # assigned in an outer SELECT via `row_number() OVER ()` (no
-        # ORDER BY — relies on the subquery ordering, which CTEs preserve
-        # in Postgres). Gate validated via EXPLAIN ANALYZE per the tech
-        # report — planner is fickle on HNSW + filters.
+        # ORDER BY in the window spec — explicit `order_by=inner_cte.c.distance`
+        # so the rank is well-defined even if a future planner choice changes
+        # the inner CTE's materialisation order. Postgres preserves CTE
+        # output order in practice, but it isn't SQL-standard guaranteed.
+        # Gate validated via EXPLAIN ANALYZE per the tech report —
+        # planner is fickle on HNSW + filters.
         inner = select(Chunk.id, distance.label('distance')).select_from(Chunk)
         if request.vault_ids:
             inner = inner.where(col(Chunk.vault_id).in_(request.vault_ids))
@@ -458,7 +461,7 @@ class NoteSearchEngine:
 
         cte = select(
             inner_cte.c.id,
-            func.row_number().over().label('rnk'),
+            func.row_number().over(order_by=inner_cte.c.distance.asc()).label('rnk'),
             literal(weight).label('weight'),
         ).cte('chunk_semantic')
         return select(cte.c.id, cte.c.rnk, cte.c.weight)

--- a/packages/core/src/memex_core/memory/retrieval/strategies.py
+++ b/packages/core/src/memex_core/memory/retrieval/strategies.py
@@ -386,7 +386,7 @@ def _build_ner_seeds(
                 lowered = name.lower()
                 escaped = _escape_like_pattern(lowered)
                 conds_canonical.append(
-                    func.lower(col(Entity.canonical_name)).ilike(f'%{escaped}%', escape='\\')
+                    func.lower(col(Entity.canonical_name)).like(f'%{escaped}%', escape='\\')
                 )
                 conds_canonical.append(
                     func.similarity(func.lower(col(Entity.canonical_name)), lowered)
@@ -403,7 +403,7 @@ def _build_ner_seeds(
                 lowered = name.lower()
                 escaped = _escape_like_pattern(lowered)
                 conds_alias.append(
-                    func.lower(col(EntityAlias.name)).ilike(f'%{escaped}%', escape='\\')
+                    func.lower(col(EntityAlias.name)).like(f'%{escaped}%', escape='\\')
                 )
                 conds_alias.append(
                     func.similarity(func.lower(col(EntityAlias.name)), lowered)
@@ -419,14 +419,14 @@ def _build_ner_seeds(
         query_escaped = _escape_like_pattern(query_lower)
         seed_from_canonical = select(col(Entity.id).label('id')).where(
             or_(
-                func.lower(col(Entity.canonical_name)).ilike(f'%{query_escaped}%', escape='\\'),
+                func.lower(col(Entity.canonical_name)).like(f'%{query_escaped}%', escape='\\'),
                 func.similarity(func.lower(col(Entity.canonical_name)), query_lower)
                 > similarity_threshold,
             )
         )
         seed_from_alias = select(col(EntityAlias.canonical_id).label('id')).where(
             or_(
-                func.lower(col(EntityAlias.name)).ilike(f'%{query_escaped}%', escape='\\'),
+                func.lower(col(EntityAlias.name)).like(f'%{query_escaped}%', escape='\\'),
                 func.similarity(func.lower(col(EntityAlias.name)), query_lower)
                 > similarity_threshold,
             )
@@ -851,6 +851,13 @@ class EntityCooccurrenceNoteGraphStrategy:
         # cooccurrence rows before the outer LIMIT 60. Split into
         # UNION ALL of two single-side joins — each branch uses its own
         # btree, and the planner sees the small per-side cardinality.
+        #
+        # `UNION ALL` (vs `UNION`) is safe here because EntityCooccurrence
+        # enforces `CHECK (entity_id_1 < entity_id_2)` at
+        # `sql_models.py:1164` — each unordered pair {X, Y} appears in
+        # exactly one row, so for any given seed S the left branch
+        # (entity_id_1 = S) and the right branch (entity_id_2 = S) match
+        # disjoint sets of rows. No (neighbor_id, link_strength) duplicates.
         link_strength_expr = (
             func.ln(col(EntityCooccurrence.cooccurrence_count) + 1)
             / func.ln(col(Entity.mention_count) + 2)

--- a/packages/core/tests/unit/memory/retrieval/test_graph_factory.py
+++ b/packages/core/tests/unit/memory/retrieval/test_graph_factory.py
@@ -204,6 +204,29 @@ class TestBuildSeedEntityCte:
             f'Expected escaped al\\_ce in params: {params}'
         )
 
+    def test_fallback_path_escapes_wildcards_in_query(self) -> None:
+        """Followup to PR #188: the no-NER fallback path takes the raw
+        user `query` string straight to LIKE; `find 100% match` would
+        otherwise widen the match if the `%` weren't escaped. PR #188
+        only had an NER-path escape test.
+        """
+        cte = build_seed_entity_cte('find 100% match', ner_model=None)
+        params = cte.compile().params
+        # Pre-lowered + escaped form for both 100% and the underscore-style
+        # wildcards should appear in at least one bound parameter.
+        bound_strs = [v for v in params.values() if isinstance(v, str)]
+        assert any('100\\%' in v for v in bound_strs), (
+            f'Expected escaped 100\\% in fallback-path params: {params}'
+        )
+
+        # And confirm a raw `_` in the query is also escaped on the
+        # fallback path.
+        cte2 = build_seed_entity_cte('Al_ce', ner_model=None)
+        bound_strs2 = [v for v in cte2.compile().params.values() if isinstance(v, str)]
+        assert any('al\\_ce' in v for v in bound_strs2), (
+            f'Expected escaped al\\_ce in fallback-path params: {cte2.compile().params}'
+        )
+
     def test_trgm_rhs_lowered_at_python_level(self) -> None:
         """The parameter side of similarity / ilike is pre-lowered in
         Python (passed to SQLAlchemy as the bound value), not via SQL's

--- a/packages/core/tests/unit/test_note_service.py
+++ b/packages/core/tests/unit/test_note_service.py
@@ -402,6 +402,72 @@ async def test_get_note_metadata_returns_none_for_legacy_list_format(note_servic
 
 
 # ---------------------------------------------------------------------------
+# note_exists — cheap pk-existence check used by HEAD /notes/{id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_note_exists_returns_true_when_pk_lookup_hits(note_service):
+    """note_exists returns True when the pk-index lookup returns a row.
+
+    Followup to PR #191 Medium — the service-layer method has a distinct
+    query shape (`select(Note.id) … LIMIT 1`) that wasn't covered by the
+    existing get_note tests.
+    """
+    note_id = uuid4()
+
+    mock_result = MagicMock()
+    mock_result.first = MagicMock(return_value=note_id)
+
+    mock_session = AsyncMock()
+    mock_session.exec = AsyncMock(return_value=mock_result)
+    note_service.metastore.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    note_service.metastore.session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    assert await note_service.note_exists(note_id) is True
+    mock_session.exec.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_note_exists_returns_false_when_pk_lookup_misses(note_service):
+    """note_exists returns False when the pk-index lookup yields no row."""
+    note_id = uuid4()
+
+    mock_result = MagicMock()
+    mock_result.first = MagicMock(return_value=None)
+
+    mock_session = AsyncMock()
+    mock_session.exec = AsyncMock(return_value=mock_result)
+    note_service.metastore.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    note_service.metastore.session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    assert await note_service.note_exists(note_id) is False
+
+
+@pytest.mark.asyncio
+async def test_note_exists_does_not_hydrate_full_note(note_service):
+    """note_exists uses session.exec (lightweight query), NOT session.get
+    (full model hydration). Regression guard: a refactor that swapped to
+    session.get would silently regress the perf win on the hot
+    _wait_for_note_row poll path.
+    """
+    note_id = uuid4()
+
+    mock_result = MagicMock()
+    mock_result.first = MagicMock(return_value=note_id)
+
+    mock_session = AsyncMock()
+    mock_session.exec = AsyncMock(return_value=mock_result)
+    mock_session.get = AsyncMock()
+    note_service.metastore.session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    note_service.metastore.session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    await note_service.note_exists(note_id)
+
+    mock_session.get.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # set_note_status — memory unit cascade tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Eight clean-ups from Hermes round-2 reviews that landed after auto-merge fired on the slate. **High**: head_note synthetic httpx.Response → real response via raise_for_status(). **Mediums**: 3 missing tests added (head_note error branch, NoteService.note_exists hit/miss/no-hydration regression, fallback-path LIKE escape); VaultConfig._coerce_csv_search json.loads-first-then-CSV (was mangling kwargs JSON strings). **Lows**: ilike→like on lower()-wrapped columns; row_number().over(order_by=…); precedence test loosened to in('bare','nested'); inline comment explaining the cooccurrence CHECK invariant makes UNION ALL dup-free. 91 targeted tests pass, ruff clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)