### PR TITLE
feat: stored-embedding exposure for HTTP/Python callers (V7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,404%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,405%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,400%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,404%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-6,755%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,375%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,390%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,400%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,375%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,390%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/docs/how-to/retrieve-data.md
+++ b/docs/how-to/retrieve-data.md
@@ -228,6 +228,52 @@ memex entity related "Acme Corp"
 The table is sorted by co-occurrence count, top 20. Add `--json` if you
 want to pipe the edges into another tool.
 
+## Stored embeddings — vector arithmetic against the vault
+
+Read surfaces accept `include_vectors=true` to return stored embeddings
+(384-dim) alongside the data: unit getters (`GET /memories/{id}`,
+`POST /memories/by-ids`, `POST /memories/by-chunks`,
+`GET /notes/{id}/memory_units`), KV reads, and the vault summary. Search
+responses never carry vectors — search lean, collect the IDs you care
+about, then batch-fetch with vectors:
+
+```bash
+# 1. Find candidate units (no vectors in search results)
+curl -s -X POST "$MEMEX/api/v1/memories/search" \
+  -H 'content-type: application/json' \
+  -d '{"query": "deploy pipeline decisions", "limit": 30}'
+
+# 2. Batch-fetch their vectors (max 500 IDs per call)
+curl -s -X POST "$MEMEX/api/v1/memories/by-ids" \
+  -H 'content-type: application/json' \
+  -d '{"unit_ids": ["<id1>", "<id2>"], "vault_id": "<vault>", "include_vectors": true}'
+
+# 3. The vault-level comparison anchor: the summary's narrative embedding
+curl -s "$MEMEX/api/v1/vaults/$VAULT_ID/summary?include_vectors=true" | jq '.embedding'
+```
+
+From Python, `RemoteMemexAPI` threads the same flag:
+
+```python
+import numpy as np
+
+summary = await client.get_vault_summary(vault_id, include_vectors=True)
+hits = await client.search('deploy pipeline decisions', limit=30)
+units = await client.get_memory_units_by_ids(
+    [u.id for u in hits], vault_id, include_vectors=True
+)
+if summary is not None and summary.embedding is not None:
+    v = np.array(summary.embedding)
+    for u in units:
+        e = np.array(u.embedding)
+        sim = float(e @ v / (np.linalg.norm(e) * np.linalg.norm(v)))
+```
+
+The summary embedding is `null` for empty vaults, summaries not yet
+(re)generated since the feature landed (lazy backfill), and encode
+failures — always handle `None`. Agent surfaces (MCP tools, CLI) do not
+expose vectors; this is an HTTP/Python-caller capability only.
+
 ## Verification
 
 Confirm a known fact appears in at least one of the surfaces:

--- a/docs/how-to/retrieve-data.md
+++ b/docs/how-to/retrieve-data.md
@@ -230,10 +230,12 @@ want to pipe the edges into another tool.
 
 ## Stored embeddings — vector arithmetic against the vault
 
-Read surfaces accept `include_vectors=true` to return stored embeddings
-(384-dim) alongside the data: unit getters (`GET /memories/{id}`,
-`POST /memories/by-ids`, `POST /memories/by-chunks`,
-`GET /notes/{id}/memory_units`), KV reads, and the vault summary. Search
+Vault-scoped read surfaces accept `include_vectors=true` to return stored
+embeddings (384-dim) alongside the data: the vault-scoped unit getters
+(`POST /memories/by-ids`, `POST /memories/by-chunks`,
+`GET /notes/{id}/memory_units`), KV reads, and the vault summary. The
+unscoped single-ID `GET /memories/{id}` never returns a vector — fetch a
+single unit's embedding via `POST /memories/by-ids` with one ID. Search
 responses never carry vectors — search lean, collect the IDs you care
 about, then batch-fetch with vectors:
 

--- a/docs/reference/api-routes.md
+++ b/docs/reference/api-routes.md
@@ -29,6 +29,7 @@ The server is FastAPI. The OpenAPI document is served at `/openapi.json`; Swagge
 | POST | `/api/v1/memories/search` | read | TEMPR memory-unit search (NDJSON). |
 | POST | `/api/v1/memories/summary` | read | Synthesize a summary with citations from texts. |
 | POST | `/api/v1/memories/by-chunks` | read | Resolve chunk IDs to memory units. |
+| POST | `/api/v1/memories/by-ids` | read | Batch-fetch memory units by ID (vault-scoped). |
 | GET | `/api/v1/memories/{id}` | read | Get one memory unit. |
 | DELETE | `/api/v1/memories/{id}` | delete | Delete a memory unit and its links. |
 | POST | `/api/v1/memories/{id}/deprioritize` | write | Flip `is_deprioritized=true`. |
@@ -403,12 +404,12 @@ Typed links from one note. <code-ref path="packages/core/src/memex_core/server/n
 
 ### GET /api/v1/notes/{note_id}/memory_units
 
-Memory units belonging to a note. Used by the eval suite to map note keys back to unit IDs. <code-ref path="packages/core/src/memex_core/server/memories.py" lines="91-123" />
+Memory units belonging to a note. Used by the eval suite to map note keys back to unit IDs. <code-ref path="packages/core/src/memex_core/server/memories.py" lines="149-185" />
 
 - **Auth.** `require_read`.
 - **Path params.** `note_id` (UUID).
-- **Query params.** `vault_id` (UUID, **required**). A mismatch returns 403.
-- **Returns.** `MemoryUnitDTO[]`.
+- **Query params.** `vault_id` (UUID, **required**). A mismatch returns 403. `include_vectors` (bool, default `false`).
+- **Returns.** `MemoryUnitDTO[]`. `embedding` is `null` unless `include_vectors=true`.
 
 ### GET /api/v1/notes/{id}/lineage
 
@@ -531,11 +532,12 @@ Get many page-index nodes by ID. <code-ref path="packages/core/src/memex_core/se
 
 ### GET /api/v1/memories/{id}
 
-Get one memory unit. <code-ref path="packages/core/src/memex_core/server/memories.py" lines="78-88" />
+Get one memory unit. <code-ref path="packages/core/src/memex_core/server/memories.py" lines="129-146" />
 
 - **Auth.** `require_read`.
 - **Path params.** `id` (UUID).
-- **Returns.** `MemoryUnitDTO`.
+- **Query params.** `include_vectors` (bool, default `false`) — populate `embedding` with the unit's stored 384-dim vector.
+- **Returns.** `MemoryUnitDTO`. `embedding` is `null` unless `include_vectors=true`.
 - **Errors.** 404 not found.
 
 ### DELETE /api/v1/memories/{id}
@@ -548,11 +550,19 @@ Delete a memory unit. <code-ref path="packages/core/src/memex_core/server/memori
 
 ### POST /api/v1/memories/by-chunks
 
-Resolve chunk IDs to memory units, vault-scoped. <code-ref path="packages/core/src/memex_core/server/memories.py" lines="54-75" />
+Resolve chunk IDs to memory units, vault-scoped. <code-ref path="packages/core/src/memex_core/server/memories.py" lines="79-100" />
 
 - **Auth.** `require_read`. The route checks vault access against the supplied `vault_id`.
-- **Body.** `{chunk_ids: UUID[], vault_id: UUID}` — both required. Cross-vault returns 403.
-- **Returns.** `MemoryUnitDTO[]`.
+- **Body.** `{chunk_ids: UUID[], vault_id: UUID, include_vectors?: bool}` — IDs and vault required. Cross-vault returns 403.
+- **Returns.** `MemoryUnitDTO[]`. `embedding` is `null` unless `include_vectors=true`.
+
+### POST /api/v1/memories/by-ids
+
+Batch-fetch memory units by ID, vault-scoped. The bulk path for vector arithmetic: search lean, then fetch the vectors for the units you care about in one call. <code-ref path="packages/core/src/memex_core/server/memories.py" lines="103-126" />
+
+- **Auth.** `require_read`. The route checks vault access against the supplied `vault_id`.
+- **Body.** `{unit_ids: UUID[] (max 500), vault_id: UUID, include_vectors?: bool}`. Cross-vault returns 403.
+- **Returns.** `MemoryUnitDTO[]`. IDs that don't exist or belong to another vault are silently omitted; duplicates deduplicate; result order does not follow input order.
 
 ### POST /api/v1/memories/{id}/deprioritize
 
@@ -630,36 +640,36 @@ Walk the contradiction graph backward to produce the supersession history tree. 
 
 ### PUT /api/v1/kv
 
-Upsert a KV entry. <code-ref path="packages/core/src/memex_core/server/kv.py" lines="49-64" />
+Upsert a KV entry. <code-ref path="packages/core/src/memex_core/server/kv.py" lines="65-80" />
 
 - **Auth.** `require_write`.
 - **Body** (`KVPutRequest`): `key`, `value`, optional `embedding`, `ttl_seconds`. If `embedding` is omitted the server generates one.
-- **Returns.** `KVEntryDTO`.
+- **Returns.** `KVEntryDTO`. The response never echoes the vector (`embedding` is `null`); read it back via `GET /api/v1/kv/get?include_vectors=true`.
 
 ### GET /api/v1/kv
 
-List KV entries. <code-ref path="packages/core/src/memex_core/server/kv.py" lines="153-186" />
+List KV entries. <code-ref path="packages/core/src/memex_core/server/kv.py" lines="173-210" />
 
 - **Auth.** `require_read`.
-- **Query params.** `limit` (1-500, default 100), `namespaces` (comma-separated prefixes), `exclude_prefix`, `key_prefix`, `pattern` (trailing `*` only).
-- **Returns.** `KVEntryDTO[]`.
+- **Query params.** `limit` (1-500, default 100), `namespaces` (comma-separated prefixes), `exclude_prefix`, `key_prefix`, `pattern` (trailing `*` only), `include_vectors` (bool, default `false`).
+- **Returns.** `KVEntryDTO[]`. `embedding` is `null` unless `include_vectors=true`.
 
 ### GET /api/v1/kv/get
 
-Get a KV entry by exact key. <code-ref path="packages/core/src/memex_core/server/kv.py" lines="67-107" />
+Get a KV entry by exact key. <code-ref path="packages/core/src/memex_core/server/kv.py" lines="83-127" />
 
 - **Auth.** `require_read`.
-- **Query params.** `key` (required), `include_history` (bool, default `false`).
-- **Returns.** `KVEntryDTO`. For procedure keys (`<scope>:procedure:<verb>:<context-tag>`) with `include_history=true`, the server returns `KVProcedureEntryDTO` carrying the active value plus version + history.
+- **Query params.** `key` (required), `include_history` (bool, default `false`), `include_vectors` (bool, default `false`).
+- **Returns.** `KVEntryDTO` (with `embedding` populated when `include_vectors=true`). For procedure keys (`<scope>:procedure:<verb>:<context-tag>`) with `include_history=true`, the server returns `KVProcedureEntryDTO` carrying the active value plus version + history — procedure envelopes never carry vectors.
 - **Errors.** 404 unknown key.
 
 ### POST /api/v1/kv/search
 
-Semantic search over KV entries. <code-ref path="packages/core/src/memex_core/server/kv.py" lines="110-133" />
+Semantic search over KV entries. <code-ref path="packages/core/src/memex_core/server/kv.py" lines="130-153" />
 
 - **Auth.** `require_read`.
-- **Body** (`KVSearchRequest`): exactly one of `query` (text — the server embeds it) or `query_embedding` (pre-computed vector); optional `namespaces` (list of prefixes), `limit` (1-500, default 5).
-- **Returns.** `KVEntryDTO[]` ranked by embedding similarity.
+- **Body** (`KVSearchRequest`): exactly one of `query` (text — the server embeds it) or `query_embedding` (pre-computed vector); optional `namespaces` (list of prefixes), `limit` (1-500, default 5), `include_vectors` (bool, default `false`).
+- **Returns.** `KVEntryDTO[]` ranked by embedding similarity. `embedding` is `null` unless `include_vectors=true`.
 
 ### DELETE /api/v1/kv/delete
 
@@ -846,11 +856,12 @@ Runtime override for the default read vault. <code-ref path="packages/core/src/m
 
 ### GET /api/v1/vaults/{vault_id}/summary
 
-Get the cached vault summary. <code-ref path="packages/core/src/memex_core/server/vault_summary.py" lines="36-56" />
+Get the cached vault summary. <code-ref path="packages/core/src/memex_core/server/vault_summary.py" lines="37-63" />
 
 - **Auth.** `require_read`.
 - **Path params.** `vault_id` (UUID).
-- **Returns.** `VaultSummaryDTO` — `id`, `vault_id`, `narrative`, `themes`, `inventory`, `key_entities`, `version`, `notes_incorporated`, `created_at`, `updated_at`.
+- **Query params.** `include_vectors` (bool, default `false`) — populate `embedding` with the stored narrative vector (384-dim). The vector is `null` for summaries not yet (re)generated since the column landed, empty vaults, and encode failures — callers must tolerate `null`.
+- **Returns.** `VaultSummaryDTO` — `id`, `vault_id`, `narrative`, `themes`, `inventory`, `key_entities`, `embedding`, `version`, `notes_incorporated`, `created_at`, `updated_at`.
 - **Errors.** 404 no summary cached.
 
 ### POST /api/v1/vaults/{vault_id}/summary/regenerate

--- a/docs/reference/api-routes.md
+++ b/docs/reference/api-routes.md
@@ -532,7 +532,7 @@ Get many page-index nodes by ID. <code-ref path="packages/core/src/memex_core/se
 
 ### GET /api/v1/memories/{id}
 
-Get one memory unit. <code-ref path="packages/core/src/memex_core/server/memories.py" lines="129-146" />
+Get one memory unit. <code-ref path="packages/core/src/memex_core/server/memories.py" lines="129-148" />
 
 - **Auth.** `require_read`. This route is **not vault-scoped** (no `vault_id`) — preserved for vault-agnostic callers.
 - **Path params.** `id` (UUID).
@@ -855,9 +855,9 @@ Runtime override for the default read vault. <code-ref path="packages/core/src/m
 
 ### GET /api/v1/vaults/{vault_id}/summary
 
-Get the cached vault summary. <code-ref path="packages/core/src/memex_core/server/vault_summary.py" lines="37-63" />
+Get the cached vault summary. <code-ref path="packages/core/src/memex_core/server/vault_summary.py" lines="44-70" />
 
-- **Auth.** `require_read`.
+- **Auth.** `require_read` + `check_vault_access` against `vault_id` (cross-vault returns 403).
 - **Path params.** `vault_id` (UUID).
 - **Query params.** `include_vectors` (bool, default `false`) — populate `embedding` with the stored narrative vector (384-dim). The vector is `null` for summaries not yet (re)generated since the column landed, empty vaults, and encode failures — callers must tolerate `null`.
 - **Returns.** `VaultSummaryDTO` — `id`, `vault_id`, `narrative`, `themes`, `inventory`, `key_entities`, `embedding`, `version`, `notes_incorporated`, `created_at`, `updated_at`.

--- a/docs/reference/api-routes.md
+++ b/docs/reference/api-routes.md
@@ -534,10 +534,9 @@ Get many page-index nodes by ID. <code-ref path="packages/core/src/memex_core/se
 
 Get one memory unit. <code-ref path="packages/core/src/memex_core/server/memories.py" lines="129-146" />
 
-- **Auth.** `require_read`.
+- **Auth.** `require_read`. This route is **not vault-scoped** (no `vault_id`) — preserved for vault-agnostic callers.
 - **Path params.** `id` (UUID).
-- **Query params.** `include_vectors` (bool, default `false`) — populate `embedding` with the unit's stored 384-dim vector.
-- **Returns.** `MemoryUnitDTO`. `embedding` is `null` unless `include_vectors=true`.
+- **Returns.** `MemoryUnitDTO`. `embedding` is always `null`: vector exposure is confined to vault-scoped routes. To fetch a single unit's vector, use `POST /memories/by-ids` with a one-element `unit_ids` and the owning `vault_id`.
 - **Errors.** 404 not found.
 
 ### DELETE /api/v1/memories/{id}

--- a/docs/reference/data-model.md
+++ b/docs/reference/data-model.md
@@ -486,6 +486,7 @@ One row per vault — enforced by the `UNIQUE` constraint on `vault_id`. Cheap-t
 | `themes` | jsonb | no | `'[]'` | List of theme blobs (see shape below). |
 | `inventory` | jsonb | no | `'{}'` | Computed content stats. |
 | `key_entities` | jsonb | no | `'[]'` | Top entities by mention count. |
+| `embedding` | vector(384) | yes | NULL | Narrative embedding, refreshed on every (re)generation. NULL for empty vaults, rows not yet rewritten since the column landed (lazy backfill), and encode failures. Read via `GET /vaults/{id}/summary?include_vectors=true`. |
 | `version` | int | no | `1` | Incremented on each update. |
 | `notes_incorporated` | int | no | `0` | Count of notes folded into this summary. |
 | `patch_log` | jsonb | no | `'[]'` | Last 20 patches. |

--- a/packages/cli/src/memex_cli/kv.py
+++ b/packages/cli/src/memex_cli/kv.py
@@ -126,7 +126,9 @@ async def kv_search(
         return
 
     if json_output:
-        console.print_json(json.dumps([r.model_dump() for r in results], default=str))
+        console.print_json(
+            json.dumps([r.model_dump(exclude={'embedding'}) for r in results], default=str)
+        )
         return
 
     table = Table(title=f'KV Search: "{query}"')
@@ -176,7 +178,9 @@ async def kv_list(
         return
 
     if json_output:
-        console.print_json(json.dumps([e.model_dump() for e in entries], default=str))
+        console.print_json(
+            json.dumps([e.model_dump(exclude={'embedding'}) for e in entries], default=str)
+        )
         return
 
     table = Table(title='KV Entries')

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -116,10 +116,14 @@ async def view_memory(
             return
 
     if json_output:
+        # exclude embedding: vectors are an HTTP/Python-caller capability; CLI
+        # JSON shape stays byte-identical to the pre-field era.
         if len(uuids) == 1:
-            console.print_json(json.dumps(units[0].model_dump(), default=str))
+            console.print_json(json.dumps(units[0].model_dump(exclude={'embedding'}), default=str))
         else:
-            console.print_json(json.dumps([u.model_dump() for u in units], default=str))
+            console.print_json(
+                json.dumps([u.model_dump(exclude={'embedding'}) for u in units], default=str)
+            )
         return
 
     for i, unit in enumerate(units):
@@ -538,7 +542,9 @@ async def search_memory(
             return
 
         if json_output:
-            console.print_json(json.dumps([u.model_dump() for u in results], default=str))
+            console.print_json(
+                json.dumps([u.model_dump(exclude={'embedding'}) for u in results], default=str)
+            )
             return
 
         # Display Table

--- a/packages/cli/src/memex_cli/vaults.py
+++ b/packages/cli/src/memex_cli/vaults.py
@@ -293,7 +293,7 @@ async def vault_summary(
             return
 
     if json_output:
-        console.print_json(json.dumps(summary.model_dump(), default=str))
+        console.print_json(json.dumps(summary.model_dump(exclude={'embedding'}), default=str))
         return
 
     if compact:

--- a/packages/cli/tests/test_no_vectors_in_cli_json.py
+++ b/packages/cli/tests/test_no_vectors_in_cli_json.py
@@ -1,0 +1,121 @@
+"""Pin: CLI ``--json`` output never carries an ``embedding`` key.
+
+Vector exposure is an HTTP/Python-caller capability; the CLI is an
+operator/agent surface and must stay byte-identical to its pre-field
+shape. The DTOs gained an ``embedding`` field, so a bare ``model_dump()``
+would emit ``embedding: null`` — every CLI JSON render excludes it.
+These tests feed vector-laden DTOs through the commands and walk the
+parsed output, so a future render path that forgets the exclusion fails
+loudly.
+"""
+
+import datetime as dt
+import json
+from uuid import uuid4
+
+from memex_cli.kv import app as kv_app
+from memex_cli.memory import app as memory_app
+from memex_cli.vaults import app as vaults_app
+from memex_common.schemas import KVEntryDTO, MemoryUnitDTO, VaultSummaryDTO
+
+
+def _walk(obj):
+    if isinstance(obj, dict):
+        yield obj
+        for value in obj.values():
+            yield from _walk(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _walk(item)
+
+
+def _assert_no_embedding_key(data) -> None:
+    for node in _walk(data):
+        assert 'embedding' not in node, f'embedding key leaked into CLI JSON: {sorted(node)}'
+
+
+def _unit(text: str) -> MemoryUnitDTO:
+    return MemoryUnitDTO(id=uuid4(), text=text, fact_type='world', embedding=[0.1] * 8)
+
+
+def _kv_entry(key: str) -> KVEntryDTO:
+    return KVEntryDTO(
+        id=uuid4(),
+        key=key,
+        value='neovim',
+        embedding=[0.5] * 8,
+        created_at=dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+        updated_at=dt.datetime(2026, 1, 2, tzinfo=dt.timezone.utc),
+    )
+
+
+def test_memory_view_json_has_no_embedding(runner, mock_api, mock_config, monkeypatch):
+    uid = uuid4()
+    mock_api.get_memory_unit.return_value = _unit('A fact with a vector')
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(memory_app, ['view', str(uid), '--json'], obj=mock_config)
+    assert result.exit_code == 0
+    _assert_no_embedding_key(json.loads(result.stdout))
+
+
+def test_memory_view_multi_json_has_no_embedding(runner, mock_api, mock_config, monkeypatch):
+    u1, u2 = uuid4(), uuid4()
+    mock_api.get_memory_unit.side_effect = [_unit('A'), _unit('B')]
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(memory_app, ['view', str(u1), str(u2), '--json'], obj=mock_config)
+    assert result.exit_code == 0
+    _assert_no_embedding_key(json.loads(result.stdout))
+
+
+def test_memory_search_json_has_no_embedding(runner, mock_api, mock_config, monkeypatch):
+    mock_api.search.return_value = [_unit('search hit')]
+    monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(memory_app, ['search', 'anything', '--json'], obj=mock_config)
+    assert result.exit_code == 0
+    # A `Searching: <query>` banner precedes the JSON payload.
+    payload = result.stdout[result.stdout.index('[') :]
+    _assert_no_embedding_key(json.loads(payload))
+
+
+def test_kv_search_json_has_no_embedding(runner, mock_api, mock_config, monkeypatch):
+    mock_api.kv_search_text.return_value = [_kv_entry('user:editor')]
+    monkeypatch.setattr('memex_cli.kv.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(kv_app, ['search', 'editor', '--json'], obj=mock_config)
+    assert result.exit_code == 0
+    _assert_no_embedding_key(json.loads(result.stdout))
+
+
+def test_kv_list_json_has_no_embedding(runner, mock_api, mock_config, monkeypatch):
+    mock_api.kv_list.return_value = [_kv_entry('user:editor'), _kv_entry('global:lang')]
+    monkeypatch.setattr('memex_cli.kv.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(kv_app, ['list', '--json'], obj=mock_config)
+    assert result.exit_code == 0
+    _assert_no_embedding_key(json.loads(result.stdout))
+
+
+def test_vault_summary_json_has_no_embedding(runner, mock_api, mock_config, monkeypatch):
+    vault_id = uuid4()
+    mock_api.resolve_vault_identifier.return_value = vault_id
+    mock_api.get_vault_summary.return_value = VaultSummaryDTO(
+        id=uuid4(),
+        vault_id=vault_id,
+        narrative='A vault with a stored vector.',
+        themes=[],
+        inventory={},
+        key_entities=[],
+        embedding=[0.25] * 8,
+        version=2,
+        notes_incorporated=4,
+        created_at=dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+        updated_at=dt.datetime(2026, 1, 2, tzinfo=dt.timezone.utc),
+    )
+    monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(vaults_app, ['summary', 'my-vault', '--json'], obj=mock_config)
+    assert result.exit_code == 0
+    _assert_no_embedding_key(json.loads(result.stdout))

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -822,13 +822,24 @@ class RemoteMemexAPI:
         turn_outcome: str | None = None,
         retrieved_set_size: int | None = None,
         exploration_tagged: bool = False,
+        session: Any | None = None,
     ) -> dict[str, Any]:
         """Record an outcome over HTTP.
 
         Preferred shape: ``units=[{unit_id, verb, reason}, ...]``. Legacy
         ``(unit_ids, success)`` shape still accepted (server emits
         FutureWarning on translation).
+
+        ``session`` is accepted for signature parity with
+        ``MemexAPI.record_outcome`` but an ``AsyncSession`` cannot cross the
+        HTTP boundary — passing one raises, same pattern as
+        ``restore_memory_unit(background_tasks=…)``.
         """
+        if session is not None:
+            raise NotImplementedError(
+                'record_outcome(session=…) cannot cross the HTTP boundary; '
+                'in-process callers holding a session should use MemexAPI directly.'
+            )
         body: dict[str, Any] = {
             'outcome_confidence': outcome_confidence,
         }

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -1049,18 +1049,15 @@ class RemoteMemexAPI:
             params['vault_id'] = [str(v) for v in resolved]
         return await self._get(f'entities/{entity_id}/cooccurrences', params=params)
 
-    async def get_memory_unit(
-        self,
-        unit_id: UUID | str,
-        *,
-        include_vectors: bool = False,
-    ) -> MemoryUnitDTO:
+    async def get_memory_unit(self, unit_id: UUID | str) -> MemoryUnitDTO:
         """Get memory unit details.
 
-        ``include_vectors=True`` populates ``embedding`` with the unit's
-        stored vector (384-dim).
+        This route is not vault-scoped and does not return the embedding
+        vector. For a unit's vector, use
+        :pymeth:`get_memory_units_by_ids` with a one-element ``unit_ids``
+        and the owning ``vault_id``.
         """
-        result = await self._get(f'memories/{unit_id}', params={'include_vectors': include_vectors})
+        result = await self._get(f'memories/{unit_id}')
         return MemoryUnitDTO(**result)
 
     async def get_memory_units_by_chunks(

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -250,10 +250,23 @@ class RemoteMemexAPI:
         response = await self.client.post(f'vaults/{identifier}/set-reader')
         return await self._handle_response(response)
 
-    async def get_vault_summary(self, vault_id: UUID) -> VaultSummaryDTO | None:
-        """Get the summary for a vault. Returns None if no summary exists."""
+    async def get_vault_summary(
+        self,
+        vault_id: UUID,
+        *,
+        include_vectors: bool = False,
+    ) -> VaultSummaryDTO | None:
+        """Get the summary for a vault. Returns None if no summary exists.
+
+        ``include_vectors=True`` populates ``embedding`` with the stored
+        narrative vector; it stays None for never-regenerated, empty, or
+        encode-failed summaries — callers must tolerate null.
+        """
         try:
-            result = await self._get(f'vaults/{vault_id}/summary')
+            result = await self._get(
+                f'vaults/{vault_id}/summary',
+                params={'include_vectors': include_vectors},
+            )
             return VaultSummaryDTO(**result)
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
@@ -1025,15 +1038,26 @@ class RemoteMemexAPI:
             params['vault_id'] = [str(v) for v in resolved]
         return await self._get(f'entities/{entity_id}/cooccurrences', params=params)
 
-    async def get_memory_unit(self, unit_id: UUID | str) -> MemoryUnitDTO:
-        """Get memory unit details."""
-        result = await self._get(f'memories/{unit_id}')
+    async def get_memory_unit(
+        self,
+        unit_id: UUID | str,
+        *,
+        include_vectors: bool = False,
+    ) -> MemoryUnitDTO:
+        """Get memory unit details.
+
+        ``include_vectors=True`` populates ``embedding`` with the unit's
+        stored vector (384-dim).
+        """
+        result = await self._get(f'memories/{unit_id}', params={'include_vectors': include_vectors})
         return MemoryUnitDTO(**result)
 
     async def get_memory_units_by_chunks(
         self,
         chunk_ids: list[UUID | str],
         vault_id: UUID | str,
+        *,
+        include_vectors: bool = False,
     ) -> list[MemoryUnitDTO]:
         """Fetch memory units belonging to the named chunks (vault-scoped).
 
@@ -1046,14 +1070,42 @@ class RemoteMemexAPI:
         body = {
             'chunk_ids': [str(c) for c in chunk_ids],
             'vault_id': str(vault_id),
+            'include_vectors': include_vectors,
         }
         result = await self._post('memories/by-chunks', body)
+        return [MemoryUnitDTO(**r) for r in result]
+
+    async def get_memory_units_by_ids(
+        self,
+        unit_ids: list[UUID | str],
+        vault_id: UUID | str,
+        *,
+        include_vectors: bool = False,
+    ) -> list[MemoryUnitDTO]:
+        """Fetch memory units by ID (vault-scoped batch lookup, max 500 per call).
+
+        IDs that don't exist or belong to another vault are silently omitted;
+        duplicates are deduplicated; result order is not guaranteed to follow
+        input order. ``include_vectors=True`` populates each unit's
+        ``embedding`` for vector arithmetic (e.g. comparing units against the
+        vault-summary embedding from :pymeth:`get_vault_summary`).
+        """
+        if not unit_ids:
+            return []
+        body = {
+            'unit_ids': [str(u) for u in unit_ids],
+            'vault_id': str(vault_id),
+            'include_vectors': include_vectors,
+        }
+        result = await self._post('memories/by-ids', body)
         return [MemoryUnitDTO(**r) for r in result]
 
     async def list_memory_units_by_note(
         self,
         note_id: UUID | str,
         vault_id: UUID | str,
+        *,
+        include_vectors: bool = False,
     ) -> list[MemoryUnitDTO]:
         """Fetch memory units belonging to a note (vault-scoped).
 
@@ -1062,7 +1114,8 @@ class RemoteMemexAPI:
         the caller's API key is not authorized for returns 403.
         """
         result = await self._get(
-            f'notes/{note_id}/memory_units', params={'vault_id': str(vault_id)}
+            f'notes/{note_id}/memory_units',
+            params={'vault_id': str(vault_id), 'include_vectors': include_vectors},
         )
         return [MemoryUnitDTO(**r) for r in result]
 
@@ -1527,6 +1580,7 @@ class RemoteMemexAPI:
         key: str,
         *,
         include_history: bool = False,
+        include_vectors: bool = False,
     ) -> KVEntryDTO | KVProcedureEntryDTO | None:
         """Get a KV entry by exact key. Returns None if not found.
 
@@ -1535,8 +1589,16 @@ class RemoteMemexAPI:
         ``include_history=True`` returns a :class:`KVProcedureEntryDTO`
         whose ``value`` field is the structured envelope
         ({value, version, history}).
+
+        ``include_vectors=True`` populates ``embedding`` with the entry's
+        stored value vector (plain entries only — procedure envelopes don't
+        carry vectors).
         """
-        params: dict[str, Any] = {'key': key, 'include_history': include_history}
+        params: dict[str, Any] = {
+            'key': key,
+            'include_history': include_history,
+            'include_vectors': include_vectors,
+        }
         try:
             result = await self._get('kv/get', params=params)
             # Procedure DTO routing: a `<scope>:procedure:<verb>:<context>`
@@ -1556,6 +1618,8 @@ class RemoteMemexAPI:
         query_embedding: list[float],
         namespaces: list[str] | None = None,
         limit: int = 5,
+        *,
+        include_vectors: bool = False,
     ) -> list[KVEntryDTO]:
         """Semantic search over KV entries.
 
@@ -1568,6 +1632,7 @@ class RemoteMemexAPI:
             query_embedding=query_embedding,
             namespaces=namespaces,
             limit=limit,
+            include_vectors=include_vectors,
         )
         result = await self._post('kv/search', request)
         return [KVEntryDTO(**r) for r in result]
@@ -1577,6 +1642,8 @@ class RemoteMemexAPI:
         query: str,
         namespaces: list[str] | None = None,
         limit: int = 5,
+        *,
+        include_vectors: bool = False,
     ) -> list[KVEntryDTO]:
         """Convenience wrapper: server embeds ``query`` before searching.
 
@@ -1588,6 +1655,7 @@ class RemoteMemexAPI:
             query=query,
             namespaces=namespaces,
             limit=limit,
+            include_vectors=include_vectors,
         )
         result = await self._post('kv/search', request)
         return [KVEntryDTO(**r) for r in result]
@@ -1613,9 +1681,11 @@ class RemoteMemexAPI:
         exclude_prefix: str | None = None,
         key_prefix: str | None = None,
         pattern: str | None = None,
+        *,
+        include_vectors: bool = False,
     ) -> list[KVEntryDTO]:
         """List KV entries, optionally filtered by namespace prefixes."""
-        params: dict[str, Any] = {'limit': limit}
+        params: dict[str, Any] = {'limit': limit, 'include_vectors': include_vectors}
         if namespaces is not None:
             params['namespaces'] = ','.join(namespaces)
         if exclude_prefix is not None:

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -351,9 +351,6 @@ class RetrievalRequest(BaseModel):
         description='Strategies to run. None = all.',
         examples=[['semantic', 'keyword', 'graph', 'temporal', 'mental_model']],
     )
-    include_vectors: bool = Field(
-        default=False, description='Include embeddings in results (slower).'
-    )
     include_stale: bool = Field(default=False, description='Include stale memory units.')
     include_superseded: bool = Field(
         default=False,
@@ -535,6 +532,11 @@ class MemoryUnitDTO(MemoryUnitBase):
         default=None,
         description='Relevance score from retrieval or reranking (0.0 to 1.0).',
         examples=[0.95],
+    )
+
+    embedding: list[float] | None = Field(
+        default=None,
+        description='Stored vector for the unit text; populated only when include_vectors=true.',
     )
 
     debug_info: list[StrategyDebugInfo] | None = Field(
@@ -1309,6 +1311,14 @@ class VaultSummaryDTO(BaseModel):
     key_entities: list[dict[str, Any]] = Field(
         description='Top entities by mention count: [{name, type, mention_count}].'
     )
+    embedding: list[float] | None = Field(
+        default=None,
+        description=(
+            'Stored vector of the narrative; populated only when include_vectors=true. '
+            'Null when the summary has never been (re)generated since the column landed, '
+            'the vault is empty, or the encode step failed.'
+        ),
+    )
     version: int = Field(description='Summary version number.')
     notes_incorporated: int = Field(description='Number of notes incorporated.')
     created_at: dt.datetime = Field(description='When the summary was created.')
@@ -1366,6 +1376,10 @@ class KVEntryDTO(BaseModel):
     id: UUID
     key: str
     value: str
+    embedding: list[float] | None = Field(
+        default=None,
+        description='Stored value vector; populated only when include_vectors=true.',
+    )
     expires_at: dt.datetime | None = None
     created_at: dt.datetime
     updated_at: dt.datetime
@@ -1426,6 +1440,10 @@ class KVSearchRequest(BaseModel):
     )
     namespaces: list[str] | None = None
     limit: int = Field(5, ge=1, le=500)
+    include_vectors: bool = Field(
+        default=False,
+        description="Include each entry's stored value vector in the results.",
+    )
 
     @model_validator(mode='after')
     def _exactly_one(self) -> 'KVSearchRequest':

--- a/packages/common/tests/test_client_eval_suite_endpoints.py
+++ b/packages/common/tests/test_client_eval_suite_endpoints.py
@@ -44,7 +44,7 @@ async def test_list_memory_units_by_note_calls_correct_endpoint(mock_client: Asy
 
     assert result == []
     assert captured['path'] == f'notes/{note_id}/memory_units'
-    assert captured['params'] == {'vault_id': vault_id}
+    assert captured['params'] == {'vault_id': vault_id, 'include_vectors': False}
 
 
 @pytest.mark.asyncio

--- a/packages/common/tests/test_client_include_vectors.py
+++ b/packages/common/tests/test_client_include_vectors.py
@@ -1,0 +1,208 @@
+"""RemoteMemexAPI ``include_vectors`` threading + the by-ids batch method.
+
+Covers the client-side short-circuit on an empty ``unit_ids`` list, the
+request shapes for the new ``memories/by-ids`` endpoint, and the
+``include_vectors`` wiring on every read method that exposes it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from memex_common.client import RemoteMemexAPI
+
+
+@pytest.fixture
+def mock_client():
+    return AsyncMock(spec=httpx.AsyncClient)
+
+
+def _json_response(payload):
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 200
+    response.headers = {'content-type': 'application/json'}
+    response.json.return_value = payload
+    response.raise_for_status = MagicMock()
+    return response
+
+
+def _capture_post(captured: dict, payload=None):
+    async def _post(path, json=None, **kwargs):
+        captured['count'] = captured.get('count', 0) + 1
+        captured['path'] = path
+        captured['json'] = json
+        return _json_response(payload if payload is not None else [])
+
+    return _post
+
+
+def _capture_get(captured: dict, payload=None):
+    async def _get(path, params=None, **kwargs):
+        captured['path'] = path
+        captured['params'] = params
+        return _json_response(payload if payload is not None else [])
+
+    return _get
+
+
+class TestGetMemoryUnitsByIds:
+    @pytest.mark.asyncio
+    async def test_empty_unit_ids_short_circuits_no_request(self, mock_client) -> None:
+        api = RemoteMemexAPI(mock_client)
+        captured: dict = {}
+        mock_client.post = _capture_post(captured)
+
+        result = await api.get_memory_units_by_ids([], vault_id='vault-uuid')
+
+        assert result == []
+        assert captured.get('count', 0) == 0, 'empty unit_ids must not trigger a HTTP POST'
+
+    @pytest.mark.asyncio
+    async def test_posts_to_by_ids_with_serialized_body(self, mock_client) -> None:
+        api = RemoteMemexAPI(mock_client)
+        captured: dict = {}
+        mock_client.post = _capture_post(captured)
+
+        await api.get_memory_units_by_ids(
+            ['11111111-1111-1111-1111-111111111111'],
+            vault_id='22222222-2222-2222-2222-222222222222',
+        )
+
+        assert captured['path'] == 'memories/by-ids'
+        assert captured['json']['unit_ids'] == ['11111111-1111-1111-1111-111111111111']
+        assert captured['json']['vault_id'] == '22222222-2222-2222-2222-222222222222'
+        assert captured['json']['include_vectors'] is False
+
+    @pytest.mark.asyncio
+    async def test_include_vectors_true_in_body(self, mock_client) -> None:
+        api = RemoteMemexAPI(mock_client)
+        captured: dict = {}
+        mock_client.post = _capture_post(captured)
+
+        await api.get_memory_units_by_ids(
+            ['11111111-1111-1111-1111-111111111111'],
+            vault_id='22222222-2222-2222-2222-222222222222',
+            include_vectors=True,
+        )
+
+        assert captured['json']['include_vectors'] is True
+
+
+class TestIncludeVectorsParamThreading:
+    @pytest.mark.asyncio
+    async def test_get_memory_unit_passes_query_param(self, mock_client) -> None:
+        api = RemoteMemexAPI(mock_client)
+        captured: dict = {}
+        unit = {
+            'id': '11111111-1111-1111-1111-111111111111',
+            'text': 't',
+            'fact_type': 'world',
+            'status': 'active',
+        }
+        mock_client.get = _capture_get(captured, payload=unit)
+
+        await api.get_memory_unit('11111111-1111-1111-1111-111111111111', include_vectors=True)
+
+        assert captured['params']['include_vectors'] is True
+
+    @pytest.mark.asyncio
+    async def test_by_chunks_body_carries_include_vectors(self, mock_client) -> None:
+        api = RemoteMemexAPI(mock_client)
+        captured: dict = {}
+        mock_client.post = _capture_post(captured)
+
+        await api.get_memory_units_by_chunks(
+            ['11111111-1111-1111-1111-111111111111'],
+            vault_id='22222222-2222-2222-2222-222222222222',
+            include_vectors=True,
+        )
+
+        assert captured['json']['include_vectors'] is True
+
+    @pytest.mark.asyncio
+    async def test_list_by_note_passes_query_param(self, mock_client) -> None:
+        api = RemoteMemexAPI(mock_client)
+        captured: dict = {}
+        mock_client.get = _capture_get(captured)
+
+        await api.list_memory_units_by_note(
+            '11111111-1111-1111-1111-111111111111',
+            vault_id='22222222-2222-2222-2222-222222222222',
+            include_vectors=True,
+        )
+
+        assert captured['params']['include_vectors'] is True
+
+    @pytest.mark.asyncio
+    async def test_get_vault_summary_passes_query_param(self, mock_client) -> None:
+        api = RemoteMemexAPI(mock_client)
+        captured: dict = {}
+        summary = {
+            'id': '11111111-1111-1111-1111-111111111111',
+            'vault_id': '22222222-2222-2222-2222-222222222222',
+            'narrative': 'n',
+            'themes': [],
+            'inventory': {},
+            'key_entities': [],
+            'version': 1,
+            'notes_incorporated': 0,
+            'created_at': '2026-01-01T00:00:00Z',
+            'updated_at': '2026-01-01T00:00:00Z',
+        }
+        mock_client.get = _capture_get(captured, payload=summary)
+
+        await api.get_vault_summary('22222222-2222-2222-2222-222222222222', include_vectors=True)
+
+        assert captured['params']['include_vectors'] is True
+
+    @pytest.mark.asyncio
+    async def test_kv_get_passes_query_param(self, mock_client) -> None:
+        api = RemoteMemexAPI(mock_client)
+        captured: dict = {}
+        entry = {
+            'id': '11111111-1111-1111-1111-111111111111',
+            'key': 'user:editor',
+            'value': 'neovim',
+            'created_at': '2026-01-01T00:00:00Z',
+            'updated_at': '2026-01-01T00:00:00Z',
+        }
+        mock_client.get = _capture_get(captured, payload=entry)
+
+        await api.kv_get('user:editor', include_vectors=True)
+
+        assert captured['params']['include_vectors'] is True
+
+    @pytest.mark.asyncio
+    async def test_kv_list_passes_query_param(self, mock_client) -> None:
+        api = RemoteMemexAPI(mock_client)
+        captured: dict = {}
+        mock_client.get = _capture_get(captured)
+
+        await api.kv_list(include_vectors=True)
+
+        assert captured['params']['include_vectors'] is True
+
+    @pytest.mark.asyncio
+    async def test_kv_search_body_carries_include_vectors(self, mock_client) -> None:
+        api = RemoteMemexAPI(mock_client)
+        captured: dict = {}
+
+        async def _post(path, json=None, content=None, **kwargs):
+            captured['path'] = path
+            captured['json'] = json
+            captured['content'] = content
+            return _json_response([])
+
+        mock_client.post = _post
+
+        await api.kv_search([0.1, 0.2], include_vectors=True)
+
+        body = captured['json']
+        if body is None and captured.get('content') is not None:
+            import json as _json
+
+            body = _json.loads(captured['content'])
+        assert body['include_vectors'] is True

--- a/packages/common/tests/test_client_include_vectors.py
+++ b/packages/common/tests/test_client_include_vectors.py
@@ -93,7 +93,8 @@ class TestGetMemoryUnitsByIds:
 
 class TestIncludeVectorsParamThreading:
     @pytest.mark.asyncio
-    async def test_get_memory_unit_passes_query_param(self, mock_client) -> None:
+    async def test_get_memory_unit_does_not_send_include_vectors(self, mock_client) -> None:
+        """The unscoped single-ID GET never exposes vectors — no flag on the wire."""
         api = RemoteMemexAPI(mock_client)
         captured: dict = {}
         unit = {
@@ -104,9 +105,9 @@ class TestIncludeVectorsParamThreading:
         }
         mock_client.get = _capture_get(captured, payload=unit)
 
-        await api.get_memory_unit('11111111-1111-1111-1111-111111111111', include_vectors=True)
+        await api.get_memory_unit('11111111-1111-1111-1111-111111111111')
 
-        assert captured['params']['include_vectors'] is True
+        assert 'include_vectors' not in (captured['params'] or {})
 
     @pytest.mark.asyncio
     async def test_by_chunks_body_carries_include_vectors(self, mock_client) -> None:

--- a/packages/common/tests/test_schemas_embedding_fields.py
+++ b/packages/common/tests/test_schemas_embedding_fields.py
@@ -1,0 +1,54 @@
+"""Wire-schema pins for opt-in vector exposure.
+
+Three DTOs gained an ``embedding`` field that defaults to None (so agent
+surfaces and existing callers see no vectors unless explicitly requested),
+and the dead ``RetrievalRequest.include_vectors`` flag was deleted (search
+results are vector-free by design — dead-flag-or-wired, never dead-flag-kept).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memex_common.schemas import (
+    KVEntryDTO,
+    KVSearchRequest,
+    MemoryUnitDTO,
+    RetrievalRequest,
+    VaultSummaryDTO,
+)
+
+
+class TestEmbeddingFieldDefaults:
+    def test_memory_unit_dto_embedding_defaults_none(self) -> None:
+        field = MemoryUnitDTO.model_fields['embedding']
+        assert field.default is None
+
+    def test_kv_entry_dto_embedding_defaults_none(self) -> None:
+        field = KVEntryDTO.model_fields['embedding']
+        assert field.default is None
+
+    def test_vault_summary_dto_embedding_defaults_none(self) -> None:
+        field = VaultSummaryDTO.model_fields['embedding']
+        assert field.default is None
+
+
+class TestDeadFlagDeleted:
+    def test_retrieval_request_has_no_include_vectors(self) -> None:
+        """The flag was dead for its whole life (zero readers); search stays
+        vector-free, so the field must not resurface on the wire model."""
+        assert 'include_vectors' not in RetrievalRequest.model_fields
+
+
+class TestKVSearchRequestIncludeVectors:
+    def test_defaults_false(self) -> None:
+        req = KVSearchRequest(query='what editor do I use?')
+        assert req.include_vectors is False
+
+    def test_exactly_one_query_validator_still_enforced(self) -> None:
+        with pytest.raises(ValueError):
+            KVSearchRequest(query='text', query_embedding=[0.1, 0.2], include_vectors=True)
+
+    def test_accepts_include_vectors_with_query_embedding(self) -> None:
+        req = KVSearchRequest(query_embedding=[0.1, 0.2], include_vectors=True)
+        assert req.include_vectors is True

--- a/packages/core/src/memex_core/alembic/versions/058_vault_summary_embedding.py
+++ b/packages/core/src/memex_core/alembic/versions/058_vault_summary_embedding.py
@@ -1,0 +1,34 @@
+"""Add a nullable narrative embedding to vault_summaries.
+
+The vault summary's narrative is the canonical vault-level text; storing its
+embedding lets HTTP/Python callers compare memory units against the vault
+without re-encoding the narrative per request. Populated lazily: the next
+``update_summary`` / ``regenerate_summary`` write fills it, so pre-existing
+rows stay NULL until their narrative is next rewritten. No index — the table
+holds one row per vault and is read by its unique ``vault_id`` key, never
+scanned by vector similarity.
+
+Revision ID: 058_vault_summary_embedding
+Revises: 057_lint_source_external
+Create Date: 2026-06-07
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from pgvector.sqlalchemy import Vector
+
+revision: str = '058_vault_summary_embedding'
+down_revision: str | None = '057_lint_source_external'
+branch_labels: str | list[str] | None = None
+depends_on: str | list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'vault_summaries',
+        sa.Column('embedding', Vector(384), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('vault_summaries', 'embedding')

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1484,8 +1484,9 @@ class MemexAPI:
         """Get a memory unit by ID. Delegates to StatsService.
 
         ``include_vectors`` exists for signature parity with
-        ``RemoteMemexAPI``; in-process rows on this path are eager-loaded,
-        so ``.embedding`` is populated regardless.
+        ``RemoteMemexAPI`` and is otherwise ignored: this returns the raw
+        ORM row (no DTO boundary in-process), whose ``.embedding``
+        attribute is eager-loaded on this path regardless of the flag.
         """
         return await self._stats.get_memory_unit(unit_id)
 

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -526,6 +526,7 @@ class MemexAPI:
             metastore=self.metastore,
             lm=self.lm,
             config=self.config.server.vault_summary,
+            embedding_model=self.embedding_model,
         )
         self._notes = NoteService(
             metastore=self.metastore,
@@ -1474,24 +1475,60 @@ class MemexAPI:
         """Get multiple entities by ID. Delegates to EntityService."""
         return await self._entities.get_entities(entity_ids, vault_id=vault_id)
 
-    async def get_memory_unit(self, unit_id: UUID | str) -> Any | None:
-        """Get a memory unit by ID. Delegates to StatsService."""
+    async def get_memory_unit(
+        self,
+        unit_id: UUID | str,
+        *,
+        include_vectors: bool = False,
+    ) -> Any | None:
+        """Get a memory unit by ID. Delegates to StatsService.
+
+        ``include_vectors`` exists for signature parity with
+        ``RemoteMemexAPI``; in-process rows on this path are eager-loaded,
+        so ``.embedding`` is populated regardless.
+        """
         return await self._stats.get_memory_unit(unit_id)
 
     async def get_memory_units_by_chunks(
         self,
         chunk_ids: list[UUID],
         vault_id: UUID,
+        *,
+        include_vectors: bool = False,
     ) -> list[Any]:
-        """Get memory units belonging to the named chunks (vault-scoped)."""
+        """Get memory units belonging to the named chunks (vault-scoped).
+
+        ``include_vectors`` exists for signature parity with
+        ``RemoteMemexAPI``; in-process rows expose ``.embedding`` regardless.
+        """
         return await self._stats.get_memory_units_by_chunks(chunk_ids, vault_id)
+
+    async def get_memory_units_by_ids(
+        self,
+        unit_ids: list[UUID],
+        vault_id: UUID,
+        *,
+        include_vectors: bool = False,
+    ) -> list[Any]:
+        """Get memory units by ID (vault-scoped). Delegates to StatsService.
+
+        ``include_vectors`` exists for signature parity with
+        ``RemoteMemexAPI``; in-process rows expose ``.embedding`` regardless.
+        """
+        return await self._stats.get_memory_units_by_ids(unit_ids, vault_id)
 
     async def list_memory_units_by_note(
         self,
         note_id: UUID,
         vault_id: UUID,
+        *,
+        include_vectors: bool = False,
     ) -> list[Any]:
-        """Get memory units belonging to a note (vault-scoped). Delegates to StatsService."""
+        """Get memory units belonging to a note (vault-scoped). Delegates to StatsService.
+
+        ``include_vectors`` exists for signature parity with
+        ``RemoteMemexAPI``; in-process rows expose ``.embedding`` regardless.
+        """
         return await self._stats.list_memory_units_by_note(note_id, vault_id)
 
     async def delete_memory_unit(self, unit_id: UUID) -> bool:
@@ -2168,12 +2205,21 @@ class MemexAPI:
             key=key, value=value, embedding=embedding, ttl_seconds=ttl_seconds
         )
 
-    async def kv_get(self, key: str, *, include_history: bool = False) -> Any | None:
+    async def kv_get(
+        self,
+        key: str,
+        *,
+        include_history: bool = False,
+        include_vectors: bool = False,
+    ) -> Any | None:
         """Get a KV entry by key. Delegates to KVService.
 
         For ``procedure:`` keys, ``include_history=True`` swaps the
         returned entry's ``value`` field from the unwrapped active string to
         a dict ``{value, version, history}``. Default behavior is unchanged.
+
+        ``include_vectors`` exists for signature parity with
+        ``RemoteMemexAPI``; in-process rows expose ``.embedding`` regardless.
         """
         return await self._kv.get(key=key, include_history=include_history)
 
@@ -2182,8 +2228,14 @@ class MemexAPI:
         query_embedding: list[float],
         namespaces: list[str] | None = None,
         limit: int = 5,
+        *,
+        include_vectors: bool = False,
     ) -> list[Any]:
-        """Semantic search over KV entries. Delegates to KVService."""
+        """Semantic search over KV entries. Delegates to KVService.
+
+        ``include_vectors`` exists for signature parity with
+        ``RemoteMemexAPI``; in-process rows expose ``.embedding`` regardless.
+        """
         return await self._kv.search(
             query_embedding=query_embedding, namespaces=namespaces, limit=limit
         )
@@ -2193,6 +2245,8 @@ class MemexAPI:
         query: str,
         namespaces: list[str] | None = None,
         limit: int = 5,
+        *,
+        include_vectors: bool = False,
     ) -> list[Any]:
         """Embed ``query`` locally, then delegate to :pymeth:`kv_search`.
 
@@ -2204,6 +2258,7 @@ class MemexAPI:
             query_embedding=embeddings[0].tolist(),
             namespaces=namespaces,
             limit=limit,
+            include_vectors=include_vectors,
         )
 
     async def kv_delete(self, key: str) -> bool:
@@ -2217,8 +2272,14 @@ class MemexAPI:
         exclude_prefix: str | None = None,
         key_prefix: str | None = None,
         pattern: str | None = None,
+        *,
+        include_vectors: bool = False,
     ) -> list[Any]:
-        """List KV entries. Delegates to KVService."""
+        """List KV entries. Delegates to KVService.
+
+        ``include_vectors`` exists for signature parity with
+        ``RemoteMemexAPI``; in-process rows expose ``.embedding`` regardless.
+        """
         return await self._kv.list_entries(
             namespaces=namespaces,
             limit=limit,

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -1475,18 +1475,12 @@ class MemexAPI:
         """Get multiple entities by ID. Delegates to EntityService."""
         return await self._entities.get_entities(entity_ids, vault_id=vault_id)
 
-    async def get_memory_unit(
-        self,
-        unit_id: UUID | str,
-        *,
-        include_vectors: bool = False,
-    ) -> Any | None:
+    async def get_memory_unit(self, unit_id: UUID | str) -> Any | None:
         """Get a memory unit by ID. Delegates to StatsService.
 
-        ``include_vectors`` exists for signature parity with
-        ``RemoteMemexAPI`` and is otherwise ignored: this returns the raw
-        ORM row (no DTO boundary in-process), whose ``.embedding``
-        attribute is eager-loaded on this path regardless of the flag.
+        Returns the raw ORM row, whose ``.embedding`` is eager-loaded; the
+        unscoped single-ID HTTP route does not serialize it (vectors are
+        confined to vault-scoped routes — use ``get_memory_units_by_ids``).
         """
         return await self._stats.get_memory_unit(unit_id)
 

--- a/packages/core/src/memex_core/memory/retrieval/models.py
+++ b/packages/core/src/memex_core/memory/retrieval/models.py
@@ -84,9 +84,6 @@ class RetrievalRequest(SQLModel):
     fusion_strategy: str = Field(
         default='rrf', description='The fusion strategy to use (e.g., rrf, position_aware).'
     )
-    include_vectors: bool = Field(
-        default=False, description='Whether to include embeddings in the result (slower).'
-    )
     include_stale: bool = Field(
         default=False, description='Whether to include stale memory units in results.'
     )

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -1787,6 +1787,14 @@ class VaultSummary(SQLModel, table=True):  # type: ignore
         sa_column=Column(JSONB, server_default=sql_text("'[]'::jsonb")),
         description='Top entities by mention count: [{name, type, mention_count}].',
     )
+    embedding: list[float] | None = Field(
+        default=None,
+        sa_column=Column(Vector(EMBEDDING_DIMENSION), nullable=True),
+        description=(
+            'Vector embedding of the narrative, refreshed on every (re)generation. '
+            'NULL for empty summaries, pre-migration rows, and encode failures.'
+        ),
+    )
     version: int = Field(
         default=1,
         description='Incremented on each update (patch or regeneration).',

--- a/packages/core/src/memex_core/server/common.py
+++ b/packages/core/src/memex_core/server/common.py
@@ -282,16 +282,30 @@ def _extract_superseded_by(unit: Any) -> list[SupersessionInfo] | None:
     return out or None
 
 
+def vector_to_list(vec: Any) -> list[float] | None:
+    """Normalize a pgvector/numpy/sequence vector to a JSON-serializable list."""
+    if vec is None:
+        return None
+    if hasattr(vec, 'tolist'):
+        return list(vec.tolist())
+    return [float(x) for x in vec]
+
+
 def build_memory_unit_dto(
     unit: Any,
     *,
     debug: bool = False,
+    include_vectors: bool = False,
 ) -> MemoryUnitDTO:
     """Build a MemoryUnitDTO from a MemoryUnit ORM/model object.
 
     Handles all field variations across retrieval, mentions, and single-unit
     endpoints.  Optional ``debug`` flag controls whether per-strategy
     attribution data is included.
+
+    ``include_vectors`` may only be True on paths whose rows were loaded
+    eagerly (the unit getters); retrieval-path rows defer the embedding
+    column, and touching it on a detached row raises.
 
     Confidence-variance is intentionally NOT passed: the DTO defaults to
     _MAX_VARIANCE, preserving the cold-start invariant (variance derived
@@ -319,6 +333,7 @@ def build_memory_unit_dto(
         id=unit.id,
         note_id=doc_id,
         source_note_ids=source_docs,
+        embedding=vector_to_list(getattr(unit, 'embedding', None)) if include_vectors else None,
         text=unit.text,
         fact_type=unit.fact_type,
         status=unit.status,

--- a/packages/core/src/memex_core/server/kv.py
+++ b/packages/core/src/memex_core/server/kv.py
@@ -16,10 +16,25 @@ from memex_common.schemas import (
 )
 
 from memex_core.api import MemexAPI
-from memex_core.server.common import _handle_error, get_api
+from memex_core.server.common import _handle_error, get_api, vector_to_list
 from memex_core.services.kv import is_procedure_key
 
 router = APIRouter(prefix='/api/v1')
+
+
+def _kv_entry_dto(entry: object, include_vectors: bool) -> KVEntryDTO:
+    """Validate a KV row into the DTO, stripping the vector unless requested.
+
+    ``model_validate(from_attributes=True)`` auto-populates every matching
+    attribute — including ``embedding`` — so the strip must be explicit or
+    every KV response would leak vectors by default.
+    """
+    dto = KVEntryDTO.model_validate(entry, from_attributes=True)
+    if include_vectors:
+        dto.embedding = vector_to_list(dto.embedding)
+    else:
+        dto.embedding = None
+    return dto
 
 
 class EmbedRequest(BaseModel):
@@ -60,7 +75,7 @@ async def kv_put(
             embedding=request.embedding,
             ttl_seconds=request.ttl_seconds,
         )
-        return KVEntryDTO.model_validate(entry, from_attributes=True)
+        return _kv_entry_dto(entry, include_vectors=False)
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, 'Failed to put KV entry')
 
@@ -79,6 +94,10 @@ async def kv_get(
             'For procedure: keys, return the full envelope (value, version, history) '
             'instead of just the active value. Ignored for non-procedure keys.'
         ),
+    ),
+    include_vectors: bool = Query(
+        False,
+        description="Include the entry's stored value vector in the response.",
     ),
 ):
     """Get a key-value entry by key.
@@ -101,7 +120,7 @@ async def kv_get(
                 created_at=entry.created_at,
                 updated_at=entry.updated_at,
             )
-        return KVEntryDTO.model_validate(entry, from_attributes=True)
+        return _kv_entry_dto(entry, include_vectors=include_vectors)
     except HTTPException:
         raise
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
@@ -129,7 +148,7 @@ async def kv_search(
             namespaces=request.namespaces,
             limit=request.limit,
         )
-        return [KVEntryDTO.model_validate(e, from_attributes=True) for e in entries]
+        return [_kv_entry_dto(e, include_vectors=request.include_vectors) for e in entries]
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, 'KV search failed')
 
@@ -168,6 +187,10 @@ async def kv_list(
         None,
         description='Wildcard filter (e.g. "global:preferences:*"). Only trailing * supported.',
     ),
+    include_vectors: bool = Query(
+        False,
+        description="Include each entry's stored value vector in the results.",
+    ),
 ):
     """List key-value entries, optionally filtered by namespace prefixes."""
     try:
@@ -182,6 +205,6 @@ async def kv_list(
             key_prefix=key_prefix,
             pattern=pattern,
         )
-        return [KVEntryDTO.model_validate(e, from_attributes=True) for e in entries]
+        return [_kv_entry_dto(e, include_vectors=include_vectors) for e in entries]
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, 'Failed to list KV entries')

--- a/packages/core/src/memex_core/server/memories.py
+++ b/packages/core/src/memex_core/server/memories.py
@@ -49,6 +49,31 @@ class MemoryUnitsByChunksRequest(BaseModel):
             'leak units from sibling vaults.'
         ),
     )
+    include_vectors: bool = Field(
+        default=False,
+        description="Include each unit's stored embedding vector in the results.",
+    )
+
+
+class MemoryUnitsByIdsRequest(BaseModel):
+    """Batch lookup of memory units by unit ID."""
+
+    unit_ids: list[UUID] = Field(
+        ...,
+        max_length=500,
+        description='Memory unit UUIDs to fetch (max 500 per request).',
+    )
+    vault_id: UUID = Field(
+        ...,
+        description=(
+            'Vault UUID to scope the lookup. REQUIRED — IDs belonging to a '
+            'sibling vault are silently omitted from the result.'
+        ),
+    )
+    include_vectors: bool = Field(
+        default=False,
+        description="Include each unit's stored embedding vector in the results.",
+    )
 
 
 @router.post(
@@ -65,7 +90,7 @@ async def get_memory_units_by_chunks(
     await check_vault_access(auth, [request.vault_id], api, permission=Permission.READ)
     try:
         units = await api.get_memory_units_by_chunks(request.chunk_ids, request.vault_id)
-        return [build_memory_unit_dto(u) for u in units]
+        return [build_memory_unit_dto(u, include_vectors=request.include_vectors) for u in units]
     except (MemexError, ValueError) as e:
         # Narrowed from (KeyError, RuntimeError, OSError) which can mask
         # genuine bugs (bad DTO dict access, filesystem errors) rather than
@@ -75,15 +100,48 @@ async def get_memory_units_by_chunks(
         raise _handle_error(e, 'Failed to get memory units by chunks')
 
 
+@router.post(
+    '/memories/by-ids',
+    response_model=list[MemoryUnitDTO],
+    dependencies=[Depends(require_read)],
+)
+async def get_memory_units_by_ids(
+    request: Annotated[MemoryUnitsByIdsRequest, Body()],
+    api: Annotated[MemexAPI, Depends(get_api)],
+    auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
+) -> list[MemoryUnitDTO]:
+    """Get memory units by ID (vault-scoped batch lookup).
+
+    IDs that don't exist or belong to another vault are silently omitted;
+    duplicates are deduplicated. Result order is not guaranteed to follow
+    input order.
+    """
+    await check_vault_access(auth, [request.vault_id], api, permission=Permission.READ)
+    try:
+        units = await api.get_memory_units_by_ids(request.unit_ids, request.vault_id)
+        return [build_memory_unit_dto(u, include_vectors=request.include_vectors) for u in units]
+    except (MemexError, ValueError) as e:
+        # Narrow catch matches get_memory_units_by_chunks above, where the
+        # comment explains the reasoning.
+        raise _handle_error(e, 'Failed to get memory units by ids')
+
+
 @router.get('/memories/{id}', response_model=MemoryUnitDTO, dependencies=[Depends(require_read)])
-async def get_memory_unit(id: UUID, api: Annotated[MemexAPI, Depends(get_api)]):
+async def get_memory_unit(
+    id: UUID,
+    api: Annotated[MemexAPI, Depends(get_api)],
+    include_vectors: Annotated[
+        bool,
+        Query(description="Include the unit's stored embedding vector in the response."),
+    ] = False,
+):
     """Get memory unit details."""
     try:
         unit = await api.get_memory_unit(id)
         if not unit:
             raise HTTPException(status_code=404, detail=f'Memory unit {id} not found')
 
-        return build_memory_unit_dto(unit)
+        return build_memory_unit_dto(unit, include_vectors=include_vectors)
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, f'Failed to get memory unit {id}')
 
@@ -101,6 +159,10 @@ async def list_memory_units_by_note(
     ],
     api: Annotated[MemexAPI, Depends(get_api)],
     auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
+    include_vectors: Annotated[
+        bool,
+        Query(description="Include each unit's stored embedding vector in the results."),
+    ] = False,
 ) -> list[MemoryUnitDTO]:
     """List memory units belonging to a note (vault-scoped).
 
@@ -112,10 +174,10 @@ async def list_memory_units_by_note(
     await check_vault_access(auth, [vault_id], api, permission=Permission.READ)
     try:
         units = await api.list_memory_units_by_note(note_id, vault_id)
-        return [build_memory_unit_dto(u) for u in units]
+        return [build_memory_unit_dto(u, include_vectors=include_vectors) for u in units]
     except (MemexError, ValueError) as e:
-        # Narrow catch matches the sibling get_memory_units_by_chunks above
-        # (lines 65-71 explain the reasoning): KeyError / RuntimeError /
+        # Narrow catch matches the sibling get_memory_units_by_chunks above,
+        # where the comment explains the reasoning: KeyError / RuntimeError /
         # OSError mask genuine bugs rather than client-visible failures.
         # Service-layer raises MemexError subclasses for known failure modes;
         # ValueError covers UUID/typing validation. Anything else propagates

--- a/packages/core/src/memex_core/server/memories.py
+++ b/packages/core/src/memex_core/server/memories.py
@@ -127,21 +127,23 @@ async def get_memory_units_by_ids(
 
 
 @router.get('/memories/{id}', response_model=MemoryUnitDTO, dependencies=[Depends(require_read)])
-async def get_memory_unit(
-    id: UUID,
-    api: Annotated[MemexAPI, Depends(get_api)],
-    include_vectors: Annotated[
-        bool,
-        Query(description="Include the unit's stored embedding vector in the response."),
-    ] = False,
-):
-    """Get memory unit details."""
+async def get_memory_unit(id: UUID, api: Annotated[MemexAPI, Depends(get_api)]):
+    """Get memory unit details.
+
+    This route is intentionally NOT vault-scoped (no ``vault_id``, no
+    ``check_vault_access``) — preserved from before this contract for the
+    many vault-agnostic callers (CLI, cockpit, MCP, Hermes). Because of
+    that, it deliberately does NOT expose embedding vectors: vector
+    exposure is confined to vault-scoped routes. To fetch a single unit's
+    vector, use ``POST /memories/by-ids`` with a one-element ``unit_ids``
+    and the owning ``vault_id``.
+    """
     try:
         unit = await api.get_memory_unit(id)
         if not unit:
             raise HTTPException(status_code=404, detail=f'Memory unit {id} not found')
 
-        return build_memory_unit_dto(unit, include_vectors=include_vectors)
+        return build_memory_unit_dto(unit)
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, f'Failed to get memory unit {id}')
 

--- a/packages/core/src/memex_core/server/vault_summary.py
+++ b/packages/core/src/memex_core/server/vault_summary.py
@@ -6,9 +6,16 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from memex_common.config import Permission
 from memex_common.exceptions import MemexError
 from memex_common.schemas import VaultSummaryDTO
-from memex_core.server.auth import require_read, require_write
+from memex_core.server.auth import (
+    AuthContext,
+    check_vault_access,
+    get_auth_context,
+    require_read,
+    require_write,
+)
 from memex_core.server.common import _handle_error, get_api, vector_to_list
 from memex_core.api import MemexAPI
 from memex_core.memory.sql_models import VaultSummary
@@ -48,8 +55,10 @@ async def get_vault_summary(
         bool,
         Query(description='Include the stored narrative embedding in the response.'),
     ] = False,
+    auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
 ) -> VaultSummaryDTO:
     """Return the current vault summary, or 404 if none exists."""
+    await check_vault_access(auth, [vault_id], api, permission=Permission.READ)
     try:
         summary = await api.vault_summary.get_summary(vault_id)
         if summary is None:
@@ -71,8 +80,10 @@ async def get_vault_summary(
 async def regenerate_vault_summary(
     vault_id: UUID,
     api: Annotated[MemexAPI, Depends(get_api)],
+    auth: Annotated[AuthContext | None, Depends(get_auth_context)] = None,
 ) -> VaultSummaryDTO:
     """Regenerate the vault summary from scratch."""
+    await check_vault_access(auth, [vault_id], api, permission=Permission.WRITE)
     try:
         summary = await api.vault_summary.regenerate_summary(vault_id)
         return _summary_to_dto(summary)

--- a/packages/core/src/memex_core/server/vault_summary.py
+++ b/packages/core/src/memex_core/server/vault_summary.py
@@ -4,12 +4,12 @@ import logging
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from memex_common.exceptions import MemexError
 from memex_common.schemas import VaultSummaryDTO
 from memex_core.server.auth import require_read, require_write
-from memex_core.server.common import _handle_error, get_api
+from memex_core.server.common import _handle_error, get_api, vector_to_list
 from memex_core.api import MemexAPI
 from memex_core.memory.sql_models import VaultSummary
 
@@ -18,7 +18,7 @@ logger = logging.getLogger('memex.core.server.vault_summary')
 router = APIRouter(prefix='/api/v1')
 
 
-def _summary_to_dto(summary: VaultSummary) -> VaultSummaryDTO:
+def _summary_to_dto(summary: VaultSummary, *, include_vectors: bool = False) -> VaultSummaryDTO:
     return VaultSummaryDTO(
         id=summary.id,
         vault_id=summary.vault_id,
@@ -26,6 +26,7 @@ def _summary_to_dto(summary: VaultSummary) -> VaultSummaryDTO:
         themes=summary.themes,
         inventory=summary.inventory,
         key_entities=summary.key_entities,
+        embedding=vector_to_list(summary.embedding) if include_vectors else None,
         version=summary.version,
         notes_incorporated=summary.notes_incorporated,
         created_at=summary.created_at,
@@ -43,13 +44,17 @@ def _summary_to_dto(summary: VaultSummary) -> VaultSummaryDTO:
 async def get_vault_summary(
     vault_id: UUID,
     api: Annotated[MemexAPI, Depends(get_api)],
+    include_vectors: Annotated[
+        bool,
+        Query(description='Include the stored narrative embedding in the response.'),
+    ] = False,
 ) -> VaultSummaryDTO:
     """Return the current vault summary, or 404 if none exists."""
     try:
         summary = await api.vault_summary.get_summary(vault_id)
         if summary is None:
             raise HTTPException(status_code=404, detail='No summary exists for this vault')
-        return _summary_to_dto(summary)
+        return _summary_to_dto(summary, include_vectors=include_vectors)
     except HTTPException:
         raise
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:

--- a/packages/core/src/memex_core/services/stats.py
+++ b/packages/core/src/memex_core/services/stats.py
@@ -114,6 +114,32 @@ class StatsService(BaseService):
             result = await session.exec(stmt)
             return list(result.all())
 
+    async def get_memory_units_by_ids(
+        self,
+        unit_ids: list[UUID],
+        vault_id: UUID,
+    ) -> list[Any]:
+        """Return memory units whose ``id`` is in ``unit_ids``, scoped to ``vault_id``.
+
+        Vault-scoping is mandatory — IDs from a sibling vault are silently
+        omitted, never returned. Duplicate IDs are deduplicated by the SQL
+        ``IN``; result order is not guaranteed to follow input order.
+        """
+        from sqlmodel import select
+
+        from memex_core.memory.sql_models import MemoryUnit
+
+        if not unit_ids:
+            return []
+
+        async with self.metastore.session() as session:
+            stmt = select(MemoryUnit).where(
+                col(MemoryUnit.id).in_(unit_ids),
+                MemoryUnit.vault_id == vault_id,
+            )
+            result = await session.exec(stmt)
+            return list(result.all())
+
     async def list_memory_units_by_note(
         self,
         note_id: UUID,

--- a/packages/core/src/memex_core/services/vault_summary.py
+++ b/packages/core/src/memex_core/services/vault_summary.py
@@ -17,6 +17,7 @@ Full regeneration is available on demand via ``regenerate_summary()``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from collections import Counter
@@ -32,6 +33,7 @@ from sqlmodel import col, func, select
 
 from memex_common.config import VaultSummaryConfig
 from memex_core.llm import run_dspy_operation
+from memex_core.memory.models.protocols import EmbeddingsModel
 from memex_core.memory.sql_models import (
     Chunk,
     ContentStatus,
@@ -140,10 +142,12 @@ class VaultSummaryService:
         metastore: AsyncBaseMetaStoreEngine,
         lm: dspy.LM,
         config: VaultSummaryConfig,
+        embedding_model: EmbeddingsModel,
     ) -> None:
         self.metastore = metastore
         self.lm = lm
         self.config = config
+        self.embedding_model = embedding_model
 
     async def get_summary(self, vault_id: UUID) -> VaultSummary | None:
         """Fetch the current vault summary, or None if none exists.
@@ -424,6 +428,8 @@ class VaultSummaryService:
             running_narrative = prediction.updated_narrative
             running_themes = prediction.updated_themes
 
+        narrative_embedding = await self._embed_narrative(running_narrative, vault_id)
+
         # Phase 4: Persist with SELECT FOR UPDATE to prevent concurrent overwrites
         async with self.metastore.session() as session:
             stmt = (
@@ -443,6 +449,7 @@ class VaultSummaryService:
                 return summary
 
             summary.narrative = running_narrative
+            summary.embedding = narrative_embedding
             summary.themes = _themes_to_dicts(running_themes)
             summary.inventory = inventory
             summary.key_entities = key_entities
@@ -514,6 +521,8 @@ class VaultSummaryService:
         else:
             narrative, themes = await self._tier3_hierarchical(notes_data, note_count, current_time)
 
+        narrative_embedding = await self._embed_narrative(narrative, vault_id)
+
         # Persist
         async with self.metastore.session() as session:
             stmt = select(VaultSummary).where(col(VaultSummary.vault_id) == vault_id)
@@ -525,6 +534,7 @@ class VaultSummaryService:
                 session.add(summary)
 
             summary.narrative = narrative
+            summary.embedding = narrative_embedding
             summary.themes = themes
             summary.inventory = inventory
             summary.key_entities = key_entities
@@ -546,6 +556,30 @@ class VaultSummaryService:
             await session.commit()
             await session.refresh(summary)
             return summary
+
+    async def _embed_narrative(self, narrative: str, vault_id: UUID) -> list[float] | None:
+        """Encode the narrative; non-fatal — a summary without a vector beats no summary."""
+        from memex_core.memory.retrieval._offload import (
+            get_embedding_call_timeout,
+            get_embedding_semaphore,
+        )
+
+        try:
+            async with get_embedding_semaphore():
+                vectors = await asyncio.wait_for(
+                    asyncio.to_thread(self.embedding_model.encode, [narrative]),
+                    timeout=get_embedding_call_timeout(),
+                )
+            return list(vectors[0].tolist())
+        except Exception as e:
+            logger.warning(
+                'Vault summary narrative embedding failed for vault %s (%s); '
+                'persisting without vector',
+                vault_id,
+                type(e).__name__,
+                exc_info=True,
+            )
+            return None
 
     # ------------------------------------------------------------------ #
     # Computed fields (no LLM)
@@ -803,6 +837,9 @@ class VaultSummaryService:
                 session.add(summary)
 
             summary.narrative = 'This vault is empty.'
+            # A vault can be EMPTIED (all notes deleted) — a previous narrative's
+            # vector must not survive as a similarity target for the placeholder.
+            summary.embedding = None
             summary.themes = []
             summary.inventory = {'total_notes': 0, 'total_entities': 0}
             summary.key_entities = []

--- a/packages/core/tests/integration/test_int_alembic_058.py
+++ b/packages/core/tests/integration/test_int_alembic_058.py
@@ -1,0 +1,137 @@
+"""Migration round-trip test for the vault-summary embedding column (058).
+
+Verifies via a real ``alembic upgrade`` / ``downgrade`` (not create_all),
+against a populated table, that:
+- 058 adds a nullable ``embedding`` column to ``vault_summaries``.
+- A pre-existing row (seeded at 057) SURVIVES the upgrade with its data
+  intact and ``embedding IS NULL`` (lazy backfill — the column is not
+  populated by the migration).
+- Downgrade drops the column and leaves the row's other data intact.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import NullPool, text
+from sqlalchemy.ext.asyncio import create_async_engine
+from testcontainers.postgres import PostgresContainer
+
+from _alembic_test_helpers import (  # noqa: F401
+    alembic_downgrade as _alembic_downgrade,
+    alembic_upgrade as _alembic_upgrade,
+    make_fresh_db,
+)
+
+pytestmark = [pytest.mark.integration]
+
+_TARGET_BEFORE = '057_lint_source_external'
+_TARGET_AFTER = '058_vault_summary_embedding'
+
+
+@pytest_asyncio.fixture
+async def fresh_db_url(postgres_container: PostgresContainer) -> AsyncGenerator[str, None]:
+    async for url in make_fresh_db(postgres_container, db_prefix='mig058'):
+        yield url
+
+
+async def _seed_summary_at_057(db_url: str) -> str:
+    """Upgrade to 057 and seed one vault + one vault_summaries row. Returns vault_id."""
+    await _alembic_upgrade(db_url, target=_TARGET_BEFORE)
+    engine = create_async_engine(db_url, poolclass=NullPool)
+    try:
+        async with engine.begin() as conn:
+            vid = (
+                await conn.execute(
+                    text(
+                        'INSERT INTO vaults (id, name) '
+                        "VALUES (gen_random_uuid(), 'emb-mig-058') RETURNING id"
+                    )
+                )
+            ).scalar()
+            await conn.execute(
+                text(
+                    'INSERT INTO vault_summaries '
+                    '(id, vault_id, narrative, themes, inventory, key_entities, '
+                    ' version, notes_incorporated, patch_log) '
+                    "VALUES (gen_random_uuid(), :v, 'pre-existing narrative', "
+                    "'[]'::jsonb, '{}'::jsonb, '[]'::jsonb, 3, 7, '[]'::jsonb)"
+                ),
+                {'v': vid},
+            )
+        return str(vid)
+    finally:
+        await engine.dispose()
+
+
+async def _column_exists(conn, table: str, column: str) -> bool:
+    return bool(
+        (
+            await conn.execute(
+                text(
+                    'SELECT 1 FROM information_schema.columns '
+                    'WHERE table_name = :t AND column_name = :c'
+                ),
+                {'t': table, 'c': column},
+            )
+        ).scalar()
+    )
+
+
+@pytest.mark.asyncio
+async def test_upgrade_adds_nullable_embedding_and_preserves_rows(fresh_db_url: str) -> None:
+    vid = await _seed_summary_at_057(fresh_db_url)
+
+    # 057 has no embedding column.
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            assert not await _column_exists(conn, 'vault_summaries', 'embedding')
+    finally:
+        await engine.dispose()
+
+    await _alembic_upgrade(fresh_db_url, target=_TARGET_AFTER)
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            assert await _column_exists(conn, 'vault_summaries', 'embedding')
+            row = (
+                await conn.execute(
+                    text(
+                        'SELECT narrative, version, notes_incorporated, embedding '
+                        'FROM vault_summaries WHERE vault_id = :v'
+                    ),
+                    {'v': vid},
+                )
+            ).one()
+            # Pre-existing data intact; embedding lazily NULL (not backfilled).
+            assert row[0] == 'pre-existing narrative'
+            assert row[1] == 3
+            assert row[2] == 7
+            assert row[3] is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_downgrade_drops_column_and_keeps_row(fresh_db_url: str) -> None:
+    vid = await _seed_summary_at_057(fresh_db_url)
+    await _alembic_upgrade(fresh_db_url, target=_TARGET_AFTER)
+    await _alembic_downgrade(fresh_db_url, _TARGET_BEFORE)
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            assert not await _column_exists(conn, 'vault_summaries', 'embedding')
+            narrative = (
+                await conn.execute(
+                    text('SELECT narrative FROM vault_summaries WHERE vault_id = :v'),
+                    {'v': vid},
+                )
+            ).scalar()
+            assert narrative == 'pre-existing narrative'
+    finally:
+        await engine.dispose()

--- a/packages/core/tests/integration/test_int_embedding_exposure.py
+++ b/packages/core/tests/integration/test_int_embedding_exposure.py
@@ -369,3 +369,58 @@ async def test_http_vault_summary_vector_matrix(http_client, metastore):
     vec = resp.json()['embedding']
     assert vec is not None and len(vec) == 384
     assert vec[0] == pytest.approx(0.6, abs=1e-4)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_vault_summary_vectors_are_vault_authz_gated(api, metastore):
+    """A vault-restricted key cannot read another vault's summary embedding —
+    the summary route enforces check_vault_access (403), so the matrix above
+    (auth disabled) does not give vectors a cross-vault bypass."""
+    import httpx
+
+    from memex_core.server import app
+    from memex_core.server.auth import (
+        AuthContext,
+        Permission,
+        Policy,
+        get_auth_context,
+    )
+
+    async with metastore.session() as session:
+        allowed_vault = await _create_vault(session, 'authz_allowed')
+        foreign_vault = await _create_vault(session, 'authz_foreign')
+        session.add(
+            VaultSummary(
+                vault_id=foreign_vault,
+                narrative='Foreign vault narrative.',
+                embedding=[0.9] * 384,
+            )
+        )
+        await session.commit()
+
+    async def _restricted_auth():
+        return AuthContext(
+            key_prefix='test...',
+            key_name='restricted',
+            policy=Policy.READER,
+            permissions=frozenset({Permission.READ}),
+            vault_ids=[str(allowed_vault)],
+            read_vault_ids=None,
+        )
+
+    app.state.api = api
+    app.dependency_overrides[get_auth_context] = _restricted_auth
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url='http://test') as client:
+            # Foreign vault → 403 even with include_vectors requested.
+            resp = await client.get(f'/api/v1/vaults/{foreign_vault}/summary?include_vectors=true')
+            assert resp.status_code == 403, resp.text
+            # The allowed vault is reachable (404 — no summary — not 403).
+            resp = await client.get(f'/api/v1/vaults/{allowed_vault}/summary')
+            assert resp.status_code == 404, resp.text
+    finally:
+        if hasattr(app.state, 'api'):
+            del app.state.api
+        app.dependency_overrides.pop(get_auth_context, None)

--- a/packages/core/tests/integration/test_int_embedding_exposure.py
+++ b/packages/core/tests/integration/test_int_embedding_exposure.py
@@ -1,0 +1,232 @@
+"""Integration tests for stored-embedding exposure (real Postgres + pgvector).
+
+Covers the DB-level truths behind the ``include_vectors`` surfaces:
+
+- vault-summary narrative embedding is persisted on regeneration and
+  round-trips through pgvector
+- encode failure persists the narrative WITHOUT a vector (non-fatal)
+- emptying a vault NULLs a stale narrative embedding
+- the by-ids batch lookup is vault-scoped, deduplicates, and omits
+  foreign-vault IDs silently
+
+Requires Docker/Postgres via testcontainers.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import text
+from sqlmodel import col, select
+
+from memex_common.config import VaultSummaryConfig
+from memex_core.memory.sql_models import MemoryUnit, Note, VaultSummary
+from memex_core.services.vault_summary import VaultSummaryService
+
+
+async def _create_vault(session, name_prefix: str) -> uuid.UUID:
+    vault_id = uuid.uuid4()
+    await session.execute(
+        text('INSERT INTO vaults (id, name) VALUES (:id, :name)'),
+        {'id': str(vault_id), 'name': f'{name_prefix}_{vault_id.hex[:8]}'},
+    )
+    return vault_id
+
+
+def _summary_service(metastore, embedding_model) -> VaultSummaryService:
+    return VaultSummaryService(
+        metastore=metastore,
+        lm=MagicMock(),
+        config=VaultSummaryConfig(),
+        embedding_model=embedding_model,
+    )
+
+
+async def _read_summary(metastore, vault_id) -> VaultSummary | None:
+    async with metastore.session() as session:
+        result = await session.execute(
+            select(VaultSummary).where(col(VaultSummary.vault_id) == vault_id)
+        )
+        return result.scalar_one_or_none()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_regenerate_persists_narrative_embedding(metastore, mock_embedding_model):
+    """Regeneration encodes the final narrative and persists the vector."""
+    async with metastore.session() as session:
+        vault_id = await _create_vault(session, 'emb_regen')
+        session.add(
+            Note(
+                id=uuid.uuid4(),
+                vault_id=vault_id,
+                title='Embedding exposure design notes',
+                original_text=f'Note about embeddings {uuid.uuid4()}',
+                content_hash=f'hash_{uuid.uuid4()}',
+            )
+        )
+        await session.commit()
+
+    service = _summary_service(metastore, mock_embedding_model)
+    fake_prediction = SimpleNamespace(narrative='A vault about embedding exposure.', themes=[])
+    with patch(
+        'memex_core.services.vault_summary.run_dspy_operation',
+        new=AsyncMock(return_value=fake_prediction),
+    ):
+        returned = await service.regenerate_summary(vault_id)
+
+    assert returned.embedding is not None
+    row = await _read_summary(metastore, vault_id)
+    assert row is not None
+    assert row.narrative == 'A vault about embedding exposure.'
+    assert row.embedding is not None
+    assert len(list(row.embedding)) == 384
+    assert list(row.embedding)[0] == pytest.approx(0.1)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_encode_failure_persists_narrative_without_vector(metastore):
+    """A broken embedding backend must not fail the summary write."""
+    async with metastore.session() as session:
+        vault_id = await _create_vault(session, 'emb_fail')
+        session.add(
+            Note(
+                id=uuid.uuid4(),
+                vault_id=vault_id,
+                title='Encode failure scenario',
+                original_text=f'Note {uuid.uuid4()}',
+                content_hash=f'hash_{uuid.uuid4()}',
+            )
+        )
+        await session.commit()
+
+    broken_model = MagicMock()
+    broken_model.encode.side_effect = RuntimeError('encode exploded')
+    service = _summary_service(metastore, broken_model)
+    fake_prediction = SimpleNamespace(narrative='Narrative survives.', themes=[])
+    with patch(
+        'memex_core.services.vault_summary.run_dspy_operation',
+        new=AsyncMock(return_value=fake_prediction),
+    ):
+        returned = await service.regenerate_summary(vault_id)
+
+    assert returned.narrative == 'Narrative survives.'
+    row = await _read_summary(metastore, vault_id)
+    assert row is not None
+    assert row.narrative == 'Narrative survives.'
+    assert row.embedding is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_empty_vault_nulls_stale_embedding(metastore, mock_embedding_model):
+    """Emptying a vault must not leave the old narrative's vector behind."""
+    async with metastore.session() as session:
+        vault_id = await _create_vault(session, 'emb_empty')
+        session.add(
+            VaultSummary(
+                vault_id=vault_id,
+                narrative='Old narrative with a vector.',
+                embedding=[0.5] * 384,
+            )
+        )
+        await session.commit()
+
+    service = _summary_service(metastore, mock_embedding_model)
+    # No notes in the vault -> regenerate routes to _create_empty_summary.
+    returned = await service.regenerate_summary(vault_id)
+
+    assert returned.narrative == 'This vault is empty.'
+    row = await _read_summary(metastore, vault_id)
+    assert row is not None
+    assert row.embedding is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_vault_summary_embedding_pgvector_roundtrip(metastore):
+    """The 384-dim vector survives a write/read cycle through pgvector."""
+    async with metastore.session() as session:
+        vault_id = await _create_vault(session, 'emb_roundtrip')
+        session.add(
+            VaultSummary(
+                vault_id=vault_id,
+                narrative='Roundtrip narrative.',
+                embedding=[0.25] * 384,
+            )
+        )
+        await session.commit()
+
+    row = await _read_summary(metastore, vault_id)
+    assert row is not None
+    values = list(row.embedding)
+    assert len(values) == 384
+    assert values[0] == pytest.approx(0.25)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_memory_units_by_ids_is_vault_scoped(api, metastore):
+    """Foreign-vault IDs are silently omitted; duplicates deduplicate."""
+    async with metastore.session() as session:
+        vault_a = await _create_vault(session, 'byids_a')
+        vault_b = await _create_vault(session, 'byids_b')
+        note_a = Note(
+            id=uuid.uuid4(),
+            vault_id=vault_a,
+            original_text=f'Note A {uuid.uuid4()}',
+            content_hash=f'hash_{uuid.uuid4()}',
+        )
+        note_b = Note(
+            id=uuid.uuid4(),
+            vault_id=vault_b,
+            original_text=f'Note B {uuid.uuid4()}',
+            content_hash=f'hash_{uuid.uuid4()}',
+        )
+        session.add(note_a)
+        session.add(note_b)
+        await session.flush()
+
+        unit_a_id, unit_b_id = uuid.uuid4(), uuid.uuid4()
+        unit_a = MemoryUnit(
+            id=unit_a_id,
+            vault_id=vault_a,
+            note_id=note_a.id,
+            text=f'Unit in vault A {uuid.uuid4()}',
+            fact_type='world',
+            embedding=[0.1] * 384,
+            event_date=datetime.now(timezone.utc),
+        )
+        unit_b = MemoryUnit(
+            id=unit_b_id,
+            vault_id=vault_b,
+            note_id=note_b.id,
+            text=f'Unit in vault B {uuid.uuid4()}',
+            fact_type='world',
+            embedding=[0.2] * 384,
+            event_date=datetime.now(timezone.utc),
+        )
+        session.add(unit_a)
+        session.add(unit_b)
+        await session.commit()
+
+    # Duplicate unit_a_id + a foreign-vault id + a nonexistent id.
+    results = await api.get_memory_units_by_ids(
+        [unit_a_id, unit_a_id, unit_b_id, uuid.uuid4()],
+        vault_a,
+    )
+
+    assert [u.id for u in results] == [unit_a_id]
+    # The eager row exposes its vector in-process regardless of any flag.
+    assert results[0].embedding is not None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_memory_units_by_ids_empty_input(api):
+    assert await api.get_memory_units_by_ids([], uuid.uuid4()) == []

--- a/packages/core/tests/integration/test_int_embedding_exposure.py
+++ b/packages/core/tests/integration/test_int_embedding_exposure.py
@@ -230,3 +230,143 @@ async def test_get_memory_units_by_ids_is_vault_scoped(api, metastore):
 @pytest.mark.asyncio
 async def test_get_memory_units_by_ids_empty_input(api):
     assert await api.get_memory_units_by_ids([], uuid.uuid4()) == []
+
+
+# --------------------------------------------------------------------------- #
+# HTTP-layer matrix: include_vectors over the real app + real Postgres
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+async def http_client(api):
+    """ASGI client on the test's own event loop — a sync TestClient would run
+    requests on a second loop and trip the session-scoped async engine."""
+    import httpx
+
+    from memex_core.server import app
+    from memex_core.server.auth import get_auth_context
+
+    app.state.api = api
+    app.dependency_overrides[get_auth_context] = lambda: None
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url='http://test') as client:
+        yield client
+    if hasattr(app.state, 'api'):
+        del app.state.api
+    app.dependency_overrides.pop(get_auth_context, None)
+
+
+async def _seed_unit(metastore) -> tuple[uuid.UUID, uuid.UUID]:
+    async with metastore.session() as session:
+        vault_id = await _create_vault(session, 'http_matrix')
+        note = Note(
+            id=uuid.uuid4(),
+            vault_id=vault_id,
+            title='HTTP matrix note',
+            original_text=f'Note {uuid.uuid4()}',
+            content_hash=f'hash_{uuid.uuid4()}',
+        )
+        session.add(note)
+        await session.flush()
+        unit_id = uuid.uuid4()
+        session.add(
+            MemoryUnit(
+                id=unit_id,
+                vault_id=vault_id,
+                note_id=note.id,
+                text=f'HTTP matrix unit {uuid.uuid4()}',
+                fact_type='world',
+                embedding=[0.3] * 384,
+                event_date=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+    return vault_id, unit_id
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_http_unit_getters_vector_matrix(http_client, metastore):
+    """Rows in Postgres carry vectors; the wire strips them unless requested."""
+    vault_id, unit_id = await _seed_unit(metastore)
+
+    resp = await http_client.get(f'/api/v1/memories/{unit_id}')
+    assert resp.status_code == 200, resp.text
+    assert resp.json()['embedding'] is None
+
+    resp = await http_client.get(f'/api/v1/memories/{unit_id}?include_vectors=true')
+    assert resp.status_code == 200
+    vec = resp.json()['embedding']
+    assert vec is not None and len(vec) == 384
+    assert vec[0] == pytest.approx(0.3, abs=1e-4)
+
+    body = {'unit_ids': [str(unit_id)], 'vault_id': str(vault_id)}
+    resp = await http_client.post('/api/v1/memories/by-ids', json=body)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()[0]['embedding'] is None
+
+    resp = await http_client.post('/api/v1/memories/by-ids', json={**body, 'include_vectors': True})
+    assert resp.status_code == 200
+    assert len(resp.json()[0]['embedding']) == 384
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_http_kv_vector_matrix(http_client, api):
+    """KV rows are fully loaded server-side (from_attributes leak surface) —
+    the wire must strip by default on get, list, and search."""
+    key = f'project:test:embed-matrix-{uuid.uuid4().hex[:8]}'
+    await api.kv_put(key=key, value='vector-laden', embedding=[0.7] * 384)
+
+    resp = await http_client.get('/api/v1/kv/get', params={'key': key})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()['embedding'] is None
+
+    resp = await http_client.get('/api/v1/kv/get', params={'key': key, 'include_vectors': True})
+    assert resp.status_code == 200
+    assert len(resp.json()['embedding']) == 384
+
+    resp = await http_client.get('/api/v1/kv', params={'key_prefix': key})
+    assert resp.status_code == 200
+    assert resp.json()[0]['embedding'] is None
+
+    resp = await http_client.get('/api/v1/kv', params={'key_prefix': key, 'include_vectors': True})
+    assert resp.status_code == 200
+    assert len(resp.json()[0]['embedding']) == 384
+
+    search_body = {'query_embedding': [0.7] * 384, 'limit': 5}
+    resp = await http_client.post('/api/v1/kv/search', json=search_body)
+    assert resp.status_code == 200
+    assert all(r['embedding'] is None for r in resp.json())
+
+    resp = await http_client.post(
+        '/api/v1/kv/search', json={**search_body, 'include_vectors': True}
+    )
+    assert resp.status_code == 200
+    hits = [r for r in resp.json() if r['key'] == key]
+    assert hits and len(hits[0]['embedding']) == 384
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_http_vault_summary_vector_matrix(http_client, metastore):
+    async with metastore.session() as session:
+        vault_id = await _create_vault(session, 'http_summary')
+        session.add(
+            VaultSummary(
+                vault_id=vault_id,
+                narrative='HTTP matrix narrative.',
+                embedding=[0.6] * 384,
+            )
+        )
+        await session.commit()
+
+    resp = await http_client.get(f'/api/v1/vaults/{vault_id}/summary')
+    assert resp.status_code == 200, resp.text
+    assert resp.json()['embedding'] is None
+
+    resp = await http_client.get(f'/api/v1/vaults/{vault_id}/summary?include_vectors=true')
+    assert resp.status_code == 200
+    vec = resp.json()['embedding']
+    assert vec is not None and len(vec) == 384
+    assert vec[0] == pytest.approx(0.6, abs=1e-4)

--- a/packages/core/tests/integration/test_int_embedding_exposure.py
+++ b/packages/core/tests/integration/test_int_embedding_exposure.py
@@ -287,18 +287,15 @@ async def _seed_unit(metastore) -> tuple[uuid.UUID, uuid.UUID]:
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_http_unit_getters_vector_matrix(http_client, metastore):
-    """Rows in Postgres carry vectors; the wire strips them unless requested."""
+    """Rows in Postgres carry vectors; the wire strips them unless requested
+    on a vault-scoped route. The unscoped single-ID GET NEVER returns a
+    vector — confirmed even though the row carries one."""
     vault_id, unit_id = await _seed_unit(metastore)
 
+    # Single-ID GET is unscoped → never serves the vector, no opt-in exists.
     resp = await http_client.get(f'/api/v1/memories/{unit_id}')
     assert resp.status_code == 200, resp.text
     assert resp.json()['embedding'] is None
-
-    resp = await http_client.get(f'/api/v1/memories/{unit_id}?include_vectors=true')
-    assert resp.status_code == 200
-    vec = resp.json()['embedding']
-    assert vec is not None and len(vec) == 384
-    assert vec[0] == pytest.approx(0.3, abs=1e-4)
 
     body = {'unit_ids': [str(unit_id)], 'vault_id': str(vault_id)}
     resp = await http_client.post('/api/v1/memories/by-ids', json=body)
@@ -307,7 +304,9 @@ async def test_http_unit_getters_vector_matrix(http_client, metastore):
 
     resp = await http_client.post('/api/v1/memories/by-ids', json={**body, 'include_vectors': True})
     assert resp.status_code == 200
-    assert len(resp.json()[0]['embedding']) == 384
+    vec = resp.json()[0]['embedding']
+    assert vec is not None and len(vec) == 384
+    assert vec[0] == pytest.approx(0.3, abs=1e-4)
 
 
 @pytest.mark.integration

--- a/packages/core/tests/integration/test_int_review_bugfixes.py
+++ b/packages/core/tests/integration/test_int_review_bugfixes.py
@@ -30,6 +30,13 @@ from memex_core.services.vault_summary_signatures import LLMTheme
 # ---------------------------------------------------------------------------
 
 
+def _mock_embedding_model() -> MagicMock:
+    """Encode returns a real 384-vector so persisted writes survive pgvector."""
+    model = MagicMock()
+    model.encode.return_value = [MagicMock(tolist=lambda: [0.1] * 384)]
+    return model
+
+
 async def _create_vault(session, vault_id=None, name=None):
     vault_id = vault_id or uuid4()
     name = name or f'test_vault_{vault_id.hex[:8]}'
@@ -248,6 +255,7 @@ async def test_update_summary_consolidates_sessions(metastore, session):
         metastore=metastore,
         lm=mock_lm,
         config=VaultSummaryConfig(),
+        embedding_model=_mock_embedding_model(),
     )
 
     with patch('memex_core.services.vault_summary.run_dspy_operation') as mock_run:
@@ -298,6 +306,7 @@ async def test_update_summary_version_conflict_skips_write(metastore, session):
         metastore=metastore,
         lm=mock_lm,
         config=VaultSummaryConfig(),
+        embedding_model=_mock_embedding_model(),
     )
 
     mock_prediction = MagicMock()
@@ -351,6 +360,7 @@ async def test_update_summary_no_delta_returns_existing(metastore, session):
         metastore=metastore,
         lm=mock_lm,
         config=VaultSummaryConfig(),
+        embedding_model=_mock_embedding_model(),
     )
 
     # No new notes → should return existing without calling LLM

--- a/packages/core/tests/integration/test_int_vault_summary.py
+++ b/packages/core/tests/integration/test_int_vault_summary.py
@@ -67,3 +67,54 @@ async def test_vault_summary_partial_index_exists(metastore):
         )
         row = result.first()
         assert row is not None, 'Partial index ix_memory_units_context does not exist'
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_freshness_overlay_leaves_embedding_intact(metastore, mock_embedding_model):
+    """``get_summary`` applies a read-time overlay (``make_transient`` +
+    inventory/trend mutation) — the narrative embedding must survive the
+    overlay on the returned object AND stay untouched in the persisted row."""
+    from unittest.mock import MagicMock
+
+    from memex_common.config import VaultSummaryConfig
+    from memex_core.services.vault_summary import VaultSummaryService
+
+    vault_id = uuid4()
+    async with metastore.session() as session:
+        await session.execute(
+            text('INSERT INTO vaults (id, name) VALUES (:id, :name)'),
+            {'id': str(vault_id), 'name': f'overlay_{vault_id.hex[:8]}'},
+        )
+        session.add(
+            VaultSummary(
+                vault_id=vault_id,
+                narrative='Overlay-test narrative.',
+                embedding=[0.4] * 384,
+                inventory={'total_notes': 3},
+            )
+        )
+        await session.commit()
+
+    service = VaultSummaryService(
+        metastore=metastore,
+        lm=MagicMock(),
+        config=VaultSummaryConfig(),
+        embedding_model=mock_embedding_model,
+    )
+    overlaid = await service.get_summary(vault_id)
+
+    assert overlaid is not None
+    assert overlaid.embedding is not None
+    assert len(list(overlaid.embedding)) == 384
+    assert list(overlaid.embedding)[0] == pytest.approx(0.4, abs=1e-4)
+
+    # Persisted row untouched by the read-time overlay.
+    async with metastore.session() as session:
+        row = (
+            await session.execute(
+                select(VaultSummary).where(col(VaultSummary.vault_id) == vault_id)
+            )
+        ).scalar_one()
+        assert row.embedding is not None
+        assert len(list(row.embedding)) == 384

--- a/packages/core/tests/integration/test_int_vault_summary_versioning.py
+++ b/packages/core/tests/integration/test_int_vault_summary_versioning.py
@@ -18,6 +18,13 @@ from memex_core.services.vault_summary import VaultSummaryService
 from memex_core.services.vault_summary_signatures import LLMTheme
 
 
+def _mock_embedding_model() -> MagicMock:
+    """Encode returns a real 384-vector so persisted writes survive pgvector."""
+    model = MagicMock()
+    model.encode.return_value = [MagicMock(tolist=lambda: [0.1] * 384)]
+    return model
+
+
 async def _insert_note(
     session,
     vault_id=GLOBAL_VAULT_ID,
@@ -123,7 +130,12 @@ class TestFetchNoteMetadataVersionFilter:
             await _insert_chunk_with_summary(session, n3.id, topic='Topic C')
             await session.commit()
 
-        svc = VaultSummaryService(metastore=metastore, lm=MagicMock(), config=VaultSummaryConfig())
+        svc = VaultSummaryService(
+            metastore=metastore,
+            lm=MagicMock(),
+            config=VaultSummaryConfig(),
+            embedding_model=_mock_embedding_model(),
+        )
         async with metastore.session() as session:
             data, ids, _all = await svc._fetch_note_metadata(
                 session, GLOBAL_VAULT_ID, summary_version=5
@@ -145,7 +157,12 @@ class TestFetchNoteMetadataVersionFilter:
             await _insert_chunk_with_summary(session, n2.id)
             await session.commit()
 
-        svc = VaultSummaryService(metastore=metastore, lm=MagicMock(), config=VaultSummaryConfig())
+        svc = VaultSummaryService(
+            metastore=metastore,
+            lm=MagicMock(),
+            config=VaultSummaryConfig(),
+            embedding_model=_mock_embedding_model(),
+        )
         async with metastore.session() as session:
             data, ids, _all = await svc._fetch_note_metadata(session, GLOBAL_VAULT_ID)
 
@@ -162,7 +179,12 @@ class TestFetchNoteMetadataVersionFilter:
             await _insert_chunk_with_summary(session, n2.id)
             await session.commit()
 
-        svc = VaultSummaryService(metastore=metastore, lm=MagicMock(), config=VaultSummaryConfig())
+        svc = VaultSummaryService(
+            metastore=metastore,
+            lm=MagicMock(),
+            config=VaultSummaryConfig(),
+            embedding_model=_mock_embedding_model(),
+        )
         async with metastore.session() as session:
             data, ids, _all = await svc._fetch_note_metadata(session, GLOBAL_VAULT_ID)
 
@@ -182,7 +204,12 @@ class TestIsStaleVersionBased:
             session.add(summary)
             await session.commit()
 
-        svc = VaultSummaryService(metastore=metastore, lm=MagicMock(), config=VaultSummaryConfig())
+        svc = VaultSummaryService(
+            metastore=metastore,
+            lm=MagicMock(),
+            config=VaultSummaryConfig(),
+            embedding_model=_mock_embedding_model(),
+        )
         assert await svc.is_stale(GLOBAL_VAULT_ID) is True
 
     @pytest.mark.asyncio
@@ -193,7 +220,12 @@ class TestIsStaleVersionBased:
             session.add(summary)
             await session.commit()
 
-        svc = VaultSummaryService(metastore=metastore, lm=MagicMock(), config=VaultSummaryConfig())
+        svc = VaultSummaryService(
+            metastore=metastore,
+            lm=MagicMock(),
+            config=VaultSummaryConfig(),
+            embedding_model=_mock_embedding_model(),
+        )
         assert await svc.is_stale(GLOBAL_VAULT_ID) is False
 
     @pytest.mark.asyncio
@@ -204,7 +236,12 @@ class TestIsStaleVersionBased:
             session.add(summary)
             await session.commit()
 
-        svc = VaultSummaryService(metastore=metastore, lm=MagicMock(), config=VaultSummaryConfig())
+        svc = VaultSummaryService(
+            metastore=metastore,
+            lm=MagicMock(),
+            config=VaultSummaryConfig(),
+            embedding_model=_mock_embedding_model(),
+        )
         assert await svc.is_stale(GLOBAL_VAULT_ID) is True
 
 
@@ -231,7 +268,12 @@ class TestNoteMarkingAfterUpdate:
             LLMTheme(name='ML', description='ML basics', note_count=1, trend='growing')
         ]
 
-        svc = VaultSummaryService(metastore=metastore, lm=MagicMock(), config=VaultSummaryConfig())
+        svc = VaultSummaryService(
+            metastore=metastore,
+            lm=MagicMock(),
+            config=VaultSummaryConfig(),
+            embedding_model=_mock_embedding_model(),
+        )
 
         with patch('memex_core.services.vault_summary.run_dspy_operation') as mock_run:
             mock_run.return_value = mock_prediction
@@ -264,7 +306,12 @@ class TestNoteMarkingAfterUpdate:
         mock_prediction.narrative = 'Full summary.'
         mock_prediction.themes_json = json.dumps([])
 
-        svc = VaultSummaryService(metastore=metastore, lm=MagicMock(), config=VaultSummaryConfig())
+        svc = VaultSummaryService(
+            metastore=metastore,
+            lm=MagicMock(),
+            config=VaultSummaryConfig(),
+            embedding_model=_mock_embedding_model(),
+        )
 
         with patch('memex_core.services.vault_summary.run_dspy_operation') as mock_run:
             mock_run.return_value = mock_prediction
@@ -303,7 +350,12 @@ class TestNoteMarkingAfterUpdate:
         mock_prediction.updated_narrative = 'Updated with only new note.'
         mock_prediction.updated_themes = []
 
-        svc = VaultSummaryService(metastore=metastore, lm=MagicMock(), config=VaultSummaryConfig())
+        svc = VaultSummaryService(
+            metastore=metastore,
+            lm=MagicMock(),
+            config=VaultSummaryConfig(),
+            embedding_model=_mock_embedding_model(),
+        )
 
         with patch('memex_core.services.vault_summary.run_dspy_operation') as mock_run:
             mock_run.return_value = mock_prediction

--- a/packages/core/tests/unit/services/test_vault_summary_embedding.py
+++ b/packages/core/tests/unit/services/test_vault_summary_embedding.py
@@ -1,0 +1,71 @@
+"""Unit tests for the vault-summary narrative embedding helper.
+
+``_embed_narrative`` must be non-fatal: a summary without a vector beats no
+summary, so encode failures log a warning and return None instead of
+propagating into the persist path.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from memex_common.config import VaultSummaryConfig
+from memex_core.services.vault_summary import VaultSummaryService
+
+
+class _FakeVector:
+    def __init__(self, values: list[float]) -> None:
+        self._values = values
+
+    def tolist(self) -> list[float]:
+        return list(self._values)
+
+
+def _service(embedding_model) -> VaultSummaryService:
+    return VaultSummaryService(
+        metastore=MagicMock(),
+        lm=MagicMock(),
+        config=VaultSummaryConfig(),
+        embedding_model=embedding_model,
+    )
+
+
+@pytest.mark.asyncio
+async def test_embed_narrative_returns_vector() -> None:
+    model = MagicMock()
+    model.encode.return_value = [_FakeVector([0.1, 0.2, 0.3])]
+    service = _service(model)
+
+    result = await service._embed_narrative('A vault about embeddings.', uuid4())
+
+    assert result == pytest.approx([0.1, 0.2, 0.3])
+    model.encode.assert_called_once_with(['A vault about embeddings.'])
+
+
+@pytest.mark.asyncio
+async def test_embed_narrative_failure_is_non_fatal(caplog: pytest.LogCaptureFixture) -> None:
+    model = MagicMock()
+    model.encode.side_effect = RuntimeError('onnx session crashed')
+    service = _service(model)
+    vault_id = uuid4()
+
+    with caplog.at_level(logging.WARNING, logger='memex.core.services.vault_summary'):
+        result = await service._embed_narrative('whatever', vault_id)
+
+    assert result is None
+    assert any('persisting without vector' in r.message for r in caplog.records)
+    assert any(str(vault_id) in r.message for r in caplog.records)
+
+
+def test_constructor_requires_embedding_model() -> None:
+    """The embedding model is a required collaborator, not an optional extra."""
+    with pytest.raises(TypeError):
+        VaultSummaryService(  # type: ignore[call-arg]
+            metastore=MagicMock(),
+            lm=MagicMock(),
+            config=VaultSummaryConfig(),
+        )

--- a/packages/core/tests/unit/services/test_vault_summary_regression.py
+++ b/packages/core/tests/unit/services/test_vault_summary_regression.py
@@ -24,10 +24,13 @@ from memex_core.services.vault_summary_signatures import LLMTheme
 def _make_service(config: VaultSummaryConfig | None = None) -> VaultSummaryService:
     metastore = MagicMock()
     lm = MagicMock()
+    embedding_model = MagicMock()
+    embedding_model.encode.return_value = [MagicMock(tolist=lambda: [0.1] * 384)]
     return VaultSummaryService(
         metastore=metastore,
         lm=lm,
         config=config or VaultSummaryConfig(),
+        embedding_model=embedding_model,
     )
 
 

--- a/packages/core/tests/unit/services/test_vault_summary_service.py
+++ b/packages/core/tests/unit/services/test_vault_summary_service.py
@@ -21,10 +21,13 @@ def _make_service(config: VaultSummaryConfig | None = None) -> VaultSummaryServi
     """Create a VaultSummaryService with mock dependencies."""
     metastore = MagicMock()
     lm = MagicMock()
+    embedding_model = MagicMock()
+    embedding_model.encode.return_value = [MagicMock(tolist=lambda: [0.1] * 384)]
     return VaultSummaryService(
         metastore=metastore,
         lm=lm,
         config=config or VaultSummaryConfig(),
+        embedding_model=embedding_model,
     )
 
 

--- a/packages/core/tests/unit/test_alembic_058_vault_summary_embedding.py
+++ b/packages/core/tests/unit/test_alembic_058_vault_summary_embedding.py
@@ -1,0 +1,75 @@
+"""Tests for migration 058_vault_summary_embedding.
+
+Asserts the nullable narrative-embedding column lands on both the SQLModel
+metadata side and as an alembic migration that chains correctly off the
+prior head.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib as plb
+from unittest.mock import patch
+
+from pgvector.sqlalchemy import Vector
+
+from memex_core.memory.sql_models import EMBEDDING_DIMENSION, VaultSummary
+
+_VERSIONS_DIR = (
+    plb.Path(__file__).resolve().parents[2] / 'src' / 'memex_core' / 'alembic' / 'versions'
+)
+
+
+def _load_migration(name: str):
+    src = _VERSIONS_DIR / f'{name}.py'
+    spec = importlib.util.spec_from_file_location(name, src)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestMigration058Metadata:
+    def test_revision_id(self) -> None:
+        mod = _load_migration('058_vault_summary_embedding')
+        assert mod.revision == '058_vault_summary_embedding'
+
+    def test_chains_off_057(self) -> None:
+        mod = _load_migration('058_vault_summary_embedding')
+        assert mod.down_revision == '057_lint_source_external'
+
+    def test_revision_id_fits_in_alembic_version_column(self) -> None:
+        """alembic_version.version_num is VARCHAR(32) post-migration 050."""
+        mod = _load_migration('058_vault_summary_embedding')
+        assert len(mod.revision) <= 32
+
+
+class TestMigration058Operations:
+    def test_upgrade_adds_nullable_vector_column(self) -> None:
+        mod = _load_migration('058_vault_summary_embedding')
+        with patch.object(mod, 'op') as mock_op:
+            mod.upgrade()
+
+        mock_op.add_column.assert_called_once()
+        args, _ = mock_op.add_column.call_args
+        assert args[0] == 'vault_summaries'
+        column = args[1]
+        assert column.name == 'embedding'
+        assert column.nullable is True
+        assert isinstance(column.type, Vector)
+        assert column.type.dim == EMBEDDING_DIMENSION
+
+    def test_downgrade_drops_column(self) -> None:
+        mod = _load_migration('058_vault_summary_embedding')
+        with patch.object(mod, 'op') as mock_op:
+            mod.downgrade()
+
+        mock_op.drop_column.assert_called_once_with('vault_summaries', 'embedding')
+
+
+class TestSqlModelSide:
+    def test_vault_summary_model_has_nullable_vector_column(self) -> None:
+        column = VaultSummary.__table__.columns['embedding']
+        assert column.nullable is True
+        assert isinstance(column.type, Vector)
+        assert column.type.dim == EMBEDDING_DIMENSION

--- a/packages/core/tests/unit/test_include_vectors_serialization.py
+++ b/packages/core/tests/unit/test_include_vectors_serialization.py
@@ -1,0 +1,155 @@
+"""Serialization-boundary tests for opt-in vector exposure.
+
+Pins the three server-side strip points and the dead-flag deletion:
+
+- ``build_memory_unit_dto`` only reads ``embedding`` under ``include_vectors``
+- ``_kv_entry_dto`` strips the auto-populated vector unless requested
+  (``model_validate(from_attributes=True)`` would otherwise leak it on
+  every KV response)
+- ``_summary_to_dto`` populates the narrative embedding only on request
+- the internal retrieval request model no longer carries ``include_vectors``
+  (search results are vector-free by design)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from memex_core.memory.retrieval.models import RetrievalRequest as InternalRetrievalRequest
+from memex_core.memory.sql_models import VaultSummary
+from memex_core.server.common import build_memory_unit_dto, vector_to_list
+from memex_core.server.kv import _kv_entry_dto
+from memex_core.server.vault_summary import _summary_to_dto
+
+
+class _FakeVector:
+    """Stands in for a numpy/pgvector array: iterable with ``tolist``."""
+
+    def __init__(self, values: list[float]) -> None:
+        self._values = values
+
+    def tolist(self) -> list[float]:
+        return list(self._values)
+
+
+def _unit(embedding):
+    return SimpleNamespace(
+        id=uuid4(),
+        note_id=str(uuid4()),
+        vault_id=str(uuid4()),
+        chunk_id=uuid4(),
+        text='unit text',
+        fact_type='world',
+        status='active',
+        mentioned_at=None,
+        event_date=None,
+        occurred_start=None,
+        occurred_end=None,
+        unit_metadata={},
+        confidence=1.0,
+        embedding=embedding,
+    )
+
+
+class TestVectorToList:
+    def test_none_passthrough(self) -> None:
+        assert vector_to_list(None) is None
+
+    def test_plain_list(self) -> None:
+        assert vector_to_list([0.1, 0.2]) == [0.1, 0.2]
+
+    def test_tolist_object(self) -> None:
+        assert vector_to_list(_FakeVector([1.0, 2.0])) == [1.0, 2.0]
+
+    def test_generic_iterable(self) -> None:
+        assert vector_to_list((0.5, 0.25)) == [0.5, 0.25]
+
+
+class TestBuildMemoryUnitDtoVectors:
+    def test_default_strips_embedding(self) -> None:
+        dto = build_memory_unit_dto(_unit(embedding=[0.1, 0.2]))
+        assert dto.embedding is None
+
+    def test_include_vectors_populates(self) -> None:
+        dto = build_memory_unit_dto(_unit(embedding=[0.1, 0.2]), include_vectors=True)
+        assert dto.embedding == pytest.approx([0.1, 0.2])
+
+    def test_include_vectors_converts_array_like(self) -> None:
+        dto = build_memory_unit_dto(_unit(embedding=_FakeVector([0.3, 0.4])), include_vectors=True)
+        assert dto.embedding == pytest.approx([0.3, 0.4])
+
+    def test_unit_without_embedding_attribute_yields_none(self) -> None:
+        unit = _unit(embedding=None)
+        del unit.embedding
+        dto = build_memory_unit_dto(unit, include_vectors=True)
+        assert dto.embedding is None
+
+
+class TestKvEntryDtoStrip:
+    def _entry(self):
+        import datetime as dt
+
+        return SimpleNamespace(
+            id=uuid4(),
+            key='user:editor',
+            value='neovim',
+            embedding=[0.9, 0.8],
+            expires_at=None,
+            created_at=dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+            updated_at=dt.datetime(2026, 1, 2, tzinfo=dt.timezone.utc),
+        )
+
+    def test_default_strips_auto_populated_vector(self) -> None:
+        """from_attributes auto-populates ``embedding`` — the strip is load-bearing."""
+        dto = _kv_entry_dto(self._entry(), include_vectors=False)
+        assert dto.embedding is None
+
+    def test_include_vectors_keeps_vector(self) -> None:
+        dto = _kv_entry_dto(self._entry(), include_vectors=True)
+        assert dto.embedding == pytest.approx([0.9, 0.8])
+
+    def test_entry_without_vector_stays_none(self) -> None:
+        entry = self._entry()
+        entry.embedding = None
+        dto = _kv_entry_dto(entry, include_vectors=True)
+        assert dto.embedding is None
+
+
+class TestVaultSummaryDtoVectors:
+    def _summary(self, embedding):
+        import datetime as dt
+
+        return VaultSummary(
+            id=uuid4(),
+            vault_id=uuid4(),
+            narrative='A vault about testing.',
+            themes=[],
+            inventory={},
+            key_entities=[],
+            embedding=embedding,
+            version=3,
+            notes_incorporated=5,
+            created_at=dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+            updated_at=dt.datetime(2026, 1, 2, tzinfo=dt.timezone.utc),
+        )
+
+    def test_default_strips_embedding(self) -> None:
+        dto = _summary_to_dto(self._summary(embedding=[0.1] * 4))
+        assert dto.embedding is None
+
+    def test_include_vectors_populates(self) -> None:
+        dto = _summary_to_dto(self._summary(embedding=[0.1] * 4), include_vectors=True)
+        assert dto.embedding == pytest.approx([0.1] * 4)
+
+    def test_null_column_stays_null_when_requested(self) -> None:
+        dto = _summary_to_dto(self._summary(embedding=None), include_vectors=True)
+        assert dto.embedding is None
+
+
+class TestDeadFlagDeleted:
+    def test_internal_retrieval_request_has_no_include_vectors(self) -> None:
+        """Search is vector-free by design — the dead flag must not resurface."""
+        assert 'include_vectors' not in InternalRetrievalRequest.model_fields

--- a/packages/core/tests/unit/test_memory_units_by_ids_endpoint.py
+++ b/packages/core/tests/unit/test_memory_units_by_ids_endpoint.py
@@ -1,0 +1,194 @@
+"""Unit tests for POST /api/v1/memories/by-ids.
+
+The route delegates to ``MemexAPI.get_memory_units_by_ids`` after a
+``check_vault_access`` gate. These tests use FastAPI's
+dependency_overrides to bypass auth and stub the API surface, verifying:
+
+- 200 + serialized DTOs on the happy path
+- ``embedding`` stays null by default even when the ORM row carries a vector
+- ``include_vectors=true`` populates ``embedding``
+- empty ``unit_ids`` returns an empty list
+- the 500-ID request bound is enforced (422)
+- vault scoping enforced via check_vault_access (403 for unauthorized vault)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memex_core.server import app
+from memex_core.server.auth import (
+    AuthContext,
+    Permission,
+    Policy,
+    get_auth_context,
+)
+
+
+def _build_unit(vault_id: str, embedding: list[float] | None = None):
+    """ORM-shape namespace that ``build_memory_unit_dto`` can serialize."""
+    return SimpleNamespace(
+        id=uuid4(),
+        note_id=str(uuid4()),
+        vault_id=vault_id,
+        chunk_id=uuid4(),
+        text='Sarah Chen leads Project Alpha.',
+        fact_type='world',
+        status='active',
+        mentioned_at=None,
+        event_date=None,
+        occurred_start=None,
+        occurred_end=None,
+        unit_metadata={},
+        confidence=1.0,
+        embedding=embedding if embedding is not None else [0.25, -0.5, 0.75],
+    )
+
+
+@pytest.fixture
+def client_with_stubbed_api():
+    """TestClient with stubbed MemexAPI and bypassed auth."""
+    vault_id = '22222222-2222-2222-2222-222222222222'
+    foreign_vault_id = '33333333-3333-3333-3333-333333333333'
+
+    mock_api = SimpleNamespace(
+        get_memory_units_by_ids=AsyncMock(return_value=[_build_unit(vault_id)]),
+        resolve_vault_identifier=AsyncMock(side_effect=lambda v: v),
+    )
+    app.state.api = mock_api
+    app.dependency_overrides[get_auth_context] = lambda: None
+
+    yield TestClient(app), mock_api, vault_id, foreign_vault_id
+
+    if hasattr(app.state, 'api'):
+        del app.state.api
+    app.dependency_overrides.pop(get_auth_context, None)
+
+
+class TestGetMemoryUnitsByIdsEndpoint:
+    def test_returns_200_with_dtos(self, client_with_stubbed_api) -> None:
+        client, mock_api, vault_id, _ = client_with_stubbed_api
+        resp = client.post(
+            '/api/v1/memories/by-ids',
+            json={'unit_ids': [str(uuid4())], 'vault_id': vault_id},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert isinstance(body, list)
+        assert len(body) == 1
+        assert body[0]['text'] == 'Sarah Chen leads Project Alpha.'
+
+    def test_embedding_null_by_default_despite_loaded_row(self, client_with_stubbed_api) -> None:
+        """The ORM stub carries a vector; the default response must NOT."""
+        client, _, vault_id, _ = client_with_stubbed_api
+        resp = client.post(
+            '/api/v1/memories/by-ids',
+            json={'unit_ids': [str(uuid4())], 'vault_id': vault_id},
+        )
+        assert resp.status_code == 200
+        assert resp.json()[0]['embedding'] is None
+
+    def test_include_vectors_false_explicit(self, client_with_stubbed_api) -> None:
+        client, _, vault_id, _ = client_with_stubbed_api
+        resp = client.post(
+            '/api/v1/memories/by-ids',
+            json={
+                'unit_ids': [str(uuid4())],
+                'vault_id': vault_id,
+                'include_vectors': False,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()[0]['embedding'] is None
+
+    def test_include_vectors_true_populates_embedding(self, client_with_stubbed_api) -> None:
+        client, mock_api, vault_id, _ = client_with_stubbed_api
+        mock_api.get_memory_units_by_ids = AsyncMock(
+            return_value=[_build_unit(vault_id, embedding=[0.1, 0.2, 0.3])]
+        )
+        resp = client.post(
+            '/api/v1/memories/by-ids',
+            json={
+                'unit_ids': [str(uuid4())],
+                'vault_id': vault_id,
+                'include_vectors': True,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()[0]['embedding'] == pytest.approx([0.1, 0.2, 0.3])
+
+    def test_calls_api_with_correct_args(self, client_with_stubbed_api) -> None:
+        client, mock_api, vault_id, _ = client_with_stubbed_api
+        unit_id = uuid4()
+        client.post(
+            '/api/v1/memories/by-ids',
+            json={'unit_ids': [str(unit_id)], 'vault_id': vault_id},
+        )
+        mock_api.get_memory_units_by_ids.assert_called_once()
+        args = mock_api.get_memory_units_by_ids.call_args.args
+        assert args[0] == [unit_id]
+        assert str(args[1]) == vault_id
+
+    def test_empty_unit_ids_returns_empty_list(self, client_with_stubbed_api) -> None:
+        client, mock_api, vault_id, _ = client_with_stubbed_api
+        mock_api.get_memory_units_by_ids = AsyncMock(return_value=[])
+        resp = client.post(
+            '/api/v1/memories/by-ids',
+            json={'unit_ids': [], 'vault_id': vault_id},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_more_than_500_ids_rejected(self, client_with_stubbed_api) -> None:
+        client, _, vault_id, _ = client_with_stubbed_api
+        resp = client.post(
+            '/api/v1/memories/by-ids',
+            json={
+                'unit_ids': [str(uuid4()) for _ in range(501)],
+                'vault_id': vault_id,
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_vault_id_required(self, client_with_stubbed_api) -> None:
+        client, _, _, _ = client_with_stubbed_api
+        resp = client.post(
+            '/api/v1/memories/by-ids',
+            json={'unit_ids': [str(uuid4())]},
+        )
+        assert resp.status_code == 422
+
+    def test_vault_isolation_blocks_cross_vault_request(self, client_with_stubbed_api) -> None:
+        """If the auth context restricts to a specific vault list, a request
+        for a different vault must return 403 from check_vault_access."""
+        client, mock_api, vault_id, foreign_vault_id = client_with_stubbed_api
+
+        from uuid import UUID as _UUID
+
+        async def _resolve(v):
+            return _UUID(v) if isinstance(v, str) else v
+
+        mock_api.resolve_vault_identifier = AsyncMock(side_effect=_resolve)
+
+        async def _restricted_auth():
+            return AuthContext(
+                key_prefix='test...',
+                key_name='restricted',
+                policy=Policy.READER,
+                permissions=frozenset({Permission.READ}),
+                vault_ids=[vault_id],
+                read_vault_ids=None,
+            )
+
+        app.dependency_overrides[get_auth_context] = _restricted_auth
+
+        resp = client.post(
+            '/api/v1/memories/by-ids',
+            json={'unit_ids': [str(uuid4())], 'vault_id': foreign_vault_id},
+        )
+        assert resp.status_code == 403

--- a/packages/core/tests/unit/test_seed_alembic_stubs.py
+++ b/packages/core/tests/unit/test_seed_alembic_stubs.py
@@ -55,8 +55,8 @@ def test_seed_chain_is_linear_and_correct() -> None:
     sd = ScriptDirectory.from_config(cfg)
 
     heads = sd.get_heads()
-    assert heads == ['057_lint_source_external'], (
-        f'Expected single head 057_lint_source_external, got {heads}'
+    assert heads == ['058_vault_summary_embedding'], (
+        f'Expected single head 058_vault_summary_embedding, got {heads}'
     )
 
     walk = list(sd.walk_revisions())
@@ -64,8 +64,10 @@ def test_seed_chain_is_linear_and_correct() -> None:
     # 053 is a merge node (down_revision is a tuple) — the cockpit/lint chain
     # (…→052) and the procedure-to-global chain (046_procedure_to_global) were
     # merged, then 054 (nodes index), 055 (inbox router), 056 (node assets),
-    # and 057 (external lint source) extend linearly from there.
+    # 057 (external lint source), and 058 (vault summary embedding) extend
+    # linearly from there.
     expected_top10 = [
+        ('058_vault_summary_embedding', '057_lint_source_external'),
         ('057_lint_source_external', '056_node_assets'),
         ('056_node_assets', '055_inbox_router'),
         ('055_inbox_router', '054_nodes_vault_active'),
@@ -75,7 +77,6 @@ def test_seed_chain_is_linear_and_correct() -> None:
         ('052_entity_cooccurrence_vault_pk', '051_fix_telemetry_pk'),
         ('051_fix_telemetry_pk', '050_mp_flagged_at'),
         ('050_mp_flagged_at', '049_lint_llm_signature'),
-        ('049_lint_llm_signature', '048_lint_rule_calibration'),
     ]
     assert top10 == expected_top10, f'Tier A chain mismatch: got {top10}'
 

--- a/packages/core/tests/unit/test_sync_offload_caps.py
+++ b/packages/core/tests/unit/test_sync_offload_caps.py
@@ -421,6 +421,7 @@ EXPECTED_GATED_SITES = [
     ('memory/retrieval/engine.py', '_NER'),
     ('memory/retrieval/engine.py', '_RERANKER'),
     ('services/inbox_router/service.py', '_EMBEDDING'),
+    ('services/vault_summary.py', '_EMBEDDING'),
 ]
 
 EXPECTED_EXEMPT_SITES = [
@@ -475,17 +476,18 @@ class TestToThreadAudit:
         return lines
 
     def test_total_call_count_matches_audit(self) -> None:
-        """RFC-001 §"Step 1.5.1" verified 18 actual calls on 8e59301; two
+        """RFC-001 §"Step 1.5.1" verified 18 actual calls on 8e59301; three
         further sites landed since (the NLI backend offload from the F10b
-        polarity work and the inbox-router vault-anchor embedding offload),
-        bringing the classified total to 20.
+        polarity work, the inbox-router vault-anchor embedding offload, and
+        the vault-summary narrative embedding offload), bringing the
+        classified total to 21.
         AC-009 (d): if origin/main adds a new asyncio.to_thread between
         this AC and merge it must be classified — this test catches a
         silent addition.
         """
         lines = self._all_call_lines()
-        assert len(lines) == 20, (
-            f'Expected 20 asyncio.to_thread calls per AC-009 four-bucket '
+        assert len(lines) == 21, (
+            f'Expected 21 asyncio.to_thread calls per AC-009 four-bucket '
             f'audit; found {len(lines)}. New calls must be classified into '
             f'gated / dead / exempt / warmup.'
         )

--- a/packages/core/tests/unit/test_vault_summary_regeneration_flag.py
+++ b/packages/core/tests/unit/test_vault_summary_regeneration_flag.py
@@ -17,7 +17,11 @@ def _make_service():
     config.batch_size = 20
     config.max_narrative_tokens = 200
     config.max_patch_log = 20
-    return VaultSummaryService(metastore=metastore, lm=lm, config=config)
+    embedding_model = MagicMock()
+    embedding_model.encode.return_value = [MagicMock(tolist=lambda: [0.1] * 384)]
+    return VaultSummaryService(
+        metastore=metastore, lm=lm, config=config, embedding_model=embedding_model
+    )
 
 
 def _mock_session(metastore, session):

--- a/packages/mcp/tests/test_no_vectors_in_tool_outputs.py
+++ b/packages/mcp/tests/test_no_vectors_in_tool_outputs.py
@@ -68,11 +68,10 @@ async def test_get_memory_units_output_has_no_embedding(mock_api, mock_config, m
     _assert_no_embedding_key(data)
 
 
-@pytest.mark.asyncio
-async def test_kv_get_output_has_no_embedding(mock_api, mock_config, mcp_client):
-    mock_api.kv_get.return_value = SimpleNamespace(
+def _kv_entry(key: str):
+    return SimpleNamespace(
         id=uuid4(),
-        key='user:editor',
+        key=key,
         value='neovim',
         embedding=[0.5] * 8,
         expires_at=None,
@@ -80,7 +79,32 @@ async def test_kv_get_output_has_no_embedding(mock_api, mock_config, mcp_client)
         updated_at=dt.datetime(2026, 1, 2, tzinfo=dt.timezone.utc),
     )
 
+
+@pytest.mark.asyncio
+async def test_kv_get_output_has_no_embedding(mock_api, mock_config, mcp_client):
+    mock_api.kv_get.return_value = _kv_entry('user:editor')
+
     result = await mcp_client.call_tool('memex_kv_get', {'key': 'user:editor'})
+    data = parse_tool_result(result)
+    assert data is not None
+    _assert_no_embedding_key(data)
+
+
+@pytest.mark.asyncio
+async def test_kv_search_output_has_no_embedding(mock_api, mock_config, mcp_client):
+    mock_api.kv_search_text.return_value = [_kv_entry('user:editor')]
+
+    result = await mcp_client.call_tool('memex_kv_search', {'query': 'editor'})
+    data = parse_tool_result(result)
+    assert data is not None
+    _assert_no_embedding_key(data)
+
+
+@pytest.mark.asyncio
+async def test_kv_list_output_has_no_embedding(mock_api, mock_config, mcp_client):
+    mock_api.kv_list.return_value = [_kv_entry('user:editor'), _kv_entry('global:lang')]
+
+    result = await mcp_client.call_tool('memex_kv_list', {})
     data = parse_tool_result(result)
     assert data is not None
     _assert_no_embedding_key(data)

--- a/packages/mcp/tests/test_no_vectors_in_tool_outputs.py
+++ b/packages/mcp/tests/test_no_vectors_in_tool_outputs.py
@@ -1,0 +1,110 @@
+"""Pin: no MCP tool output ever carries an ``embedding`` key.
+
+Vector exposure is an HTTP/Python-caller capability, deliberately withheld
+from agent surfaces. MCP tools render their own projection models
+(``McpFact`` / ``McpKVEntry`` / explicit dicts), so even DTOs that arrive
+from the client WITH vectors populated must serialize without an
+``embedding`` key. These tests feed vector-laden DTOs through the tools and
+assert the rendered output stays vector-free, so a future refactor that
+starts passing common DTOs through raw fails loudly.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from helpers import parse_tool_result
+from memex_common.schemas import FactTypes, MemoryUnitDTO, VaultSummaryDTO
+
+
+def _walk(obj):
+    """Yield every dict reachable in a parsed tool result."""
+    if isinstance(obj, dict):
+        yield obj
+        for value in obj.values():
+            yield from _walk(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _walk(item)
+
+
+def _assert_no_embedding_key(data) -> None:
+    for node in _walk(data):
+        assert 'embedding' not in node, f'embedding key leaked into MCP output: {node.keys()}'
+
+
+def _vector_laden_unit(vault_id, chunk_id) -> MemoryUnitDTO:
+    return MemoryUnitDTO(
+        id=uuid4(),
+        text='unit with a vector attached',
+        fact_type=FactTypes.WORLD,
+        status='active',
+        note_id=uuid4(),
+        vault_id=vault_id,
+        metadata={},
+        mentioned_at=dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+        chunk_id=chunk_id,
+        embedding=[0.1] * 8,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_memory_units_output_has_no_embedding(mock_api, mock_config, mcp_client):
+    vault_uuid = uuid4()
+    chunk_id = uuid4()
+    mock_api.resolve_vault_identifier.return_value = vault_uuid
+    mock_api.get_memory_units_by_chunks.return_value = [_vector_laden_unit(vault_uuid, chunk_id)]
+
+    result = await mcp_client.call_tool(
+        'memex_get_memory_units',
+        {'chunk_ids': [str(chunk_id)], 'vault_id': 'my-vault'},
+    )
+    data = parse_tool_result(result)
+    assert data, 'expected at least one unit in the output'
+    _assert_no_embedding_key(data)
+
+
+@pytest.mark.asyncio
+async def test_kv_get_output_has_no_embedding(mock_api, mock_config, mcp_client):
+    mock_api.kv_get.return_value = SimpleNamespace(
+        id=uuid4(),
+        key='user:editor',
+        value='neovim',
+        embedding=[0.5] * 8,
+        expires_at=None,
+        created_at=dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+        updated_at=dt.datetime(2026, 1, 2, tzinfo=dt.timezone.utc),
+    )
+
+    result = await mcp_client.call_tool('memex_kv_get', {'key': 'user:editor'})
+    data = parse_tool_result(result)
+    assert data is not None
+    _assert_no_embedding_key(data)
+
+
+@pytest.mark.asyncio
+async def test_get_vault_summary_output_has_no_embedding(mock_api, mock_config, mcp_client):
+    vault_uuid = uuid4()
+    mock_api.resolve_vault_identifier.return_value = vault_uuid
+    mock_api.get_vault_summary.return_value = VaultSummaryDTO(
+        id=uuid4(),
+        vault_id=vault_uuid,
+        narrative='A vault with a stored narrative vector.',
+        themes=[],
+        inventory={},
+        key_entities=[],
+        embedding=[0.25] * 8,
+        version=2,
+        notes_incorporated=4,
+        created_at=dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+        updated_at=dt.datetime(2026, 1, 2, tzinfo=dt.timezone.utc),
+    )
+
+    result = await mcp_client.call_tool('memex_get_vault_summary', {'vault_id': str(vault_uuid)})
+    data = parse_tool_result(result)
+    assert data is not None
+    _assert_no_embedding_key(data)


### PR DESCRIPTION
## Summary

Stored embeddings become retrievable by **HTTP/Python callers only** — opt-in `include_vectors` (default `false`) on read surfaces, plus a new vault-scoped batch getter. Agent surfaces (MCP, CLI, Claude Code plugin, Hermes, firefox) stay **byte-identical**, each pinned by tests.

1. **`vault_summaries.embedding`** (alembic `058`, nullable `vector(384)`): the narrative is encoded at both write paths (`update_summary`, `regenerate_summary`) under the shared embedding offload semaphore (classified in the AC-009 four-bucket audit, now 21 calls). Encode failure logs a warning and persists the narrative with `NULL`; emptying a vault NULLs the stale vector. Backfill is lazy — the next narrative write populates it; pre-existing rows return `null` until then.
2. **`include_vectors` on vault-scoped getters**: `POST /memories/by-chunks`, `GET /notes/{id}/memory_units`, `GET /kv/get`, `GET /kv`, `POST /kv/search`, `GET /vaults/{id}/summary`. The unscoped single-ID `GET /memories/{id}` deliberately does **not** carry it — vector exposure is confined to vault-scoped routes (invariant enforced after review: the summary route now calls `check_vault_access`). The KV routes build DTOs via `model_validate(from_attributes=True)`, which would auto-leak vectors on every response (including `PUT /kv`'s echo) — a strip helper + leak-regression tests pin that boundary.
3. **NEW `POST /api/v1/memories/by-ids`** (max 500 IDs, `vault_id` required, mirrors by-chunks auth + scoping): the bulk path — search lean, then batch-fetch vectors. Foreign-vault IDs are silently omitted; duplicates dedupe.
4. **Dead flag deleted**: `RetrievalRequest.include_vectors` (zero readers since the initial import) and its internal twin are gone — search responses are vector-free **by design**; the retrieval engine has zero delta (defers stay unconditional; no benchmark exposure).
5. **`RemoteMemexAPI`** threads the flag + gains `get_memory_units_by_ids`; `MemexAPI` mirrors the kwargs (accepted-for-parity; in-process rows are eager — documented per method).

## Tracking

- **BACKLOG**: `V7 — Embedding exposure for Python/HTTP callers` (BACKLOG.md is a gitignored workspace-local operator file; entry exists there, will be ticked after merge).
- **Plan**: `~/.claude/plans/memex-embedding-exposure-getters.md` (anchor-verified 33/33 `ok`, incl. an "Implementation deviations" section).
- **Investigation report**: `.claude/reports/2026-06-05-embedding-exposure-design.md` (workspace-local).
- **Design doc**: `DESIGN_DOCUMENT.md` §3.3 (schema table), §3.4.1 (capability-boundary note), component table (vault-summary row) — updated in the workspace copy; the file is gitignored so the edits cannot appear in this diff.

## Deviations & pre-existing issues (explicit)

- **Base branch is `release/tier-a-cognitive-memory`, not `main`** — the plan, its anchors, and the alembic chain (055–057) only exist there; this work stream merges PRs into the release branch (cf. #212).
- **`fix(common): record_outcome session parity stub` is a pre-existing break** (the ProposalAction-protocol refactor added `session` to `MemexAPI.record_outcome` without the client mirror; `test_client_signature_parity` was red on base). Fixed via the test's own sanctioned resolution #3, isolated in its own commit.
- **Pre-existing eval failures, verified failing on base `6891bcbe` and NOT addressed here**: mlflow missing from the env, agent-integration scenario-count drift (46 ≠ 39), `retrieval_stability` snapshot manifest already 12 revisions stale (captured at `045`). Migration 058 adds one more revision of staleness to that already-failing gate; the documented remedy is `memex-eval suite refresh-snapshot retrieval_stability`.
- **Deferred LOW (with rationale)**: on a concurrent vault-summary update losing the version race, one narrative encode is wasted (embed-before-`FOR UPDATE`). Correctness unaffected — the early return precedes the assignment; encodes are cheap and the race is rare.

## Agent-surface parity (8 rows)

| Surface | Decision |
|---|---|
| HTTP routes | **touched** — new route + params, vault-scoped |
| MCP server | not touched + **pinned** — projection models can't serialize vectors; `test_no_vectors_in_tool_outputs.py` |
| CLI | code touched **only to preserve byte-identity** — 6 `model_dump` sites exclude `embedding`; `test_no_vectors_in_cli_json.py` |
| Claude Code plugin (skills/rules, hooks) | not touched — zero diff |
| Hermes plugin (tools, briefing) | not touched — zero diff; serializers whitelist fields |
| firefox-extension | not touched — zero diff |

The six load-bearing agent-surface enforcement test files pass **unchanged**.

## Test evidence (all at HEAD)

- core unit **3519** · common **377** (incl. strict signature parity) · MCP **471** · CLI **432** · hermes **559** · feature integration files **33** (real Postgres via testcontainers).
- **Full integration suite at HEAD: 851 passed.** The 6 failures are all pre-existing/environmental, fully accounted: 5 real-LLM tests fail on the retired `gemini-2.0-flash` endpoint (404 — fails identically on base), and `test_int_audit_middleware::test_logs_http_request_for_api_endpoint` is an order-dependent flake that passes standalone (5/5) and failed in full-suite order before this branch's HTTP fixtures existed.
- **HTTP-layer matrix over the real app + real Postgres** (ASGI transport): default-strip leak regression + `include_vectors=true` for unit getters, by-ids, KV get/list/search, vault summary.
- **Populated-DB migration proof**: `057→058` upgrade with existing `vault_summaries` rows (data intact, `embedding` NULL), then clean downgrade — run against a fresh pgvector container.
- Benchmarks: N/A — retrieval pipeline untouched (engine zero-delta). Real-LLM-turn: N/A — no prompt/schema changes. Eval: skip justified in plan §2.9 (all suites + framework gates considered; `packages/eval` has zero `include_vectors` references).

## Adversarial review loop (pre-PR, no cycle cap)

- **Round 1** (fresh agent): 0 CRITICAL / 3 HIGH / 2 MEDIUM / 2 LOW → all HIGH+MEDIUM fixed (+1 LOW), one LOW deferred with rationale above (`ac592a8c`).
- **Round 2** (fresh agent, fix-verification + independent sweep): **0 / 0 / 0 / 0** — loop exited clean.
- **Post-PR rounds** (in-house, substituting the bot which hit an Ollama 429): round 1 found 2 HIGH (single-ID GET widened a cross-vault read to the embedding; missing real-container migration test) + 2 LOW — fixed. Round 2 found 1 HIGH (the **symmetric** `GET /vaults/{id}/summary` leak — same class, missed by the earlier passes) — fixed by authz-gating the summary route. Round 3 verifies clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

