### PR TITLE
fix(server): log 404s at info level without traceback (memex#175)

### DIFF
--- a/packages/core/src/memex_core/server/common.py
+++ b/packages/core/src/memex_core/server/common.py
@@ -52,7 +52,12 @@ def _handle_error(e: Exception, context: str) -> HTTPException:
     if isinstance(e, HTTPException):
         raise e
 
-    logger.error(f'{context}: {e}', exc_info=True)
+    # Log 404s (not-found) at info level without traceback — these are expected
+    # client paths, not server errors (e.g. GET /notes/{id} before note is visible)
+    if isinstance(e, (VaultNotFoundError, ResourceNotFoundError)):
+        logger.info(f'{context}: {e}')
+    else:
+        logger.error(f'{context}: {e}', exc_info=True)
 
     if isinstance(e, VaultNotFoundError):
         return HTTPException(status_code=404, detail=str(e))


### PR DESCRIPTION
## Fix: Log 404s at info level without traceback

**Addresses:** JasperHG90/memex#175

### Problem
`GET /api/v1/notes/{id}` for a not-yet-visible note produces a full-traceback ERROR in the server log. These 404s are expected client paths (e.g. polling before a note is visible) - logging them as ERROR with full traceback is noisy and misleading in production logs.

### Fix
In `_handle_error()`, log `VaultNotFoundError` and `ResourceNotFoundError` as `logger.info` without `exc_info=True`. All other errors retain the existing `logger.error` + traceback behavior.

```python
if isinstance(e, (VaultNotFoundError, ResourceNotFoundError)):
    logger.info(f'{context}: {e}')
else:
    logger.error(f'{context}: {e}', exc_info=True)
```

### Changed
- `packages/core/src/memex_core/server/common.py`: 6-line addition to `_handle_error()`
- Single commit, minimal diff

### Testing
- No schema, API, or behavior change - only logging verbosity
