### PR TITLE
fix: reviewable cockpit (queue labels, collapse members, note detail) + targeted entity scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,151%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,152%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,161%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,162%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,152%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,160%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,162%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,165%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,160%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,161%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,166%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,167%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,165%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,166%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,144%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,151%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/packages/cli/src/memex_cli/cockpit/app.py
+++ b/packages/cli/src/memex_cli/cockpit/app.py
@@ -220,6 +220,47 @@ class _ActionListItem(ListItem):
             pass  # widget not yet mounted
 
 
+class _CollapseMemberItem(ListItem):
+    """One entity in the entity-collapse selection list.
+
+    Holds its own include/exclude + winner state so the reviewer can pick
+    exactly which entities merge into the winner.
+    """
+
+    def __init__(
+        self,
+        member_id: str,
+        name: str,
+        *,
+        included: bool = True,
+        is_winner: bool = False,
+        highlighted: bool = False,
+    ) -> None:
+        self.member_id = member_id
+        self.member_name = name
+        self.included = included
+        self.is_winner = is_winner
+        super().__init__(Label(self._render_label(highlighted)))
+
+    def _render_label(self, highlighted: bool = False) -> str:
+        cursor = '[bold]▸[/bold] ' if highlighted else '  '
+        box = '[green]✓[/green]' if self.included else '[red]✗[/red]'
+        name = f'[bold]{self.member_name}[/bold]' if highlighted else self.member_name
+        if self.is_winner:
+            tag = '  [yellow]★ winner[/yellow]'
+        elif self.included:
+            tag = '  [dim]→ merge[/dim]'
+        else:
+            tag = '  [dim]kept separate[/dim]'
+        return f'{cursor}{box} {name}  [dim]{self.member_id[:8]}[/dim]{tag}'
+
+    def refresh_label(self, highlighted: bool = False) -> None:
+        try:
+            self.query_one(Label).update(self._render_label(highlighted))
+        except Exception:  # noqa: BLE001
+            pass  # widget not yet mounted
+
+
 # ---------------------------------------------------------------------------
 # Inline note widget (Submit on Enter, newline on Shift+Enter)
 # ---------------------------------------------------------------------------
@@ -412,6 +453,9 @@ class ProposalCockpitApp(App):
         # Set when the highlighted finding targets a note directly (target_id is
         # a note id, not a unit id) so DETAIL renders the note, not a unit.
         self._detail_note_id: str | None = None
+        # COLLAPSE mode state (entity_collapse_cluster member selection).
+        self._collapse_proposal: CockpitProposal | None = None
+        self._collapse_winner_id: str | None = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -465,9 +509,10 @@ class ProposalCockpitApp(App):
             self._detail_unit_ids = []
             self._detail_unit_index = 0
             self._viewing_source_note = False
+            self._collapse_proposal = None
             self.query_one('#queue-list', ListView).focus()
             self._update_footer()
-        elif new in ('review', 'batch'):
+        elif new in ('review', 'batch', 'collapse'):
             queue_pane.add_class('dimmed')
             action_section.add_class('visible')
             note_section.remove_class('visible')
@@ -499,6 +544,8 @@ class ProposalCockpitApp(App):
             n = len(self._detail_unit_ids)
             idx = self._detail_unit_index + 1
             mode_label = f'DETAIL (unit {idx}/{n})' if n > 1 else 'DETAIL'
+        elif self.mode == 'collapse':
+            mode_label = 'COLLAPSE'
         self.sub_title = f'{mode_label} · {count} pending'
 
     def _update_footer(self) -> None:
@@ -509,6 +556,7 @@ class ProposalCockpitApp(App):
             'review': '[↑↓] Navigate  [Enter] Confirm  [Esc] Back',
             'note': '[Enter] Submit  [Shift+Enter] Newline  [Esc] Cancel',
             'detail': '[n] View note  [Tab] Cycle units  [Esc] Back',
+            'collapse': ('[Space] in/out  [w] winner  [a] apply  [x] dismiss  [Esc] cancel'),
         }
         hint = hints.get(self.mode, '')
         self.query_one('#status-bar', Static).update(f' [dim]{hint}[/dim]')
@@ -881,10 +929,14 @@ class ProposalCockpitApp(App):
         elif event.list_view.id == 'action-list' and self.mode in ('review', 'batch'):
             if isinstance(event.item, _ActionListItem):
                 self._show_action_detail(event.item.option)
+        elif event.list_view.id == 'action-list' and self.mode == 'collapse':
+            self._refresh_collapse_items()
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         if event.list_view.id == 'queue-list' and self.mode == 'list':
             self._enter_review_mode()
+        elif event.list_view.id == 'action-list' and self.mode == 'collapse':
+            self._toggle_collapse_current()
         elif event.list_view.id == 'action-list' and self.mode in ('review', 'batch'):
             self._enter_note_mode()
 
@@ -908,6 +960,8 @@ class ProposalCockpitApp(App):
 
         if self.mode == 'list':
             self._handle_list_key(event)
+        elif self.mode == 'collapse':
+            self._handle_collapse_key(event)
         elif self.mode in ('review', 'batch'):
             self._handle_review_key(event)
         elif self.mode == 'detail':
@@ -954,6 +1008,191 @@ class ProposalCockpitApp(App):
             event.prevent_default()
             event.stop()
             self.mode = 'list'
+
+    # ------------------------------------------------------------------
+    # COLLAPSE mode (entity_collapse_cluster member selection)
+    # ------------------------------------------------------------------
+
+    def _enter_collapse_mode(self, proposal: CockpitProposal) -> None:
+        ev = proposal.raw_evidence if isinstance(proposal.raw_evidence, dict) else {}
+        names = ev.get('member_canonical_names')
+        if not isinstance(names, dict):
+            names = {}
+        members = ev.get('cluster_members')
+        if not isinstance(members, list) or not members:
+            members = list(names.keys())
+        member_ids = [str(m) for m in members]
+        winner = str(ev.get('suggested_winner_id') or proposal.target_id)
+        if winner not in member_ids:
+            winner = member_ids[0] if member_ids else ''
+
+        self._collapse_proposal = proposal
+        self._collapse_winner_id = winner or None
+
+        action_list = self.query_one('#action-list', ListView)
+        action_list.clear()
+        for i, mid in enumerate(member_ids):
+            action_list.append(
+                _CollapseMemberItem(
+                    mid,
+                    names.get(mid) or '(name unavailable)',
+                    included=True,
+                    is_winner=(mid == winner),
+                    highlighted=(i == 0),
+                )
+            )
+        if member_ids:
+            action_list.index = 0
+        self.mode = 'collapse'
+        self._render_collapse_detail()
+
+    def _collapse_items(self) -> list[_CollapseMemberItem]:
+        return [
+            c
+            for c in self.query_one('#action-list', ListView).children
+            if isinstance(c, _CollapseMemberItem)
+        ]
+
+    def _collapse_included_ids(self) -> list[str]:
+        return [it.member_id for it in self._collapse_items() if it.included]
+
+    def _collapse_member_name(self, member_id: str | None) -> str:
+        for it in self._collapse_items():
+            if it.member_id == member_id:
+                return it.member_name
+        return (member_id or '?')[:8]
+
+    def _refresh_collapse_items(self) -> None:
+        action_list = self.query_one('#action-list', ListView)
+        for i, it in enumerate(self._collapse_items()):
+            it.refresh_label(highlighted=(i == action_list.index))
+
+    def _render_collapse_detail(self) -> None:
+        items = self._collapse_items()
+        included = [it for it in items if it.included]
+        winner_name = self._collapse_member_name(self._collapse_winner_id)
+        lines = [
+            '[bold]SELECT ENTITIES TO MERGE[/bold]',
+            '',
+            f'Winner: [green]{winner_name}[/green]',
+            f'Merging [bold]{len(included)}[/bold] of {len(items)} entities '
+            'into the winner; the rest stay separate.',
+            '',
+            '[dim][Space] include/exclude · [w] set winner · [a] apply · '
+            '[x] dismiss · [Esc] cancel[/dim]',
+        ]
+        self.query_one('#detail-header', Static).update('[bold]─── ENTITY COLLAPSE ───[/bold]')
+        self.query_one('#detail-body', Static).update('\n'.join(lines))
+
+    def _collapse_current_item(self) -> _CollapseMemberItem | None:
+        action_list = self.query_one('#action-list', ListView)
+        items = self._collapse_items()
+        idx = action_list.index
+        if idx is None or not (0 <= idx < len(items)):
+            return None
+        return items[idx]
+
+    def _toggle_collapse_current(self) -> None:
+        current = self._collapse_current_item()
+        if current is None:
+            return
+        if current.is_winner and current.included:
+            self._show_status(
+                'Cannot exclude the winner — set a different winner first.', error=True
+            )
+            return
+        current.included = not current.included
+        self._refresh_collapse_items()
+        self._render_collapse_detail()
+
+    def _set_collapse_winner(self) -> None:
+        current = self._collapse_current_item()
+        if current is None:
+            return
+        current.included = True  # the winner is always part of the merge
+        self._collapse_winner_id = current.member_id
+        for it in self._collapse_items():
+            it.is_winner = it.member_id == current.member_id
+        self._refresh_collapse_items()
+        self._render_collapse_detail()
+
+    def _handle_collapse_key(self, event: Any) -> None:
+        key = event.key
+        if key == 'space':
+            event.prevent_default()
+            event.stop()
+            self._toggle_collapse_current()
+        elif key == 'w':
+            event.prevent_default()
+            event.stop()
+            self._set_collapse_winner()
+        elif key == 'a':
+            event.prevent_default()
+            event.stop()
+            self._apply_collapse()
+        elif key == 'x':
+            event.prevent_default()
+            event.stop()
+            self._dismiss_collapse()
+        elif key == 'escape':
+            event.prevent_default()
+            event.stop()
+            self.mode = 'list'
+
+    def _apply_collapse(self) -> None:
+        proposal = self._collapse_proposal
+        if proposal is None:
+            return
+        included = self._collapse_included_ids()
+        if len(included) < 2:
+            self._show_status('Select at least 2 entities (a winner + one to merge).', error=True)
+            return
+        if self._collapse_winner_id not in included:
+            self._show_status('The winner must be one of the selected entities.', error=True)
+            return
+        winner_id = self._collapse_winner_id
+        winner_name = self._collapse_member_name(winner_id)
+        self.run_worker(
+            self._apply_collapse_async(proposal, winner_id, included, winner_name),
+            exclusive=True,
+            name='apply_collapse',
+        )
+
+    async def _apply_collapse_async(
+        self,
+        proposal: CockpitProposal,
+        winner_id: str,
+        member_ids: list[str],
+        winner_name: str,
+    ) -> None:
+        try:
+            await self._controller.apply_entity_collapse(
+                proposal.finding_id, winner_id=winner_id, member_ids=member_ids
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._show_status(f'Collapse failed: {exc}', error=True)
+            self.mode = 'list'
+            return
+        self._show_status(f'Merged {len(member_ids)} entities into "{winner_name}".')
+        await self._refresh_queue()
+
+    def _dismiss_collapse(self) -> None:
+        proposal = self._collapse_proposal
+        if proposal is None:
+            return
+        self.run_worker(
+            self._dismiss_collapse_async(proposal), exclusive=True, name='dismiss_collapse'
+        )
+
+    async def _dismiss_collapse_async(self, proposal: CockpitProposal) -> None:
+        try:
+            await self._controller.resolve(proposal, DISMISS_OPTION, note=None)
+        except Exception as exc:  # noqa: BLE001
+            self._show_status(f'Dismiss failed: {exc}', error=True)
+            self.mode = 'list'
+            return
+        self._show_status('Dismissed.')
+        await self._refresh_queue()
 
     # ------------------------------------------------------------------
     # LIST mode actions
@@ -1258,6 +1497,10 @@ class ProposalCockpitApp(App):
             if proposal is None:
                 return
             self._batch_targets = []
+            if proposal.rule_name == 'entity_collapse_cluster':
+                # Interactive member selection instead of the dismiss-only menu.
+                self._enter_collapse_mode(proposal)
+                return
             self._show_proposal_preview(proposal)
             self._populate_actions(proposal)
             self.mode = 'review'

--- a/packages/cli/src/memex_cli/cockpit/app.py
+++ b/packages/cli/src/memex_cli/cockpit/app.py
@@ -184,7 +184,7 @@ class _ProposalQueueItem(ListItem):
         flag = '[yellow]⚑[/yellow] ' if self.proposal.is_flagged else ''
         return (
             f'{mark}{flag}[{self._badge}] {self.proposal.rule_name}\n'
-            f'    {self.proposal.target_type} · {self.proposal.target_id[:8]}…'
+            f'    {self.proposal.target_type} · {self.proposal.target_display}'
         )
 
     def toggle(self) -> None:
@@ -409,6 +409,9 @@ class ProposalCockpitApp(App):
         self._viewing_source_note: bool = False
         self._detail_unit_ids: list[str] = []
         self._detail_unit_index: int = 0
+        # Set when the highlighted finding targets a note directly (target_id is
+        # a note id, not a unit id) so DETAIL renders the note, not a unit.
+        self._detail_note_id: str | None = None
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -567,6 +570,8 @@ class ProposalCockpitApp(App):
 
         if proposal.rule_name == 'llm_semantic_contradiction':
             body_lines.extend(self._build_contradiction_body(proposal))
+        elif proposal.rule_name == 'entity_collapse_cluster':
+            body_lines.extend(self._build_entity_collapse_body(proposal))
         else:
             label_suffix = (
                 f'  [white]{proposal.target_label}[/white]' if proposal.target_label else ''
@@ -633,6 +638,53 @@ class ProposalCockpitApp(App):
         right = f'  [dim]{" · ".join(right_parts)}[/dim]' if right_parts else ''
         line2 = f' [dim]vault {vault_label} · {proposal.created_at or "?"}[/dim]{right}'
         return f'{line1}\n{line2}'
+
+    def _build_entity_collapse_body(self, proposal: CockpitProposal) -> list[str]:
+        """Detail body for an entity-collapse proposal.
+
+        Lists EVERY member entity by name and marks the winner, so a reviewer
+        can actually see which entities get merged away — the member names live
+        in ``evidence.member_canonical_names`` (a dict the generic evidence
+        renderer drops).
+        """
+        ev = proposal.raw_evidence if isinstance(proposal.raw_evidence, dict) else {}
+        names = ev.get('member_canonical_names')
+        if not isinstance(names, dict):
+            names = {}
+        members = ev.get('cluster_members')
+        if not isinstance(members, list) or not members:
+            members = list(names.keys())
+        winner_id = str(ev.get('suggested_winner_id') or proposal.target_id)
+        winner_name = names.get(winner_id) or proposal.target_label or winner_id[:8]
+
+        lines: list[str] = []
+        lines.append(
+            f'[bold]MERGE {len(members)} entities[/bold] → winner [green]"{winner_name}"[/green]'
+        )
+        lines.append('')
+        for mid in members:
+            mid = str(mid)
+            nm = names.get(mid) or '[dim](name unavailable)[/dim]'
+            if mid == winner_id:
+                lines.append(
+                    f'  [green]★[/green] [white]{nm}[/white]  [dim]{mid[:8]} · winner[/dim]'
+                )
+            else:
+                lines.append(
+                    f'  [red]→[/red] [white]{nm}[/white]  [dim]{mid[:8]} · merged into winner[/dim]'
+                )
+
+        vaults = ev.get('vaults_affected')
+        if isinstance(vaults, list) and vaults:
+            lines.append('')
+            lines.append(f'[dim]Affects {len(vaults)} vault(s).[/dim]')
+        pmin, pmax = ev.get('pair_min_similarity'), ev.get('pair_max_similarity')
+        try:
+            if pmin is not None and pmax is not None:
+                lines.append(f'[dim]Pairwise similarity {float(pmin):.2f}–{float(pmax):.2f}.[/dim]')
+        except (TypeError, ValueError):
+            pass
+        return lines
 
     def _build_contradiction_body(self, proposal: CockpitProposal) -> list[str]:
         lines: list[str] = []
@@ -962,6 +1014,18 @@ class ProposalCockpitApp(App):
         proposal = self._current_proposal()
         if proposal is None:
             return
+        self._viewing_source_note = False
+        # Note-target findings (e.g. inbox routing) carry a NOTE id in target_id,
+        # not a unit id — render the note directly instead of a unit lookup that
+        # would 404.
+        if proposal.target_type == 'note':
+            self._detail_note_id = proposal.target_id
+            self._detail_unit_ids = []
+            self._detail_unit_index = 0
+            self.mode = 'detail'
+            self._load_note_detail()
+            return
+        self._detail_note_id = None
         # Collect all unit IDs from the finding: target first, then related.
         unit_ids: list[str] = [proposal.target_id]
         for rid in proposal.related_unit_ids:
@@ -971,6 +1035,48 @@ class ProposalCockpitApp(App):
         self._detail_unit_index = 0
         self.mode = 'detail'
         self._load_detail_for_current_unit()
+
+    def _load_note_detail(self) -> None:
+        if not self._detail_note_id:
+            return
+        self.query_one('#detail-header', Static).update(
+            f'[bold]─── NOTE DETAIL: {self._detail_note_id[:8]} ───[/bold]'
+        )
+        self.query_one('#detail-body', Static).update('[dim]loading…[/dim]')
+        self.run_worker(
+            self._load_note_detail_async(self._detail_note_id),
+            name='load_note_detail',
+            exclusive=True,
+        )
+
+    async def _load_note_detail_async(self, note_id: str) -> None:
+        data = await self._controller.fetch_note_detail(note_id)
+        self._render_note_detail_panel(note_id, data)
+
+    def _render_note_detail_panel(
+        self, note_id: str, data: tuple[str | None, str | None] | None
+    ) -> None:
+        self.query_one('#detail-header', Static).update(
+            f'[bold]─── NOTE DETAIL: {note_id[:8]} ───[/bold]'
+        )
+        if data is None:
+            self.query_one('#detail-body', Static).update(
+                f'[red]Could not load note {note_id}[/red]'
+            )
+            return
+        title, text = data
+        lines: list[str] = []
+        lines.append(f'  [bold]TITLE[/bold]    {title or "[dim](untitled)[/dim]"}')
+        lines.append(f'  [bold]NOTE ID[/bold]  {note_id}')
+        lines.append('')
+        lines.append('[dim]' + '─' * 60 + '[/dim]')
+        lines.append('[bold]TEXT[/bold]')
+        lines.append('')
+        lines.append(f'  {text}' if text else '  [dim](no text)[/dim]')
+        lines.append('')
+        lines.append('[dim]' + '─' * 60 + '[/dim]')
+        lines.append('  [bold][Esc][/bold] Back to list')
+        self.query_one('#detail-body', Static).update('\n'.join(lines))
 
     def _handle_detail_key(self, event: Any) -> None:
         key = event.key

--- a/packages/cli/src/memex_cli/cockpit/app.py
+++ b/packages/cli/src/memex_cli/cockpit/app.py
@@ -1186,7 +1186,9 @@ class ProposalCockpitApp(App):
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception('entity-collapse apply failed for finding %s', proposal.finding_id)
-            self._show_status(f'Collapse failed: {exc}', error=True)
+            # Full traceback is logged; keep the status bar terse so it doesn't
+            # leak internal error detail.
+            self._show_status(f'Collapse failed: {str(exc)[:120]}', error=True)
             self.mode = 'list'
             return
         self._show_status(f'Merged {len(member_ids)} entities into "{winner_name}".')
@@ -1205,7 +1207,7 @@ class ProposalCockpitApp(App):
             await self._controller.resolve(proposal, DISMISS_OPTION, note=None)
         except Exception as exc:  # noqa: BLE001
             logger.exception('entity-collapse dismiss failed for finding %s', proposal.finding_id)
-            self._show_status(f'Dismiss failed: {exc}', error=True)
+            self._show_status(f'Dismiss failed: {str(exc)[:120]}', error=True)
             self.mode = 'list'
             return
         self._show_status('Dismissed.')

--- a/packages/cli/src/memex_cli/cockpit/app.py
+++ b/packages/cli/src/memex_cli/cockpit/app.py
@@ -508,8 +508,10 @@ class ProposalCockpitApp(App):
             self._batch_targets = []
             self._detail_unit_ids = []
             self._detail_unit_index = 0
+            self._detail_note_id = None
             self._viewing_source_note = False
             self._collapse_proposal = None
+            self._collapse_winner_id = None
             self.query_one('#queue-list', ListView).focus()
             self._update_footer()
         elif new in ('review', 'batch', 'collapse'):

--- a/packages/cli/src/memex_cli/cockpit/app.py
+++ b/packages/cli/src/memex_cli/cockpit/app.py
@@ -943,6 +943,9 @@ class ProposalCockpitApp(App):
         if event.list_view.id == 'queue-list' and self.mode == 'list':
             self._enter_review_mode()
         elif event.list_view.id == 'action-list' and self.mode == 'collapse':
+            # In collapse mode Enter toggles the highlighted member (same as
+            # Space) — apply is the explicit [a] key, never Enter, so a stray
+            # Enter can't commit a merge.
             self._toggle_collapse_current()
         elif event.list_view.id == 'action-list' and self.mode in ('review', 'batch'):
             self._enter_note_mode()
@@ -1184,11 +1187,11 @@ class ProposalCockpitApp(App):
             await self._controller.apply_entity_collapse(
                 proposal.finding_id, winner_id=winner_id, member_ids=member_ids
             )
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             logger.exception('entity-collapse apply failed for finding %s', proposal.finding_id)
-            # Full traceback is logged; keep the status bar terse so it doesn't
-            # leak internal error detail.
-            self._show_status(f'Collapse failed: {str(exc)[:120]}', error=True)
+            # Generic UI message — the full detail (which may contain internal
+            # error strings) goes to the log, not the status bar.
+            self._show_status('Collapse failed — see logs for details.', error=True)
             self.mode = 'list'
             return
         self._show_status(f'Merged {len(member_ids)} entities into "{winner_name}".')
@@ -1205,9 +1208,9 @@ class ProposalCockpitApp(App):
     async def _dismiss_collapse_async(self, proposal: CockpitProposal) -> None:
         try:
             await self._controller.resolve(proposal, DISMISS_OPTION, note=None)
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             logger.exception('entity-collapse dismiss failed for finding %s', proposal.finding_id)
-            self._show_status(f'Dismiss failed: {str(exc)[:120]}', error=True)
+            self._show_status('Dismiss failed — see logs for details.', error=True)
             self.mode = 'list'
             return
         self._show_status('Dismissed.')

--- a/packages/cli/src/memex_cli/cockpit/app.py
+++ b/packages/cli/src/memex_cli/cockpit/app.py
@@ -10,6 +10,7 @@ DETAIL — drill-down view of a finding's memory units: metadata, lineage, sourc
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from rich.markdown import Markdown as RichMarkdown
@@ -45,6 +46,8 @@ from memex_cli.cockpit.controller import (
     options_for_proposal,
     recommended_resolve_option,
 )
+
+logger = logging.getLogger('memex.cli.cockpit')
 
 
 # Batch sentinel: applies each proposal's OWN recommended action (with its
@@ -231,14 +234,14 @@ class _CollapseMemberItem(ListItem):
     def __init__(
         self,
         member_id: str,
-        name: str,
+        display_name: str,
         *,
         included: bool = True,
         is_winner: bool = False,
         highlighted: bool = False,
     ) -> None:
         self.member_id = member_id
-        self.member_name = name
+        self.member_name = display_name
         self.included = included
         self.is_winner = is_winner
         super().__init__(Label(self._render_label(highlighted)))
@@ -1032,6 +1035,8 @@ class ProposalCockpitApp(App):
             self._show_status('This cluster has no members to review.', error=True)
             self.mode = 'list'
             return
+        # ``or`` fallback is safe here: entity ids are always non-empty UUID
+        # strings, so a present suggested_winner_id is never falsy.
         winner = str(ev.get('suggested_winner_id') or proposal.target_id)
         if winner not in member_ids:
             winner = member_ids[0]
@@ -1180,6 +1185,7 @@ class ProposalCockpitApp(App):
                 proposal.finding_id, winner_id=winner_id, member_ids=member_ids
             )
         except Exception as exc:  # noqa: BLE001
+            logger.exception('entity-collapse apply failed for finding %s', proposal.finding_id)
             self._show_status(f'Collapse failed: {exc}', error=True)
             self.mode = 'list'
             return
@@ -1198,6 +1204,7 @@ class ProposalCockpitApp(App):
         try:
             await self._controller.resolve(proposal, DISMISS_OPTION, note=None)
         except Exception as exc:  # noqa: BLE001
+            logger.exception('entity-collapse dismiss failed for finding %s', proposal.finding_id)
             self._show_status(f'Dismiss failed: {exc}', error=True)
             self.mode = 'list'
             return

--- a/packages/cli/src/memex_cli/cockpit/app.py
+++ b/packages/cli/src/memex_cli/cockpit/app.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Any
 
 from rich.markdown import Markdown as RichMarkdown
+from rich.markup import escape as _esc
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -184,7 +185,7 @@ class _ProposalQueueItem(ListItem):
         flag = '[yellow]⚑[/yellow] ' if self.proposal.is_flagged else ''
         return (
             f'{mark}{flag}[{self._badge}] {self.proposal.rule_name}\n'
-            f'    {self.proposal.target_type} · {self.proposal.target_display}'
+            f'    {self.proposal.target_type} · {_esc(self.proposal.target_display)}'
         )
 
     def toggle(self) -> None:
@@ -245,7 +246,8 @@ class _CollapseMemberItem(ListItem):
     def _render_label(self, highlighted: bool = False) -> str:
         cursor = '[bold]▸[/bold] ' if highlighted else '  '
         box = '[green]✓[/green]' if self.included else '[red]✗[/red]'
-        name = f'[bold]{self.member_name}[/bold]' if highlighted else self.member_name
+        safe_name = _esc(self.member_name)
+        name = f'[bold]{safe_name}[/bold]' if highlighted else safe_name
         if self.is_winner:
             tag = '  [yellow]★ winner[/yellow]'
         elif self.included:
@@ -705,7 +707,7 @@ class ProposalCockpitApp(App):
         if not isinstance(members, list) or not members:
             members = list(names.keys())
         winner_id = str(ev.get('suggested_winner_id') or proposal.target_id)
-        winner_name = names.get(winner_id) or proposal.target_label or winner_id[:8]
+        winner_name = _esc(str(names.get(winner_id) or proposal.target_label or winner_id[:8]))
 
         lines: list[str] = []
         lines.append(
@@ -714,7 +716,7 @@ class ProposalCockpitApp(App):
         lines.append('')
         for mid in members:
             mid = str(mid)
-            nm = names.get(mid) or '[dim](name unavailable)[/dim]'
+            nm = _esc(str(names.get(mid))) if names.get(mid) else '[dim](name unavailable)[/dim]'
             if mid == winner_id:
                 lines.append(
                     f'  [green]★[/green] [white]{nm}[/white]  [dim]{mid[:8]} · winner[/dim]'
@@ -1024,9 +1026,15 @@ class ProposalCockpitApp(App):
         if not isinstance(members, list) or not members:
             members = list(names.keys())
         member_ids = [str(m) for m in members]
+        if not member_ids:
+            # Degenerate finding (no members to review) — don't strand the user
+            # in an empty selection screen.
+            self._show_status('This cluster has no members to review.', error=True)
+            self.mode = 'list'
+            return
         winner = str(ev.get('suggested_winner_id') or proposal.target_id)
         if winner not in member_ids:
-            winner = member_ids[0] if member_ids else ''
+            winner = member_ids[0]
 
         self._collapse_proposal = proposal
         self._collapse_winner_id = winner or None
@@ -1072,7 +1080,7 @@ class ProposalCockpitApp(App):
     def _render_collapse_detail(self) -> None:
         items = self._collapse_items()
         included = [it for it in items if it.included]
-        winner_name = self._collapse_member_name(self._collapse_winner_id)
+        winner_name = _esc(self._collapse_member_name(self._collapse_winner_id))
         lines = [
             '[bold]SELECT ENTITIES TO MERGE[/bold]',
             '',
@@ -1307,13 +1315,15 @@ class ProposalCockpitApp(App):
             return
         title, text = data
         lines: list[str] = []
-        lines.append(f'  [bold]TITLE[/bold]    {title or "[dim](untitled)[/dim]"}')
+        # Escape note content — titles/bodies may contain [..] that Rich would
+        # otherwise parse as markup tags.
+        lines.append(f'  [bold]TITLE[/bold]    {_esc(title) if title else "[dim](untitled)[/dim]"}')
         lines.append(f'  [bold]NOTE ID[/bold]  {note_id}')
         lines.append('')
         lines.append('[dim]' + '─' * 60 + '[/dim]')
         lines.append('[bold]TEXT[/bold]')
         lines.append('')
-        lines.append(f'  {text}' if text else '  [dim](no text)[/dim]')
+        lines.append(f'  {_esc(text)}' if text else '  [dim](no text)[/dim]')
         lines.append('')
         lines.append('[dim]' + '─' * 60 + '[/dim]')
         lines.append('  [bold][Esc][/bold] Back to list')

--- a/packages/cli/src/memex_cli/cockpit/controller.py
+++ b/packages/cli/src/memex_cli/cockpit/controller.py
@@ -988,6 +988,10 @@ class CockpitController:
             note = await self._client.get_note(note_id)
         except Exception:  # noqa: BLE001
             return None
+        # Handle both a model object (attrs) and a raw dict, so a client that
+        # returns either still surfaces the note's title/body.
+        if isinstance(note, dict):
+            return note.get('title'), note.get('original_text')
         return getattr(note, 'title', None), getattr(note, 'original_text', None)
 
 

--- a/packages/cli/src/memex_cli/cockpit/controller.py
+++ b/packages/cli/src/memex_cli/cockpit/controller.py
@@ -649,6 +649,7 @@ class CockpitClient(Protocol):
         action: str | None = None,
         params: dict[str, Any] | None = None,
         note: str | None = None,
+        legacy_params: dict[str, Any] | None = None,
     ) -> dict[str, Any]: ...
 
     async def lint_dismiss(
@@ -735,6 +736,28 @@ class CockpitController:
             action=action_id,
             params=params,
             note=note,
+        )
+
+    async def apply_entity_collapse(
+        self,
+        finding_id: str,
+        *,
+        winner_id: str,
+        member_ids: list[str],
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Apply an entity-cluster collapse with a chosen winner + member subset.
+
+        Uses the server's ``entity_collapse_cluster`` carveout (no canned
+        ``action``; ``winner_id`` / ``member_ids`` are read from the top-level
+        body, so they go through ``legacy_params``). Only ``member_ids`` are
+        merged into ``winner_id`` — deselected members stay separate.
+        """
+        return await self._client.lint_resolve(
+            finding_id,
+            action=None,
+            note=note,
+            legacy_params={'winner_id': winner_id, 'member_ids': member_ids},
         )
 
     async def reverse(self, finding_id: str) -> dict[str, Any]:

--- a/packages/cli/src/memex_cli/cockpit/controller.py
+++ b/packages/cli/src/memex_cli/cockpit/controller.py
@@ -598,7 +598,7 @@ class CockpitProposal:
         snippet, and finally a truncated ``target_id`` — so the reviewer never
         stares at a bare UUID.
         """
-        label: Any = self.target_label
+        label: str | None = self.target_label
         if not label and isinstance(self.raw_evidence, dict):
             names = self.raw_evidence.get('member_canonical_names') or self.raw_evidence.get(
                 'canonical_names'
@@ -611,12 +611,13 @@ class CockpitProposal:
                 shown = ', '.join(str(n) for n in names[:3])
                 label = shown if len(names) <= 3 else f'{shown} +{len(names) - 3} more'
             else:
-                label = self.raw_evidence.get('entity_name')
+                entity_name = self.raw_evidence.get('entity_name')
+                label = str(entity_name) if entity_name else None
         if not label:
             label = self.target_text
         if not label:
             return f'{self.target_id[:8]}…'
-        collapsed = ' '.join(str(label).split())
+        collapsed = ' '.join(label.split())
         return collapsed if len(collapsed) <= 56 else collapsed[:55] + '…'
 
     @property

--- a/packages/cli/src/memex_cli/cockpit/controller.py
+++ b/packages/cli/src/memex_cli/cockpit/controller.py
@@ -590,6 +590,33 @@ class CockpitProposal:
         )
 
     @property
+    def target_display(self) -> str:
+        """Compact human-readable target for queue / detail rows.
+
+        Prefers the server-resolved ``target_label`` (note title / entity /
+        mental-model name), then evidence-embedded names, then a unit-text
+        snippet, and finally a truncated ``target_id`` — so the reviewer never
+        stares at a bare UUID.
+        """
+        label: Any = self.target_label
+        if not label and isinstance(self.raw_evidence, dict):
+            names = self.raw_evidence.get('member_canonical_names') or self.raw_evidence.get(
+                'canonical_names'
+            )
+            if isinstance(names, dict):
+                names = list(names.values())
+            if isinstance(names, list) and names:
+                label = ', '.join(str(n) for n in names)
+            else:
+                label = self.raw_evidence.get('entity_name')
+        if not label:
+            label = self.target_text
+        if not label:
+            return f'{self.target_id[:8]}…'
+        collapsed = ' '.join(str(label).split())
+        return collapsed if len(collapsed) <= 56 else collapsed[:55] + '…'
+
+    @property
     def is_llm_source(self) -> bool:
         return self.source == 'llm'
 
@@ -923,6 +950,19 @@ class CockpitController:
             return getattr(note, 'original_text', None)
         except Exception:  # noqa: BLE001
             return None
+
+    async def fetch_note_detail(self, note_id: str) -> tuple[str | None, str | None] | None:
+        """Fetch ``(title, original_text)`` for a note by ID.
+
+        Used by DETAIL mode when a finding targets a note directly (e.g. inbox
+        routing proposals), where ``target_id`` is a note id, not a unit id.
+        Returns ``None`` on any error so the caller can render a load failure.
+        """
+        try:
+            note = await self._client.get_note(note_id)
+        except Exception:  # noqa: BLE001
+            return None
+        return getattr(note, 'title', None), getattr(note, 'original_text', None)
 
 
 def _count_toc_nodes(toc: list[dict[str, Any]]) -> int:

--- a/packages/cli/src/memex_cli/cockpit/controller.py
+++ b/packages/cli/src/memex_cli/cockpit/controller.py
@@ -606,7 +606,10 @@ class CockpitProposal:
             if isinstance(names, dict):
                 names = list(names.values())
             if isinstance(names, list) and names:
-                label = ', '.join(str(n) for n in names)
+                # Cap to a few names + "+N more" so a many-member cluster reads
+                # as a deliberate summary, not a mid-name truncation.
+                shown = ', '.join(str(n) for n in names[:3])
+                label = shown if len(names) <= 3 else f'{shown} +{len(names) - 3} more'
             else:
                 label = self.raw_evidence.get('entity_name')
         if not label:

--- a/packages/cli/src/memex_cli/entities.py
+++ b/packages/cli/src/memex_cli/entities.py
@@ -458,6 +458,18 @@ async def scan_merges_cmd(
             ),
         ),
     ] = None,
+    entity: Annotated[
+        str | None,
+        typer.Option(
+            '--entity',
+            '-e',
+            help=(
+                'Scan only entities whose name contains this string '
+                '(case-insensitive), ignoring the cooldown — e.g. '
+                '`--entity Marc` to re-scan the Marc cluster on demand.'
+            ),
+        ),
+    ] = None,
 ):
     """Run an on-demand cross-batch entity-cluster collapse scan.
 
@@ -465,6 +477,9 @@ async def scan_merges_cmd(
     NOT applied — review the proposals with ``memex lint findings`` and
     approve via ``memex lint resolve <id> --winner <member>``. The collapse
     affects every vault listed in ``evidence.vaults_affected``.
+
+    Pass ``--entity <name>`` to target a specific cluster (e.g. "Marc") without
+    waiting out the per-entity cooldown.
     """
     config: MemexConfig = ctx.obj
     async with get_api_context(config) as api:
@@ -474,6 +489,7 @@ async def scan_merges_cmd(
                 scan_cooldown_days=scan_cooldown_days,
                 pair_threshold=pair_threshold,
                 cluster_min_threshold=cluster_min_threshold,
+                focus=entity,
             )
         except Exception as e:
             handle_api_error(e)

--- a/packages/cli/tests/test_cockpit_app_smoke.py
+++ b/packages/cli/tests/test_cockpit_app_smoke.py
@@ -12,8 +12,10 @@ from uuid import uuid4
 
 import pytest
 
+from textual.widgets import Static
+
 from memex_cli.cockpit.app import ProposalCockpitApp, _ProposalQueueItem
-from memex_cli.cockpit.controller import CockpitController
+from memex_cli.cockpit.controller import CockpitController, CockpitProposal
 
 
 class _FakeClient:
@@ -274,3 +276,78 @@ async def test_detail_mode_cycles_units_with_tab() -> None:
         await pilot.press('escape')
         await pilot.pause()
         assert app.mode == 'list'
+
+
+def _entity_collapse_finding() -> dict[str, Any]:
+    winner, loser = 'a' * 36, 'b' * 36
+    return {
+        'id': str(uuid4()),
+        'vault_id': None,
+        'rule_name': 'entity_collapse_cluster',
+        'lint_type': 'quality',
+        'target_type': 'entity',
+        'target_id': winner,
+        'target_label': 'Governance team',
+        'source': 'rule',
+        'created_at': '2026-06-03T00:00:00Z',
+        'evidence': {
+            'cluster_members': [winner, loser],
+            'member_canonical_names': {winner: 'Governance team', loser: 'governance team'},
+            'suggested_winner_id': winner,
+            'vaults_affected': ['v1'],
+            'pair_min_similarity': 1.0,
+            'pair_max_similarity': 1.0,
+        },
+        'suggested_action': 'Cluster of near-duplicate entities detected.',
+    }
+
+
+def test_entity_collapse_body_lists_every_member_and_marks_winner() -> None:
+    """A reviewer MUST see which entities merge and which one wins."""
+    app = ProposalCockpitApp(CockpitController(_FakeClient([])), limit=5)
+    proposal = CockpitProposal.from_finding(_entity_collapse_finding())
+    body = '\n'.join(app._build_entity_collapse_body(proposal))
+    assert 'MERGE 2 entities' in body
+    assert 'Governance team' in body  # the winner
+    assert 'governance team' in body  # the member merged away
+    assert 'winner' in body
+    assert 'merged into winner' in body
+
+
+@pytest.mark.asyncio
+async def test_render_note_detail_panel_shows_title_text_and_error() -> None:
+    """Note-target findings render the NOTE (title + body), never a unit 404."""
+    app = ProposalCockpitApp(CockpitController(_FakeClient([])), limit=5)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app._render_note_detail_panel('n0deadbee', ('Quarterly Planning', 'The note body.'))
+        body = str(app.query_one('#detail-body', Static).render())
+        assert 'Quarterly Planning' in body
+        assert 'The note body.' in body
+        assert 'Could not load unit' not in body
+        # Failure path resolves to a note error, not a unit error.
+        app._render_note_detail_panel('n0deadbee', None)
+        assert 'Could not load note' in str(app.query_one('#detail-body', Static).render())
+
+
+@pytest.mark.asyncio
+async def test_note_target_enter_detail_targets_note_not_unit() -> None:
+    """Pressing Detail on a note-target finding records a note id, no unit lookup."""
+    finding = _finding(rule='inbox_vault_no_fit', target_type='note')
+    app = ProposalCockpitApp(CockpitController(_FakeClient([finding])), limit=5)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.press('d')
+        await pilot.pause()
+        assert app.mode == 'detail'
+        assert app._detail_note_id == finding['target_id']
+        assert app._detail_unit_ids == []
+
+
+def test_queue_item_label_shows_human_target_not_uuid() -> None:
+    """The queue row renders the human target_display, not the raw UUID."""
+    proposal = CockpitProposal.from_finding(_entity_collapse_finding())
+    item = _ProposalQueueItem(proposal)
+    label = item._render_label()
+    assert 'Governance team' in label
+    assert proposal.target_id not in label  # no full bare UUID

--- a/packages/cli/tests/test_cockpit_app_smoke.py
+++ b/packages/cli/tests/test_cockpit_app_smoke.py
@@ -34,9 +34,16 @@ class _FakeClient:
         action: str | None = None,
         params: dict[str, Any] | None = None,
         note: str | None = None,
+        legacy_params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         self.resolves.append(
-            {'finding_id': finding_id, 'action': action, 'params': params, 'note': note}
+            {
+                'finding_id': finding_id,
+                'action': action,
+                'params': params,
+                'note': note,
+                'legacy_params': legacy_params,
+            }
         )
         self._findings = [f for f in self._findings if f['id'] != finding_id]
         return {'finding_id': finding_id, 'status': 'resolved'}
@@ -351,3 +358,117 @@ def test_queue_item_label_shows_human_target_not_uuid() -> None:
     label = item._render_label()
     assert 'Governance team' in label
     assert proposal.target_id not in label  # no full bare UUID
+
+
+def _entity_collapse_finding_3() -> dict[str, Any]:
+    w, l1, l2 = 'a' * 36, 'b' * 36, 'c' * 36
+    return {
+        'id': str(uuid4()),
+        'vault_id': None,
+        'rule_name': 'entity_collapse_cluster',
+        'lint_type': 'quality',
+        'target_type': 'entity',
+        'target_id': w,
+        'target_label': 'Governance team',
+        'source': 'rule',
+        'created_at': '2026-06-03T00:00:00Z',
+        'evidence': {
+            'cluster_members': [w, l1, l2],
+            'member_canonical_names': {w: 'Governance team', l1: 'governance team', l2: 'Gov Team'},
+            'suggested_winner_id': w,
+            'vaults_affected': ['v1'],
+        },
+        'suggested_action': 'Cluster of near-duplicate entities detected.',
+    }
+
+
+@pytest.mark.asyncio
+async def test_collapse_mode_select_deselect_and_apply_subset() -> None:
+    """Enter collapse mode on an entity cluster, exclude one member, apply the
+    chosen winner + subset via the carveout."""
+    finding = _entity_collapse_finding_3()
+    client = _FakeClient([finding])
+    app = ProposalCockpitApp(CockpitController(client), limit=5)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        # Enter review → collapse mode (entity_collapse routes here).
+        await pilot.press('enter')
+        await pilot.pause()
+        assert app.mode == 'collapse'
+        items = app._collapse_items()
+        assert len(items) == 3
+        # All included by default; first member is the suggested winner.
+        assert all(it.included for it in items)
+        assert items[0].is_winner
+
+        # Exclude the third member (navigate down twice, toggle).
+        await pilot.press('down')
+        await pilot.press('down')
+        await pilot.pause()
+        await pilot.press('space')
+        await pilot.pause()
+        excluded_id = items[2].member_id
+        assert not items[2].included
+        assert app._collapse_included_ids() == ['a' * 36, 'b' * 36]
+
+        # Apply.
+        await pilot.press('a')
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert client.resolves, 'apply should issue a resolve carveout call'
+    call = client.resolves[0]
+    assert call['action'] is None  # carveout (no canned action)
+    assert call['legacy_params'] == {
+        'winner_id': 'a' * 36,
+        'member_ids': ['a' * 36, 'b' * 36],
+    }
+    assert excluded_id not in call['legacy_params']['member_ids']
+
+
+@pytest.mark.asyncio
+async def test_collapse_mode_set_winner_then_apply() -> None:
+    """'w' reassigns the winner; apply sends the chosen winner."""
+    finding = _entity_collapse_finding_3()
+    client = _FakeClient([finding])
+    app = ProposalCockpitApp(CockpitController(client), limit=5)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.press('enter')
+        await pilot.pause()
+        assert app.mode == 'collapse'
+        # Move to the 2nd member and make it the winner.
+        await pilot.press('down')
+        await pilot.pause()
+        await pilot.press('w')
+        await pilot.pause()
+        assert app._collapse_winner_id == 'b' * 36
+        items = app._collapse_items()
+        assert items[1].is_winner and not items[0].is_winner
+        await pilot.press('a')
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+    assert client.resolves[0]['legacy_params']['winner_id'] == 'b' * 36
+
+
+@pytest.mark.asyncio
+async def test_collapse_apply_rejects_single_member() -> None:
+    """Excluding down to <2 members blocks apply (no resolve call)."""
+    finding = _entity_collapse_finding_3()
+    client = _FakeClient([finding])
+    app = ProposalCockpitApp(CockpitController(client), limit=5)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.press('enter')
+        await pilot.pause()
+        # Exclude both losers (members 2 and 3), leaving only the winner.
+        await pilot.press('down')
+        await pilot.press('space')
+        await pilot.press('down')
+        await pilot.press('space')
+        await pilot.pause()
+        assert app._collapse_included_ids() == ['a' * 36]
+        await pilot.press('a')
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+    assert client.resolves == [], 'apply must be blocked with fewer than 2 members'

--- a/packages/cli/tests/test_cockpit_app_smoke.py
+++ b/packages/cli/tests/test_cockpit_app_smoke.py
@@ -472,3 +472,42 @@ async def test_collapse_apply_rejects_single_member() -> None:
         await app.workers.wait_for_complete()
         await pilot.pause()
     assert client.resolves == [], 'apply must be blocked with fewer than 2 members'
+
+
+@pytest.mark.asyncio
+async def test_note_detail_escapes_rich_markup_in_content() -> None:
+    """Note titles/bodies containing [..] must render literally, not as tags."""
+    app = ProposalCockpitApp(CockpitController(_FakeClient([])), limit=5)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app._render_note_detail_panel(
+            'n0deadbee', ('[ALERT] Q3 plan', 'see [section 2] for detail')
+        )
+        body = str(app.query_one('#detail-body', Static).render())
+        # Bracketed body content survives as visible text — if it were parsed as
+        # markup, "[section 2]" would be eaten as an (invalid) tag and dropped.
+        assert '[section 2]' in body
+        assert 'Q3 plan' in body
+
+
+@pytest.mark.asyncio
+async def test_collapse_mode_empty_cluster_bounces_to_list() -> None:
+    """A finding with no members must not strand the user in an empty selector."""
+    finding: dict[str, Any] = {
+        'id': str(uuid4()),
+        'vault_id': None,
+        'rule_name': 'entity_collapse_cluster',
+        'lint_type': 'quality',
+        'target_type': 'entity',
+        'target_id': 'a' * 36,
+        'source': 'rule',
+        'created_at': '2026-06-03T00:00:00Z',
+        'evidence': {'cluster_members': [], 'member_canonical_names': {}},
+        'suggested_action': 'x',
+    }
+    app = ProposalCockpitApp(CockpitController(_FakeClient([finding])), limit=5)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await pilot.press('enter')
+        await pilot.pause()
+        assert app.mode == 'list'  # bounced back, not stuck in 'collapse'

--- a/packages/cli/tests/test_cockpit_controller.py
+++ b/packages/cli/tests/test_cockpit_controller.py
@@ -88,6 +88,18 @@ async def test_fetch_note_detail_none_on_error():
 
 
 @pytest.mark.asyncio
+async def test_fetch_note_detail_handles_dict_note():
+    """A client returning a dict (not a model) still yields title/text."""
+
+    class _Client:
+        async def get_note(self, note_id: Any) -> Any:
+            return {'title': 'Quarterly Planning', 'original_text': 'Body.'}
+
+    ctrl = CockpitController(_Client())
+    assert await ctrl.fetch_note_detail('n') == ('Quarterly Planning', 'Body.')
+
+
+@pytest.mark.asyncio
 async def test_apply_entity_collapse_uses_carveout_with_member_subset():
     """The collapse apply hits the server carveout (action=None) and sends the
     chosen winner + member subset via top-level (legacy_params) body keys."""

--- a/packages/cli/tests/test_cockpit_controller.py
+++ b/packages/cli/tests/test_cockpit_controller.py
@@ -87,6 +87,34 @@ async def test_fetch_note_detail_none_on_error():
     assert await ctrl.fetch_note_detail('n') is None
 
 
+@pytest.mark.asyncio
+async def test_apply_entity_collapse_uses_carveout_with_member_subset():
+    """The collapse apply hits the server carveout (action=None) and sends the
+    chosen winner + member subset via top-level (legacy_params) body keys."""
+    captured: dict[str, Any] = {}
+
+    class _Client:
+        async def lint_resolve(
+            self,
+            finding_id: str,
+            *,
+            action: Any = None,
+            params: Any = None,
+            note: Any = None,
+            legacy_params: Any = None,
+        ) -> dict[str, Any]:
+            captured.update(
+                finding_id=finding_id, action=action, params=params, legacy_params=legacy_params
+            )
+            return {'status': 'resolved'}
+
+    ctrl = CockpitController(_Client())
+    await ctrl.apply_entity_collapse('f1', winner_id='w', member_ids=['w', 'l1'])
+    assert captured['action'] is None  # carveout, not a canned action
+    assert captured['params'] is None
+    assert captured['legacy_params'] == {'winner_id': 'w', 'member_ids': ['w', 'l1']}
+
+
 def test_recommended_resolve_option_inbox_route_carries_vault_param():
     """An inbox route's recommended option must carry its target_vault_id.
 

--- a/packages/cli/tests/test_cockpit_controller.py
+++ b/packages/cli/tests/test_cockpit_controller.py
@@ -23,6 +23,70 @@ from memex_cli.cockpit.controller import (
 )
 
 
+def test_target_display_prefers_label_then_evidence_then_text_then_id():
+    """Queue/detail rows must show a human label, never a bare UUID."""
+    base = {'id': '1', 'rule_name': 'r', 'lint_type': 'quality'}
+    # 1) Server-resolved label (note title / entity / mm name) wins.
+    p = CockpitProposal.from_finding(
+        {
+            **base,
+            'target_type': 'note',
+            'target_id': 'a' * 36,
+            'target_label': 'AlphaEvolve article',
+        }
+    )
+    assert p.target_display == 'AlphaEvolve article'
+    # 2) Entity-collapse member names from evidence when no server label.
+    p2 = CockpitProposal.from_finding(
+        {
+            **base,
+            'target_type': 'entity',
+            'target_id': 'b' * 36,
+            'evidence': {'member_canonical_names': {'b' * 36: 'Marc', 'c' * 36: 'Marc Haas'}},
+        }
+    )
+    assert 'Marc' in p2.target_display and 'Marc Haas' in p2.target_display
+    # 3) Unit text snippet when that's all there is.
+    p3 = CockpitProposal.from_finding(
+        {
+            **base,
+            'target_type': 'memory_unit',
+            'target_id': 'd' * 36,
+            'target_text': 'the fact body',
+        }
+    )
+    assert p3.target_display == 'the fact body'
+    # 4) Last resort: truncated id (never the full bare UUID).
+    p4 = CockpitProposal.from_finding(
+        {**base, 'target_type': 'memory_unit', 'target_id': 'abcdef1234567890'}
+    )
+    assert p4.target_display == 'abcdef12…'
+
+
+@pytest.mark.asyncio
+async def test_fetch_note_detail_returns_title_and_text():
+    class _Note:
+        title = 'Quarterly Planning'
+        original_text = 'Body of the note.'
+
+    class _Client:
+        async def get_note(self, note_id: Any) -> Any:
+            return _Note()
+
+    ctrl = CockpitController(_Client())
+    assert await ctrl.fetch_note_detail('n') == ('Quarterly Planning', 'Body of the note.')
+
+
+@pytest.mark.asyncio
+async def test_fetch_note_detail_none_on_error():
+    class _Client:
+        async def get_note(self, note_id: Any) -> Any:
+            raise RuntimeError('boom')
+
+    ctrl = CockpitController(_Client())
+    assert await ctrl.fetch_note_detail('n') is None
+
+
 def test_recommended_resolve_option_inbox_route_carries_vault_param():
     """An inbox route's recommended option must carry its target_vault_id.
 

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -695,12 +695,17 @@ class RemoteMemexAPI:
         scan_cooldown_days: int | None = None,
         pair_threshold: float | None = None,
         cluster_min_threshold: float | None = None,
+        focus: str | None = None,
     ) -> dict[str, Any]:
         """Run a one-shot cross-batch entity-cluster collapse scan.
 
         Emits one MaintenanceProposal per surviving cluster (cohesion-guarded);
         on rescan, existing pending findings are UPDATEd in place. Does NOT
         apply the collapse — operators approve via ``memex lint resolve``.
+
+        ``focus`` restricts the scan to entities whose canonical_name contains
+        the given string (case-insensitive) and ignores the cooldown — e.g.
+        ``focus="Marc"`` re-scans the Marc cluster on demand.
         """
         params: dict[str, Any] = {}
         if top_n is not None:
@@ -711,6 +716,8 @@ class RemoteMemexAPI:
             params['pair_threshold'] = pair_threshold
         if cluster_min_threshold is not None:
             params['cluster_min_threshold'] = cluster_min_threshold
+        if focus is not None:
+            params['focus'] = focus
         response = await self.client.post('entities/scan-merges', params=params or None, json={})
         return await self._handle_response(response)
 

--- a/packages/common/tests/test_client_lint_resolve_legacy_params.py
+++ b/packages/common/tests/test_client_lint_resolve_legacy_params.py
@@ -1,0 +1,44 @@
+"""The HTTP client must serialize ``legacy_params`` as TOP-LEVEL body keys.
+
+The cockpit's entity-collapse apply sends ``winner_id`` / ``member_ids`` via
+``legacy_params`` so the server carveout (which reads them from the top-level
+payload) honours the chosen subset. If they were nested under ``params`` — or
+dropped — the server would silently merge the entire cluster. This pins the
+wire format.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from memex_common.client import RemoteMemexAPI
+
+
+@pytest.mark.asyncio
+async def test_lint_resolve_puts_legacy_params_at_body_top_level():
+    api = RemoteMemexAPI.__new__(RemoteMemexAPI)  # bypass HTTP/__init__
+    captured: dict[str, Any] = {}
+
+    async def _fake_post(path: str, data: Any, params: Any = None) -> Any:
+        captured['path'] = path
+        captured['body'] = data
+        return {'status': 'resolved'}
+
+    api._post = _fake_post  # type: ignore[method-assign]
+
+    await api.lint_resolve(
+        'finding-1',
+        action=None,
+        legacy_params={'winner_id': 'w', 'member_ids': ['w', 'l1']},
+    )
+
+    body = captured['body']
+    assert captured['path'] == 'lint/findings/finding-1/resolve'
+    # No canned action → server carveout fires; winner/members are top-level.
+    assert 'action' not in body
+    assert body['winner_id'] == 'w'
+    assert body['member_ids'] == ['w', 'l1']
+    # And NOT nested under a 'params' slot.
+    assert 'params' not in body or 'winner_id' not in (body.get('params') or {})

--- a/packages/core/src/memex_core/server/entities.py
+++ b/packages/core/src/memex_core/server/entities.py
@@ -306,6 +306,7 @@ async def scan_entity_merges(
     scan_cooldown_days: Annotated[int | None, Query(ge=0)] = None,
     pair_threshold: Annotated[float | None, Query(ge=0.0, le=1.0)] = None,
     cluster_min_threshold: Annotated[float | None, Query(ge=0.0, le=1.0)] = None,
+    focus: Annotated[str | None, Query(max_length=200)] = None,
 ):
     """Run a one-shot cross-batch entity-cluster collapse scan.
 
@@ -330,6 +331,7 @@ async def scan_entity_merges(
             scan_cooldown_days=scan_cooldown_days,
             pair_threshold=pair_threshold,
             cluster_min_threshold=cluster_min_threshold,
+            focus=focus,
         )
         return summary
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -610,9 +610,30 @@ async def _resolve_entity_collapse_cluster(
             ),
         )
 
-    losers = [m for m in cluster_members if m != winner_id]
+    # Optional member subset: collapse ONLY the selected members, leaving the
+    # rest as separate entities. Lets a reviewer deselect a member that should
+    # not merge. Defaults to the full cluster when absent.
+    member_subset = params.get('member_ids')
+    if member_subset:
+        selected = [str(m) for m in member_subset]
+        unknown = [m for m in selected if m not in cluster_members]
+        if unknown:
+            raise HTTPException(
+                status_code=400,
+                detail=f'member_ids contains entities outside the cluster: {unknown}',
+            )
+        if winner_id not in selected:
+            raise HTTPException(
+                status_code=400, detail='winner must be among the selected member_ids'
+            )
+        losers = [m for m in selected if m != winner_id]
+    else:
+        losers = [m for m in cluster_members if m != winner_id]
     if not losers:
-        raise HTTPException(status_code=400, detail='cluster has no losers to collapse')
+        raise HTTPException(
+            status_code=400,
+            detail='select at least two members (a winner and one entity to merge into it)',
+        )
 
     actor_id = getattr(auth, 'api_key_id', None) if auth else None
     try:

--- a/packages/core/src/memex_core/server/lint.py
+++ b/packages/core/src/memex_core/server/lint.py
@@ -630,10 +630,14 @@ async def _resolve_entity_collapse_cluster(
     else:
         losers = [m for m in cluster_members if m != winner_id]
     if not losers:
-        raise HTTPException(
-            status_code=400,
-            detail='select at least two members (a winner and one entity to merge into it)',
+        # Message reflects the path: a user-chosen subset vs the whole
+        # (degenerate ≤1-member) cluster.
+        detail = (
+            'select at least two members (a winner and one entity to merge into it)'
+            if member_subset
+            else 'cluster has no members to collapse'
         )
+        raise HTTPException(status_code=400, detail=detail)
 
     actor_id = getattr(auth, 'api_key_id', None) if auth else None
     try:

--- a/packages/core/src/memex_core/services/entity_maintenance.py
+++ b/packages/core/src/memex_core/services/entity_maintenance.py
@@ -60,6 +60,16 @@ _SUGGESTED_ACTION = (
 )
 
 
+def _like_escape(value: str) -> str:
+    """Escape LIKE/ILIKE metacharacters so a focus string matches literally.
+
+    Without this, ``%`` and ``_`` in an operator-supplied ``--entity`` value
+    act as wildcards (e.g. ``ma_c`` would match ``marc``). The backslash must
+    be escaped first since it is the default LIKE escape character.
+    """
+    return value.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+
+
 def _composition_hash(member_ids: list[str]) -> str:
     """Order-independent fingerprint of a cluster's membership."""
     canonical = sorted(str(m) for m in member_ids)
@@ -211,7 +221,10 @@ async def scan_collapse_clusters(
                     ORDER BY mention_count DESC, first_seen ASC
                     LIMIT :limit
                 """
-                cand_params: dict[str, Any] = {'focus_pattern': f'%{focus}%', 'limit': top_n}
+                cand_params: dict[str, Any] = {
+                    'focus_pattern': f'%{_like_escape(focus)}%',
+                    'limit': top_n,
+                }
             else:
                 cand_sql = """
                     SELECT id::text AS id, canonical_name, phonetic_code,

--- a/packages/core/src/memex_core/services/entity_maintenance.py
+++ b/packages/core/src/memex_core/services/entity_maintenance.py
@@ -217,7 +217,7 @@ async def scan_collapse_clusters(
                     SELECT id::text AS id, canonical_name, phonetic_code,
                            mention_count, first_seen, last_merge_scan_at
                     FROM entities
-                    WHERE canonical_name ILIKE :focus_pattern
+                    WHERE canonical_name ILIKE :focus_pattern ESCAPE '\\'
                     ORDER BY mention_count DESC, first_seen ASC
                     LIMIT :limit
                 """

--- a/packages/core/src/memex_core/services/entity_maintenance.py
+++ b/packages/core/src/memex_core/services/entity_maintenance.py
@@ -126,6 +126,7 @@ async def scan_collapse_clusters(
     scan_cooldown_days: int | None = None,
     pair_threshold: float | None = None,
     cluster_min_threshold: float | None = None,
+    focus: str | None = None,
 ) -> dict[str, Any]:
     """Scan top-N active entities, cluster duplicates, emit cluster proposals.
 
@@ -196,30 +197,34 @@ async def scan_collapse_clusters(
                 logger.info('entity_collapse_scan: concurrent scan in progress, skipping')
                 return summary
 
-            cand_rows = (
-                (
-                    await session.execute(
-                        text(
-                            """
-                        SELECT id::text AS id,
-                               canonical_name,
-                               phonetic_code,
-                               mention_count,
-                               first_seen,
-                               last_merge_scan_at
-                        FROM entities
-                        WHERE last_merge_scan_at IS NULL
-                           OR last_merge_scan_at < :cutoff
-                        ORDER BY mention_count DESC, first_seen ASC
-                        LIMIT :limit
-                        """
-                        ),
-                        {'cutoff': cutoff, 'limit': top_n},
-                    )
-                )
-                .mappings()
-                .all()
-            )
+            # Targeted scan: when ``focus`` is given (e.g. "Marc"), select every
+            # entity whose canonical_name contains it — case-insensitive — and
+            # ignore the per-entity cooldown, so an operator can re-scan a known
+            # cluster on demand without waiting out the cooldown window. Without
+            # focus, scan the most-active entities subject to the cooldown.
+            if focus:
+                cand_sql = """
+                    SELECT id::text AS id, canonical_name, phonetic_code,
+                           mention_count, first_seen, last_merge_scan_at
+                    FROM entities
+                    WHERE canonical_name ILIKE :focus_pattern
+                    ORDER BY mention_count DESC, first_seen ASC
+                    LIMIT :limit
+                """
+                cand_params: dict[str, Any] = {'focus_pattern': f'%{focus}%', 'limit': top_n}
+            else:
+                cand_sql = """
+                    SELECT id::text AS id, canonical_name, phonetic_code,
+                           mention_count, first_seen, last_merge_scan_at
+                    FROM entities
+                    WHERE last_merge_scan_at IS NULL
+                       OR last_merge_scan_at < :cutoff
+                    ORDER BY mention_count DESC, first_seen ASC
+                    LIMIT :limit
+                """
+                cand_params = {'cutoff': cutoff, 'limit': top_n}
+
+            cand_rows = (await session.execute(text(cand_sql), cand_params)).mappings().all()
 
             candidates: list[dict[str, Any]] = [dict(r) for r in cand_rows]
             summary['scanned'] = len(candidates)

--- a/packages/core/src/memex_core/services/lint.py
+++ b/packages/core/src/memex_core/services/lint.py
@@ -89,6 +89,9 @@ TARGET_ENRICHMENT_SQL = (
     'COALESCE('
     '(SELECT n.title FROM memory_units mu LEFT JOIN notes n ON n.id = mu.note_id '
     "WHERE mp.target_type IN ('memory_unit', 'unit_entity') AND mu.id::text = mp.target_id), "
+    # Note targets (e.g. inbox routing proposals) carry the note id directly.
+    '(SELECT n.title FROM notes n '
+    "WHERE mp.target_type = 'note' AND n.id::text = mp.target_id), "
     '(SELECT mm.name FROM mental_models mm '
     "WHERE mp.target_type = 'mental_model' AND mm.id::text = mp.target_id), "
     '(SELECT e.canonical_name FROM entities e '

--- a/packages/core/tests/integration/services/test_int_f8_lint_query.py
+++ b/packages/core/tests/integration/services/test_int_f8_lint_query.py
@@ -179,6 +179,10 @@ async def test_findings_endpoint_resolves_target_label_per_type(session: AsyncSe
     ent_fid = await _seed_finding(
         session, vault_id=vault_id, target_type='entity', target_id=str(entity.id)
     )
+    # Note-target finding (e.g. inbox routing): target_id is the NOTE id.
+    note_fid = await _seed_finding(
+        session, vault_id=vault_id, target_type='note', target_id=str(note.id)
+    )
 
     # Pass every param explicitly: FastAPI Query(...) defaults are sentinel
     # objects, not real values, when the route function is called directly.
@@ -199,6 +203,7 @@ async def test_findings_endpoint_resolves_target_label_per_type(session: AsyncSe
     assert by_id[str(unit_fid)]['target_text'] == 'The release captain signs off on staging.'
     assert by_id[str(mm_fid)]['target_label'] == 'Marc de Haas'
     assert by_id[str(ent_fid)]['target_label'] == 'Marc de Haas'
+    assert by_id[str(note_fid)]['target_label'] == 'Quarterly Planning'
 
     # Same enrichment must flow through the service DTO path (the MCP
     # `memex_get_lint_flags` agent surface), not just the HTTP endpoint.
@@ -208,6 +213,7 @@ async def test_findings_endpoint_resolves_target_label_per_type(session: AsyncSe
     assert dto_by_id[unit_fid].target_text == 'The release captain signs off on staging.'
     assert dto_by_id[mm_fid].target_label == 'Marc de Haas'
     assert dto_by_id[ent_fid].target_label == 'Marc de Haas'
+    assert dto_by_id[note_fid].target_label == 'Quarterly Planning'
 
 
 @pytest.mark.asyncio

--- a/packages/core/tests/integration/test_entity_collapse_maintenance.py
+++ b/packages/core/tests/integration/test_entity_collapse_maintenance.py
@@ -561,6 +561,71 @@ async def test_scan_emits_cluster_of_three(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_focus_scan_targets_named_cluster_ignoring_cooldown(
+    session: AsyncSession,
+    metastore,
+):
+    """``focus`` (CLI ``--entity Marc``) re-scans the named cluster even when the
+    entities were recently scanned — the cooldown that would otherwise exclude
+    them is bypassed for a targeted scan."""
+    from datetime import timedelta
+
+    from memex_common.config import EntityMaintenanceConfig, MemexConfig
+    from memex_core.services.entity_maintenance import scan_collapse_clusters
+
+    suffix = uuid4().hex[:8]
+    a = await _make_entity(
+        session,
+        f'Marc de haas {suffix}',
+        mention_count=13,
+        first_seen=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    b = await _make_entity(
+        session,
+        f'Marc de Haas {suffix}',
+        mention_count=3,
+        first_seen=datetime(2026, 2, 1, tzinfo=timezone.utc),
+    )
+    # Stamp both as scanned 1 day ago — inside the default 7-day cooldown.
+    async with metastore.session() as s:
+        await s.execute(
+            text(
+                'UPDATE entities SET last_merge_scan_at = :ts WHERE id = ANY(CAST(:ids AS uuid[]))'
+            ),
+            {'ts': datetime.now(timezone.utc) - timedelta(days=1), 'ids': [str(a.id), str(b.id)]},
+        )
+        await s.commit()
+
+    config = MemexConfig()
+    config.server.memory.entity_maintenance = EntityMaintenanceConfig(scan_enabled=True)
+    api_stub = MagicMock()
+    api_stub.metastore = metastore
+    api_stub.config = config
+
+    async def _cluster_has(eid: str) -> bool:
+        async with metastore.session() as s:
+            rows = (
+                await s.execute(
+                    text(
+                        'SELECT evidence FROM maintenance_proposals '
+                        "WHERE rule_name = 'entity_collapse_cluster' AND status = 'pending'"
+                    )
+                )
+            ).all()
+        return any(eid in (r[0].get('cluster_members') or []) for r in rows)
+
+    # Plain scan: the cooldown excludes the recently-stamped Marcs.
+    await scan_collapse_clusters(api_stub)
+    assert not await _cluster_has(str(a.id)), 'cooldown should exclude the stamped Marc cluster'
+
+    # Focused scan: bypasses cooldown, targets the cluster by name → emits.
+    focused = await scan_collapse_clusters(api_stub, focus=suffix)
+    assert focused['clusters_emitted'] >= 1
+    assert await _cluster_has(str(a.id)) and await _cluster_has(str(b.id))
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_scan_emits_with_default_thresholds(
     session: AsyncSession,
     metastore,

--- a/packages/core/tests/unit/services/test_entity_maintenance.py
+++ b/packages/core/tests/unit/services/test_entity_maintenance.py
@@ -20,10 +20,20 @@ from unittest.mock import MagicMock
 from memex_core.services.entity_maintenance import (
     _composition_hash,
     _connected_components,
+    _like_escape,
     _min_pairwise_similarity,
     _suggested_winner,
     scan_collapse_clusters,
 )
+
+
+def test_like_escape_neutralizes_wildcards():
+    """``--entity`` focus metacharacters must match literally, not as wildcards."""
+    assert _like_escape('ma_c') == 'ma\\_c'
+    assert _like_escape('50%') == '50\\%'
+    # Backslash escaped first so it can't swallow a following metachar.
+    assert _like_escape('a\\b') == 'a\\\\b'
+    assert _like_escape('Marc') == 'Marc'  # plain text untouched
 
 
 def test_connected_components_groups_three_pairs_into_one_cluster():

--- a/packages/core/tests/unit/test_resolve_entity_collapse_subset.py
+++ b/packages/core/tests/unit/test_resolve_entity_collapse_subset.py
@@ -55,6 +55,31 @@ async def test_subset_merges_only_selected_members():
 
 
 @pytest.mark.asyncio
+async def test_resolve_endpoint_routes_top_level_member_ids_to_subset():
+    """Full route path: the cockpit sends winner_id/member_ids as TOP-LEVEL body
+    keys (via the client's legacy_params); the ``lint_resolve`` endpoint passes
+    the whole body as ``params`` to the carveout, so the subset reaches
+    collapse_cluster. Closes the client→route→function glue gap.
+    """
+    w, l1, l2 = str(uuid4()), str(uuid4()), str(uuid4())
+    finding = _finding([w, l1, l2], w)
+    api = _api()
+    with (
+        patch.object(lint_mod, '_load_finding_or_404', AsyncMock(return_value=finding)),
+        patch.object(lint_mod, 'check_vault_access', AsyncMock(return_value=None)),
+    ):
+        result = await lint_mod.lint_resolve(
+            finding_id=UUID(finding['id']),
+            api=api,
+            auth=None,
+            # Mirrors the on-the-wire body: no 'action', top-level winner/members.
+            payload={'winner_id': w, 'member_ids': [w, l1]},
+        )
+    assert result['status'] == 'resolved'
+    assert api.entities.collapse_cluster.await_args.kwargs['loser_ids'] == [UUID(l1)]
+
+
+@pytest.mark.asyncio
 async def test_no_subset_merges_whole_cluster():
     w, l1, l2 = str(uuid4()), str(uuid4()), str(uuid4())
     api = _api()

--- a/packages/core/tests/unit/test_resolve_entity_collapse_subset.py
+++ b/packages/core/tests/unit/test_resolve_entity_collapse_subset.py
@@ -121,3 +121,20 @@ async def test_subset_excluding_winner_rejected():
             )
     assert exc.value.status_code == 400
     api.entities.collapse_cluster.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_subset_single_member_cluster_message():
+    """No-subset path on a degenerate ≤1-member cluster reports the cluster has
+    no members — not the subset-selection message."""
+    w = str(uuid4())
+    api = _api()
+    with patch.object(lint_mod, 'check_vault_access', AsyncMock(return_value=None)):
+        with pytest.raises(HTTPException) as exc:
+            await lint_mod._resolve_entity_collapse_cluster(
+                finding=_finding([w], w), api=api, auth=None, params={'winner_id': w}
+            )
+    assert exc.value.status_code == 400
+    assert 'no members' in exc.value.detail
+    assert 'select at least two' not in exc.value.detail
+    api.entities.collapse_cluster.assert_not_called()

--- a/packages/core/tests/unit/test_resolve_entity_collapse_subset.py
+++ b/packages/core/tests/unit/test_resolve_entity_collapse_subset.py
@@ -1,0 +1,98 @@
+"""Unit tests for the entity-collapse resolve carveout's member-subset support.
+
+The cockpit lets a reviewer deselect cluster members; the server must merge
+ONLY the selected members into the winner and leave the rest as separate
+entities. These tests mock the DB collapse so they assert the loser-set
+computation + validation deterministically.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from memex_core.server import lint as lint_mod
+
+
+def _finding(members: list[str], winner: str) -> dict:
+    return {
+        'id': str(uuid4()),
+        'rule_name': 'entity_collapse_cluster',
+        'target_id': winner,
+        'evidence': {
+            'cluster_members': members,
+            'suggested_winner_id': winner,
+            'vaults_affected': [str(uuid4())],
+        },
+    }
+
+
+def _api() -> MagicMock:
+    api = MagicMock()
+    api.entities.collapse_cluster = AsyncMock(return_value={'cluster_size': 2})
+    api.lint.set_status = AsyncMock(return_value=True)
+    return api
+
+
+@pytest.mark.asyncio
+async def test_subset_merges_only_selected_members():
+    w, l1, l2 = str(uuid4()), str(uuid4()), str(uuid4())
+    api = _api()
+    with patch.object(lint_mod, 'check_vault_access', AsyncMock(return_value=None)):
+        result = await lint_mod._resolve_entity_collapse_cluster(
+            finding=_finding([w, l1, l2], w),
+            api=api,
+            auth=None,
+            params={'winner_id': w, 'member_ids': [w, l1]},
+        )
+    kwargs = api.entities.collapse_cluster.await_args.kwargs
+    assert kwargs['winner_id'] == UUID(w)
+    assert kwargs['loser_ids'] == [UUID(l1)]  # l2 was deselected → left separate
+    assert result['status'] == 'resolved'
+
+
+@pytest.mark.asyncio
+async def test_no_subset_merges_whole_cluster():
+    w, l1, l2 = str(uuid4()), str(uuid4()), str(uuid4())
+    api = _api()
+    with patch.object(lint_mod, 'check_vault_access', AsyncMock(return_value=None)):
+        await lint_mod._resolve_entity_collapse_cluster(
+            finding=_finding([w, l1, l2], w), api=api, auth=None, params={'winner_id': w}
+        )
+    assert api.entities.collapse_cluster.await_args.kwargs['loser_ids'] == [UUID(l1), UUID(l2)]
+
+
+@pytest.mark.asyncio
+async def test_subset_with_non_cluster_member_rejected():
+    w, l1 = str(uuid4()), str(uuid4())
+    stranger = str(uuid4())
+    api = _api()
+    with patch.object(lint_mod, 'check_vault_access', AsyncMock(return_value=None)):
+        with pytest.raises(HTTPException) as exc:
+            await lint_mod._resolve_entity_collapse_cluster(
+                finding=_finding([w, l1], w),
+                api=api,
+                auth=None,
+                params={'winner_id': w, 'member_ids': [w, stranger]},
+            )
+    assert exc.value.status_code == 400
+    api.entities.collapse_cluster.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subset_excluding_winner_rejected():
+    w, l1 = str(uuid4()), str(uuid4())
+    api = _api()
+    with patch.object(lint_mod, 'check_vault_access', AsyncMock(return_value=None)):
+        with pytest.raises(HTTPException) as exc:
+            await lint_mod._resolve_entity_collapse_cluster(
+                finding=_finding([w, l1], w),
+                api=api,
+                auth=None,
+                params={'winner_id': w, 'member_ids': [l1]},
+            )
+    assert exc.value.status_code == 400
+    api.entities.collapse_cluster.assert_not_called()


### PR DESCRIPTION
## Why

Follow-up to #207 / rc21: the maintenance cockpit was still unusable for real review.

## Fixes (all tested)

**Cockpit reviewability** (`feat(cli)`)
- **Queue rows** rendered opaque `target_type · <uuid8>`. Now show a human label (note title / entity / mental-model name / unit snippet) via `CockpitProposal.target_display`.
- **entity_collapse_cluster** detail showed only the winner — you couldn't tell *which entities merge*. It now lists **every member by name and marks the winner** (member names live in `evidence.member_canonical_names`, a dict the generic renderer dropped).
- **Note-target findings** (inbox routing) 404'd with "Could not load unit" because DETAIL assumed `target_id` was a unit id. It now loads the **note** (title + body). `TARGET_ENRICHMENT_SQL` also resolves `target_label` for `target_type='note'`.

**Targeted entity scan** (`feat(entity)`)
- `memex entity scan-merges --entity Marc` (HTTP `?focus=`) scans only entities whose name contains the string, **ignoring the cooldown** — so a known cluster can be re-scanned on demand. (The 7-day cooldown was why repeated `scan-merges` runs reported `emitted=0`: once scanned, entities are excluded from the candidate set.)

## Tests

New assertions on **rendered content**, not just state:
- queue label shows the human target, never a bare UUID
- entity-collapse body lists all members + winner marker
- note detail renders title/body (+ "Could not load note" error path), never a unit lookup
- per-type `target_label` (incl. `note`) via both the HTTP endpoint and the `get_findings` DTO
- focused scan bypasses cooldown and emits while a plain scan excludes the stamped cluster

Full CLI suite: 417 passed. Touched integration suites green. ruff + mypy clean.

## Not in this PR

Interactive **select/deselect of which entities collapse** from the cockpit is a separate feature (the server `collapse_cluster` already accepts an arbitrary loser subset; it needs a resolve param for the chosen subset + an interactive multi-select UI). Scoped as the next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)