### PR TITLE
fix(core): close BadHost (CVE-2026-48710) audit-evasion follow-ups

### DIFF
--- a/packages/core/src/memex_core/server/__init__.py
+++ b/packages/core/src/memex_core/server/__init__.py
@@ -272,7 +272,13 @@ async def audit_access_log(request: Request, call_next):
     """Layer 1: HTTP access log for every non-skipped request."""
     t0 = time.monotonic()
     response = await call_next(request)
-    if request.url.path not in _AUDIT_SKIP_PATHS:
+    # CVE-2026-48710 (BadHost): use the ASGI scope path, not request.url.path.
+    # request.url.path is reconstructed from the client-supplied Host header on
+    # Starlette < 1.0.1 and can be spoofed to collapse onto an _AUDIT_SKIP_PATHS
+    # entry, suppressing the access-log line for the attacker's real request.
+    # scope['path'] is the path the router dispatched on and is unspoofable.
+    request_path = request.scope['path']
+    if request_path not in _AUDIT_SKIP_PATHS:
         latency_ms = round((time.monotonic() - t0) * 1000, 1)
         audit: AuditService | None = getattr(request.app.state, 'audit_service', None)
         if audit:
@@ -282,7 +288,7 @@ async def audit_access_log(request: Request, call_next):
                 session_id=get_session_id(),
                 details={
                     'method': request.method,
-                    'path': request.url.path,
+                    'path': request_path,
                     'status': response.status_code,
                     'latency_ms': latency_ms,
                 },

--- a/packages/core/src/memex_core/server/ingestion.py
+++ b/packages/core/src/memex_core/server/ingestion.py
@@ -108,7 +108,9 @@ def _overlap_to_409(e: OverlapError, request: Request | None = None) -> JSONResp
             resource_id=str(e.existing_id),
             existing_status=e.status,
             overlapping_keys_count=len(e.overlapping_keys),
-            path=request.url.path,
+            # CVE-2026-48710 (BadHost): scope['path'] is unspoofable; request.url.path
+            # is reconstructed from the Host header on Starlette < 1.0.1.
+            path=request.scope['path'],
         )
     return JSONResponse(
         status_code=409,

--- a/packages/core/tests/integration/test_int_audit_middleware.py
+++ b/packages/core/tests/integration/test_int_audit_middleware.py
@@ -189,3 +189,40 @@ class TestAccessLogMiddlewareIntegration:
         entry = entries[0]
         assert entry['session_id'] == custom_session
         assert entry['actor'] == f'{KEY_DESCRIPTION} ({KEY_PREFIX})'
+
+
+@pytest.mark.integration
+class TestBadHostAccessLogCVE202648710:
+    """CVE-2026-48710 (BadHost): the access-log skip decision must use scope['path'].
+
+    Starlette < 1.0.1 reconstructs ``request.url`` from the client-supplied Host
+    header. A spoofed Host can make ``request.url.path`` collapse onto an entry in
+    ``_AUDIT_SKIP_PATHS``, suppressing the ``http.request`` access-log line for the
+    attacker's real (protected) request. The fix keys the skip decision on
+    ``request.scope['path']``, which is unspoofable.
+    """
+
+    def test_spoofed_skip_path_does_not_suppress_access_log(
+        self, audit_client: TestClient, postgres_uri: str, monkeypatch
+    ) -> None:
+        from starlette.datastructures import URL
+        from starlette.requests import Request as StarletteRequest
+
+        # Simulate the BadHost reconstruction: request.url.path collapses onto an
+        # _AUDIT_SKIP_PATHS entry while scope['path'] stays the real dispatched path.
+        monkeypatch.setattr(
+            StarletteRequest,
+            'url',
+            property(lambda self: URL('http://attacker.example/api/v1/health')),
+        )
+
+        resp = audit_client.get('/api/v1/vaults', headers={'X-API-Key': VALID_KEY})
+        assert resp.status_code == 200
+
+        entries = _query_audit_logs(postgres_uri, action='http.request')
+        paths = [e['details']['path'] for e in entries]
+        assert '/api/v1/vaults' in paths, (
+            'CVE-2026-48710 regression: the access-log skip decision trusted the '
+            "spoofed request.url.path (/api/v1/health) instead of scope['path'], so the "
+            'protected request was omitted from the audit access log.'
+        )

--- a/packages/core/tests/unit/test_server_auth.py
+++ b/packages/core/tests/unit/test_server_auth.py
@@ -5,7 +5,7 @@ import pathlib as plb
 
 import pytest
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
@@ -26,6 +26,7 @@ sys.modules['_auth'] = _auth_mod
 _spec.loader.exec_module(_auth_mod)
 setup_auth = _auth_mod.setup_auth
 auth_middleware = _auth_mod.auth_middleware
+require_admin_auth = _auth_mod.require_admin_auth
 _validate_key = _auth_mod._validate_key
 _resolve_key = _auth_mod._resolve_key
 AuthContext = _auth_mod.AuthContext
@@ -427,6 +428,54 @@ class TestBadHostCVE202648710:
         client = TestClient(app)
         response = client.get('/api/v1/notes')
         assert response.status_code == 401
+
+
+class TestBadHostAdminAuditPath:
+    """CVE-2026-48710 (BadHost): ``require_admin_auth`` records ``scope['path']``.
+
+    ``require_admin_auth`` has no exempt-path branch, so the BadHost spoof
+    cannot bypass it — but it writes the request path into five admin audit
+    events. A spoofed ``request.url.path`` would poison that audit trail. This
+    pins the audit detail to the unspoofable dispatched path.
+    """
+
+    def test_admin_missing_key_audits_scope_path_not_spoofed_url(self, monkeypatch):
+        from starlette.datastructures import URL
+        from starlette.requests import Request as StarletteRequest
+
+        # Simulate the BadHost reconstruction: request.url.path claims an exempt path.
+        monkeypatch.setattr(
+            StarletteRequest,
+            'url',
+            property(lambda self: URL('http://attacker.example/api/v1/health')),
+        )
+
+        # Auth disabled globally → the global middleware passes through, so the
+        # route-level require_admin_auth dependency is what enforces and audits.
+        app = _make_app(AuthConfig(enabled=False))
+
+        captured: list[dict] = []
+
+        class _CapturingAudit:
+            def log(self, **kwargs):
+                captured.append(kwargs)
+
+        app.state.audit_service = _CapturingAudit()
+
+        @app.get('/api/v1/admin/thing', dependencies=[Depends(require_admin_auth)])
+        async def _admin_thing():
+            return {'ok': True}
+
+        client = TestClient(app)
+        response = client.get('/api/v1/admin/thing')  # no X-API-Key
+
+        assert response.status_code == 401
+        events = [e for e in captured if e.get('action') == 'auth.admin.missing_key']
+        assert events, 'expected an auth.admin.missing_key audit event'
+        assert events[0]['details']['path'] == '/api/v1/admin/thing', (
+            'CVE-2026-48710 regression: require_admin_auth wrote the spoofed '
+            "request.url.path into the audit detail instead of scope['path']."
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #201 (which closed [CVE-2026-48710](https://nvd.nist.gov/vuln/detail/CVE-2026-48710) "BadHost"). #201 fixed the **access-control bypass** in `auth.py` — that hole is fully closed. This PR plugs two remaining sites that share the same root cause but were outside #201's scope: a spoofable **audit/skip decision** in a second middleware (detection-evasion) and one audit-field consistency gap.

## What #201 missed

`#201` keyed the auth decision on `request.scope['path']` everywhere in `auth.py`, but two `request.url.path` sites with the identical BadHost weakness live elsewhere:

1. **`server/__init__.py` `audit_access_log` middleware** — the `_AUDIT_SKIP_PATHS` skip decision (and the logged `path`) read `request.url.path`. A request like `Host: localhost/api/v1/health?` collapses `request.url.path` onto `/api/v1/health` (a skip path) while `scope['path']` stays the real protected path. Result: the `http.request` access-log line for the attacker's real request — **including the 401 that #201 now correctly returns** — is suppressed. This is detection-evasion, strictly lower severity than the (already-closed) bypass, but the same CVE class.
2. **`server/ingestion.py`** — the `ingestion.overlap_rejected` audit event wrote `request.url.path`; same spoofable-value-in-audit-log concern #201 cleaned up for the five auth audit fields.

Both now use `request.scope['path']`, the unspoofable value the ASGI router actually dispatches on — matching #201's approach and the upstream Starlette advisory's code-level mitigation.

## Tests

- **Integration** (`test_int_audit_middleware.py::TestBadHostAccessLogCVE202648710`): a spoofed-Host request to a protected route is still access-logged with the real path. Verified **RED** against the pre-fix skip decision, **GREEN** after.
- **Unit** (`test_server_auth.py::TestBadHostAdminAuditPath`): `require_admin_auth` records `scope['path']`, not the spoofable `url.path` — closes the property-level coverage gap on #201's admin-path audit change (its fix was real but untested).

## Verification

- `pytest test_server_auth.py` → 68 passed; `pytest -m integration test_int_audit_middleware.py` → 5 passed.
- ruff, ruff-format, mypy: pass.

## Scope notes

No dependency changes (consistent with #201; the `starlette >= 1.0.1` belt-and-suspenders bump remains tracked in #202). No access-control behavior changes — `auth.py` is untouched here; this is audit-trail integrity only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)