### PR TITLE
fix: make the memory-maintenance / review surface usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,136%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,144%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,134%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,136%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,131%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,134%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/docs/reference/configuration-options.md
+++ b/docs/reference/configuration-options.md
@@ -843,14 +843,14 @@ The model validator accepts the legacy flat `{type: ...}` form and lifts `type` 
 
 Cross-batch entity-cluster collapse. Lives at `server.memory.entity_maintenance`. Off by default.
 
-> Thresholds are literature-precedent — not fine-tuned. The `cluster_min_threshold` must be <= `pair_threshold`; the model validator rejects otherwise.
+> The `cluster_min_threshold` must be <= `pair_threshold`; the model validator rejects otherwise. Two entities whose canonical names are identical after case-folding + whitespace-stripping always cluster via an exact-name fast path (score 1.0), regardless of `pair_threshold` — this is what surfaces `ACME Corp` / `acme corp` and `Marc de haas` / `Marc de Haas`. The threshold governs only non-identical near-duplicates and is kept high (0.85): a token-insertion variant like `Marc Haas` / `Marc de Haas` only scores ~0.39, while distinct names sharing a phonetic code (`Robert`/`Roberta`) reach ~0.60, so lowering it floods proposals with false positives without catching the token-insertion case. Proposals are non-destructive until approved via `memex lint resolve`.
 
 | Key | Type | Default | Env var | Description |
 |---|---|---|---|---|
 | `scan_enabled` | `bool` | `false` | `MEMEX_SERVER__MEMORY__ENTITY_MAINTENANCE__SCAN_ENABLED` | Master switch. Off by default. |
 | `top_n` | `int` (>= 2) | `100` | `…__TOP_N` | Max entities per scan, by `mention_count`. |
 | `scan_cooldown_days` | `int` (>= 0) | `7` | `…__SCAN_COOLDOWN_DAYS` | Per-entity cooldown between scans. |
-| `pair_threshold` | `float` (`[0, 1]`) | `0.85` | `…__PAIR_THRESHOLD` | Min pairwise similarity to connect two entities. |
+| `pair_threshold` | `float` (`[0, 1]`) | `0.85` | `…__PAIR_THRESHOLD` | Min pairwise similarity to connect two non-identical entities (identical names always cluster via the fast path). |
 | `cluster_min_threshold` | `float` (`[0, 1]`) | `0.70` | `…__CLUSTER_MIN_THRESHOLD` | Cohesion guard — min pairwise similarity across every pair in a cluster. |
 
 ---

--- a/packages/cli/src/memex_cli/cockpit/app.py
+++ b/packages/cli/src/memex_cli/cockpit/app.py
@@ -36,12 +36,39 @@ from memex_cli.cockpit.controller import (
     CockpitController,
     CockpitOption,
     CockpitProposal,
+    DISMISS_OPTION,
+    FLAG_OPTION,
     UnitDetail,
     UnitLineage,
     UnitMeta,
-    options_for_contradiction,
-    options_for_inbox_route,
-    options_for_rule,
+    options_for_proposal,
+    recommended_resolve_option,
+)
+
+
+# Batch sentinel: applies each proposal's OWN recommended action (with its
+# proposal-specific params) rather than one shared option — so an inbox route in
+# a mixed batch still migrates to its top vault. Never sent to the server; the
+# batch submitter translates it per proposal.
+_BATCH_RECOMMENDED_ACTION_ID = '__recommended__'
+_BATCH_RECOMMENDED_OPTION = CockpitOption(
+    action_id=_BATCH_RECOMMENDED_ACTION_ID,
+    label='Accept recommended action (per proposal)',
+    summary=(
+        "Apply each selected proposal's own recommended action — e.g. route "
+        'each inbox note to its top vault, deprioritize each contradiction '
+        'target. Findings with no actionable default are skipped.'
+    ),
+    effect="Per-proposal: the recommended mutation for each finding's rule.",
+    reversible=False,
+    recommended=True,
+)
+_BATCH_NO_OP_OPTION = CockpitOption(
+    action_id='no_op',
+    label='Mark reviewed (no mutation)',
+    summary='Flip every selected finding to resolved without mutating its target.',
+    effect='No mutation. Status flips to resolved.',
+    reversible=True,
 )
 
 
@@ -541,7 +568,12 @@ class ProposalCockpitApp(App):
         if proposal.rule_name == 'llm_semantic_contradiction':
             body_lines.extend(self._build_contradiction_body(proposal))
         else:
-            body_lines.append(f'[bold]TARGET[/bold]  [dim cyan]{proposal.target_id[:8]}[/dim cyan]')
+            label_suffix = (
+                f'  [white]{proposal.target_label}[/white]' if proposal.target_label else ''
+            )
+            body_lines.append(
+                f'[bold]TARGET[/bold]  [dim cyan]{proposal.target_id[:8]}[/dim cyan]{label_suffix}'
+            )
 
             # For orphan_mental_model, show the entity name prominently.
             entity_name = proposal.raw_evidence.get('entity_name')
@@ -604,7 +636,10 @@ class ProposalCockpitApp(App):
 
     def _build_contradiction_body(self, proposal: CockpitProposal) -> list[str]:
         lines: list[str] = []
-        lines.append(f' [bold]TARGET[/bold]   [dim cyan]{proposal.target_id[:8]}[/dim cyan]')
+        label_suffix = f'  [white]{proposal.target_label}[/white]' if proposal.target_label else ''
+        lines.append(
+            f' [bold]TARGET[/bold]   [dim cyan]{proposal.target_id[:8]}[/dim cyan]{label_suffix}'
+        )
         if proposal.target_text:
             lines.append(f' {proposal.target_text}')
         else:
@@ -640,7 +675,10 @@ class ProposalCockpitApp(App):
         contra_meta = all_meta.get(contra_id)
 
         body_lines: list[str] = []
-        body_lines.append(f' [bold]TARGET[/bold]   [dim cyan]{proposal.target_id[:8]}[/dim cyan]')
+        label_suffix = f'  [white]{proposal.target_label}[/white]' if proposal.target_label else ''
+        body_lines.append(
+            f' [bold]TARGET[/bold]   [dim cyan]{proposal.target_id[:8]}[/dim cyan]{label_suffix}'
+        )
         if target_meta:
             meta_line = _format_unit_meta_line(target_meta)
             if meta_line:
@@ -688,12 +726,7 @@ class ProposalCockpitApp(App):
     # ------------------------------------------------------------------
 
     def _populate_actions(self, proposal: CockpitProposal) -> None:
-        if proposal.rule_name == 'llm_semantic_contradiction':
-            options = options_for_contradiction(proposal)
-        elif proposal.rule_name == 'inbox_vault_route':
-            options = options_for_inbox_route(proposal)
-        else:
-            options = options_for_rule(proposal.rule_name, proposal.target_type)
+        options = options_for_proposal(proposal)
         action_list = self.query_one('#action-list', ListView)
         action_list.clear()
         for i, opt in enumerate(options):
@@ -707,31 +740,33 @@ class ProposalCockpitApp(App):
     def _populate_batch_actions(self, proposals: list[CockpitProposal]) -> None:
         if not proposals:
             return
-        option_sets = [
-            {o.action_id for o in options_for_rule(p.rule_name, p.target_type)} for p in proposals
-        ]
-        common_ids = option_sets[0]
-        for s in option_sets[1:]:
-            common_ids = common_ids & s
-
-        ref = proposals[0]
-        all_options = options_for_rule(ref.rule_name, ref.target_type)
-        filtered = [o for o in all_options if o.action_id in common_ids]
+        # A single shared option cannot carry per-proposal params (e.g. each
+        # inbox route's target_vault_id), and the old intersection over
+        # ``options_for_rule`` never even included the dynamic route /
+        # contradiction actions — so a batch could never route. Offer verb-level
+        # batch actions instead: "accept recommended" fans out to each
+        # proposal's own option at submit time; no-op / flag / dismiss apply
+        # uniformly because they need no params.
+        n_actionable = sum(1 for p in proposals if recommended_resolve_option(p) is not None)
+        options: list[CockpitOption] = []
+        if n_actionable:
+            options.append(_BATCH_RECOMMENDED_OPTION)
+        options.extend([_BATCH_NO_OP_OPTION, FLAG_OPTION, DISMISS_OPTION])
 
         action_list = self.query_one('#action-list', ListView)
         action_list.clear()
-        for i, opt in enumerate(filtered):
+        for i, opt in enumerate(options):
             action_list.append(_ActionListItem(opt, highlighted=(i == 0)))
-        if filtered:
-            action_list.index = 0
-            self._show_action_detail(filtered[0])
+        action_list.index = 0
+        self._show_action_detail(options[0])
 
         self.query_one('#detail-header', Static).update(
             f'[bold]BATCH — {len(proposals)} proposals selected[/bold]'
         )
         rule_names = {p.rule_name for p in proposals}
         self.query_one('#detail-body', Static).update(
-            f'Rules: {", ".join(sorted(rule_names))}\nCommon actions: {len(filtered)}'
+            f'Rules: {", ".join(sorted(rule_names))}\n'
+            f'{n_actionable}/{len(proposals)} have a recommended action'
         )
 
     def _show_action_detail(self, option: CockpitOption) -> None:
@@ -1245,15 +1280,31 @@ class ProposalCockpitApp(App):
             self._show_status(', '.join(parts), error=bool(fail))
             await self._refresh_queue()
             return
+        skipped = 0
         for proposal in proposals:
+            # For "accept recommended", resolve each proposal with ITS OWN option
+            # so proposal-specific params (e.g. an inbox route's target_vault_id)
+            # are not dropped. For the uniform verbs (no_op / dismiss) the shared
+            # option carries no params and applies to every proposal as-is.
+            if option.action_id == _BATCH_RECOMMENDED_ACTION_ID:
+                per_option = recommended_resolve_option(proposal)
+                if per_option is None:
+                    skipped += 1
+                    continue
+            else:
+                per_option = option
             try:
-                await self._controller.resolve(proposal, option, note=note)
+                await self._controller.resolve(
+                    proposal, per_option, note=note, params=per_option.params
+                )
                 ok += 1
             except Exception:  # noqa: BLE001
                 fail += 1
         parts = []
         if ok:
             parts.append(f'{ok} resolved')
+        if skipped:
+            parts.append(f'{skipped} skipped (no recommended action)')
         if fail:
             parts.append(f'{fail} failed')
         self._show_status(', '.join(parts), error=bool(fail))

--- a/packages/cli/src/memex_cli/cockpit/controller.py
+++ b/packages/cli/src/memex_cli/cockpit/controller.py
@@ -475,6 +475,38 @@ def options_for_rule(rule_name: str, target_type: str) -> list[CockpitOption]:
     return filtered
 
 
+def options_for_proposal(proposal: CockpitProposal) -> list[CockpitOption]:
+    """Dispatch to the correct option builder for a proposal's rule/target.
+
+    Single source of truth for both the single-detail panel and batch
+    resolution so the two never drift. The batch path historically called only
+    ``options_for_rule`` and therefore never offered the dynamically-built
+    inbox-route / contradiction actions (which carry per-proposal ``params``),
+    so a batch could never actually route a note.
+    """
+    if proposal.rule_name == 'llm_semantic_contradiction':
+        return options_for_contradiction(proposal)
+    if proposal.rule_name == 'inbox_vault_route':
+        return options_for_inbox_route(proposal)
+    return options_for_rule(proposal.rule_name, proposal.target_type)
+
+
+def recommended_resolve_option(proposal: CockpitProposal) -> CockpitOption | None:
+    """The option a per-proposal batch 'accept' applies to one proposal.
+
+    Prefers an explicitly ``recommended`` resolve option — which carries any
+    proposal-specific ``params`` such as ``target_vault_id`` for an inbox route
+    — and falls back to the first concrete resolve action. Returns ``None`` when
+    the proposal exposes no actionable resolve (only flag/dismiss), so the
+    caller can skip it rather than silently no-op.
+    """
+    resolves = [o for o in options_for_proposal(proposal) if o.verb == 'resolve']
+    for option in resolves:
+        if option.recommended:
+            return option
+    return resolves[0] if resolves else None
+
+
 def custom_action_options(target_type: str) -> list[CockpitOption]:
     """Return the full action catalogue filtered to this target_type — used by [O]ther.
 
@@ -511,6 +543,7 @@ class CockpitProposal:
     target_type: str
     target_id: str
     target_text: str | None
+    target_label: str | None
     vault_id: str | None
     created_at: str | None
     source: str  # 'rule' or 'llm'
@@ -543,6 +576,7 @@ class CockpitProposal:
             target_type=str(finding.get('target_type') or ''),
             target_id=str(finding.get('target_id') or ''),
             target_text=finding.get('target_text'),
+            target_label=finding.get('target_label'),
             vault_id=finding.get('vault_id'),
             created_at=finding.get('created_at'),
             source=str(finding.get('source') or 'rule'),

--- a/packages/cli/src/memex_cli/inbox.py
+++ b/packages/cli/src/memex_cli/inbox.py
@@ -44,12 +44,23 @@ async def triage(
         console.print_json(json.dumps(result))
         return
     verb = 'Would route' if dry_run else 'Routed'
+    # ``blocked_*`` keys are absent on responses from an older server; default to 0.
+    blocked_cooldown = result.get('blocked_cooldown', 0)
+    blocked_backoff = result.get('blocked_backoff', 0)
     console.print(
         f'[bold]Inbox triage[/bold] ({"dry-run" if dry_run else "live"}): '
         f'scored={result["scored"]}  {verb.lower()}/auto={result["auto_routed"]}  '
         f'proposed={result["proposed"]}  no_fit={result["no_fit"]}  '
-        f'skipped_cap={result["skipped_cap"]}  errors={result["errors"]}'
+        f'skipped_cap={result["skipped_cap"]}  '
+        f'blocked_cooldown={blocked_cooldown}  blocked_backoff={blocked_backoff}  '
+        f'errors={result["errors"]}'
     )
+    if blocked_cooldown:
+        console.print(
+            f'[dim]{blocked_cooldown} note(s) were not re-proposed because they were '
+            'routed/dismissed recently. To re-evaluate them now, set '
+            'inbox_router.reproposal_cooldown_days=0.[/dim]'
+        )
 
 
 @app.command('status')

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -25,7 +25,7 @@ from rich.console import Console
 from rich.table import Table
 
 from memex_common.config import MemexConfig
-from memex_cli.lint_review import render_summary, run_review_loop
+from memex_cli.lint_review import finding_target_label, render_summary, run_review_loop
 from memex_cli.utils import async_command, get_api_context, handle_api_error, parse_uuid
 
 console = Console()
@@ -179,7 +179,7 @@ async def lint_findings(
     table.add_column('lint_type')
     table.add_column('rule_name')
     table.add_column('target_type')
-    table.add_column('target_id', max_width=36)
+    table.add_column('target', max_width=60, overflow='fold')
     table.add_column('vault', max_width=36)
     table.add_column('⚑', justify='center')
     for f in findings:
@@ -191,7 +191,7 @@ async def lint_findings(
             f['lint_type'],
             f['rule_name'],
             f['target_type'],
-            f['target_id'],
+            finding_target_label(f),
             v_label,
             flag_indicator,
         )

--- a/packages/cli/src/memex_cli/lint_review.py
+++ b/packages/cli/src/memex_cli/lint_review.py
@@ -60,6 +60,35 @@ class ReviewSummary:
         return len(self.accepted) + len(self.dismissed) + len(self.skipped)
 
 
+def finding_target_label(finding: dict[str, Any], *, max_len: int = 80) -> str:
+    """Best-effort human-readable label for a finding's target.
+
+    A finding's ``target_id`` is an opaque UUID — useless for review on its
+    own. Prefer, in order: the server-resolved ``target_label`` (note title /
+    entity / mental-model name), then evidence-embedded names, then a
+    unit-text snippet, and finally a truncated ``target_id`` so the reviewer
+    always sees *something* legible.
+    """
+    label: Any = finding.get('target_label')
+    if not label:
+        evidence = finding.get('evidence') or {}
+        if isinstance(evidence, dict):
+            names = evidence.get('member_canonical_names') or evidence.get('canonical_names')
+            if isinstance(names, dict):
+                names = list(names.values())
+            if isinstance(names, list) and names:
+                label = ', '.join(str(n) for n in names)
+            else:
+                label = evidence.get('entity_name')
+    if not label:
+        label = finding.get('target_text')
+    if not label:
+        tid = str(finding.get('target_id') or '?')
+        return tid[:8] + '…' if len(tid) > 9 else tid
+    collapsed = ' '.join(str(label).split())
+    return collapsed if len(collapsed) <= max_len else collapsed[: max_len - 1] + '…'
+
+
 def _render_finding(console: Console, index: int, total: int, finding: dict[str, Any]) -> None:
     """Render a single finding as a rich panel: header + evidence + suggested action."""
     rule = finding.get('rule_name', '?')
@@ -82,7 +111,8 @@ def _render_finding(console: Console, index: int, total: int, finding: dict[str,
     body.add_column(style='dim', no_wrap=True)
     body.add_column(overflow='fold')
     body.add_row('id', finding.get('id', '?'))
-    body.add_row('target', str(target_id))
+    body.add_row('target', finding_target_label(finding, max_len=200))
+    body.add_row('target_id', str(target_id))
     if target_text:
         body.add_row('text', str(target_text))
     if created_at:

--- a/packages/cli/tests/test_cockpit_controller.py
+++ b/packages/cli/tests/test_cockpit_controller.py
@@ -15,9 +15,55 @@ import pytest
 from memex_cli.cockpit.controller import (
     CockpitController,
     CockpitOption,
+    CockpitProposal,
     DISMISS_OPTION,
+    options_for_proposal,
     options_for_rule,
+    recommended_resolve_option,
 )
+
+
+def test_recommended_resolve_option_inbox_route_carries_vault_param():
+    """An inbox route's recommended option must carry its target_vault_id.
+
+    Regression pin for the batch-resolve bug: batch resolution fans out to this
+    per-proposal option, so the params must be present or the note never moves.
+    """
+    vault_id = str(uuid4())
+    proposal = CockpitProposal.from_finding(
+        _finding(
+            'inbox_vault_route',
+            target_type='note',
+            evidence={
+                'top_candidates': [
+                    {'vault_id': vault_id, 'vault_name': 'projects', 'p_match': 0.7},
+                    {'vault_id': str(uuid4()), 'vault_name': 'archive', 'p_match': 0.3},
+                ]
+            },
+        )
+    )
+    option = recommended_resolve_option(proposal)
+    assert option is not None
+    assert option.action_id == 'route_note_to_vault'
+    assert option.params == {
+        'target_vault_id': vault_id,
+        'other_vault_ids': [proposal.raw_evidence['top_candidates'][1]['vault_id']],
+    }
+
+
+def test_options_for_proposal_dispatches_by_rule():
+    """Contradiction and inbox-route rules get their dynamic builders, not the generic fallback."""
+    contra = CockpitProposal.from_finding(_finding('llm_semantic_contradiction'))
+    assert any(o.action_id == 'deprioritize_unit' for o in options_for_proposal(contra))
+
+    route = CockpitProposal.from_finding(
+        _finding(
+            'inbox_vault_route',
+            target_type='note',
+            evidence={'top_candidates': [{'vault_id': str(uuid4()), 'vault_name': 'x'}]},
+        )
+    )
+    assert any(o.action_id == 'route_note_to_vault' for o in options_for_proposal(route))
 
 
 def _finding(

--- a/packages/cli/tests/test_lint_review_unit.py
+++ b/packages/cli/tests/test_lint_review_unit.py
@@ -17,6 +17,34 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from memex_cli.lint import app
+from memex_cli.lint_review import finding_target_label
+
+
+def test_finding_target_label_prefers_server_label():
+    """Server-resolved ``target_label`` (e.g. a note title) wins outright."""
+    assert (
+        finding_target_label({'target_label': 'Q3 Planning Notes', 'target_id': 'x' * 36})
+        == 'Q3 Planning Notes'
+    )
+
+
+def test_finding_target_label_falls_back_to_evidence_names():
+    """When no server label, entity-collapse member names render."""
+    label = finding_target_label(
+        {
+            'target_id': 'e' * 36,
+            'evidence': {'member_canonical_names': {'a': 'Marc Haas', 'b': 'Marc de Haas'}},
+        }
+    )
+    assert 'Marc Haas' in label and 'Marc de Haas' in label
+
+
+def test_finding_target_label_falls_back_to_unit_text_then_id():
+    """Unit snippet beats the raw id; a bare UUID is truncated as a last resort."""
+    assert finding_target_label({'target_id': 'u', 'target_text': 'staging approved'}) == (
+        'staging approved'
+    )
+    assert finding_target_label({'target_id': 'abcdefghijklmnop'}) == 'abcdefgh…'
 
 
 _FINDINGS = [

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1765,7 +1765,16 @@ class EntityMaintenanceConfig(BaseModel):
         le=1.0,
         description=(
             'Minimum pairwise similarity to connect two entities in the '
-            'candidate-cluster graph. Placeholder — empirical tuning pending.'
+            'candidate-cluster graph. Names that are identical after '
+            'case-folding + whitespace-stripping always cluster via an exact-name '
+            'fast path (score 1.0), regardless of this threshold. The threshold '
+            'governs only NON-identical near-duplicates; kept high (0.85) because '
+            'at the name-similarity weights a token-insertion variant such as '
+            '"Marc Haas" / "Marc de Haas" only scores ~0.39 while distinct names '
+            'that share a phonetic code ("Robert"/"Roberta") reach ~0.60 — so a '
+            'lower threshold floods proposals with false positives without '
+            'catching the token-insertion case (which needs cooccurrence signal '
+            'or human review instead).'
         ),
     )
     cluster_min_threshold: float = Field(

--- a/packages/common/src/memex_common/config.py
+++ b/packages/common/src/memex_common/config.py
@@ -1716,6 +1716,17 @@ class InboxRouterConfig(BaseModel):
             'cannot reshuffle the whole inbox at once.'
         ),
     )
+    reproposal_cooldown_days: int = Field(
+        default=30,
+        ge=0,
+        description=(
+            'After a route proposal is resolved or dismissed, the router will '
+            'not re-propose the same note for this many days (so a rejected '
+            'route is not immediately re-offered). Set to 0 to bootstrap a fresh '
+            'inbox where notes were dismissed during earlier experimentation and '
+            'should be re-evaluated immediately.'
+        ),
+    )
     excluded_vaults: list[str] = Field(
         default_factory=lambda: ['global'],
         description=(

--- a/packages/core/src/memex_core/diagnostics/lint_dashboard.py
+++ b/packages/core/src/memex_core/diagnostics/lint_dashboard.py
@@ -56,7 +56,12 @@ async def aggregate_lint_findings(
             MaintenanceProposal.source.label('source'),
             func.count().label('count'),
         )
-        .where(MaintenanceProposal.vault_id == vault_id)
+        .where(
+            MaintenanceProposal.vault_id == vault_id,
+            # Exclude internal cost-cap bookkeeping (retried by process_deferred);
+            # it must not inflate the pending pivot the briefing/dashboard show.
+            MaintenanceProposal.rule_name != 'llm_deferred',
+        )
         .group_by(
             MaintenanceProposal.lint_type,
             MaintenanceProposal.status,
@@ -78,6 +83,7 @@ async def aggregate_lint_findings(
         .where(
             MaintenanceProposal.vault_id == vault_id,
             MaintenanceProposal.status == LintStatus.PENDING,
+            MaintenanceProposal.rule_name != 'llm_deferred',
         )
         .order_by(desc(MaintenanceProposal.created_at))
         .limit(5)
@@ -137,6 +143,7 @@ async def pending_by_type(
         .where(
             MaintenanceProposal.vault_id == vault_id,
             MaintenanceProposal.status == LintStatus.PENDING,
+            MaintenanceProposal.rule_name != 'llm_deferred',
         )
         .group_by(MaintenanceProposal.lint_type)
     )

--- a/packages/core/src/memex_core/memory/entity_resolver.py
+++ b/packages/core/src/memex_core/memory/entity_resolver.py
@@ -76,10 +76,29 @@ def score_entity_pair(
       - 20% neighbourhood (overlap of cooccurrence partners, TF-IDF
         weighted by partner mention frequency)
 
+    Names that are identical after case-folding + whitespace normalization
+    short-circuit to ``1.0`` (exact-name fast path) so they always cluster
+    regardless of the configured thresholds or phonetic availability.
+
     Returns a float in ``[0.0, 1.0]``. Deterministic given inputs.
     """
-    a = (a_name or '').lower().strip()
-    b = (b_name or '').lower().strip()
+    # Case-fold and collapse ALL whitespace runs (leading/trailing AND internal)
+    # so messy extractions like ``ACME  Corp`` and ``ACME Corp`` normalize equal.
+    # ``str.split()`` with no args splits on any whitespace and drops empties, so
+    # ``'   '`` → ``''`` (the fast-path guard below stays falsy).
+    a = ' '.join((a_name or '').lower().split())
+    b = ' '.join((b_name or '').lower().split())
+
+    # Exact normalized-name fast path: two entities whose canonical names are
+    # identical after case-folding + whitespace normalization (e.g. ``Marc de
+    # haas`` / ``Marc de Haas``, ``ACME  Corp`` / ``ACME Corp``) are the same
+    # entity by definition. Return the maximum score so they always cluster,
+    # independent of the configured thresholds or whether a phonetic code was
+    # computed. Without this, identical names cap at ``trigram_weight +
+    # phonetic_weight`` (0.80 at the defaults), which can sit below
+    # ``pair_threshold`` and silently suppress every merge.
+    if a and a == b:
+        return 1.0
 
     name_score = _trigram_similarity(a, b)
     phonetic_match = bool(a_phonetic and b_phonetic and a_phonetic == b_phonetic)

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -47,7 +47,7 @@ from memex_core.server.auth import (
     require_write,
 )
 from memex_core.server.common import _handle_error, get_api
-from memex_core.services.lint import LintSubsystemNotInitializedError
+from memex_core.services.lint import TARGET_ENRICHMENT_SQL, LintSubsystemNotInitializedError
 from memex_core.services.proposal_actions import (
     ActionValidationError,
     ProposalActionError,
@@ -149,7 +149,12 @@ async def lint_findings(
         # column/operator strings are trusted constants and user-supplied values
         # are safely bound via :named parameters. SQLAlchemy Core constructs
         # would be more idiomatic but offer no additional safety here.
-        clauses = ['status = :status']
+        # ``llm_deferred`` rows are internal cost-cap bookkeeping (units the LLM
+        # lint pass skipped when the 24h quota was exhausted; retried
+        # automatically by ``process_deferred``). They are persisted as
+        # status='pending' for lack of a dedicated state, but they are not
+        # operator-actionable findings — keep them out of the human review list.
+        clauses = ['status = :status', "rule_name != 'llm_deferred'"]
         params: dict[str, Any] = {'status': status}
         if vault_id is not None:
             clauses.append('vault_id = :vault_id')
@@ -172,9 +177,9 @@ async def lint_findings(
                     'SELECT mp.id::text, mp.vault_id::text, mp.lint_type, mp.target_type, '
                     'mp.target_id, mp.rule_name, mp.evidence, mp.suggested_action, mp.status, '
                     'mp.source, mp.created_at, mp.resolved_at, mp.resolved_by, mp.flagged_at, '
-                    '(SELECT mu.text FROM memory_units mu '
-                    "WHERE mp.target_type = 'memory_unit' "
-                    'AND mu.id::text = mp.target_id) AS target_text '
+                    # Shared enrichment fragment (target_text snippet + per-type
+                    # human-readable target_label) — see services.lint.
+                    f'{TARGET_ENRICHMENT_SQL} '
                     f'FROM maintenance_proposals mp WHERE {where} '  # noqa: S608
                     'ORDER BY mp.created_at DESC '
                     'LIMIT :limit OFFSET :offset'

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -61,6 +61,17 @@ _ROUTER_LOCK_ID = 5432789123456790
 
 @dataclass
 class TriageResult:
+    """Per-tick triage counters.
+
+    Every scored note increments at least one terminal-disposition bucket
+    (``auto_routed`` / ``proposed`` / ``no_fit`` / ``blocked_cooldown`` /
+    ``blocked_backoff`` / ``errors``). ``skipped_cap`` is NOT a terminal
+    bucket but an orthogonal reason-tag: an over-budget AUTO_ROUTE increments
+    ``skipped_cap`` AND its terminal bucket (``proposed`` or
+    ``blocked_cooldown``). So the buckets are intentionally non-additive — do
+    not assume they sum to ``scored``.
+    """
+
     vault_id: UUID | None = None
     scored: int = 0
     auto_routed: int = 0

--- a/packages/core/src/memex_core/services/inbox_router/service.py
+++ b/packages/core/src/memex_core/services/inbox_router/service.py
@@ -67,6 +67,13 @@ class TriageResult:
     proposed: int = 0
     no_fit: int = 0
     skipped_cap: int = 0
+    # A route proposal the re-proposal cooldown suppressed (the note was routed/
+    # dismissed recently). Previously these notes were silently uncounted, so a
+    # tick that "scored 22" could show "proposed 0" with no explanation.
+    blocked_cooldown: int = 0
+    # A no-fit proposal whose backoff window is not yet due — also previously
+    # silent.
+    blocked_backoff: int = 0
     errors: int = 0
     # Populated only on a dry run: one entry per scored note with the would-be
     # decision + top candidate. Lets callers (e.g. the eval suite) read per-note
@@ -81,6 +88,8 @@ class TriageResult:
             'proposed': self.proposed,
             'no_fit': self.no_fit,
             'skipped_cap': self.skipped_cap,
+            'blocked_cooldown': self.blocked_cooldown,
+            'blocked_backoff': self.blocked_backoff,
             'errors': self.errors,
             'decisions': self.decisions,
         }
@@ -107,7 +116,7 @@ WHERE NOT EXISTS (
        AND mp.target_id = :target_id
        AND mp.vault_id = :vault_id ::uuid
        AND mp.status IN ('resolved', 'dismissed')
-       AND mp.resolved_at > now() - interval '30 days'
+       AND mp.resolved_at > now() - make_interval(days => :cooldown_days)
 )
 ON CONFLICT (rule_name, target_type, target_id, vault_id)
     WHERE status = 'pending'
@@ -456,11 +465,18 @@ class InboxRouterService(BaseService):
                     # The daily cap applies to the count in both modes so a dry run
                     # previews the same auto/skipped split a live tick would produce.
                     if remaining_budget <= 0:
+                        # skipped_cap is a reason-tag (hit the daily auto-apply
+                        # cap), orthogonal to the terminal disposition below: the
+                        # note still falls through to a proposal, which either
+                        # lands (proposed) or is suppressed by the cooldown
+                        # (blocked_cooldown) — never silently dropped.
                         result.skipped_cap += 1
                         if dry_run:
                             result.proposed += 1
                         elif await self._emit_route(inbox_vault_id=inbox_id, decision=decision):
                             result.proposed += 1
+                        else:
+                            result.blocked_cooldown += 1
                     else:
                         if not dry_run:
                             await self._auto_apply(inbox_id, decision)
@@ -468,16 +484,21 @@ class InboxRouterService(BaseService):
                         remaining_budget -= 1
                 elif decision.kind == DecisionKind.PROPOSE_CANDIDATES:
                     # Count only proposals that actually landed (the cooldown guard
-                    # in _EMIT_PENDING_SQL can skip the insert).
+                    # in _EMIT_PENDING_SQL can skip the insert). A suppressed insert
+                    # is counted as blocked_cooldown rather than silently dropped.
                     if dry_run:
                         result.proposed += 1
                     elif await self._emit_route(inbox_vault_id=inbox_id, decision=decision):
                         result.proposed += 1
+                    else:
+                        result.blocked_cooldown += 1
                 else:  # PROPOSE_NO_FIT
                     if dry_run:
                         result.no_fit += 1
                     elif await self._emit_no_fit(inbox_id, decision):
                         result.no_fit += 1
+                    else:
+                        result.blocked_backoff += 1
             except Exception:
                 logger.exception('inbox_router: failed to act on note %s', nid)
                 result.errors += 1
@@ -625,6 +646,7 @@ class InboxRouterService(BaseService):
                     'rule_name': ROUTE_RULE,
                     'evidence': evidence.model_dump_json(),
                     'suggested_action': f'Route to {top.vault_name}?',
+                    'cooldown_days': self._cfg.reproposal_cooldown_days,
                 },
             )
             await session.commit()

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -75,6 +75,28 @@ class LintSubsystemNotInitializedError(RuntimeError):
         )
 
 
+# Correlated-subquery SELECT fragment that resolves a human-readable label
+# (+ a unit-body snippet) for a finding's target, per target_type — so reviewers
+# (and the agent surface) see a title/name instead of an opaque UUID. Each arm
+# is single-row (PK equality) and tolerant (no match → NULL → COALESCE falls
+# through). Assumes the ``maintenance_proposals`` row is aliased ``mp``. Shared
+# verbatim by ``LintService.get_findings`` and the HTTP ``/lint/findings``
+# endpoint so the two never drift.
+TARGET_ENRICHMENT_SQL = (
+    '(SELECT mu.text FROM memory_units mu '
+    "WHERE mp.target_type IN ('memory_unit', 'unit_entity') "
+    'AND mu.id::text = mp.target_id) AS target_text, '
+    'COALESCE('
+    '(SELECT n.title FROM memory_units mu LEFT JOIN notes n ON n.id = mu.note_id '
+    "WHERE mp.target_type IN ('memory_unit', 'unit_entity') AND mu.id::text = mp.target_id), "
+    '(SELECT mm.name FROM mental_models mm '
+    "WHERE mp.target_type = 'mental_model' AND mm.id::text = mp.target_id), "
+    '(SELECT e.canonical_name FROM entities e '
+    "WHERE mp.target_type = 'entity' AND e.id::text = mp.target_id)"
+    ') AS target_label'
+)
+
+
 class LintFindingDTO(BaseModel):
     """Shape-stable read view over a :class:`MaintenanceProposal` row."""
 
@@ -91,9 +113,15 @@ class LintFindingDTO(BaseModel):
     created_at: datetime
     resolved_at: datetime | None
     resolved_by: str | None = None
+    # Human-readable target context (note title / entity / mental-model name and
+    # a unit-body snippet). Optional for shape stability — older rows / callers
+    # that don't select them get None.
+    target_text: str | None = None
+    target_label: str | None = None
 
     @classmethod
     def from_row(cls, row: Any) -> LintFindingDTO:
+        keys = row.keys()
         return cls(
             finding_id=row['id'],
             target_id=row['target_id'],
@@ -107,7 +135,9 @@ class LintFindingDTO(BaseModel):
             vault_id=row['vault_id'],
             created_at=row['created_at'],
             resolved_at=row['resolved_at'],
-            resolved_by=row['resolved_by'] if 'resolved_by' in row.keys() else None,
+            resolved_by=row['resolved_by'] if 'resolved_by' in keys else None,
+            target_text=row['target_text'] if 'target_text' in keys else None,
+            target_label=row['target_label'] if 'target_label' in keys else None,
         )
 
 
@@ -916,16 +946,20 @@ class LintService(BaseService):
         Total-across-everything is intentionally not exposed here; the server
         handles ``scope='all'`` with its own SQL.
         """
+        # Exclude ``llm_deferred`` bookkeeping rows — they are not operator-
+        # actionable findings (see ``lint_llm.process_deferred``).
         if vault_id is None:
             stmt = text(
                 'SELECT count(*) FROM maintenance_proposals '
-                "WHERE status = 'pending' AND vault_id IS NULL"
+                "WHERE status = 'pending' AND vault_id IS NULL "
+                "AND rule_name != 'llm_deferred'"
             )
             params: dict[str, Any] = {}
         else:
             stmt = text(
                 'SELECT count(*) FROM maintenance_proposals '
-                "WHERE status = 'pending' AND vault_id = :v"
+                "WHERE status = 'pending' AND vault_id = :v "
+                "AND rule_name != 'llm_deferred'"
             )
             params = {'v': str(vault_id)}
 
@@ -1063,7 +1097,9 @@ class LintService(BaseService):
         # arithmetic on a bound parameter — `:limit + 1` inside SQL leaves the
         # `+ 1` as a literal addition the driver may reject or interpret oddly.
         fetch_limit = capped_limit + 1
-        clauses: list[str] = ['status = :status']
+        # Exclude ``llm_deferred`` bookkeeping rows — internal cost-cap deferrals
+        # retried by ``process_deferred``, not operator-actionable findings.
+        clauses: list[str] = ['status = :status', "rule_name != 'llm_deferred'"]
         params: dict[str, Any] = {'status': status, 'fetch_limit': fetch_limit}
         if vault_id is not None:
             clauses.append('vault_id = CAST(:vault_id AS uuid)')
@@ -1095,11 +1131,11 @@ class LintService(BaseService):
         # through the closing string.
         where_sql = ' AND '.join(clauses)
         stmt = text(
-            f'SELECT id, vault_id, lint_type, target_type, target_id, rule_name, '  # noqa: S608
-            f'evidence, suggested_action, status, source, created_at, resolved_at, '
-            f'resolved_by '
-            f'FROM maintenance_proposals WHERE {where_sql} '
-            'ORDER BY created_at DESC, id DESC LIMIT :fetch_limit'
+            f'SELECT mp.id, mp.vault_id, mp.lint_type, mp.target_type, mp.target_id, '  # noqa: S608
+            f'mp.rule_name, mp.evidence, mp.suggested_action, mp.status, mp.source, '
+            f'mp.created_at, mp.resolved_at, mp.resolved_by, {TARGET_ENRICHMENT_SQL} '
+            f'FROM maintenance_proposals mp WHERE {where_sql} '
+            'ORDER BY mp.created_at DESC, mp.id DESC LIMIT :fetch_limit'
         )
 
         async with self.metastore.session() as session:

--- a/packages/core/tests/integration/services/test_int_f8_lint_query.py
+++ b/packages/core/tests/integration/services/test_int_f8_lint_query.py
@@ -137,6 +137,98 @@ async def test_invalid_status_raises(session: AsyncSession, api) -> None:
         await api.lint.get_findings(vault_id=vault_id, status='garbage')
 
 
+@pytest.mark.asyncio
+async def test_findings_endpoint_resolves_target_label_per_type(session: AsyncSession, api) -> None:
+    """The /lint/findings SELECT resolves a human-readable label for each
+    target_type — exercises the correlated-subquery enrichment against real
+    Postgres (otherwise a column typo would ship undetected)."""
+    from uuid import uuid4 as _uuid4
+
+    from memex_core.memory.sql_models import Entity, MemoryUnit, MentalModel, Note
+    from memex_core.server.lint import lint_findings
+
+    vault_id = await _make_vault(session)
+
+    note = Note(
+        id=_uuid4(), vault_id=vault_id, title='Quarterly Planning', content_hash=uuid4().hex
+    )
+    session.add(note)
+    await session.commit()
+    unit = MemoryUnit(
+        id=_uuid4(),
+        vault_id=vault_id,
+        note_id=note.id,
+        text='The release captain signs off on staging.',
+        event_date=datetime.now(timezone.utc),
+    )
+    entity = Entity(id=_uuid4(), canonical_name='Marc de Haas', phonetic_code='MRTKS')
+    session.add_all([unit, entity])
+    await session.commit()
+    mm = MentalModel(
+        id=_uuid4(), vault_id=vault_id, entity_id=entity.id, name='Marc de Haas', observations=[]
+    )
+    session.add(mm)
+    await session.commit()
+
+    unit_fid = await _seed_finding(
+        session, vault_id=vault_id, target_type='memory_unit', target_id=str(unit.id)
+    )
+    mm_fid = await _seed_finding(
+        session, vault_id=vault_id, target_type='mental_model', target_id=str(mm.id)
+    )
+    ent_fid = await _seed_finding(
+        session, vault_id=vault_id, target_type='entity', target_id=str(entity.id)
+    )
+
+    # Pass every param explicitly: FastAPI Query(...) defaults are sentinel
+    # objects, not real values, when the route function is called directly.
+    # vault_id=None skips the per-vault auth gate; we filter to our ids below.
+    payload = await lint_findings(
+        api=api,
+        vault_id=None,
+        lint_type=None,
+        status='pending',
+        flagged=None,
+        limit=500,
+        offset=0,
+        auth=None,
+    )
+    by_id = {f['id']: f for f in payload['findings']}
+
+    assert by_id[str(unit_fid)]['target_label'] == 'Quarterly Planning'
+    assert by_id[str(unit_fid)]['target_text'] == 'The release captain signs off on staging.'
+    assert by_id[str(mm_fid)]['target_label'] == 'Marc de Haas'
+    assert by_id[str(ent_fid)]['target_label'] == 'Marc de Haas'
+
+    # Same enrichment must flow through the service DTO path (the MCP
+    # `memex_get_lint_flags` agent surface), not just the HTTP endpoint.
+    page = await api.lint.get_findings(vault_id=vault_id)
+    dto_by_id = {f.finding_id: f for f in page.findings}
+    assert dto_by_id[unit_fid].target_label == 'Quarterly Planning'
+    assert dto_by_id[unit_fid].target_text == 'The release captain signs off on staging.'
+    assert dto_by_id[mm_fid].target_label == 'Marc de Haas'
+    assert dto_by_id[ent_fid].target_label == 'Marc de Haas'
+
+
+@pytest.mark.asyncio
+async def test_llm_deferred_rows_excluded_from_findings(session: AsyncSession, api) -> None:
+    """``llm_deferred`` bookkeeping rows must not surface in the review list.
+
+    They are internal cost-cap deferrals (retried by ``process_deferred``);
+    only genuine findings are operator-actionable.
+    """
+    vault_id = await _make_vault(session)
+    real_id = await _seed_finding(session, vault_id=vault_id, rule_name='cold_low_mw_unit')
+    await _seed_finding(session, vault_id=vault_id, rule_name='llm_deferred')
+
+    page = await api.lint.get_findings(vault_id=vault_id)
+    returned = {f.finding_id for f in page.findings}
+    assert returned == {real_id}
+
+    # The deferred row is also excluded from the pending count.
+    assert await api.lint.count_pending(vault_id=vault_id) == 1
+
+
 # ---------------------------------------------------------------------------
 # TC-21-6 — DTO surfaces every documented field
 # ---------------------------------------------------------------------------

--- a/packages/core/tests/integration/test_entity_collapse_maintenance.py
+++ b/packages/core/tests/integration/test_entity_collapse_maintenance.py
@@ -561,6 +561,68 @@ async def test_scan_emits_cluster_of_three(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_scan_emits_with_default_thresholds(
+    session: AsyncSession,
+    metastore,
+):
+    """The scan emits under the PRODUCTION default thresholds — no overrides.
+
+    Regression pin for the structural bug where identical/case-variant names
+    capped below the default ``pair_threshold`` so the scan emitted nothing.
+    Every other scan test loosens the thresholds to 0.55/0.4 and thus masks it;
+    this one drives the defaults straight from ``EntityMaintenanceConfig()``.
+    """
+    from memex_common.config import EntityMaintenanceConfig, MemexConfig
+    from memex_core.services.entity_maintenance import scan_collapse_clusters
+
+    suffix = uuid4().hex[:6]
+    a = await _make_entity(
+        session,
+        f'Beacon Labs {suffix}',
+        mention_count=10,
+        first_seen=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    b = await _make_entity(
+        session,
+        f'beacon labs {suffix}',
+        mention_count=4,
+        first_seen=datetime(2026, 2, 1, tzinfo=timezone.utc),
+    )
+
+    config = MemexConfig()
+    # Use the real production defaults for the thresholds; only flip the master
+    # switch on and drop the cooldown so the seeded rows are eligible.
+    config.server.memory.entity_maintenance = EntityMaintenanceConfig(
+        scan_enabled=True,
+        scan_cooldown_days=0,
+    )
+    api_stub = MagicMock()
+    api_stub.metastore = metastore
+    api_stub.config = config
+
+    summary = await scan_collapse_clusters(api_stub)
+    assert summary['clusters_emitted'] >= 1, (
+        f'scan must emit at least one cluster under default thresholds; got {summary}'
+    )
+
+    async with metastore.session() as s:
+        rows = (
+            await s.execute(
+                text(
+                    'SELECT evidence FROM maintenance_proposals '
+                    "WHERE rule_name = 'entity_collapse_cluster' "
+                    "AND status = 'pending' AND target_id = :wid"
+                ),
+                {'wid': str(a.id)},
+            )
+        ).all()
+    assert rows, 'cluster proposal for the suggested winner must exist'
+    members = set(rows[0][0]['cluster_members'])
+    assert {str(a.id), str(b.id)}.issubset(members)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_scan_rescan_updates_evidence_in_place(
     session: AsyncSession,
     metastore,

--- a/packages/core/tests/integration/test_int_f26_lint_dashboard_aggregator.py
+++ b/packages/core/tests/integration/test_int_f26_lint_dashboard_aggregator.py
@@ -227,3 +227,48 @@ async def test_pending_by_type_slice_matches_aggregator(
 
     assert slice_only == full['pending_by_type']
     assert slice_only == {'structural': 1, 'quality': 1}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_llm_deferred_rows_excluded_from_dashboard(
+    session: AsyncSession,
+    metastore,
+):
+    """Internal ``llm_deferred`` bookkeeping must not inflate the dashboard
+    pivot / pending_by_type / top-5 — it is hidden from the findings list and
+    pending count, so the dashboard must agree (no inconsistent badge)."""
+    vault = Vault(name=f'F26-deferred-{uuid4().hex[:8]}')
+    session.add(vault)
+    await session.commit()
+    await session.refresh(vault)
+
+    session.add_all(
+        [
+            _proposal(
+                vault.id,
+                lint_type=LintType.QUALITY,
+                status=LintStatus.PENDING,
+                rule_name='cold_low_mw_unit',
+            ),
+            _proposal(
+                vault.id,
+                lint_type=LintType.QUALITY,
+                status=LintStatus.PENDING,
+                rule_name='llm_deferred',
+            ),
+        ]
+    )
+    await session.commit()
+
+    agg = await aggregate_lint_findings(metastore, vault.id)
+    assert agg['pending_by_type'] == {'quality': 1}
+    assert await pending_by_type(metastore, vault.id) == {'quality': 1}
+    assert all(r['rule_name'] != 'llm_deferred' for r in agg['top_5_pending'])
+    # The deferred row is also absent from the type/status/source pivot counts.
+    quality_pending = [
+        c
+        for c in agg['counts_by_type_status_source']
+        if c['lint_type'] == 'quality' and c['status'] == 'pending'
+    ]
+    assert sum(c['count'] for c in quality_pending) == 1

--- a/packages/core/tests/integration/test_int_inbox_router.py
+++ b/packages/core/tests/integration/test_int_inbox_router.py
@@ -140,6 +140,72 @@ async def test_triage_tick_emits_routing_proposal(api, session):
     assert n >= 1
 
 
+async def test_blocked_backoff_counts_suppressed_no_fit(api, session):
+    """A no-fit emission suppressed by the backoff window (``_emit_no_fit``
+    returns False) is counted in ``blocked_backoff`` — not silently dropped."""
+    from unittest.mock import AsyncMock
+
+    inbox = await _seed_empty_vault(session, 'inbox')
+    await _seed_vault_with_note(session, 'vault-a', _VEC_A)
+    await _seed_inbox_note(session, inbox, _VEC_A)
+
+    # Force PROPOSE_NO_FIT regardless of the cold-start score.
+    api.config.server.memory.inbox_router.t_low = 0.99
+    # Simulate a not-yet-due backoff window: the upsert lands 0 rows.
+    api.inbox_router._emit_no_fit = AsyncMock(return_value=False)
+
+    result = await api.inbox_router.triage_tick()
+    assert result.scored == 1
+    assert result.no_fit == 0
+    assert result.blocked_backoff == 1
+    assert result.errors == 0
+
+
+async def test_reproposal_cooldown_blocks_then_bootstrap_unblocks(api, session):
+    """A recently-dismissed route is not re-proposed (counted, not silently
+    dropped); setting the cooldown to 0 re-evaluates it immediately."""
+    inbox = await _seed_empty_vault(session, 'inbox')
+    await _seed_vault_with_note(session, 'vault-a', _VEC_A)
+    await _seed_vault_with_note(session, 'vault-b', _VEC_B)
+    note_id = await _seed_inbox_note(session, inbox, _VEC_A)
+
+    cfg = api.config.server.memory.inbox_router
+    # Drop the no-fit floor so the note routes (PROPOSE_CANDIDATES) rather than
+    # falling to no-fit under the cold-start NB scores — this test is about the
+    # route re-proposal cooldown specifically.
+    cfg.t_low = 0.0
+
+    # First tick emits a pending route proposal; dismiss it (status flip +
+    # resolved_at=now) so the note is eligible again but inside the cooldown.
+    first = await api.inbox_router.triage_tick()
+    assert first.proposed >= 1, f'expected a route proposal on first tick; got {first.as_dict()}'
+    async with api.metastore.session() as s:
+        await s.execute(
+            text(
+                "UPDATE maintenance_proposals SET status = 'dismissed', resolved_at = now() "
+                "WHERE lint_type = 'routing' AND target_id = :tid"
+            ),
+            {'tid': str(note_id)},
+        )
+        await s.commit()
+
+    # Default cooldown (30d) → the re-proposal is suppressed and ACCOUNTED.
+    cfg.reproposal_cooldown_days = 30
+    blocked = await api.inbox_router.triage_tick()
+    assert blocked.proposed == 0
+    assert blocked.blocked_cooldown >= 1, (
+        f'cooldown-suppressed note must be counted, not dropped; got {blocked.as_dict()}'
+    )
+
+    # Bootstrap: cooldown 0 → re-evaluated immediately.
+    cfg.reproposal_cooldown_days = 0
+    unblocked = await api.inbox_router.triage_tick()
+    assert unblocked.proposed >= 1, (
+        f'cooldown=0 must re-propose the dismissed note; got {unblocked.as_dict()}'
+    )
+    assert unblocked.blocked_cooldown == 0
+
+
 async def test_record_feedback_updates_sufficient_stats(api, session):
     """An online update increments the match class count and a feature's n."""
     inbox = await _seed_empty_vault(session, 'inbox')

--- a/packages/core/tests/unit/memory/test_entity_resolver.py
+++ b/packages/core/tests/unit/memory/test_entity_resolver.py
@@ -262,7 +262,7 @@ def test_score_entity_pair_neighbor_overlap_contributes():
 
 
 def test_score_entity_pair_identical_names_max():
-    """Identical names + matching phonetic = perfect score."""
+    """Identical names hit the exact-name fast path → perfect score (1.0)."""
     score = score_entity_pair(
         a_name='Same Name',
         b_name='Same Name',
@@ -271,4 +271,67 @@ def test_score_entity_pair_identical_names_max():
         a_neighbors={},
         b_neighbors={},
     )
-    assert score >= 0.8
+    assert score == 1.0
+
+
+def test_score_entity_pair_normalized_case_variant_fast_path():
+    """Case/whitespace-only variants normalize equal → fast path returns 1.0.
+
+    Pins the fix for the scan that never emitted: ``Marc de haas`` /
+    ``Marc de Haas`` must cluster regardless of phonetic codes or thresholds.
+    """
+    assert (
+        score_entity_pair(
+            a_name='Marc de haas',
+            b_name='Marc de Haas',
+            a_phonetic=None,
+            b_phonetic=None,
+            a_neighbors={},
+            b_neighbors={},
+        )
+        == 1.0
+    )
+    # Surrounding/duplicated whitespace also normalizes away.
+    assert (
+        score_entity_pair(
+            a_name='  ACME Corp',
+            b_name='acme corp',
+            a_phonetic='AKM',
+            b_phonetic='AKM',
+            a_neighbors={},
+            b_neighbors={},
+        )
+        == 1.0
+    )
+    # Internal whitespace runs collapse too (messy extraction): "ACME  Corp".
+    assert (
+        score_entity_pair(
+            a_name='ACME  Corp',
+            b_name='ACME Corp',
+            a_phonetic=None,
+            b_phonetic=None,
+            a_neighbors={},
+            b_neighbors={},
+        )
+        == 1.0
+    )
+
+
+def test_score_entity_pair_identical_clears_default_threshold():
+    """An identical name with no neighbour overlap clears the default pair_threshold.
+
+    Regression pin for the structural bug: before the fast path, identical
+    names capped at 0.80 (trigram_weight + phonetic_weight) and the production
+    default threshold sat above that, so no edge ever formed.
+    """
+    from memex_common.config import EntityMaintenanceConfig
+
+    score = score_entity_pair(
+        a_name='Same Name',
+        b_name='Same Name',
+        a_phonetic='SNM',
+        b_phonetic='SNM',
+        a_neighbors={},
+        b_neighbors={},
+    )
+    assert score >= EntityMaintenanceConfig().pair_threshold


### PR DESCRIPTION
## Context

The maintenance & review surface generated internal state but failed to make it human-actionable. Six issues surfaced from live CLI use; five were real defects, one was already correct. Throughline: **proposals don't get emitted, findings can't be read, and resolves don't apply.**

## Defects fixed

**A — Entity scan emitted zero proposals** (`fix(core)`)
`score_entity_pair` scored identical/case-variant names at 0.80 (trigram 0.6 + phonetic 0.2), below `pair_threshold`, so no merge edge ever formed. Added an exact normalized-name fast path (case-fold + collapse all whitespace → 1.0). Thresholds kept at 0.85/0.70 — token-insertion variants (`Marc Haas`/`Marc de Haas`) only score ~0.39 while distinct phonetically-equal names (`Robert`/`Roberta`) reach ~0.60, so lowering would flood false positives without catching the real case.

**C — Inbox triage silently dropped notes** (`fix(inbox)`)
`PROPOSE_*` branches and the AUTO_ROUTE over-budget fallback had no `else`, so cooldown/backoff-suppressed notes incremented no counter (`scored=22 … proposed=0` with 17 invisible). Added `blocked_cooldown`/`blocked_backoff` buckets so every scored note lands in ≥1 bucket. Made the 30-day re-proposal cooldown configurable (`reproposal_cooldown_days`; set 0 to bootstrap a fresh inbox).

**D — Findings showed opaque UUIDs** (`feat(lint)`)
Resolve a human-readable `target_label` (note title / entity / mental-model name) + unit snippet per `target_type` via a shared `TARGET_ENRICHMENT_SQL`, used by **both** the HTTP endpoint and `get_findings` (so the MCP agent surface gets labels too). Rendered in the CLI table, review panel, and TUI cockpit.

**E — `llm_deferred` cluttered review** (`feat(lint)`)
Internal cost-cap bookkeeping (retried by `process_deferred`) leaked into the review list as `status='pending'`. Excluded from the findings list, `count_pending`, and the diagnostics dashboard pivot/top-5/pending_by_type so the "N pending" badge agrees with the list.

**F — Mixed-type batch resolve skipped the inbox route** (`feat(lint)`)
The cockpit batch path dropped per-proposal params and intersected `options_for_rule` (which never includes the dynamic route/contradiction actions). Now dispatches via a shared `options_for_proposal` and fans an "accept recommended" batch verb out to each proposal's own option (carrying its `target_vault_id`), so a route in a mixed batch actually migrates the note.

**B — same-vault mental-model merge+dedup:** already correct (`collapse_cluster`); no change. It only *appeared* broken because A blocked every proposal.

## Review

Three rounds of adversarial review (subagents prompted to refute, running tests + revert experiments). Round 1 found 5 medium/major issues → all fixed; rounds 2–3 clean on all critical/high/medium. Fixes verified load-bearing (e.g. removing the fast path fails both unit and integration tests).

## Tests

core unit 3391 ✓ · mcp/common/cli 1201 ✓ · all touched integration suites green. New tests: default-threshold scan emission, per-type `target_label` resolution (endpoint + DTO), `llm_deferred` exclusion (findings + dashboard), cooldown bootstrap + accounting, `blocked_backoff` accounting. ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)