### PR TITLE
refactor(cli): V9 — shared helpers + actionable error & onboarding UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,416%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,420%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,405%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-6,839%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-6,839%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,416%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/docs/explanation/how-memex-works/high-level-architecture.md
+++ b/docs/explanation/how-memex-works/high-level-architecture.md
@@ -163,7 +163,7 @@ You could put every line of Python in one package, import everything from `memex
 
 **Independent deployment.** The MCP server, the Hermes plugin, the Firefox extension, and the Memex server itself are four different runtime artifacts with four different release cadences. The package boundary lets you ship the MCP server without rebuilding the eval suite, or roll the Hermes plugin forward without touching the CLI.
 
-**Optional dependencies.** `memex-core` pulls in heavy machine-learning libraries — embedders, rerankers, ONNX runtimes. A CLI user who only wants to type `memex note add` shouldn't pay that cost on install. `memex-cli` declares `memex-core` as an *extra*: `pip install memex-cli[server]` brings the engine in, plain `pip install memex-cli` does not.
+**Optional dependencies.** `memex-core` pulls in heavy machine-learning libraries — embedders, rerankers, ONNX runtimes. A CLI user who only wants to type `memex note add` shouldn't pay that cost on install. `memex-cli` declares `memex-core` as an *extra*: `uv pip install 'memex-cli[server]'` brings the engine in, plain `uv pip install memex-cli` does not.
 
 **A boundary the type checker can enforce.** When `memex-mcp` imports a type from `memex-core`, mypy makes sure that import goes through the public surface — the schemas in `memex-common`, the facade, or the documented entry points. Imports that reach into private internals get flagged. A single-package layout has no such fence.
 

--- a/packages/cli/src/memex_cli/__init__.py
+++ b/packages/cli/src/memex_cli/__init__.py
@@ -207,9 +207,18 @@ def main(
         setup_logging(ctx, debug, plb.Path(user_log_dir('memex', appauthor=False)) / 'memex.log')
         logger.critical(f'Configuration Error: {e}')
 
-        # Heuristic check for missing config
+        err_console = Console(stderr=True)
         if not global_data and not local_data and not overrides_data:
-            logger.info("Run 'memex init' to generate a valid configuration.")
+            err_console.print('[bold red]Error:[/bold red] No Memex configuration found.')
+            err_console.print(
+                'Run [bold cyan]memex config init[/bold cyan] to create one interactively.'
+            )
+        else:
+            err_console.print(f'[bold red]Configuration error:[/bold red] {e}')
+            err_console.print(
+                'Inspect your configuration with [bold cyan]memex config show[/bold cyan] '
+                'or regenerate it with [bold cyan]memex config init[/bold cyan].'
+            )
 
         raise typer.Exit(code=1)
 

--- a/packages/cli/src/memex_cli/__init__.py
+++ b/packages/cli/src/memex_cli/__init__.py
@@ -208,13 +208,14 @@ def main(
         logger.critical(f'Configuration Error: {e}')
 
         err_console = Console(stderr=True)
-        if not global_data and not local_data and not overrides_data:
+        has_env_config = any(key.startswith('MEMEX_') for key in os.environ)
+        if not global_data and not local_data and not overrides_data and not has_env_config:
             err_console.print('[bold red]Error:[/bold red] No Memex configuration found.')
             err_console.print(
                 'Run [bold cyan]memex config init[/bold cyan] to create one interactively.'
             )
         else:
-            err_console.print(f'[bold red]Configuration error:[/bold red] {e}')
+            # logger.critical above already printed the parse error to stderr; add the CTA only.
             err_console.print(
                 'Inspect your configuration with [bold cyan]memex config show[/bold cyan] '
                 'or regenerate it with [bold cyan]memex config init[/bold cyan].'

--- a/packages/cli/src/memex_cli/assets.py
+++ b/packages/cli/src/memex_cli/assets.py
@@ -3,7 +3,6 @@ Note Asset Management Commands.
 """
 
 import asyncio
-import json
 import mimetypes
 import pathlib
 import sys
@@ -15,7 +14,13 @@ from rich.console import Console
 from rich.table import Table
 
 from memex_common.config import MemexConfig
-from memex_cli.utils import get_api_context, async_command, handle_api_error, parse_uuid
+from memex_cli.utils import (
+    emit_json,
+    get_api_context,
+    async_command,
+    handle_api_error,
+    parse_uuid,
+)
 
 console = Console()
 
@@ -62,7 +67,7 @@ async def list_assets(
                     'mime_type': mime_type,
                 }
             )
-        console.print_json(json.dumps(items))
+        emit_json(items)
         return
 
     table = Table(title=f'Assets ({note_id})')

--- a/packages/cli/src/memex_cli/diagnose.py
+++ b/packages/cli/src/memex_cli/diagnose.py
@@ -9,13 +9,19 @@ Subcommands:
 
 from __future__ import annotations
 
-import json
 from typing import Annotated
 
 import typer
 from rich.console import Console
 
-from memex_cli.utils import async_command, get_api_context, handle_api_error
+from memex_cli.utils import (
+    VaultOption,
+    async_command,
+    get_api_context,
+    emit_json,
+    handle_api_error,
+    resolve_active_vault,
+)
 from memex_common.config import MemexConfig
 
 console = Console()
@@ -31,20 +37,16 @@ app = typer.Typer(
 @async_command
 async def manifold_cmd(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
-    ] = None,
+    vault: VaultOption = None,
     force_refresh: Annotated[
         bool, typer.Option('--force-refresh', help='Force recompute, ignore cache.')
     ] = False,
 ):
     """Print the UMAP manifold JSON. 202 task info if cache is cold."""
     config: MemexConfig = ctx.obj
-    effective_vault = vault if vault is not None else config.write_vault
     async with get_api_context(config) as api:
         try:
-            vault_id = await api.resolve_vault_identifier(effective_vault)
+            vault_id = await resolve_active_vault(api, config, vault)
             status_code, payload = await api.get_diagnostics_manifold(
                 vault_id, force_refresh=force_refresh
             )
@@ -52,62 +54,51 @@ async def manifold_cmd(
             handle_api_error(e)
             return
     payload['_http_status'] = status_code
-    console.print_json(json.dumps(payload, default=str))
+    emit_json(payload)
 
 
 @app.command('retrieval')
 @async_command
 async def retrieval_cmd(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
-    ] = None,
+    vault: VaultOption = None,
     top_n: Annotated[int, typer.Option('--top-n', help='Number of entities to return.')] = 50,
 ):
     """Print the top-N entity outcome heatmap JSON."""
     config: MemexConfig = ctx.obj
-    effective_vault = vault if vault is not None else config.write_vault
     async with get_api_context(config) as api:
         try:
-            vault_id = await api.resolve_vault_identifier(effective_vault)
+            vault_id = await resolve_active_vault(api, config, vault)
             payload = await api.get_diagnostics_retrieval(vault_id, top_n=top_n)
         except Exception as e:
             handle_api_error(e)
             return
-    console.print_json(json.dumps(payload, default=str))
+    emit_json(payload)
 
 
 @app.command('summary')
 @async_command
 async def summary_cmd(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
-    ] = None,
+    vault: VaultOption = None,
 ):
     """Print the full diagnostics summary JSON (synchronous, no UMAP block)."""
     config: MemexConfig = ctx.obj
-    effective_vault = vault if vault is not None else config.write_vault
     async with get_api_context(config) as api:
         try:
-            vault_id = await api.resolve_vault_identifier(effective_vault)
+            vault_id = await resolve_active_vault(api, config, vault)
             payload = await api.get_diagnostics_summary(vault_id)
         except Exception as e:
             handle_api_error(e)
             return
-    console.print_json(json.dumps(payload, default=str))
+    emit_json(payload)
 
 
 @app.command('lint')
 @async_command
 async def lint_cmd(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
-    ] = None,
+    vault: VaultOption = None,
 ):
     """Print the lint-finding pivot JSON.
 
@@ -117,12 +108,11 @@ async def lint_cmd(
     rows) — this is the operator/observability dashboard view.
     """
     config: MemexConfig = ctx.obj
-    effective_vault = vault if vault is not None else config.write_vault
     async with get_api_context(config) as api:
         try:
-            vault_id = await api.resolve_vault_identifier(effective_vault)
+            vault_id = await resolve_active_vault(api, config, vault)
             payload = await api.get_diagnostics_lint(vault_id)
         except Exception as e:
             handle_api_error(e)
             return
-    console.print_json(json.dumps(payload, default=str))
+    emit_json(payload)

--- a/packages/cli/src/memex_cli/entities.py
+++ b/packages/cli/src/memex_cli/entities.py
@@ -3,7 +3,6 @@ Entity Management Commands.
 """
 
 import asyncio
-import json
 import logging
 from typing import Annotated, Any
 from uuid import UUID
@@ -16,7 +15,13 @@ from rich.table import Table
 
 from memex_common.config import MemexConfig
 from memex_common.schemas import EntityDTO
-from memex_cli.utils import get_api_context, async_command, handle_api_error
+from memex_cli.utils import (
+    VaultOption,
+    emit_json,
+    get_api_context,
+    async_command,
+    handle_api_error,
+)
 
 console = Console()
 
@@ -109,10 +114,7 @@ async def delete_entity(
 async def delete_mental_model(
     ctx: typer.Context,
     identifier: Annotated[str, typer.Argument(help='Name or UUID of the entity.')],
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
-    ] = None,
+    vault: VaultOption = None,
     force: Annotated[bool, typer.Option('--force', '-f', help='Skip confirmation.')] = False,
 ):
     """
@@ -200,7 +202,7 @@ async def list_entities(
             handle_api_error(exc)
 
     if json_output:
-        console.print_json(json.dumps([e.model_dump() for e in entities], default=str))
+        emit_json([e.model_dump() for e in entities])
         return
 
     table = Table(title=f'Entities (Top {limit})')
@@ -263,9 +265,9 @@ async def view_entity(
 
     if json_output:
         if len(identifiers) == 1:
-            console.print_json(json.dumps(entities[0].model_dump(), default=str))
+            emit_json(entities[0].model_dump())
         else:
-            console.print_json(json.dumps([e.model_dump() for e in entities], default=str))
+            emit_json([e.model_dump() for e in entities])
         return
 
     for i, entity in enumerate(entities):
@@ -320,7 +322,7 @@ async def list_mentions(
         return
 
     if json_output:
-        console.print_json(json.dumps(results, default=str))
+        emit_json(results)
         return
 
     table = Table(title=f'Mentions for {entity.name}')
@@ -394,7 +396,7 @@ async def list_related(
         return
 
     if json_output:
-        console.print_json(json.dumps(edges, default=str))
+        emit_json(edges)
         return
 
     table = Table(title=f'Related to: {entity.name}')

--- a/packages/cli/src/memex_cli/inbox.py
+++ b/packages/cli/src/memex_cli/inbox.py
@@ -5,7 +5,6 @@
 proposals.
 """
 
-import json
 from typing import Annotated
 
 import typer
@@ -13,7 +12,7 @@ from rich.console import Console
 from rich.table import Table
 
 from memex_common.config import MemexConfig
-from memex_cli.utils import async_command, get_api_context
+from memex_cli.utils import async_command, emit_json, get_api_context
 
 console = Console()
 
@@ -41,7 +40,7 @@ async def triage(
     async with get_api_context(config) as api:
         result = await api.trigger_inbox_triage(dry_run=dry_run)
     if json_output:
-        console.print_json(json.dumps(result))
+        emit_json(result)
         return
     verb = 'Would route' if dry_run else 'Routed'
     # ``blocked_*`` keys are absent on responses from an older server; default to 0.
@@ -74,7 +73,7 @@ async def status(
     async with get_api_context(config) as api:
         payload = await api.inbox_status()
     if json_output:
-        console.print_json(json.dumps(payload))
+        emit_json(payload)
         return
     table = Table(title='Inbox Router Status')
     table.add_column('Field')

--- a/packages/cli/src/memex_cli/kv.py
+++ b/packages/cli/src/memex_cli/kv.py
@@ -2,7 +2,6 @@
 Key-Value Store Commands.
 """
 
-import json
 from typing import Annotated
 
 import typer
@@ -10,7 +9,7 @@ from rich.console import Console
 from rich.table import Table
 
 from memex_common.config import MemexConfig
-from memex_cli.utils import get_api_context, async_command, handle_api_error
+from memex_cli.utils import emit_json, get_api_context, async_command, handle_api_error
 
 console = Console()
 
@@ -126,9 +125,7 @@ async def kv_search(
         return
 
     if json_output:
-        console.print_json(
-            json.dumps([r.model_dump(exclude={'embedding'}) for r in results], default=str)
-        )
+        emit_json([r.model_dump(exclude={'embedding'}) for r in results])
         return
 
     table = Table(title=f'KV Search: "{query}"')
@@ -178,9 +175,7 @@ async def kv_list(
         return
 
     if json_output:
-        console.print_json(
-            json.dumps([e.model_dump(exclude={'embedding'}) for e in entries], default=str)
-        )
+        emit_json([e.model_dump(exclude={'embedding'}) for e in entries])
         return
 
     table = Table(title='KV Entries')

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -32,6 +32,7 @@ from memex_common.lint import LINT_TYPES
 from memex_cli.lint_review import finding_target_label, render_summary, run_review_loop
 from memex_cli.utils import (
     VaultFilterOption,
+    VaultScopeOption,
     async_command,
     emit_json,
     get_api_context,
@@ -780,7 +781,7 @@ async def lint_optimize_run_cmd(
         str | None,
         typer.Option('--rule', help='Rule to compile. Omit to compile all LLM rules.'),
     ] = None,
-    vault: VaultFilterOption = None,
+    vault: VaultScopeOption = None,
 ):
     """Compile optimized LLM lint signatures from your review history.
 
@@ -869,7 +870,7 @@ async def lint_optimize_rollback_cmd(
     ctx: typer.Context,
     rule: Annotated[str, typer.Option('--rule', help='Rule to rollback.')],
     version: Annotated[int, typer.Option('--version', help='Version to rollback to.')],
-    vault: VaultFilterOption = None,
+    vault: VaultScopeOption = None,
 ):
     """Rollback a rule's DSPy signature to a specific version."""
     config: MemexConfig = ctx.obj
@@ -912,7 +913,7 @@ async def lint_calibration_list(
         str | None,
         typer.Option('--rule', help='Filter to one rule_name.'),
     ] = None,
-    vault: VaultFilterOption = None,
+    vault: VaultScopeOption = None,
 ):
     """List calibration rows — versioned per-rule thresholds."""
     config: MemexConfig = ctx.obj
@@ -953,7 +954,7 @@ async def lint_calibration_list(
 @async_command
 async def lint_calibration_run(
     ctx: typer.Context,
-    vault: VaultFilterOption = None,
+    vault: VaultScopeOption = None,
 ):
     """Run threshold calibration now — adjust per-rule emission thresholds from telemetry."""
     config: MemexConfig = ctx.obj
@@ -988,7 +989,7 @@ async def lint_calibration_run(
 async def lint_calibration_freeze(
     ctx: typer.Context,
     rule: Annotated[str, typer.Argument(help='Rule to freeze.')],
-    vault: VaultFilterOption = None,
+    vault: VaultScopeOption = None,
     unfreeze: Annotated[
         bool,
         typer.Option('--unfreeze', help='Unfreeze instead of freezing.'),
@@ -1015,7 +1016,7 @@ async def lint_calibration_rollback(
     ctx: typer.Context,
     rule: Annotated[str, typer.Argument(help='Rule to rollback.')],
     version: Annotated[int, typer.Argument(help='Version to rollback to.')],
-    vault: VaultFilterOption = None,
+    vault: VaultScopeOption = None,
 ):
     """Rollback a rule to a specific calibration version."""
     config: MemexConfig = ctx.obj
@@ -1107,7 +1108,7 @@ async def signatures_list_cmd(
         str | None,
         typer.Option('--rule', help='Filter to one rule_name.'),
     ] = None,
-    vault: VaultFilterOption = None,
+    vault: VaultScopeOption = None,
 ):
     """List compiled signature versions with status indicators."""
     config: MemexConfig = ctx.obj
@@ -1163,7 +1164,7 @@ async def signatures_show_cmd(
     ctx: typer.Context,
     rule: Annotated[str, typer.Argument(help='Rule name.')],
     version: Annotated[int, typer.Argument(help='Signature version number.')],
-    vault: VaultFilterOption = None,
+    vault: VaultScopeOption = None,
 ):
     """Show full detail for a specific signature version, including demos."""
     config: MemexConfig = ctx.obj
@@ -1239,7 +1240,7 @@ async def signatures_diff_cmd(
     rule: Annotated[str, typer.Argument(help='Rule name.')],
     v1: Annotated[int, typer.Argument(help='First version to compare.')],
     v2: Annotated[int, typer.Argument(help='Second version to compare.')],
-    vault: VaultFilterOption = None,
+    vault: VaultScopeOption = None,
 ):
     """Compare two signature versions side by side."""
     config: MemexConfig = ctx.obj
@@ -1346,7 +1347,7 @@ async def signatures_status_cmd(
         str | None,
         typer.Option('--rule', help='Filter to one rule_name.'),
     ] = None,
-    vault: VaultFilterOption = None,
+    vault: VaultScopeOption = None,
 ):
     """Composite status: signature + calibration + telemetry + optimizer readiness per rule."""
     config: MemexConfig = ctx.obj

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -30,7 +30,14 @@ from rich.table import Table
 from memex_common.config import MemexConfig
 from memex_common.lint import LINT_TYPES
 from memex_cli.lint_review import finding_target_label, render_summary, run_review_loop
-from memex_cli.utils import async_command, get_api_context, handle_api_error, parse_uuid
+from memex_cli.utils import (
+    VaultFilterOption,
+    async_command,
+    emit_json,
+    get_api_context,
+    handle_api_error,
+    parse_uuid,
+)
 
 console = Console()
 
@@ -72,10 +79,7 @@ def _resolve_scope(
 @async_command
 async def lint_status(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Filter to one vault by name or UUID.'),
-    ] = None,
+    vault: VaultFilterOption = None,
     is_global: Annotated[
         bool,
         typer.Option('--global/--no-global', help='Show only global (vault_id NULL) findings.'),
@@ -115,10 +119,7 @@ async def lint_status(
 @async_command
 async def lint_findings(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Filter to one vault by name or UUID.'),
-    ] = None,
+    vault: VaultFilterOption = None,
     lint_type: Annotated[
         str | None,
         typer.Option(
@@ -206,10 +207,7 @@ async def lint_findings(
 @async_command
 async def lint_run_cmd(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault to scan. Omit to scan all vaults.'),
-    ] = None,
+    vault: VaultFilterOption = None,
     no_llm: Annotated[
         bool,
         typer.Option('--no-llm', help='Skip LLM checks (SQL rules only).'),
@@ -349,10 +347,7 @@ def _render_telemetry_table(rows: list[dict[str, Any]]) -> Table:
 @async_command
 async def lint_stats_default(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Filter to one vault by name or UUID.'),
-    ] = None,
+    vault: VaultFilterOption = None,
     rule: Annotated[
         str | None,
         typer.Option('--rule', help='Filter to one rule_name.'),
@@ -459,7 +454,7 @@ async def lint_actions_cmd(
             return
     actions = payload.get('actions', [])
     if json_output:
-        console.print_json(data=actions)
+        emit_json(actions)
         return
     table = Table(title='Proposal actions (closed catalogue)')
     table.add_column('id', no_wrap=True)
@@ -634,10 +629,7 @@ async def lint_reverse_cmd(
 @async_command
 async def lint_review_cmd(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Filter to one vault by name or UUID.'),
-    ] = None,
+    vault: VaultFilterOption = None,
     is_global: Annotated[
         bool,
         typer.Option('--global/--no-global', help='Review only global (vault_id NULL) findings.'),
@@ -788,10 +780,7 @@ async def lint_optimize_run_cmd(
         str | None,
         typer.Option('--rule', help='Rule to compile. Omit to compile all LLM rules.'),
     ] = None,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault scope.'),
-    ] = None,
+    vault: VaultFilterOption = None,
 ):
     """Compile optimized LLM lint signatures from your review history.
 
@@ -880,10 +869,7 @@ async def lint_optimize_rollback_cmd(
     ctx: typer.Context,
     rule: Annotated[str, typer.Option('--rule', help='Rule to rollback.')],
     version: Annotated[int, typer.Option('--version', help='Version to rollback to.')],
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault scope.'),
-    ] = None,
+    vault: VaultFilterOption = None,
 ):
     """Rollback a rule's DSPy signature to a specific version."""
     config: MemexConfig = ctx.obj
@@ -926,10 +912,7 @@ async def lint_calibration_list(
         str | None,
         typer.Option('--rule', help='Filter to one rule_name.'),
     ] = None,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault scope.'),
-    ] = None,
+    vault: VaultFilterOption = None,
 ):
     """List calibration rows — versioned per-rule thresholds."""
     config: MemexConfig = ctx.obj
@@ -970,10 +953,7 @@ async def lint_calibration_list(
 @async_command
 async def lint_calibration_run(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault scope.'),
-    ] = None,
+    vault: VaultFilterOption = None,
 ):
     """Run threshold calibration now — adjust per-rule emission thresholds from telemetry."""
     config: MemexConfig = ctx.obj
@@ -1008,10 +988,7 @@ async def lint_calibration_run(
 async def lint_calibration_freeze(
     ctx: typer.Context,
     rule: Annotated[str, typer.Argument(help='Rule to freeze.')],
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault scope.'),
-    ] = None,
+    vault: VaultFilterOption = None,
     unfreeze: Annotated[
         bool,
         typer.Option('--unfreeze', help='Unfreeze instead of freezing.'),
@@ -1038,10 +1015,7 @@ async def lint_calibration_rollback(
     ctx: typer.Context,
     rule: Annotated[str, typer.Argument(help='Rule to rollback.')],
     version: Annotated[int, typer.Argument(help='Version to rollback to.')],
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault scope.'),
-    ] = None,
+    vault: VaultFilterOption = None,
 ):
     """Rollback a rule to a specific calibration version."""
     config: MemexConfig = ctx.obj
@@ -1133,10 +1107,7 @@ async def signatures_list_cmd(
         str | None,
         typer.Option('--rule', help='Filter to one rule_name.'),
     ] = None,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault scope (name or UUID).'),
-    ] = None,
+    vault: VaultFilterOption = None,
 ):
     """List compiled signature versions with status indicators."""
     config: MemexConfig = ctx.obj
@@ -1192,10 +1163,7 @@ async def signatures_show_cmd(
     ctx: typer.Context,
     rule: Annotated[str, typer.Argument(help='Rule name.')],
     version: Annotated[int, typer.Argument(help='Signature version number.')],
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault scope (name or UUID).'),
-    ] = None,
+    vault: VaultFilterOption = None,
 ):
     """Show full detail for a specific signature version, including demos."""
     config: MemexConfig = ctx.obj
@@ -1271,10 +1239,7 @@ async def signatures_diff_cmd(
     rule: Annotated[str, typer.Argument(help='Rule name.')],
     v1: Annotated[int, typer.Argument(help='First version to compare.')],
     v2: Annotated[int, typer.Argument(help='Second version to compare.')],
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault scope (name or UUID).'),
-    ] = None,
+    vault: VaultFilterOption = None,
 ):
     """Compare two signature versions side by side."""
     config: MemexConfig = ctx.obj
@@ -1381,10 +1346,7 @@ async def signatures_status_cmd(
         str | None,
         typer.Option('--rule', help='Filter to one rule_name.'),
     ] = None,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault scope (name or UUID).'),
-    ] = None,
+    vault: VaultFilterOption = None,
 ):
     """Composite status: signature + calibration + telemetry + optimizer readiness per rule."""
     config: MemexConfig = ctx.obj

--- a/packages/cli/src/memex_cli/mcp.py
+++ b/packages/cli/src/memex_cli/mcp.py
@@ -4,6 +4,9 @@ Memex MCP CLI commands.
 
 import asyncio
 import typer
+from rich.console import Console
+
+console = Console()
 
 app = typer.Typer(name='mcp', help='Manage the Memex MCP server.', no_args_is_help=True)
 
@@ -29,9 +32,9 @@ def run(
     try:
         from memex_mcp.server import mcp
     except ImportError:
-        raise ModuleNotFoundError(
-            "'memex_mcp' is not installed. Please install 'memex_cli' with the 'mcp' extra"
-        )
+        console.print('[bold red]Error:[/bold red] Missing dependency for the MCP server.')
+        console.print("Install with: [cyan]uv pip install 'memex-cli\\[mcp]'[/cyan]")
+        raise typer.Exit(1)
     if transport in ('http', 'sse'):
         asyncio.run(mcp.run_async(transport=transport, host=host, port=port))
     else:

--- a/packages/cli/src/memex_cli/mcp.py
+++ b/packages/cli/src/memex_cli/mcp.py
@@ -6,7 +6,7 @@ import asyncio
 import typer
 from rich.console import Console
 
-console = Console()
+console = Console(stderr=True)
 
 app = typer.Typer(name='mcp', help='Manage the Memex MCP server.', no_args_is_help=True)
 

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -165,14 +165,7 @@ async def view_memory(
 async def deprioritize_memory(
     ctx: typer.Context,
     unit_id: Annotated[str, typer.Argument(help='UUID of the memory unit to deprioritize.')],
-    vault: Annotated[
-        str | None,
-        typer.Option(
-            '--vault',
-            '-v',
-            help='Vault name or UUID. Defaults to the active vault.',
-        ),
-    ] = None,
+    vault: VaultOption = None,
     reason: Annotated[
         str,
         typer.Option('--reason', '-r', help='Why this unit is being deprioritized.'),
@@ -205,14 +198,7 @@ async def deprioritize_memory(
 async def restore_memory(
     ctx: typer.Context,
     unit_id: Annotated[str, typer.Argument(help='UUID of the memory unit to restore.')],
-    vault: Annotated[
-        str | None,
-        typer.Option(
-            '--vault',
-            '-v',
-            help='Vault name or UUID. Defaults to the active vault.',
-        ),
-    ] = None,
+    vault: VaultOption = None,
 ):
     """Restore a deprioritized memory unit (flips ``is_deprioritized`` back to false)."""
     config: MemexConfig = ctx.obj

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -3,7 +3,6 @@ Memory Management Commands (Ingest & Retrieval).
 """
 
 import asyncio
-import json
 import logging
 from typing import Annotated
 from uuid import UUID
@@ -17,7 +16,10 @@ from rich.panel import Panel
 from rich.markdown import Markdown
 
 from memex_cli.utils import (
+    VaultOption,
     async_command,
+    emit_json,
+    resolve_active_vault,
     get_api_context,
     handle_api_error,
     parse_uuid,
@@ -119,11 +121,9 @@ async def view_memory(
         # exclude embedding: vectors are an HTTP/Python-caller capability; CLI
         # JSON shape stays byte-identical to the pre-field era.
         if len(uuids) == 1:
-            console.print_json(json.dumps(units[0].model_dump(exclude={'embedding'}), default=str))
+            emit_json(units[0].model_dump(exclude={'embedding'}))
         else:
-            console.print_json(
-                json.dumps([u.model_dump(exclude={'embedding'}) for u in units], default=str)
-            )
+            emit_json([u.model_dump(exclude={'embedding'}) for u in units])
         return
 
     for i, unit in enumerate(units):
@@ -184,11 +184,10 @@ async def deprioritize_memory(
     """
     config: MemexConfig = ctx.obj
     uuid_obj = parse_uuid(unit_id, 'memory unit')
-    effective_vault = vault if vault is not None else config.write_vault
 
     async with get_api_context(config) as api:
         try:
-            resolved_vault = await api.resolve_vault_identifier(effective_vault)
+            resolved_vault = await resolve_active_vault(api, config, vault)
             unit = await api.deprioritize_memory_unit(
                 uuid_obj, reason=reason, vault_id=resolved_vault
             )
@@ -218,11 +217,10 @@ async def restore_memory(
     """Restore a deprioritized memory unit (flips ``is_deprioritized`` back to false)."""
     config: MemexConfig = ctx.obj
     uuid_obj = parse_uuid(unit_id, 'memory unit')
-    effective_vault = vault if vault is not None else config.write_vault
 
     async with get_api_context(config) as api:
         try:
-            resolved_vault = await api.resolve_vault_identifier(effective_vault)
+            resolved_vault = await resolve_active_vault(api, config, vault)
             unit = await api.restore_memory_unit(uuid_obj, vault_id=resolved_vault)
         except Exception as e:
             handle_api_error(e)
@@ -236,10 +234,7 @@ async def restore_memory(
 async def reconsolidate_memory(
     ctx: typer.Context,
     entity_id: Annotated[str, typer.Argument(help='UUID of the entity to reconsolidate.')],
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
-    ] = None,
+    vault: VaultOption = None,
 ):
     """Re-evaluate every memory unit linked to one entity. **Use sparingly.**
 
@@ -270,27 +265,23 @@ async def reconsolidate_memory(
     """
     config: MemexConfig = ctx.obj
     entity_uuid = parse_uuid(entity_id, 'entity')
-    effective_vault = vault if vault is not None else config.write_vault
 
     async with get_api_context(config) as api:
         try:
-            vault_uuid = await api.resolve_vault_identifier(effective_vault)
+            vault_uuid = await resolve_active_vault(api, config, vault)
             result = await api.reconsolidate_entity(entity_uuid, vault_uuid)
         except Exception as e:
             handle_api_error(e)
             return
 
-    console.print_json(json.dumps(result, default=str))
+    emit_json(result)
 
 
 @app.command('consolidate')
 @async_command
 async def consolidate_memory(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
-    ] = None,
+    vault: VaultOption = None,
     dry_run: Annotated[
         bool,
         typer.Option('--dry-run', help='Preview without making changes.'),
@@ -324,17 +315,16 @@ async def consolidate_memory(
     writing.
     """
     config: MemexConfig = ctx.obj
-    effective_vault = vault if vault is not None else config.write_vault
 
     async with get_api_context(config) as api:
         try:
-            vault_uuid = await api.resolve_vault_identifier(effective_vault)
+            vault_uuid = await resolve_active_vault(api, config, vault)
             result = await api.consolidate_vault(vault_uuid, dry_run=dry_run)
         except Exception as e:
             handle_api_error(e)
             return
 
-    console.print_json(json.dumps(result, default=str))
+    emit_json(result)
 
 
 @app.command('delete')
@@ -542,9 +532,7 @@ async def search_memory(
             return
 
         if json_output:
-            console.print_json(
-                json.dumps([u.model_dump(exclude={'embedding'}) for u in results], default=str)
-            )
+            emit_json([u.model_dump(exclude={'embedding'}) for u in results])
             return
 
         # Display Table
@@ -712,7 +700,7 @@ async def memory_links(
         return
 
     if json_output:
-        console.print_json(json.dumps([lnk.model_dump() for lnk in links], default=str))
+        emit_json([lnk.model_dump() for lnk in links])
         return
 
     table = Table(title=f'Links for {unit_id[:8]}...')
@@ -807,7 +795,7 @@ async def get_lineage(
             return tree
 
         if json_output:
-            console.print_json(json.dumps(response.model_dump(), default=str))
+            emit_json(response.model_dump())
             return
 
         console.print(f'\n[bold green]Lineage Visualization ({direction.value})[/bold green]')

--- a/packages/cli/src/memex_cli/notes.py
+++ b/packages/cli/src/memex_cli/notes.py
@@ -30,7 +30,14 @@ from memex_common.schemas import (
 )
 import httpx
 
-from memex_cli.utils import get_api_context, async_command, handle_api_error, parse_uuid
+from memex_cli.utils import (
+    VaultOption,
+    emit_json,
+    get_api_context,
+    async_command,
+    handle_api_error,
+    parse_uuid,
+)
 
 console = Console()
 
@@ -50,7 +57,7 @@ try:
 except ImportError:
     _sync_stub = typer.Typer(
         name='sync',
-        help='Sync a folder of Markdown notes to Memex. (requires: pip install memex-cli[sync])',
+        help="Sync a folder of Markdown notes to Memex. (requires: uv pip install 'memex-cli[sync]')",
         invoke_without_command=True,
     )
 
@@ -58,7 +65,7 @@ except ImportError:
     def _sync_not_installed(ctx: typer.Context) -> None:
         console.print(
             '[bold red]Error:[/bold red] Missing dependencies for note sync.\n'
-            'Install with: [cyan]pip install memex-cli\\[sync][/cyan]'
+            "Install with: [cyan]uv pip install 'memex-cli\\[sync]'[/cyan]"
         )
         raise typer.Exit(1)
 
@@ -82,10 +89,7 @@ async def add_note(
         list[pathlib.Path] | None,
         typer.Option('--asset', '-a', help='Path to an asset file to attach to the note.'),
     ] = None,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
-    ] = None,
+    vault: VaultOption = None,
     key: Annotated[
         str | None, typer.Option('--key', '-k', help='Unique stable key for the note.')
     ] = None,
@@ -321,10 +325,7 @@ async def append_note(
             '--key', '-k', help='Stable note key set at creation time. Preferred identifier.'
         ),
     ] = None,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
-    ] = None,
+    vault: VaultOption = None,
     delta: Annotated[
         str | None,
         typer.Option('--delta', '-d', help='Content snippet to append.'),
@@ -541,7 +542,7 @@ async def list_notes(
         return
 
     if json_output:
-        console.print_json(json.dumps([d.model_dump() for d in notes], default=str))
+        emit_json([d.model_dump() for d in notes])
         return
 
     table = Table(title='Notes')
@@ -665,7 +666,7 @@ async def list_recent(
         return
 
     if json_output:
-        console.print_json(json.dumps([d.model_dump() for d in notes], default=str))
+        emit_json([d.model_dump() for d in notes])
         return
 
     table = Table(title='Recent Notes')
@@ -735,7 +736,7 @@ async def find_note(
         return
 
     if json_output:
-        console.print_json(json.dumps([r.model_dump() for r in results], default=str))
+        emit_json([r.model_dump() for r in results])
         return
 
     table = Table(title=f'Notes matching "{query}"')
@@ -793,7 +794,7 @@ async def note_links(
         return
 
     if json_output:
-        console.print_json(json.dumps([lnk.model_dump() for lnk in links], default=str))
+        emit_json([lnk.model_dump() for lnk in links])
         return
 
     table = Table(title=f'Links for note {note_id[:8]}...')
@@ -967,7 +968,7 @@ async def view_note(
             return
 
     if json_output:
-        console.print_json(json.dumps(note.model_dump(), default=str))
+        emit_json(note.model_dump())
         return
 
     name = note.name or 'Untitled Note'
@@ -1030,7 +1031,7 @@ async def view_metadata(
             console.print('[dim]Only notes with a page index have metadata.[/dim]')
             return
         if json_output:
-            console.print_json(json.dumps(metadata, default=str))
+            emit_json(metadata)
             return
         _render_metadata_table(metadata, note_ids[0])
         return
@@ -1041,7 +1042,7 @@ async def view_metadata(
         return
 
     if json_output:
-        console.print_json(json.dumps(metadata_list, default=str))
+        emit_json(metadata_list)
         return
 
     for i, metadata in enumerate(metadata_list):
@@ -1092,7 +1093,7 @@ async def view_page_index(
             )
             return
         if json_output:
-            console.print_json(json.dumps(page_index, default=str))
+            emit_json(page_index)
             return
         nodes = page_index if isinstance(page_index, list) else page_index.get('toc', [])
         tree = Tree(f'[bold cyan]Page Index[/bold cyan] [dim]({nid})[/dim]')
@@ -1105,7 +1106,7 @@ async def view_page_index(
         out = []
         for nid, pi in results:
             out.append({'note_id': nid, 'page_index': pi})
-        console.print_json(json.dumps(out, default=str))
+        emit_json(out)
         return
 
     for i, (nid, page_index) in enumerate(results):
@@ -1164,9 +1165,9 @@ async def view_node(
 
     if json_output:
         if len(uuids) == 1:
-            console.print_json(json.dumps(nodes[0].model_dump(), default=str))
+            emit_json(nodes[0].model_dump())
         else:
-            console.print_json(json.dumps([n.model_dump() for n in nodes], default=str))
+            emit_json([n.model_dump() for n in nodes])
         return
 
     for i, node in enumerate(nodes):
@@ -1291,7 +1292,7 @@ async def search_notes(
         return
 
     if json_output:
-        console.print_json(json.dumps([r.model_dump() for r in results], default=str))
+        emit_json([r.model_dump() for r in results])
         return
 
     table = Table(title=f'Search Results: "{query}"', show_lines=True)
@@ -1725,7 +1726,7 @@ async def update_user_notes(
             handle_api_error(e)
 
     if json_output:
-        console.print_json(json.dumps(result, default=str))
+        emit_json(result)
         return
 
     console.print(f'[green]User notes updated for note {nid}.[/green]')

--- a/packages/cli/src/memex_cli/server.py
+++ b/packages/cli/src/memex_cli/server.py
@@ -33,13 +33,13 @@ def check_core_installed():
         import asyncpg  # noqa: F401
     except ImportError as e:
         console.print(f"[bold red]Error:[/bold red] Missing dependency '{e.name}'.")
-        console.print('To run the server, install memex-core:')
-        console.print('  [cyan]uv add memex-core[/cyan]')
+        console.print('To run the server, install the server extra:')
+        console.print("  [cyan]uv pip install 'memex-cli\\[server]'[/cyan]")
         raise typer.Exit(1)
 
 
-async def _readiness_check(config: PostgresInstanceConfig):
-    """Attempt to connect to the database."""
+async def _readiness_check(config: PostgresInstanceConfig) -> Exception | None:
+    """Attempt to connect to the database. Returns the failure, or None when reachable."""
     import asyncpg
 
     try:
@@ -52,10 +52,9 @@ async def _readiness_check(config: PostgresInstanceConfig):
         )
         await conn.execute('SELECT 1')
         await conn.close()
-        return True
+        return None
     except Exception as e:
-        console.print(f'[yellow]Database check failed: {e}[/yellow]')
-        return False
+        return e
 
 
 async def _initialize_database(config):
@@ -199,10 +198,17 @@ def start(
     if not check_port_available(host, port):
         console.print(f'[bold red]Error:[/bold red] Port {port} is already in use.')
         raise typer.Exit(1)
-    db_ready = asyncio.run(_readiness_check(conf.server.meta_store.instance))
-    if not db_ready:
+    instance = conf.server.meta_store.instance
+    db_error = asyncio.run(_readiness_check(instance))
+    if db_error is not None:
         console.print(
-            f'[bold red]Error:[/bold red] Unable to connect to database on {conf.server.meta_store.instance.host}:{conf.server.meta_store.instance.port}.'
+            f'[bold red]Error:[/bold red] Unable to connect to database on '
+            f'{instance.host}:{instance.port}: {db_error}'
+        )
+        console.print('  - Check that Postgres is running and reachable at that address.')
+        console.print(
+            '  - Verify credentials and connection settings: '
+            '[bold cyan]memex config show[/bold cyan]'
         )
         raise typer.Exit(1)
 

--- a/packages/cli/src/memex_cli/session.py
+++ b/packages/cli/src/memex_cli/session.py
@@ -11,7 +11,6 @@ from memex_cli.utils import (
     VaultOption,
     async_command,
     get_api_context,
-    handle_api_error,
     resolve_active_vault,
 )
 
@@ -51,26 +50,27 @@ async def briefing(
 
     config: MemexConfig = ctx.obj
 
+    # This command is consumed by hooks/scripts: errors go to stderr as plain text,
+    # never through the interactive (stdout, rich) handler used elsewhere.
     try:
         async with get_api_context(config) as api:
-            try:
-                vault_uuid = await resolve_active_vault(api, config, vault)
-            except Exception as e:
-                handle_api_error(e)
-
-            try:
-                result = await api.get_session_briefing(
-                    vault_id=vault_uuid,
-                    budget=budget,
-                    project_id=project_id,
-                )
-            except Exception as e:
-                handle_api_error(e)
-    except (httpx.ConnectError, httpx.ConnectTimeout, OSError) as e:
+            vault_uuid = await resolve_active_vault(api, config, vault)
+            result = await api.get_session_briefing(
+                vault_id=vault_uuid,
+                budget=budget,
+                project_id=project_id,
+            )
+    except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout, OSError) as e:
         print(
-            f'Error: Could not connect to Memex server. Is it running? ({e})',
+            f'Error: Could not reach the Memex server. Is it running? ({e})',
             file=sys.stderr,
         )
+        raise typer.Exit(1)
+    except httpx.HTTPStatusError as e:
+        print(f'Error: Memex server returned {e.response.status_code}.', file=sys.stderr)
+        raise typer.Exit(1)
+    except Exception as e:
+        print(f'Error: Failed to generate briefing ({e}).', file=sys.stderr)
         raise typer.Exit(1)
 
     # Output raw markdown to stdout (no Rich formatting)

--- a/packages/cli/src/memex_cli/session.py
+++ b/packages/cli/src/memex_cli/session.py
@@ -7,7 +7,13 @@ import httpx
 import typer
 
 from memex_common.config import MemexConfig
-from memex_cli.utils import async_command, get_api_context, handle_api_error
+from memex_cli.utils import (
+    VaultOption,
+    async_command,
+    get_api_context,
+    handle_api_error,
+    resolve_active_vault,
+)
 
 app = typer.Typer(
     name='briefing',
@@ -22,10 +28,7 @@ _VALID_BUDGETS = (1000, 2000)
 @async_command
 async def briefing(
     ctx: typer.Context,
-    vault: Annotated[
-        str | None,
-        typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
-    ] = None,
+    vault: VaultOption = None,
     budget: Annotated[
         int,
         typer.Option('--budget', '-b', help='Token budget (1000 or 2000).'),
@@ -50,9 +53,8 @@ async def briefing(
 
     try:
         async with get_api_context(config) as api:
-            vault_name = vault or config.write_vault
             try:
-                vault_uuid = await api.resolve_vault_identifier(vault_name)
+                vault_uuid = await resolve_active_vault(api, config, vault)
             except Exception as e:
                 handle_api_error(e)
 

--- a/packages/cli/src/memex_cli/stats.py
+++ b/packages/cli/src/memex_cli/stats.py
@@ -2,7 +2,6 @@
 System Statistics Commands.
 """
 
-import json
 from typing import Annotated
 
 import typer
@@ -11,7 +10,7 @@ from rich.table import Table
 from rich.panel import Panel
 
 from memex_common.config import MemexConfig
-from memex_cli.utils import get_api_context, async_command, handle_api_error
+from memex_cli.utils import emit_json, get_api_context, async_command, handle_api_error
 
 console = Console()
 
@@ -41,7 +40,7 @@ async def system_stats(
             return
 
     if json_output:
-        console.print_json(json.dumps(counts.model_dump(), default=str))
+        emit_json(counts.model_dump())
         return
 
     grid = Table.grid(expand=True)

--- a/packages/cli/src/memex_cli/utils.py
+++ b/packages/cli/src/memex_cli/utils.py
@@ -34,6 +34,11 @@ VaultFilterOption = Annotated[
     typer.Option('--vault', '-v', help='Filter to one vault by name or UUID. Omit for all scopes.'),
 ]
 
+VaultScopeOption = Annotated[
+    str | None,
+    typer.Option('--vault', '-v', help='Vault scope (name or UUID). Omit for the global scope.'),
+]
+
 # Lazy loaded subcommands map: command_name -> import_path:object_name
 LAZY_SUBCOMMANDS: dict[str, str] = {
     'vault': 'memex_cli.vaults:app',
@@ -142,18 +147,17 @@ def handle_api_error(e: Exception) -> NoReturn:
     """
     Handle exceptions from RemoteMemexAPI and provide helpful feedback.
     """
-    connection_errors = (
-        httpx.ConnectError,
-        httpx.ConnectTimeout,
-        httpx.ReadTimeout,
-        httpx.PoolTimeout,
-    )
-    if isinstance(e, connection_errors):
+    if isinstance(e, (httpx.ConnectError, httpx.ConnectTimeout)):
         console.print('[bold red]Error:[/bold red] Could not reach the Memex server.')
         console.print(
             '  - Is it running? Start it with: [bold cyan]memex server start --daemon[/bold cyan]'
         )
         console.print('  - Check the configured URL: [bold cyan]memex config show[/bold cyan]')
+        raise typer.Exit(1)
+    if isinstance(e, (httpx.ReadTimeout, httpx.PoolTimeout)):
+        console.print('[bold red]Error:[/bold red] The Memex server did not respond in time.')
+        console.print('  - The operation may still be running on the server; retry shortly.')
+        console.print('  - Check server health: [bold cyan]memex server status[/bold cyan]')
         raise typer.Exit(1)
     if isinstance(e, httpx.HTTPStatusError):
         try:

--- a/packages/cli/src/memex_cli/utils.py
+++ b/packages/cli/src/memex_cli/utils.py
@@ -5,7 +5,7 @@ import importlib
 import json
 import logging
 from functools import wraps
-from typing import Any, Callable, Coroutine, NoReturn, TypeVar, AsyncGenerator
+from typing import Annotated, Any, Callable, Coroutine, NoReturn, TypeVar, AsyncGenerator
 from contextlib import asynccontextmanager
 from uuid import UUID
 
@@ -23,6 +23,16 @@ console = Console()
 logger = logging.getLogger('memex_cli')
 
 T = TypeVar('T')
+
+VaultOption = Annotated[
+    str | None,
+    typer.Option('--vault', '-v', help='Vault name or UUID. Defaults to the active vault.'),
+]
+
+VaultFilterOption = Annotated[
+    str | None,
+    typer.Option('--vault', '-v', help='Filter to one vault by name or UUID. Omit for all scopes.'),
+]
 
 # Lazy loaded subcommands map: command_name -> import_path:object_name
 LAZY_SUBCOMMANDS: dict[str, str] = {
@@ -93,12 +103,13 @@ class LazyTyperGroup(TyperGroup):
             # Check if this is due to missing optional dependencies
             if cmd_name == 'server':
                 console.print('[bold red]Error:[/bold red] Missing dependency for server.')
-                console.print('Install with: [cyan]uv add memex-cli[server][/cyan]')
+                console.print("Install with: [cyan]uv pip install 'memex-cli\\[server]'[/cyan]")
                 raise typer.Exit(code=1)
             elif cmd_name == 'mcp':
                 console.print('[bold red]Error:[/bold red] Missing dependency for MCP.')
-                console.print('Install with: [cyan]uv add memex-cli[mcp][/cyan]')
+                console.print("Install with: [cyan]uv pip install 'memex-cli\\[mcp]'[/cyan]")
                 raise typer.Exit(code=1)
+            console.print(f"[bold red]Error:[/bold red] Failed to load command '{cmd_name}': {e}")
             logger.error(f"Failed to load command '{cmd_name}': {e}")
             raise typer.Exit(code=1) from e
 
@@ -116,10 +127,34 @@ def async_command(f: Callable[..., Coroutine[Any, Any, Any]]) -> Callable[..., A
     return wrapper
 
 
+async def resolve_active_vault(api: RemoteMemexAPI, config: MemexConfig, vault: str | None) -> UUID:
+    """Resolve a --vault value (or the configured active vault) to a vault UUID."""
+    effective_vault = vault if vault is not None else config.write_vault
+    return await api.resolve_vault_identifier(effective_vault)
+
+
+def emit_json(data: Any) -> None:
+    """Print data as formatted JSON, serializing non-JSON types via str()."""
+    console.print_json(json.dumps(data, default=str))
+
+
 def handle_api_error(e: Exception) -> NoReturn:
     """
     Handle exceptions from RemoteMemexAPI and provide helpful feedback.
     """
+    connection_errors = (
+        httpx.ConnectError,
+        httpx.ConnectTimeout,
+        httpx.ReadTimeout,
+        httpx.PoolTimeout,
+    )
+    if isinstance(e, connection_errors):
+        console.print('[bold red]Error:[/bold red] Could not reach the Memex server.')
+        console.print(
+            '  - Is it running? Start it with: [bold cyan]memex server start --daemon[/bold cyan]'
+        )
+        console.print('  - Check the configured URL: [bold cyan]memex config show[/bold cyan]')
+        raise typer.Exit(1)
     if isinstance(e, httpx.HTTPStatusError):
         try:
             detail = e.response.json().get('detail', str(e))

--- a/packages/cli/src/memex_cli/vaults.py
+++ b/packages/cli/src/memex_cli/vaults.py
@@ -2,7 +2,6 @@
 Vault Management Commands.
 """
 
-import json
 from pathlib import Path
 from typing import Annotated
 from uuid import UUID
@@ -12,7 +11,7 @@ from rich.console import Console
 from rich.table import Table
 
 from memex_common.config import MemexConfig
-from memex_cli.utils import get_api_context, async_command, handle_api_error
+from memex_cli.utils import emit_json, get_api_context, async_command, handle_api_error
 
 console = Console()
 
@@ -97,7 +96,7 @@ async def list_vaults(
         return
 
     if json_output:
-        console.print_json(json.dumps([v.model_dump() for v in vaults], default=str))
+        emit_json([v.model_dump() for v in vaults])
         return
 
     has_access = any(v.access is not None for v in vaults)
@@ -293,7 +292,7 @@ async def vault_summary(
             return
 
     if json_output:
-        console.print_json(json.dumps(summary.model_dump(exclude={'embedding'}), default=str))
+        emit_json(summary.model_dump(exclude={'embedding'}))
         return
 
     if compact:

--- a/packages/cli/tests/test_cli_utils.py
+++ b/packages/cli/tests/test_cli_utils.py
@@ -96,12 +96,7 @@ def test_emit_json_serializes_non_json_types(capsys):
 
 @pytest.mark.parametrize(
     'exc',
-    [
-        httpx.ConnectError('refused'),
-        httpx.ConnectTimeout('timed out'),
-        httpx.ReadTimeout('timed out'),
-        httpx.PoolTimeout('timed out'),
-    ],
+    [httpx.ConnectError('refused'), httpx.ConnectTimeout('timed out')],
 )
 def test_handle_api_error_connection_failure_suggests_server_start(exc, capsys):
     with pytest.raises(typer.Exit) as exc_info:
@@ -112,6 +107,21 @@ def test_handle_api_error_connection_failure_suggests_server_start(exc, capsys):
     assert 'Could not reach the Memex server' in out
     assert 'memex server start --daemon' in out
     assert 'memex config show' in out
+
+
+@pytest.mark.parametrize(
+    'exc',
+    [httpx.ReadTimeout('timed out'), httpx.PoolTimeout('timed out')],
+)
+def test_handle_api_error_slow_server_does_not_suggest_start(exc, capsys):
+    with pytest.raises(typer.Exit) as exc_info:
+        handle_api_error(exc)
+
+    assert exc_info.value.exit_code == 1
+    out = capsys.readouterr().out
+    assert 'did not respond in time' in out
+    assert 'memex server status' in out
+    assert 'server start' not in out
 
 
 def test_handle_api_error_http_status_unaffected(capsys):
@@ -127,18 +137,25 @@ def test_handle_api_error_http_status_unaffected(capsys):
     assert 'Resource not found' in capsys.readouterr().out
 
 
-def test_missing_config_prints_init_cta(runner):
+def _invoke_with_config_failure(runner, global_data, env):
+    import os
+
     from memex_cli import app
 
     with (
+        patch.dict(os.environ, env, clear=True),
         patch('memex_cli.GlobalYamlConfigSettingsSource') as global_source,
         patch('memex_cli.LocalYamlConfigSettingsSource') as local_source,
-        patch('memex_cli.parse_memex_config', side_effect=ValueError('missing fields')),
+        patch('memex_cli.parse_memex_config', side_effect=ValueError('bad config')),
         patch('memex_cli.setup_logging'),
     ):
-        global_source.return_value.return_value = {}
+        global_source.return_value.return_value = global_data
         local_source.return_value.return_value = {}
-        result = runner.invoke(app, ['vault', 'list'])
+        return runner.invoke(app, ['vault', 'list'])
+
+
+def test_missing_config_prints_init_cta(runner):
+    result = _invoke_with_config_failure(runner, global_data={}, env={})
 
     assert result.exit_code == 1
     assert 'No Memex configuration found' in result.output
@@ -146,18 +163,20 @@ def test_missing_config_prints_init_cta(runner):
 
 
 def test_invalid_config_points_at_config_commands(runner):
-    from memex_cli import app
-
-    with (
-        patch('memex_cli.GlobalYamlConfigSettingsSource') as global_source,
-        patch('memex_cli.LocalYamlConfigSettingsSource') as local_source,
-        patch('memex_cli.parse_memex_config', side_effect=ValueError('bad port')),
-        patch('memex_cli.setup_logging'),
-    ):
-        global_source.return_value.return_value = {'server': {'port': 'bad'}}
-        local_source.return_value.return_value = {}
-        result = runner.invoke(app, ['vault', 'list'])
+    result = _invoke_with_config_failure(runner, global_data={'server': {'port': 'bad'}}, env={})
 
     assert result.exit_code == 1
-    assert 'Configuration error' in result.output
+    assert 'No Memex configuration found' not in result.output
+    flat_output = ' '.join(result.output.split())
+    assert 'memex config show' in flat_output
+    assert 'memex config init' in flat_output
+
+
+def test_env_var_config_failure_not_misdiagnosed_as_missing(runner):
+    result = _invoke_with_config_failure(
+        runner, global_data={}, env={'MEMEX_SERVER__PORT': 'not-a-port'}
+    )
+
+    assert result.exit_code == 1
+    assert 'No Memex configuration found' not in result.output
     assert 'memex config show' in result.output

--- a/packages/cli/tests/test_cli_utils.py
+++ b/packages/cli/tests/test_cli_utils.py
@@ -1,5 +1,18 @@
+import json
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import httpx
 import pytest
-from memex_cli.utils import merge_overrides, async_command
+import typer
+
+from memex_cli.utils import (
+    async_command,
+    emit_json,
+    handle_api_error,
+    merge_overrides,
+    resolve_active_vault,
+)
 
 
 def test_merge_overrides_simple():
@@ -48,3 +61,103 @@ async def test_async_command_wrapper():
     # async_command uses asyncio.run() internally to make it synchronous for Typer.
     # In a test with an already-running loop we can only verify the wrapper is callable.
     assert callable(dummy_async)
+
+
+@pytest.mark.asyncio
+async def test_resolve_active_vault_explicit_vault_wins():
+    vault_id = uuid4()
+    api = AsyncMock()
+    api.resolve_vault_identifier.return_value = vault_id
+    config = type('Config', (), {'write_vault': 'active-vault'})()
+
+    result = await resolve_active_vault(api, config, 'explicit-vault')
+
+    assert result == vault_id
+    api.resolve_vault_identifier.assert_awaited_once_with('explicit-vault')
+
+
+@pytest.mark.asyncio
+async def test_resolve_active_vault_falls_back_to_config():
+    api = AsyncMock()
+    config = type('Config', (), {'write_vault': 'active-vault'})()
+
+    await resolve_active_vault(api, config, None)
+
+    api.resolve_vault_identifier.assert_awaited_once_with('active-vault')
+
+
+def test_emit_json_serializes_non_json_types(capsys):
+    vault_id = uuid4()
+    emit_json({'id': vault_id, 'count': 2})
+
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed == {'id': str(vault_id), 'count': 2}
+
+
+@pytest.mark.parametrize(
+    'exc',
+    [
+        httpx.ConnectError('refused'),
+        httpx.ConnectTimeout('timed out'),
+        httpx.ReadTimeout('timed out'),
+        httpx.PoolTimeout('timed out'),
+    ],
+)
+def test_handle_api_error_connection_failure_suggests_server_start(exc, capsys):
+    with pytest.raises(typer.Exit) as exc_info:
+        handle_api_error(exc)
+
+    assert exc_info.value.exit_code == 1
+    out = capsys.readouterr().out
+    assert 'Could not reach the Memex server' in out
+    assert 'memex server start --daemon' in out
+    assert 'memex config show' in out
+
+
+def test_handle_api_error_http_status_unaffected(capsys):
+    response = httpx.Response(404, json={'detail': 'Note not found'})
+    exc = httpx.HTTPStatusError(
+        'not found', request=httpx.Request('GET', 'http://x'), response=response
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        handle_api_error(exc)
+
+    assert exc_info.value.exit_code == 1
+    assert 'Resource not found' in capsys.readouterr().out
+
+
+def test_missing_config_prints_init_cta(runner):
+    from memex_cli import app
+
+    with (
+        patch('memex_cli.GlobalYamlConfigSettingsSource') as global_source,
+        patch('memex_cli.LocalYamlConfigSettingsSource') as local_source,
+        patch('memex_cli.parse_memex_config', side_effect=ValueError('missing fields')),
+        patch('memex_cli.setup_logging'),
+    ):
+        global_source.return_value.return_value = {}
+        local_source.return_value.return_value = {}
+        result = runner.invoke(app, ['vault', 'list'])
+
+    assert result.exit_code == 1
+    assert 'No Memex configuration found' in result.output
+    assert 'memex config init' in result.output
+
+
+def test_invalid_config_points_at_config_commands(runner):
+    from memex_cli import app
+
+    with (
+        patch('memex_cli.GlobalYamlConfigSettingsSource') as global_source,
+        patch('memex_cli.LocalYamlConfigSettingsSource') as local_source,
+        patch('memex_cli.parse_memex_config', side_effect=ValueError('bad port')),
+        patch('memex_cli.setup_logging'),
+    ):
+        global_source.return_value.return_value = {'server': {'port': 'bad'}}
+        local_source.return_value.return_value = {}
+        result = runner.invoke(app, ['vault', 'list'])
+
+    assert result.exit_code == 1
+    assert 'Configuration error' in result.output
+    assert 'memex config show' in result.output

--- a/packages/cli/tests/test_server_cli.py
+++ b/packages/cli/tests/test_server_cli.py
@@ -8,7 +8,7 @@ from memex_cli.server import app
 def mock_dependencies():
     with (
         patch('memex_cli.server.check_core_installed'),
-        patch('memex_cli.server._readiness_check', return_value=True),
+        patch('memex_cli.server._readiness_check', return_value=None),
         patch('memex_cli.server._initialize_database'),
         patch('memex_cli.server._initialize_models'),
         patch('memex_cli.server.parse_memex_config') as mock_conf,

--- a/packages/cli/tests/test_session_cli.py
+++ b/packages/cli/tests/test_session_cli.py
@@ -1,0 +1,64 @@
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from memex_cli.session import app
+
+
+@pytest.fixture
+def _patched_api(mock_config):
+    api = AsyncMock()
+    api.__aenter__.return_value = api
+    api.__aexit__.return_value = None
+    with (
+        patch('memex_cli.session.get_api_context', return_value=api),
+        patch('memex_cli.utils.MemexConfig'),
+    ):
+        yield api
+
+
+def _invoke(runner, mock_config, args):
+    return runner.invoke(app, args, obj=mock_config)
+
+
+def test_briefing_success_writes_markdown_to_stdout(runner, mock_config, _patched_api):
+    _patched_api.resolve_vault_identifier.return_value = uuid4()
+    _patched_api.get_session_briefing.return_value = '# Briefing\n\nfacts'
+
+    result = _invoke(runner, mock_config, ['--budget', '1000'])
+
+    assert result.exit_code == 0
+    assert '# Briefing' in result.stdout
+
+
+def test_briefing_invalid_budget_exits_2_to_stderr(runner, mock_config, _patched_api):
+    result = _invoke(runner, mock_config, ['--budget', '500'])
+
+    assert result.exit_code == 1
+    assert '--budget must be one of' in result.output
+
+
+def test_briefing_connection_error_is_plain_stderr(runner, mock_config, _patched_api):
+    _patched_api.resolve_vault_identifier.side_effect = httpx.ConnectError('refused')
+
+    result = _invoke(runner, mock_config, [])
+
+    assert result.exit_code == 1
+    # Plain text for the hook consumer — no rich markup, no stdout briefing.
+    assert 'Could not reach the Memex server' in result.output
+    assert 'memex server start' not in result.output
+
+
+def test_briefing_http_error_is_plain_stderr(runner, mock_config, _patched_api):
+    _patched_api.resolve_vault_identifier.return_value = uuid4()
+    response = httpx.Response(500, request=httpx.Request('GET', 'http://x'))
+    _patched_api.get_session_briefing.side_effect = httpx.HTTPStatusError(
+        'boom', request=response.request, response=response
+    )
+
+    result = _invoke(runner, mock_config, [])
+
+    assert result.exit_code == 1
+    assert 'returned 500' in result.output


### PR DESCRIPTION
## What & why

Implements **V9** from the CLI/TUI UX overhaul: collapse duplicated CLI boilerplate into shared helpers and make every failure path console-visible and actionable. Non-breaking — no command renames (those are V8).

- **Backlog**: `BACKLOG.md` → `## V9 — CLI shared helpers & error/onboarding UX` (BACKLOG.md is gitignored locally; entry tracked in the working tree)
- **Plan**: `~/.claude/plans/memex-cli-tui-ux-overhaul.md` §V9 (87/87 anchors verified `ok`)
- **Design doc**: N/A — `DESIGN_DOCUMENT.md` is not present on `release/tier-a-cognitive-memory`

## Changes

- **`utils.py` helpers**: `VaultOption` / `VaultFilterOption` / `VaultScopeOption` Annotated aliases (canonical, behavior-accurate `--vault` help — active-vault default vs. all-scopes filter vs. global scope); `resolve_active_vault()`; `emit_json()`. Migrated ~40 `print_json` sites and 9 vault-resolution sites across `memory`/`diagnose`/`session`/`lint`/`kv`/`entities`/`vaults`/`stats`/`inbox`/`notes`.
- **`handle_api_error`**: connect/connect-timeout failures suggest `memex server start --daemon` + `memex config show`; read/pool timeouts point at `memex server status` (a live-but-slow server should not be told to "start"). 404-vault special case preserved.
- **First-run**: config-load failure prints a stderr CTA naming the real command (`memex config init`); the old hint named a nonexistent `memex init` and went to the log file only. Env-var (`MEMEX_*`) configs are not misdiagnosed as "no config".
- **Install hints**: standardized on `uv pip install 'memex-cli[<extra>]'` (sync stub, server, mcp, lazy-loader); lazy-load failures for any group are now console-visible; mcp hint goes to stderr.
- **`server start`**: readiness failure is one red actionable message carrying the underlying asyncpg error, instead of a yellow-warning-then-red-exit pair.
- **`memex briefing`**: keeps plain-stderr error handling (it feeds the SessionStart hook) — success → stdout markdown; budget/connection/HTTP/other errors → stderr + exit 1.

## Tests

- `test_cli_utils.py`: `resolve_active_vault`, `emit_json`, connect-vs-slow-server branches, env-var-aware first-run CTA.
- `test_session_cli.py` (new): briefing success + the three error paths land on stderr with exit 1.
- Full CLI suite green (447 passing); `just prek` (ruff + mypy) clean.

## Validation

- Pre-PR self-assessment ≥ 99%; adversarial review loop run to a clean pass (3 rounds, fresh reviewer each round, zero CRITICAL/HIGH/MEDIUM on the final).
- Manually exercised against the real CLI: no-config first-run, connection-refused, and `vault list` golden path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)