### PR TITLE
fix(core): stable log-sigmoid scoring + rc18 Hermes follow-ups

### DIFF
--- a/packages/core/src/memex_core/alembic/env.py
+++ b/packages/core/src/memex_core/alembic/env.py
@@ -171,9 +171,24 @@ def do_run_migrations(connection):
     to HEAD, and a trailing ``create_all`` would both add HEAD-only columns to
     an earlier revision AND re-create tables a downgrade just dropped.
     """
+    # ``context.get_revision_argument()`` returns the destination revision when
+    # alembic was invoked with one (``upgrade <rev>`` / ``downgrade <rev>``), or
+    # ``None`` for ``upgrade head`` / programmatic invocations. AttributeError
+    # is the documented failure when the call site has no command-args context
+    # (e.g. some programmatic alembic.command flows pre-3.0). Anything else is
+    # unexpected and we surface it via a warning so it isn't silently masked as
+    # ``target = None`` → ``to_head = True``.
     try:
         target = context.get_revision_argument()
+    except AttributeError:
+        target = None
     except Exception:
+        logger.warning(
+            'alembic.env: get_revision_argument() raised unexpectedly; '
+            'falling back to target=None (treated as HEAD). '
+            'This may mask a misconfigured alembic context.',
+            exc_info=True,
+        )
         target = None
     to_head = target is None or target in ('head', 'heads')
 
@@ -222,7 +237,7 @@ def _sync_url(url: str) -> str:
 
 
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode with a synchronous (psycopg2) engine.
+    """Run migrations in 'online' mode with a synchronous psycopg (v3) engine.
 
     Acquires a PostgreSQL advisory lock first to prevent concurrent
     migration execution across multiple workers.

--- a/packages/core/src/memex_core/services/entities.py
+++ b/packages/core/src/memex_core/services/entities.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, AsyncGenerator
+from typing import TYPE_CHECKING, Any, AsyncGenerator
 from uuid import UUID
 
 from sqlmodel import col
@@ -13,6 +13,9 @@ from memex_common.exceptions import EntityNotFoundError, ResourceNotFoundError
 
 from memex_core.services.audit import audit_event
 from memex_core.services.base import BaseService
+
+if TYPE_CHECKING:
+    from memex_core.memory.sql_models import Entity
 
 logger = logging.getLogger('memex.core.services.entities')
 
@@ -36,15 +39,23 @@ class AggregatedCooccurrence:
     Hermes ``get_entity_cooccurrences`` tools) must collapse the per-vault rows
     for a counterpart into a single edge, or the same entity shows up once per
     vault with un-summed counts. This carries the summed count; ``vault_id`` is
-    ``None`` because the edge spans vaults. Exposes the same attribute surface
-    (``entity_1``/``entity_2`` ORM Entities, ids, count) the server serializer
-    and CLI already consume, so it is a drop-in for the prior ORM rows.
+    ``None`` because the edge spans vaults.
+
+    ``entity_1`` / ``entity_2`` are populated by
+    :meth:`EntityService.get_entity_cooccurrences` (the per-entity endpoint
+    serialiser at ``server/entities.py:get_entity_cooccurrences`` reads
+    ``.canonical_name`` / ``.entity_type`` off them) but are intentionally left
+    ``None`` by :meth:`EntityService.get_bulk_cooccurrences`, whose only caller
+    (the bulk endpoint at ``server/entities.py:get_bulk_cooccurrences``) emits
+    just ids + counts and never dereferences them. Callers introducing new bulk
+    consumers must either resolve the entities themselves or use the per-entity
+    method.
     """
 
     entity_id_1: UUID
     entity_id_2: UUID
-    entity_1: Any
-    entity_2: Any
+    entity_1: 'Entity | None'
+    entity_2: 'Entity | None'
     cooccurrence_count: int
     vault_id: UUID | None = None
 

--- a/packages/core/src/memex_core/services/inbox_router/sql.py
+++ b/packages/core/src/memex_core/services/inbox_router/sql.py
@@ -195,6 +195,13 @@ p_match_raw AS (
     --   * ``exp(-LEAST(|x|, 700))`` in the softplus — beyond |x|≈37 the term is
     --     already negligible, so the cap changes nothing numerically.
     --   * the softmax exponent is floored at -700 below.
+    --
+    -- NOTE: ``p_match_raw`` clamps ``x`` to ±700 while ``log_p`` does not, so
+    -- the two columns are intentionally NOT numerically consistent for extreme
+    -- logits (``exp(log_p) ≠ p_match_raw`` once the sigmoid saturates). They
+    -- serve different jobs — ``p_match_raw`` is the absolute t_low gate,
+    -- ``log_p`` is the relative cross-vault ranking input — and must not be
+    -- treated as interchangeable by downstream consumers.
     SELECT note_id, vault_id, vault_name,
         1.0 / (1.0 + exp(LEAST(GREATEST(log_post_no_match - log_post_match, -700.0), 700.0)))
             AS p_match_raw,

--- a/packages/core/src/memex_core/services/inbox_router/sql.py
+++ b/packages/core/src/memex_core/services/inbox_router/sql.py
@@ -171,20 +171,36 @@ per_pair_posterior AS (
 p_match_raw AS (
     -- ``p_match_raw`` is the absolute pairwise sigmoid P(match|x) — used by the
     -- t_low gate to decide "does ANY vault clear minimum confidence?".
+    --
     -- ``log_p`` carries the per-vault ranking signal forward to the softmax
-    -- across vaults. We use ``log_post_match`` directly (not the sigmoid's log)
-    -- because the sigmoid saturates at ±700 when feature likelihoods are
-    -- extreme — and when it saturates for every vault (e.g. a note whose
-    -- keyword_ts_rank is far from the tight POC match distribution), the
-    -- ``ln(p_match_raw)`` path collapses every vault to the same floor and the
-    -- softmax returns a uniform tie. ``log_post_match`` keeps the relative
-    -- per-vault ranking through saturation; softmax-of-log_post_match is the
-    -- standard NB ranking form. Note that the cross-vault normalisation
-    -- constant cancels out inside the softmax's max-subtraction below.
+    -- across vaults. We need ``ln(p_match_raw)`` — i.e. ``ln(sigmoid(x))`` with
+    -- ``x = log_post_match - log_post_no_match`` — but computed *without* going
+    -- through the saturating sigmoid intermediate. The naive
+    -- ``ln(GREATEST(p_match_raw, 1e-12))`` form collapses every vault to the
+    -- same -27.6 floor once the sigmoid clamps for all of them (which the POC's
+    -- tight keyword distribution — σ²=0.00014 for label=1 — triggers on any
+    -- note whose keyword_ts_rank lands far from μ≈0.98). When that happens the
+    -- softmax returns a uniform tie and the ranking signal is destroyed.
+    --
+    -- The branch-free numerically-stable identity
+    --   ln(sigmoid(x)) = -softplus(-x) = min(x, 0) - ln(1 + exp(-|x|))
+    -- preserves the POC's validated pairwise-log-odds ranking exactly in the
+    -- non-saturating regime AND keeps the per-vault rank ordering through
+    -- saturation: at x → +∞ it returns 0 (the sigmoid's true ceiling), at
+    -- x → −∞ it returns x itself (a linear descent that retains relative
+    -- differences across vaults).
+    --
+    -- Two clamps keep it inside float8's exp() domain (Postgres raises
+    -- ``value out of range: underflow`` rather than flushing to zero):
+    --   * ``exp(-LEAST(|x|, 700))`` in the softplus — beyond |x|≈37 the term is
+    --     already negligible, so the cap changes nothing numerically.
+    --   * the softmax exponent is floored at -700 below.
     SELECT note_id, vault_id, vault_name,
         1.0 / (1.0 + exp(LEAST(GREATEST(log_post_no_match - log_post_match, -700.0), 700.0)))
             AS p_match_raw,
-        log_post_match AS log_p
+        (LEAST(log_post_match - log_post_no_match, 0.0)
+            - ln(1 + exp(-LEAST(ABS(log_post_match - log_post_no_match), 700.0))))::float8
+            AS log_p
       FROM per_pair_posterior
 ),
 note_log_max AS (
@@ -192,9 +208,13 @@ note_log_max AS (
         MAX(log_p) OVER (PARTITION BY note_id) AS log_max FROM p_match_raw
 ),
 note_exp_sum AS (
+    -- Standard stable softmax: subtract the per-note max before exp. Floor the
+    -- exponent at -700 so a vault whose log_p is astronomically below the best
+    -- (a strong non-match under the linear tail above) contributes ~0 instead
+    -- of underflowing exp().
     SELECT note_id, vault_id, vault_name, p_match_raw,
-        exp(log_p - log_max) AS num,
-        SUM(exp(log_p - log_max)) OVER (PARTITION BY note_id) AS denom
+        exp(GREATEST(log_p - log_max, -700.0)) AS num,
+        SUM(exp(GREATEST(log_p - log_max, -700.0))) OVER (PARTITION BY note_id) AS denom
       FROM note_log_max
 )
 SELECT

--- a/packages/core/tests/unit/test_alembic_031_resolved_by.py
+++ b/packages/core/tests/unit/test_alembic_031_resolved_by.py
@@ -1,4 +1,7 @@
-"""Unit tests for migration 030_proposal_resolved_by (issue #34).
+"""Unit tests for migration 031_proposal_resolved_by (issue #34).
+
+Renumbered from 030 → 031 when 030_revisit_last_reviewed_at landed between
+029_lint_llm_quota and this migration; identifiers below were renamed to match.
 
 Static checks that don't need a database. The behavioural round-trip
 assertion (column appears on upgrade, disappears on downgrade) lives in the
@@ -15,21 +18,21 @@ import re
 from typing import Any
 
 
-def _load_migration_030() -> Any:
+def _load_migration_031() -> Any:
     import memex_core
 
     package_dir = plb.Path(memex_core.__file__).resolve().parent
     migration_path = (
         package_dir / 'alembic' / 'versions' / '031_maintenance_proposals_resolved_by.py'
     )
-    spec = importlib.util.spec_from_file_location('migration_030', migration_path)
+    spec = importlib.util.spec_from_file_location('migration_031', migration_path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-def _migration_030_source() -> str:
+def _migration_031_source() -> str:
     import memex_core
 
     package_dir = plb.Path(memex_core.__file__).resolve().parent
@@ -39,9 +42,9 @@ def _migration_030_source() -> str:
     return migration_path.read_text(encoding='utf-8')
 
 
-class TestMigration030Metadata:
+class TestMigration031Metadata:
     def test_revision_id_fits_in_alembic_version_column(self):
-        m = _load_migration_030()
+        m = _load_migration_031()
         # alembic_version.version_num is varchar(32) by default — keep ids short.
         assert len(m.revision) <= 32, (
             'revision id must fit in alembic_version.version_num (varchar(32))'
@@ -51,15 +54,15 @@ class TestMigration030Metadata:
     def test_down_revision_chains_from_030(self):
         # Renumbered 030 → 031 when 030_revisit_last_reviewed_at was inserted
         # between 029_lint_llm_quota and this migration.
-        m = _load_migration_030()
+        m = _load_migration_031()
         assert m.down_revision == '030_revisit_last_reviewed_at'
 
 
-class TestMigration030AddsNullableColumn:
+class TestMigration031AddsNullableColumn:
     """The schema patch is purely additive: nullable resolved_by TEXT column."""
 
     def test_upgrade_adds_resolved_by_column(self):
-        source = _migration_030_source()
+        source = _migration_031_source()
         pattern = re.compile(
             r"add_column\(\s*'maintenance_proposals'\s*,\s*"
             r"sa\.Column\(\s*'resolved_by'\s*,\s*sa\.Text\(\)\s*,\s*nullable=True",
@@ -71,7 +74,7 @@ class TestMigration030AddsNullableColumn:
         )
 
     def test_downgrade_drops_resolved_by_column(self):
-        source = _migration_030_source()
+        source = _migration_031_source()
         pattern = re.compile(
             r"drop_column\(\s*'maintenance_proposals'\s*,\s*'resolved_by'\s*\)",
             re.DOTALL,


### PR DESCRIPTION
Follow-up to PR #197 (rc18). Two things:

## 1. Inbox-router scoring: stable log-sigmoid instead of `log_post_match` direct

rc18 fixed the uniform-tie bug by softmaxing over `log_post_match` directly. That works but **drops the per-vault `log_post_no_match` term**, which is not constant across vaults — a semantic divergence from the POC's validated pairwise-log-odds ranking.

This replaces it with the numerically-stable identity for the quantity we actually want:

```
ln(sigmoid(x)) = min(x, 0) - ln(1 + exp(-|x|)),   x = log_post_match - log_post_no_match
```

- Reproduces the POC ranking **exactly** in the non-saturating regime.
- Keeps per-vault rank ordering **through** saturation (linear tail as x → -∞), so the uniform-tie bug stays fixed.
- Both `exp()` calls clamped to float8's domain (softplus inner term `|x|<=700`; softmax exponent floored at `-700`) — without this, Postgres raises `value out of range: underflow` on a strong non-match. Caught + fixed locally before pushing.

## 2. rc18 Hermes review follow-ups (from PR #197, commit `434b9bcf`)

| Severity | Finding | Action |
|---|---|---|
| HIGH | `get_bulk_cooccurrences` "drop-in" returns `entity_1=None` | **Verified false positive** — sole caller (bulk endpoint) emits ids+counts only, never dereferences. Docstring now states the contract explicitly. |
| MED | `env.py` docstring says psycopg2 | Fixed → psycopg v3 |
| MED | broad `except Exception` on `get_revision_argument()` | Narrowed to `AttributeError`; anything else logs a warning before fallback |
| MED | `AggregatedCooccurrence.entity_1/2` typed `Any` | Typed `Entity \| None` |
| LOW | test class refers to renumbered 030 migration | Renamed file + class/helpers → 031 |
| MED | `_exec_each` semicolon-split fragility | Declined — already documented; keyword-guard is over-engineering |

## Validation (local, real Postgres via testcontainers)
- 3357 unit passed
- 681 integration passed, 0 failed (incl. all 6 inbox-router + alembic round-trip)
- ruff + ruff-format + mypy clean (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)