### PR TITLE
fix(core): close CVE-2026-48710 BadHost auth bypass

### DIFF
--- a/packages/core/src/memex_core/server/auth.py
+++ b/packages/core/src/memex_core/server/auth.py
@@ -136,7 +136,16 @@ async def auth_middleware(request: Request, call_next):  # type: ignore[no-untyp
     if request.method == 'OPTIONS':
         return await call_next(request)
 
-    if request.url.path in auth_config.exempt_paths:
+    # CVE-2026-48710 (BadHost): use the ASGI scope path, not request.url.path.
+    # Starlette < 1.0.1 reconstructs request.url from the client-supplied
+    # Host header; a malformed Host can make request.url.path collapse onto
+    # an exempt path while the router still dispatches the original.
+    # scope['path'] comes from the ASGI server and matches what the router
+    # actually uses, so it is safe for security decisions regardless of the
+    # installed Starlette version.
+    request_path = request.scope['path']
+
+    if request_path in auth_config.exempt_paths:
         return await call_next(request)
 
     audit = _get_audit_service(request)
@@ -146,7 +155,7 @@ async def auth_middleware(request: Request, call_next):  # type: ignore[no-untyp
         if audit:
             audit.log(
                 action='auth.missing_key',
-                details={'path': request.url.path, 'method': request.method},
+                details={'path': request_path, 'method': request.method},
             )
         return JSONResponse(
             status_code=401,
@@ -158,7 +167,7 @@ async def auth_middleware(request: Request, call_next):  # type: ignore[no-untyp
         if audit:
             audit.log(
                 action='auth.failure',
-                details={'path': request.url.path, 'method': request.method},
+                details={'path': request_path, 'method': request.method},
             )
         return JSONResponse(
             status_code=403,
@@ -278,13 +287,17 @@ async def require_admin_auth(request: Request) -> None:
     """
     auth_config: AuthConfig | None = getattr(request.app.state, 'auth_config', None)
 
+    # CVE-2026-48710 (BadHost): scope['path'] is the path the router dispatched
+    # on; request.url.path is reconstructed from the Host header and can be spoofed.
+    request_path = request.scope['path']
+
     audit = _get_audit_service(request)
     api_key = request.headers.get('X-API-Key')
     if not api_key:
         if audit:
             audit.log(
                 action='auth.admin.missing_key',
-                details={'path': request.url.path, 'method': request.method},
+                details={'path': request_path, 'method': request.method},
             )
         raise HTTPException(
             status_code=401,
@@ -299,7 +312,7 @@ async def require_admin_auth(request: Request) -> None:
         if audit:
             audit.log(
                 action='auth.admin.failure',
-                details={'path': request.url.path, 'method': request.method},
+                details={'path': request_path, 'method': request.method},
             )
         raise HTTPException(status_code=403, detail='Invalid API key.')
 
@@ -307,7 +320,7 @@ async def require_admin_auth(request: Request) -> None:
         if audit:
             audit.log(
                 action='auth.admin.insufficient',
-                details={'path': request.url.path, 'method': request.method},
+                details={'path': request_path, 'method': request.method},
             )
         raise HTTPException(
             status_code=403,

--- a/packages/core/tests/unit/test_server_auth.py
+++ b/packages/core/tests/unit/test_server_auth.py
@@ -346,6 +346,90 @@ class TestSetupAuth:
 
 
 # ---------------------------------------------------------------------------
+# CVE-2026-48710 BadHost regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestBadHostCVE202648710:
+    """Regression tests for CVE-2026-48710 (BadHost) — host-header auth bypass.
+
+    Starlette < 1.0.1 reconstructs ``request.url`` by concatenating the
+    client-supplied ``Host`` header with the request path and re-parsing the
+    result. A ``Host`` value like ``localhost/api/v1/health?`` makes
+    ``request.url.path`` collapse onto ``'/api/v1/health'`` (an exempt path)
+    while ``scope['path']`` — what the router actually dispatches on — stays
+    ``'/api/v1/notes'``. Auth middleware that compares ``request.url.path``
+    against ``exempt_paths`` is therefore bypassed.
+
+    The fix uses ``request.scope['path']`` for security decisions. ``scope['path']``
+    comes from the ASGI server directly, matches what the router uses, and is
+    immune regardless of installed Starlette version.
+
+    These tests assert the property directly. They simulate the Starlette bug
+    by hijacking ``Request.url`` so it returns a different path than
+    ``scope['path']``; a middleware that uses ``request.url.path`` will
+    bypass auth, a middleware that uses ``scope['path']`` will enforce it.
+    """
+
+    @staticmethod
+    def _patch_url_to_exempt_path(monkeypatch, exempt_path: str = '/api/v1/health') -> None:
+        """Make ``Request.url.path`` always return *exempt_path* regardless of scope."""
+        from starlette.datastructures import URL
+        from starlette.requests import Request as StarletteRequest
+
+        def hijacked_url(self):  # type: ignore[no-untyped-def]
+            return URL(f'http://attacker.example{exempt_path}')
+
+        monkeypatch.setattr(StarletteRequest, 'url', property(hijacked_url))
+
+    def test_badhost_path_divergence_does_not_bypass_auth(self, monkeypatch):
+        """Hijacked request.url.path pointing at an exempt route must NOT bypass auth."""
+        self._patch_url_to_exempt_path(monkeypatch, '/api/v1/health')
+
+        config = AuthConfig(enabled=True, keys=[_key(VALID_KEY)])
+        app = _make_app(config)
+        client = TestClient(app)
+
+        # /api/v1/notes is protected. Even though url.path now claims to be
+        # '/api/v1/health' (an exempt path), the dispatcher uses scope['path']
+        # and runs the /notes handler. The middleware must do the same and
+        # require a key.
+        response = client.get('/api/v1/notes')
+        assert response.status_code == 401, (
+            f'CVE-2026-48710 regression: got {response.status_code}; protected '
+            "'/api/v1/notes' was reached without an API key because the middleware "
+            "trusted request.url.path (spoofed) instead of scope['path']."
+        )
+
+    def test_badhost_path_divergence_with_invalid_key_returns_403(self, monkeypatch):
+        """Same attack with a wrong key still hits the validate step → 403, not 200."""
+        self._patch_url_to_exempt_path(monkeypatch, '/api/v1/health')
+
+        config = AuthConfig(enabled=True, keys=[_key(VALID_KEY)])
+        app = _make_app(config)
+        client = TestClient(app)
+
+        response = client.get('/api/v1/notes', headers={'X-API-Key': 'wrong'})
+        assert response.status_code == 403
+
+    def test_clean_host_still_serves_exempt_paths(self):
+        """Regression: legitimate exempt-path requests still work without a key."""
+        config = AuthConfig(enabled=True, keys=[_key(VALID_KEY)])
+        app = _make_app(config)
+        client = TestClient(app)
+        response = client.get('/api/v1/health')
+        assert response.status_code == 200
+
+    def test_clean_host_still_requires_key_on_protected_routes(self):
+        """Regression: protected routes still 401 without a key on clean Host."""
+        config = AuthConfig(enabled=True, keys=[_key(VALID_KEY)])
+        app = _make_app(config)
+        client = TestClient(app)
+        response = client.get('/api/v1/notes')
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
 # Policy permissions mapping
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

This PR closes [CVE-2026-48710](https://nvd.nist.gov/vuln/detail/CVE-2026-48710) ("BadHost", [GHSA-86qp-5c8j-p5mr](https://github.com/encode/starlette/security/advisories/GHSA-86qp-5c8j-p5mr)) in the Memex API-key authentication middleware and the `require_admin_auth` dependency. It is a **code-only** patch — no dependency changes — chosen deliberately to keep the surface small and easy to review.

## Vulnerability

Starlette `< 1.0.1` reconstructs `request.url` by concatenating the client-supplied `Host` header with the request path and re-parsing the result, without validating Host against RFC 9112/3986. A request like:

```
GET /api/v1/notes HTTP/1.1
Host: localhost/api/v1/health?
```

makes `request.url.path` collapse onto `/api/v1/health` (an exempt path in `AuthConfig.default_exempt_paths`) while `scope["path"]` — the value the ASGI router actually dispatches on — stays `/api/v1/notes`. The `auth_middleware` short-circuits at `if request.url.path in auth_config.exempt_paths:` and returns `await call_next(request)`, so the router runs the protected notes handler with no key. No credentials, no chain, single character.

The same gap exists in `require_admin_auth` and across the five audit-log fields, where the spoofable path would also be written to `details.path`.

## Fix

Reads `request.scope["path"]` for all six sites in `packages/core/src/memex_core/server/auth.py`:

- the security decision on line 139 (`auth_middleware` exempt-path lookup)
- the matching `require_admin_auth` lookup
- the five `audit.log(... details={'path': ..., ...})` fields (`auth.missing_key`, `auth.failure`, `auth.admin.missing_key`, `auth.admin.failure`, `auth.admin.insufficient`)

`scope["path"]` comes directly from the ASGI server and is the exact value the router uses, so it is **immune regardless of installed Starlette version**. This matches the code-level mitigation recommended in the upstream Starlette advisory:

> Replace `request.url.path` with `request.scope["path"]` in any middleware that makes security decisions.

## Tests

Adds class `TestBadHostCVE202648710` in `packages/core/tests/unit/test_server_auth.py` with four tests:

| Test | What it asserts |
|---|---|
| `test_badhost_path_divergence_does_not_bypass_auth` | Protected `/api/v1/notes` still returns 401 when `Request.url.path` is hijacked to claim an exempt path (simulates the pre-Starlette-1.0.1 reconstruction bug at the property level). |
| `test_badhost_path_divergence_with_invalid_key_returns_403` | Same attack with a wrong key reaches the validate step and returns 403, not 200. |
| `test_clean_host_still_serves_exempt_paths` | Regression baseline: clean exempt-path request still serves without a key. |
| `test_clean_host_still_requires_key_on_protected_routes` | Regression baseline: protected route still 401s without a key on clean Host. |

The hijacking is done via `monkeypatch.setattr(Request, 'url', property(...))` — this is a property-pinning unit test, not an HTTP-level integration test. The advantage is that it tests the security property regardless of whether the installed Starlette is patched: a future regression to `request.url.path` would fail these tests even on Starlette 1.0.1+.

All 63 existing `test_server_auth.py` tests still pass alongside the 4 new ones (67 total).

## Defense in depth (left out of this PR by design)

Upstream Starlette 1.0.1 also fixes the URL reconstruction at the parser level. Combining the code fix in this PR with `starlette >= 1.0.1` is belt-and-suspenders. I left the dep bump out of this PR for two reasons:

1. The code change alone closes the vulnerability — a Starlette bump isn't required for correctness.
2. There's a transitive snag worth a separate discussion: `prometheus-fastapi-instrumentator==7.1.0` (currently the latest) caps `starlette<1.0.0`, so a clean `starlette>=1.0.1` floor needs either an upstream release from `trallnag/prometheus-fastapi-instrumentator` or a `[tool.uv.override-dependencies]` workaround. I've filed a companion issue (#202) to surface that context so you can decide independently.

## Verification

- `prek run --files <changed files>`: ruff, ruff-format, mypy all pass.
- `pytest packages/core/tests/unit/test_server_auth.py` → 67 passed.
- New tests RED on `b704a586` (pre-fix), GREEN after this patch.
- All commits GPG-signed.

## References

- [CVE-2026-48710](https://nvd.nist.gov/vuln/detail/CVE-2026-48710)
- [GHSA-86qp-5c8j-p5mr](https://github.com/encode/starlette/security/advisories/GHSA-86qp-5c8j-p5mr) — Starlette security advisory
- [OSTIF disclosure](https://ostif.org/disclosing-the-badhost-vulnerability-in-starlette/)
- [BadHost project page](https://badhost.org/)

Happy to adjust scope, naming, or commit shape if you'd prefer something different. Thanks for maintaining Memex.
