### PR TITLE
feat(cli)!: V8 — command-tree & naming overhaul (breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,420%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,428%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,428%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,430%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/docs/how-to/diagnostics.md
+++ b/docs/how-to/diagnostics.md
@@ -49,7 +49,7 @@ The payload's `points` array is one entry per memory unit: `{unit_id, x, y}`. Fe
 ### 3. See which entities dominate retrieval
 
 ```bash
-memex diagnostics retrieval --vault my-vault --top-n 20 | jq '.entities[] | {name, volume, avg_mw_score}'
+memex diagnostics retrieval --vault my-vault --limit 20 | jq '.entities[] | {name, volume, avg_mw_score}'
 ```
 
 `retrieval` returns the top-N entities ranked by outcome volume — the sum of `success_co_count + failure_co_count` across every unit linked to the entity. <code-ref path="packages/core/src/memex_core/diagnostics/heatmap.py" lines="18-43" /> Each row also carries the Bayesian-smoothed average MW score for the entity's units. The default top-N is 50; the server caps it at 500.
@@ -59,7 +59,7 @@ Use this when retrieval feels skewed. An entity at the top of the list with a lo
 ### 4. Pivot the lint backlog
 
 ```bash
-memex diagnostics lint --vault my-vault | jq '.pending_by_type'
+memex diagnostics findings --vault my-vault | jq '.pending_by_type'
 ```
 
 The lint subcommand emits a JSON pivot over the `maintenance_proposals` table:
@@ -73,7 +73,7 @@ This is the dashboard view. It is distinct from `memex lint status` (single glob
 To watch the backlog over time, capture the pivot daily:
 
 ```bash
-memex diagnostics lint --vault my-vault \
+memex diagnostics findings --vault my-vault \
   | jq '{at: now, pending: .pending_by_type}' \
   >> ~/memex-lint-history.ndjson
 ```

--- a/docs/how-to/note-templates.md
+++ b/docs/how-to/note-templates.md
@@ -103,7 +103,7 @@ memex note template dir --local
 memex note template delete sprint_retrospective
 ```
 
-Add `--yes` to skip the confirmation prompt. Use `--local` to target a project-local template specifically.
+Add `--force` to skip the confirmation prompt. Use `--local` to target a project-local template specifically.
 
 > **Note:** Built-in templates cannot be deleted.
 

--- a/docs/how-to/trace-lineage.md
+++ b/docs/how-to/trace-lineage.md
@@ -119,7 +119,7 @@ The leaf entity id should match the source note you ingested.
 
 **Observation appears in the lineage tree but you cannot deprioritize it.** Observations are read-only projections of memory units (their `unit_metadata.virtual` flag is `true`). Calling `memex_memory_deprioritize` on an observation UUID returns HTTP 400 with a `source_memory_units` list — re-issue the call against one of the listed underlying memory unit IDs.
 
-**Empty downstream tree from a note you just ingested.** Extraction is asynchronous; the reflection loop has not run yet. Wait a few seconds, or check the scheduler with `memex system status`. Once units are extracted, downstream lineage from the note will populate.
+**Empty downstream tree from a note you just ingested.** Extraction is asynchronous; the reflection loop has not run yet. Wait a few seconds, or check the scheduler with `memex stats`. Once units are extracted, downstream lineage from the note will populate.
 
 ## See also
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -217,7 +217,7 @@ Search the knowledge base using TEMPR retrieval strategies.
 |--------|-------|------|---------|-------------|
 | `--vault` | `-v` | str (list) | - | Filter by vault(s). Repeatable. Use `"*"` for all vaults. |
 | `--limit` | | int | `5` | Maximum number of results to return. |
-| `--token-budget` | `-t` | int | - | Token budget for retrieval context. |
+| `--budget` | `-b` | int | - | Token budget for retrieval context. |
 | `--answer` | `-a` | bool | `False` | Generate an AI-synthesized answer from results. |
 | `--json` | | bool | `False` | Output results as JSON. |
 | `--minimal` | | bool | `False` | Output memory unit IDs only (one per line). |
@@ -1604,10 +1604,10 @@ Delete a vault by name or UUID.
 
 ---
 
-### `vault truncate`
+### `vault clear`
 
 ```
-memex vault truncate IDENTIFIER [OPTIONS]
+memex vault clear IDENTIFIER [OPTIONS]
 ```
 
 Remove all content from a vault (notes, memories, entities, etc.). The vault itself is preserved.
@@ -1616,7 +1616,7 @@ Remove all content from a vault (notes, memories, entities, etc.). The vault its
 
 | Name | Required | Description |
 |------|----------|-------------|
-| `IDENTIFIER` | Yes | Name or UUID of the vault to truncate. |
+| `IDENTIFIER` | Yes | Name or UUID of the vault to clear. |
 
 #### Options
 
@@ -1627,11 +1627,11 @@ Remove all content from a vault (notes, memories, entities, etc.). The vault its
 #### Examples
 
 ```bash
-# Truncate a vault by name (with confirmation prompt)
-memex vault truncate my-vault
+# Clear a vault by name (with confirmation prompt)
+memex vault clear my-vault
 
-# Truncate without confirmation
-memex vault truncate my-vault --force
+# Clear without confirmation
+memex vault clear my-vault --force
 ```
 
 > [!WARNING]
@@ -1814,14 +1814,12 @@ memex mcp run --transport sse --port 8080
 
 ---
 
-## `system`
+## `stats`
 
 Show overview of system counts (memories, entities, queue).
 
-### `system system`
-
 ```
-memex system system [OPTIONS]
+memex stats [OPTIONS]
 ```
 
 Show an overview of system counts: total memories (documents), entities, and reflection queue size.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1075,7 +1075,7 @@ Delete a user template. Cannot delete built-in templates.
 | Option | Short | Type | Default | Description |
 |--------|-------|------|---------|-------------|
 | `--local` | | bool | `False` | Delete from project-local scope instead of global. |
-| `--yes` | `-y` | bool | `False` | Skip the confirmation prompt. |
+| `--force` | `-f` | bool | `False` | Skip the confirmation prompt. |
 
 ---
 

--- a/docs/tutorial/memory-worth-and-deprioritization.md
+++ b/docs/tutorial/memory-worth-and-deprioritization.md
@@ -7,7 +7,7 @@ You will ingest the three notes, watch them rank identically at first, record on
 ## Prerequisites
 
 - A running Memex server with the HTTP API reachable at `http://localhost:8000` (set a different host with `MEMEX_URL` if you have one).
-- The `memex` CLI installed and configured against that server. Run `memex system status` to confirm.
+- The `memex` CLI installed and configured against that server. Run `memex stats` to confirm.
 - An active vault. `memex vault list` will show one. If none exists, run `memex vault create demo` and `memex vault use demo`.
 - `curl` and `jq` on your shell — used to record outcomes against the HTTP endpoint, since Memex has no CLI for recording outcomes today.
 - About fifteen minutes.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -44,7 +44,7 @@ memex memory search "What are the key points?"
 | `memex kv` | Key-value store operations (get, write, search, list). |
 | `memex server` | Start, stop, and check status of the API server. |
 | `memex mcp` | Run the MCP server (stdio or SSE transport). |
-| `memex system` | View system statistics and token usage. |
+| `memex stats` | View system statistics and token usage. |
 | `memex config` | Show current configuration or initialize a config file. |
 | `memex database` | Database migrations via Alembic (upgrade, downgrade, history, stamp, revision). |
 | `memex report-bug` | Open a pre-filled GitHub issue with system info. |

--- a/packages/cli/src/memex_cli/agent_surface.py
+++ b/packages/cli/src/memex_cli/agent_surface.py
@@ -149,6 +149,7 @@ def agent_surface(
     output_dir: Optional[Path] = typer.Option(
         None,
         '--output-dir',
+        '-d',
         help=(
             'If set, write to <dir>/memex-agent-surface.md atomically instead of '
             'stdout. Creates <dir> if missing. Skips the rewrite when content is '

--- a/packages/cli/src/memex_cli/diagnose.py
+++ b/packages/cli/src/memex_cli/diagnose.py
@@ -4,7 +4,7 @@ Subcommands:
 - manifold   — emit UMAP projection JSON (or 202 task info)
 - retrieval  — emit top-N entities heatmap JSON
 - summary    — emit full diagnostics summary JSON
-- lint       — emit lint-finding pivot JSON
+- findings   — emit lint-finding pivot JSON
 """
 
 from __future__ import annotations
@@ -62,7 +62,9 @@ async def manifold_cmd(
 async def retrieval_cmd(
     ctx: typer.Context,
     vault: VaultOption = None,
-    top_n: Annotated[int, typer.Option('--top-n', help='Number of entities to return.')] = 50,
+    top_n: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of entities to return.')
+    ] = 50,
 ):
     """Print the top-N entity outcome heatmap JSON."""
     config: MemexConfig = ctx.obj
@@ -94,9 +96,9 @@ async def summary_cmd(
     emit_json(payload)
 
 
-@app.command('lint')
+@app.command('findings')
 @async_command
-async def lint_cmd(
+async def findings_cmd(
     ctx: typer.Context,
     vault: VaultOption = None,
 ):

--- a/packages/cli/src/memex_cli/entities.py
+++ b/packages/cli/src/memex_cli/entities.py
@@ -162,7 +162,9 @@ async def delete_mental_model(
 @async_command
 async def list_entities(
     ctx: typer.Context,
-    limit: Annotated[int, typer.Option('--limit', '-l', help='Max number of entities.')] = 50,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of entities to return.')
+    ] = 50,
     query: Annotated[str | None, typer.Option('--query', '-q', help='Search query.')] = None,
     entity_type: Annotated[
         str | None,
@@ -281,7 +283,9 @@ async def view_entity(
 async def list_mentions(
     ctx: typer.Context,
     identifier: Annotated[str, typer.Argument(help='Name or UUID of the entity.')],
-    limit: int = 20,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of mentions to return.')
+    ] = 20,
     json_output: Annotated[bool, typer.Option('--json', help='Output as JSON.')] = False,
     include_stale: Annotated[
         bool,
@@ -425,7 +429,8 @@ async def scan_merges_cmd(
     top_n: Annotated[
         int | None,
         typer.Option(
-            '--top-n',
+            '--limit',
+            '-l',
             min=2,
             max=10_000,
             help='Override the config default for how many entities to scan.',

--- a/packages/cli/src/memex_cli/kv.py
+++ b/packages/cli/src/memex_cli/kv.py
@@ -102,7 +102,9 @@ async def kv_get(
 async def kv_search(
     ctx: typer.Context,
     query: Annotated[str, typer.Argument(help='Search query.')],
-    limit: Annotated[int, typer.Option('--limit', '-l', help='Max results.')] = 5,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of results to return.')
+    ] = 5,
     namespace: Annotated[
         list[str] | None,
         typer.Option('--namespace', '-n', help='Filter by namespace prefix (repeatable).'),

--- a/packages/cli/src/memex_cli/lint.py
+++ b/packages/cli/src/memex_cli/lint.py
@@ -125,6 +125,7 @@ async def lint_findings(
         str | None,
         typer.Option(
             '--type',
+            '-t',
             help='Filter by lint_type: structural, quality, governance, schema, routing.',
         ),
     ] = None,
@@ -143,7 +144,10 @@ async def lint_findings(
             show_default=False,
         ),
     ] = False,
-    limit: Annotated[int, typer.Option('--limit', min=1, max=500)] = 50,
+    limit: Annotated[
+        int,
+        typer.Option('--limit', '-l', min=1, max=500, help='Maximum number of findings to return.'),
+    ] = 50,
 ):
     """List maintenance findings."""
     if lint_type is not None and lint_type not in LINT_TYPES:
@@ -643,6 +647,7 @@ async def lint_review_cmd(
         str | None,
         typer.Option(
             '--type',
+            '-t',
             help='Filter by lint_type: structural, quality, governance, schema, routing.',
         ),
     ] = None,
@@ -650,9 +655,10 @@ async def lint_review_cmd(
         int,
         typer.Option(
             '--limit',
+            '-l',
             min=1,
             max=500,
-            help='Max findings to load into the cockpit at once.',
+            help='Maximum number of findings to load into the cockpit.',
         ),
     ] = 50,
     use_tui: Annotated[

--- a/packages/cli/src/memex_cli/mcp.py
+++ b/packages/cli/src/memex_cli/mcp.py
@@ -21,10 +21,10 @@ def main():
 @app.command()
 def run(
     transport: str = typer.Option(
-        'stdio', '--transport', '-t', help='Transport mode: stdio, http, or sse'
+        'stdio', '--transport', '-t', help='Transport mode: stdio, http, or sse.'
     ),
-    host: str = typer.Option('0.0.0.0', help='Host for network transports'),
-    port: int = typer.Option(8000, help='Port for network transports'),
+    host: str = typer.Option('0.0.0.0', help='Host for network transports.'),
+    port: int = typer.Option(8000, help='Port for network transports.'),
 ):
     """
     Run the Memex MCP server.

--- a/packages/cli/src/memex_cli/memory.py
+++ b/packages/cli/src/memex_cli/memory.py
@@ -357,9 +357,11 @@ async def search_memory(
             '--vault', '-v', help='Vault(s) to search. Accepts names or UUIDs. Use "*" for all.'
         ),
     ] = None,
-    limit: int = 5,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of results to return.')
+    ] = 5,
     token_budget: Annotated[
-        int | None, typer.Option('--token-budget', '-t', help='Token budget for retrieval.')
+        int | None, typer.Option('--budget', '-b', help='Token budget for retrieval.')
     ] = None,
     answer: Annotated[
         bool, typer.Option('--answer', '-a', help='Generate an AI answer from results.')
@@ -471,7 +473,7 @@ async def search_memory(
             console.print(
                 f'[red]Invalid --intent {intent!r}. Allowed: {sorted(VALID_INTENT_CLASSES)}[/red]'
             )
-            raise typer.Exit(1)
+            raise typer.Exit(2)
         intent_value = IntentClass(intent_str)
 
     risk_value: RiskClass | None = None
@@ -481,7 +483,7 @@ async def search_memory(
             console.print(
                 f'[red]Invalid --risk {risk!r}. Allowed: {sorted(VALID_RISK_CLASSES)}[/red]'
             )
-            raise typer.Exit(1)
+            raise typer.Exit(2)
         risk_value = RiskClass(risk_str)
 
     async with get_api_context(config) as api:
@@ -559,7 +561,9 @@ async def reflect(
             help='ID of the entity to reflect on. If omitted, reflects on top entities.'
         ),
     ] = None,
-    limit: int = 5,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of entities to reflect on.')
+    ] = 5,
     batch_size: int = 10,
 ):
     """
@@ -664,7 +668,9 @@ async def memory_links(
         str | None,
         typer.Option('--type', '-t', help='Filter by link type (e.g. contradicts).'),
     ] = None,
-    limit: Annotated[int, typer.Option('--limit', '-l', help='Max links to return.')] = 20,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of links to return.')
+    ] = 20,
     json_output: Annotated[bool, typer.Option('--json', help='Output as JSON.')] = False,
 ):
     """
@@ -713,14 +719,16 @@ async def memory_links(
 async def get_lineage(
     ctx: typer.Context,
     entity_type: Annotated[
-        str, typer.Argument(help='Type: mental_model, observation, memory_unit, note')
+        str, typer.Argument(help='Type: mental_model, observation, memory_unit, note.')
     ],
     entity_id: Annotated[str, typer.Argument(help='UUID of the entity.')],
     direction: Annotated[
         LineageDirection, typer.Option('--direction', '-d', help='Traverse direction.')
     ] = LineageDirection.UPSTREAM,
     depth: Annotated[int, typer.Option('--depth', help='Max recursion depth.')] = 3,
-    limit: Annotated[int, typer.Option('--limit', help='Max children per node.')] = 5,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of children per node to return.')
+    ] = 5,
     json_output: Annotated[bool, typer.Option('--json', help='Output as JSON.')] = False,
 ):
     """

--- a/packages/cli/src/memex_cli/notes.py
+++ b/packages/cli/src/memex_cli/notes.py
@@ -106,7 +106,7 @@ async def add_note(
     ] = None,
     description_opt: Annotated[
         str | None,
-        typer.Option('--description', help='Note description/summary.'),
+        typer.Option('--description', '-d', help='Note description/summary.'),
     ] = None,
     author: Annotated[
         str | None,
@@ -118,7 +118,7 @@ async def add_note(
     ] = None,
     date: Annotated[
         str | None,
-        typer.Option('--date', '-d', help='Note date in ISO 8601 format (e.g. 2026-03-15).'),
+        typer.Option('--date', help='Note date in ISO 8601 format (e.g. 2026-03-15).'),
     ] = None,
     template: Annotated[
         str | None,
@@ -435,7 +435,9 @@ async def append_note(
 @async_command
 async def list_notes(
     ctx: typer.Context,
-    limit: int = 50,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of notes to return.')
+    ] = 50,
     offset: int = 0,
     vault: Annotated[
         list[str],
@@ -566,7 +568,9 @@ async def list_notes(
 @async_command
 async def list_recent(
     ctx: typer.Context,
-    limit: int = 10,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of notes to return.')
+    ] = 10,
     vault: Annotated[
         list[str],
         typer.Option(
@@ -705,7 +709,9 @@ def _print_compact_note(d: Any) -> None:
 async def find_note(
     ctx: typer.Context,
     query: Annotated[str, typer.Argument(help='Approximate title to search for.')],
-    limit: int = 5,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of matches to return.')
+    ] = 5,
     vault: Annotated[
         list[str],
         typer.Option(
@@ -772,7 +778,9 @@ async def note_links(
         str | None,
         typer.Option('--type', '-t', help='Filter by link type (e.g. contradicts).'),
     ] = None,
-    limit: Annotated[int, typer.Option('--limit', '-l', help='Max links to return.')] = 20,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of links to return.')
+    ] = 20,
     json_output: Annotated[bool, typer.Option('--json', help='Output as JSON.')] = False,
 ):
     """
@@ -1197,7 +1205,9 @@ def _render_toc_nodes(nodes: list[dict[str, Any]], parent: Tree) -> None:
 async def search_notes(
     ctx: typer.Context,
     query: Annotated[str, typer.Argument(help='Search query.')],
-    limit: Annotated[int, typer.Option('--limit', '-l', help='Max number of notes.')] = 5,
+    limit: Annotated[
+        int, typer.Option('--limit', '-l', help='Maximum number of notes to return.')
+    ] = 5,
     expand: Annotated[bool, typer.Option('--expand', help='Enable query expansion.')] = False,
     blend: Annotated[bool, typer.Option('--blend', help='Enable position-aware blending.')] = False,
     vault: Annotated[
@@ -1208,7 +1218,9 @@ async def search_notes(
     ] = [],
     reason: Annotated[
         bool,
-        typer.Option('--reason', help='Run skeleton-tree identification; shows relevant sections.'),
+        typer.Option(
+            '--reason', '-r', help='Run skeleton-tree identification; shows relevant sections.'
+        ),
     ] = False,
     summarize: Annotated[
         bool,
@@ -1640,12 +1652,12 @@ def template_delete(
     local: Annotated[
         bool, typer.Option('--local', help='Delete from project-local scope instead of global.')
     ] = False,
-    yes: Annotated[bool, typer.Option('--yes', '-y', help='Skip confirmation prompt.')] = False,
+    force: Annotated[bool, typer.Option('--force', '-f', help='Skip confirmation.')] = False,
 ) -> None:
     """Delete a user template. Cannot delete built-in templates."""
     scope = 'local' if local else 'global'
 
-    if not yes:
+    if not force:
         confirm = typer.confirm(
             f'Delete template "{slug}" from {scope} scope? This cannot be undone.'
         )

--- a/packages/cli/src/memex_cli/notes.py
+++ b/packages/cli/src/memex_cli/notes.py
@@ -144,7 +144,7 @@ async def add_note(
         pass
     else:
         console.print('[red]Error: Must provide content, --file, or --url.[/red]')
-        raise typer.Exit(1)
+        raise typer.Exit(2)
 
     effective_vault = vault if vault is not None else config.write_vault
 
@@ -233,7 +233,7 @@ async def add_note(
                         console.print(
                             '[red]Error: --asset cannot be used with a directory --file. Point --file to a markdown file instead.[/red]'
                         )
-                        raise typer.Exit(1)
+                        raise typer.Exit(2)
 
                     console.print(f'[cyan]Reading main note file {file.name}...[/cyan]')
                     async with aiofiles.open(file, 'r', encoding='utf-8') as f:
@@ -364,7 +364,7 @@ async def append_note(
     # Resolve delta from --delta, --delta-file, or stdin
     if delta and delta_file:
         console.print('[red]Cannot pass both --delta and --delta-file.[/red]')
-        raise typer.Exit(1)
+        raise typer.Exit(2)
 
     delta_text: str | None = delta
     if delta_text is None and delta_file is not None:
@@ -374,11 +374,11 @@ async def append_note(
         delta_text = sys.stdin.read()
     if not delta_text:
         console.print('[red]Provide a delta via --delta, --delta-file, or stdin.[/red]')
-        raise typer.Exit(1)
+        raise typer.Exit(2)
 
     if not note_id and not key:
         console.print('[red]Pass either a note_id argument or --key.[/red]')
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     if note_id and key:
         # Both ways of identifying the note were supplied. The schema would
         # silently let note_id win, which is hostile if the user genuinely
@@ -387,7 +387,7 @@ async def append_note(
             '[red]Pass either a note_id argument or --key, not both. '
             'If you meant --key, drop the positional note_id.[/red]'
         )
-        raise typer.Exit(1)
+        raise typer.Exit(2)
 
     config: MemexConfig = ctx.obj
     effective_vault = vault if vault is not None else config.write_vault
@@ -396,12 +396,12 @@ async def append_note(
         resolved_append_id = UUID(append_id) if append_id else uuid4()
     except ValueError:
         console.print(f'[red]--append-id must be a UUID. Got: {append_id!r}[/red]')
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     try:
         resolved_note_id: UUID | None = UUID(note_id) if note_id else None
     except ValueError:
         console.print(f'[red]note_id must be a UUID. Got: {note_id!r}[/red]')
-        raise typer.Exit(1)
+        raise typer.Exit(2)
 
     request = NoteAppendRequest(
         note_id=resolved_note_id,

--- a/packages/cli/src/memex_cli/server.py
+++ b/packages/cli/src/memex_cli/server.py
@@ -157,16 +157,16 @@ async def _initialize_models(cache_dir: str):
 @app.command()
 def start(
     ctx: typer.Context,
-    host: str = typer.Option('0.0.0.0', envvar='MEMEX_HOST', help='Host to bind the server to'),
-    port: int | None = typer.Option(None, envvar='MEMEX_PORT', help='Port to bind the server to'),
+    host: str = typer.Option('0.0.0.0', envvar='MEMEX_HOST', help='Host to bind the server to.'),
+    port: int | None = typer.Option(None, envvar='MEMEX_PORT', help='Port to bind the server to.'),
     workers: int = typer.Option(
-        None, '--workers', '-w', envvar='MEMEX_WORKERS', help='Number of worker processes'
+        None, '--workers', '-w', envvar='MEMEX_WORKERS', help='Number of worker processes.'
     ),
     config: str = typer.Option(
-        None, '--config', '-c', envvar='MEMEX_CONFIG_PATH', help='Path to configuration file'
+        None, '--config', '-c', envvar='MEMEX_CONFIG_PATH', help='Path to configuration file.'
     ),
-    reload: bool = typer.Option(False, help='Enable auto-reload for development'),
-    daemon: bool = typer.Option(False, '--daemon', '-d', help='Run the server in the background'),
+    reload: bool = typer.Option(False, help='Enable auto-reload for development.'),
+    daemon: bool = typer.Option(False, '--daemon', '-d', help='Run the server in the background.'),
 ):
     """Start the Memex Core API server."""
     from memex_cli.banner import print_banner

--- a/packages/cli/src/memex_cli/session.py
+++ b/packages/cli/src/memex_cli/session.py
@@ -46,7 +46,7 @@ async def briefing(
             f'Error: --budget must be one of {_VALID_BUDGETS}, got {budget}',
             file=sys.stderr,
         )
-        raise typer.Exit(1)
+        raise typer.Exit(2)
 
     config: MemexConfig = ctx.obj
 

--- a/packages/cli/src/memex_cli/stats.py
+++ b/packages/cli/src/memex_cli/stats.py
@@ -15,15 +15,15 @@ from memex_cli.utils import emit_json, get_api_context, async_command, handle_ap
 console = Console()
 
 app = typer.Typer(
-    name='system',
+    name='stats',
     help='Show overview of system counts (memories, entities, queue).',
     no_args_is_help=True,
 )
 
 
-@app.command('system')
+@app.command('stats')
 @async_command
-async def system_stats(
+async def stats(
     ctx: typer.Context,
     json_output: Annotated[bool, typer.Option('--json', help='Output as JSON.')] = False,
 ):

--- a/packages/cli/src/memex_cli/sync/__init__.py
+++ b/packages/cli/src/memex_cli/sync/__init__.py
@@ -57,15 +57,15 @@ def _make_progress() -> Progress:
 @async_command
 async def run_sync(
     ctx: typer.Context,
-    vault_path: Path = typer.Argument(..., help='Path to the notes folder'),
-    config: Path | None = typer.Option(None, '--config', '-c', help='Path to config TOML'),
-    full: bool = typer.Option(False, '--full', help='Ignore last sync, re-sync all'),
-    dry_run: bool = typer.Option(False, '--dry-run', help='Show what would be synced'),
+    vault_path: Path = typer.Argument(..., help='Path to the notes folder.'),
+    config: Path | None = typer.Option(None, '--config', '-c', help='Path to config TOML.'),
+    full: bool = typer.Option(False, '--full', help='Ignore last sync, re-sync all.'),
+    dry_run: bool = typer.Option(False, '--dry-run', help='Show what would be synced.'),
     background: bool = typer.Option(
         False,
         '--background',
         '-b',
-        help='Submit batch job and return immediately without waiting',
+        help='Submit batch job and return immediately without waiting.',
     ),
     no_handle_deletes: bool = typer.Option(
         False,
@@ -185,8 +185,8 @@ async def run_sync(
 @app.command(no_args_is_help=True)
 def status(
     ctx: typer.Context,
-    vault_path: Path = typer.Argument(..., help='Path to the notes folder'),
-    config: Path | None = typer.Option(None, '--config', '-c', help='Path to config TOML'),
+    vault_path: Path = typer.Argument(..., help='Path to the notes folder.'),
+    config: Path | None = typer.Option(None, '--config', '-c', help='Path to config TOML.'),
 ) -> None:
     """Show sync state and pending changes."""
     vault_path = vault_path.resolve()
@@ -247,7 +247,7 @@ def status(
 @async_command
 async def job_status(
     ctx: typer.Context,
-    job_id: str = typer.Argument(..., help='Batch job ID returned by sync --background'),
+    job_id: str = typer.Argument(..., help='Batch job ID returned by sync --background.'),
 ) -> None:
     """Check the status of a background batch ingestion job."""
     memex_config: MemexConfig = ctx.obj
@@ -276,9 +276,9 @@ async def job_status(
 @async_command
 async def watch(
     ctx: typer.Context,
-    vault_path: Path = typer.Argument(..., help='Path to the notes folder'),
-    config: Path | None = typer.Option(None, '--config', '-c', help='Path to config TOML'),
-    mode: str | None = typer.Option(None, help='Override watch mode: events|poll'),
+    vault_path: Path = typer.Argument(..., help='Path to the notes folder.'),
+    config: Path | None = typer.Option(None, '--config', '-c', help='Path to config TOML.'),
+    mode: str | None = typer.Option(None, help='Override watch mode: events|poll.'),
 ) -> None:
     """Watch folder for changes and sync continuously."""
     vault_path = vault_path.resolve()
@@ -309,7 +309,7 @@ async def watch(
 
 @app.command(no_args_is_help=True)
 def init(
-    vault_path: Path = typer.Argument(..., help='Path to the notes folder'),
+    vault_path: Path = typer.Argument(..., help='Path to the notes folder.'),
 ) -> None:
     """Create a default note-sync.toml in the folder."""
     vault_path = vault_path.resolve()

--- a/packages/cli/src/memex_cli/utils.py
+++ b/packages/cli/src/memex_cli/utils.py
@@ -48,7 +48,7 @@ LAZY_SUBCOMMANDS: dict[str, str] = {
     'kv': 'memex_cli.kv:app',
     'lint': 'memex_cli.lint:app',
     'inbox': 'memex_cli.inbox:app',
-    'system': 'memex_cli.stats:app',
+    'stats': 'memex_cli.stats:app',
     'config': 'memex_cli.config:app',
     'server': 'memex_cli.server:app',
     'database': 'memex_cli.db:app',
@@ -196,7 +196,7 @@ def parse_uuid(value: str, label: str = 'ID') -> UUID:
         return UUID(value)
     except ValueError:
         console.print(f'[red]Invalid UUID for {label}: {value}[/red]')
-        raise typer.Exit(1)
+        raise typer.Exit(2)
 
 
 def merge_overrides(config_data: dict[str, Any], overrides: list[str]) -> dict[str, Any]:

--- a/packages/cli/src/memex_cli/vaults.py
+++ b/packages/cli/src/memex_cli/vaults.py
@@ -149,11 +149,11 @@ async def create_vault(
     console.print(f'[bold green]Vault created successfully![/bold green] ID: {vault.id}')
 
 
-@app.command('truncate')
+@app.command('clear')
 @async_command
-async def truncate_vault(
+async def clear_vault(
     ctx: typer.Context,
-    identifier: Annotated[str, typer.Argument(help='Name or UUID of the vault to truncate.')],
+    identifier: Annotated[str, typer.Argument(help='Name or UUID of the vault to clear.')],
     force: Annotated[bool, typer.Option('--force', '-f', help='Skip confirmation.')] = False,
 ):
     """
@@ -198,13 +198,13 @@ async def truncate_vault(
                 console.print('[yellow]Aborted.[/yellow]')
                 return
 
-        console.print(f'[red]Truncating vault:[/red] {identifier}...')
+        console.print(f'[red]Clearing vault:[/red] {identifier}...')
         try:
             counts = await api.truncate_vault(vault_uuid)
         except Exception as e:
             handle_api_error(e)
 
-    console.print('[bold green]Vault truncated.[/bold green]')
+    console.print('[bold green]Vault cleared.[/bold green]')
     for label, count in counts.items():
         if count > 0:
             console.print(f'  {label}: [dim]{count} removed[/dim]')

--- a/packages/cli/tests/test_cli_conventions.py
+++ b/packages/cli/tests/test_cli_conventions.py
@@ -131,3 +131,41 @@ def test_renamed_options_are_gone(removed):
     for _path, cmd in _all_leaf_commands():
         for opt in _option_params(cmd):
             assert removed not in opt.opts
+
+
+# --limit help follows the canonical "Maximum number of <items> to return." pattern,
+# except where the count has genuinely different semantics (cockpit load, scan cap).
+_LIMIT_HELP_EXEMPT = {
+    ('review', '--limit'),  # loads into the cockpit, not "returns"
+    ('scan-merges', '--limit'),  # caps how many entities are scanned
+}
+
+
+def test_limit_help_is_canonical():
+    offenders = []
+    for path, cmd in _all_leaf_commands():
+        leaf = path[-1] if path else ''
+        for opt in _option_params(cmd):
+            if '--limit' not in opt.opts or (leaf, '--limit') in _LIMIT_HELP_EXEMPT:
+                continue
+            if not (opt.help or '').startswith('Maximum number of'):
+                offenders.append(f'{" ".join(path)} -> {opt.help!r}')
+    assert not offenders, '--limit help drifted from canonical pattern:\n' + '\n'.join(offenders)
+
+
+def test_local_validation_uses_exit_code_2():
+    """Local usage errors exit 2 (distinct from runtime/server errors, which exit 1)."""
+    from typer.testing import CliRunner
+
+    from memex_cli import app
+
+    runner = CliRunner()
+    cases = [
+        # missing/conflicting arguments — validated before any network call
+        ['memory', 'search', 'q', '--intent', 'bogus'],
+        ['note', 'append', 'some-id', '--delta', 'x', '--delta-file', 'y'],
+        ['note', 'page-index', 'not-a-uuid'],
+    ]
+    for argv in cases:
+        result = runner.invoke(app, argv)
+        assert result.exit_code == 2, f'{argv} -> {result.exit_code}\n{result.output}'

--- a/packages/cli/tests/test_cli_conventions.py
+++ b/packages/cli/tests/test_cli_conventions.py
@@ -1,0 +1,133 @@
+"""CLI-wide convention fences.
+
+Walk the entire lazy-loaded command tree and assert the option conventions hold,
+so new commands cannot silently drift from them:
+
+- one long option carries the same short flag (or none) at every site it appears;
+- short flags are unique within a single command;
+- shared flags carry their canonical help string;
+- every option/argument help string ends with a period.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import click
+import pytest
+from typer.main import get_command as typer_get_command
+
+from memex_cli.utils import LAZY_SUBCOMMANDS
+
+# Long options whose help text is intentionally non-uniform (distinct semantics
+# per command) and therefore exempt from the canonical-help check.
+_HELP_EXEMPT = {'--vault'}
+
+_CANONICAL_HELP = {
+    '--json': 'Output as JSON.',
+    '--force': 'Skip confirmation.',
+}
+
+# (leaf-command-name, flag) pairs whose help is intentionally distinct.
+_CANONICAL_HELP_EXEMPT = {
+    # The lint catalogue dump emits more than a table; its help says so.
+    ('actions', '--json'),
+}
+
+
+def _iter_commands(cmd: click.Command, path: tuple[str, ...] = ()):
+    """Yield (path, command) for every leaf command in the tree."""
+    if isinstance(cmd, click.Group):
+        ctx = click.Context(cmd)
+        for name in cmd.list_commands(ctx):
+            sub = cmd.get_command(ctx, name)
+            if sub is None:
+                continue
+            yield from _iter_commands(sub, path + (name,))
+    else:
+        yield path, cmd
+
+
+def _all_leaf_commands():
+    leaves = []
+    for import_path in LAZY_SUBCOMMANDS.values():
+        modname, app_name = import_path.split(':')
+        try:
+            mod = importlib.import_module(modname)
+        except ImportError:
+            continue  # optional-extra group not installed in this env
+        root = typer_get_command(getattr(mod, app_name))
+        leaves.extend(_iter_commands(root))
+    return leaves
+
+
+def _option_params(cmd: click.Command):
+    for p in cmd.params:
+        if isinstance(p, click.Option):
+            yield p
+
+
+def test_long_option_has_consistent_short_flag():
+    """The same --long-flag must map to the same short flag everywhere (or none)."""
+    long_to_shorts: dict[str, set[str | None]] = {}
+    for path, cmd in _all_leaf_commands():
+        for opt in _option_params(cmd):
+            longs = [o for o in opt.opts if o.startswith('--')]
+            shorts = [o for o in opt.opts if o.startswith('-') and not o.startswith('--')]
+            short = shorts[0] if shorts else None
+            for long in longs:
+                long_to_shorts.setdefault(long, set()).add(short)
+
+    drifted = {long: shorts for long, shorts in long_to_shorts.items() if len(shorts) > 1}
+    assert not drifted, f'long options shorthanded inconsistently across commands: {drifted}'
+
+
+def test_short_flags_unique_within_command():
+    for path, cmd in _all_leaf_commands():
+        seen: dict[str, str] = {}
+        for opt in _option_params(cmd):
+            for o in opt.opts:
+                if o.startswith('-') and not o.startswith('--'):
+                    assert o not in seen, (
+                        f'{" ".join(path)}: short flag {o} reused by {seen.get(o)} and {opt.name}'
+                    )
+                    seen[o] = opt.name
+
+
+def test_shared_flags_use_canonical_help():
+    for path, cmd in _all_leaf_commands():
+        leaf = path[-1] if path else ''
+        for opt in _option_params(cmd):
+            for o in opt.opts:
+                if o in _CANONICAL_HELP and o not in _HELP_EXEMPT:
+                    if (leaf, o) in _CANONICAL_HELP_EXEMPT:
+                        continue
+                    assert opt.help == _CANONICAL_HELP[o], (
+                        f'{" ".join(path)}: {o} help is {opt.help!r}, '
+                        f'expected {_CANONICAL_HELP[o]!r}'
+                    )
+
+
+def test_help_strings_end_with_period():
+    offenders = []
+    for path, cmd in _all_leaf_commands():
+        for p in cmd.params:
+            help_text = getattr(p, 'help', None)
+            if help_text and not help_text.rstrip().endswith(('.', ')', ':')):
+                offenders.append(f'{" ".join(path)}:{p.name} -> {help_text!r}')
+    assert not offenders, 'help strings missing trailing period:\n' + '\n'.join(offenders)
+
+
+def test_renamed_command_groups():
+    """The V8 group renames are reflected in the lazy registry."""
+    top_level = set(LAZY_SUBCOMMANDS)
+    assert 'system' not in top_level
+    assert 'stats' in top_level
+
+
+@pytest.mark.parametrize('removed', ['--token-budget', '--top-n', '--yes'])
+def test_renamed_options_are_gone(removed):
+    """The V8 option renames must not leave the old long flags anywhere."""
+    for _path, cmd in _all_leaf_commands():
+        for opt in _option_params(cmd):
+            assert removed not in opt.opts

--- a/packages/cli/tests/test_diagnose.py
+++ b/packages/cli/tests/test_diagnose.py
@@ -1,8 +1,8 @@
 """F32 CLI — `memex diagnostics ...` smoke tests (Test 10).
 
 Verifies:
-- `--help` lists the four F32 subcommands (manifold, retrieval, summary, lint).
-- `manifold --help` / `retrieval --help` / `lint --help` emit usable help text.
+- `--help` lists the four diagnostics subcommands (manifold, retrieval, summary, findings).
+- `manifold --help` / `retrieval --help` / `findings --help` emit usable help text.
 - Each command emits JSON shape when invoked against a mocked api.
 """
 
@@ -22,8 +22,8 @@ def test_help_lists_subcommands(runner):
     assert 'manifold' in result.output
     assert 'retrieval' in result.output
     assert 'summary' in result.output
-    # F26: lint dashboard subcommand is now part of the diagnostics surface.
-    assert 'lint' in result.output
+    # The lint-finding pivot dashboard is part of the diagnostics surface.
+    assert 'findings' in result.output
 
 
 def test_manifold_help_and_json_shape(runner, mock_api, monkeypatch, mock_config):
@@ -55,7 +55,7 @@ def test_retrieval_help_and_json_shape(runner, mock_api, monkeypatch, mock_confi
     help_result = runner.invoke(diagnose_app, ['retrieval', '--help'])
     assert help_result.exit_code == 0
     assert '--vault' in help_result.output
-    assert '--top-n' in help_result.output
+    assert '--limit' in help_result.output
 
     fake_vault = uuid4()
     payload = {
@@ -76,10 +76,10 @@ def test_retrieval_help_and_json_shape(runner, mock_api, monkeypatch, mock_confi
     assert parsed['top_n'] == 50
 
 
-def test_lint_help_and_json_shape(runner, mock_api, monkeypatch, mock_config):
-    """F26: `memex diagnostics lint --help` works, and the command emits the
+def test_findings_help_and_json_shape(runner, mock_api, monkeypatch, mock_config):
+    """`memex diagnostics findings --help` works, and the command emits the
     aggregator pivot JSON 1:1 from the API."""
-    help_result = runner.invoke(diagnose_app, ['lint', '--help'])
+    help_result = runner.invoke(diagnose_app, ['findings', '--help'])
     assert help_result.exit_code == 0
     assert '--vault' in help_result.output
 
@@ -99,7 +99,7 @@ def test_lint_help_and_json_shape(runner, mock_api, monkeypatch, mock_config):
 
     monkeypatch.setattr('memex_cli.diagnose.get_api_context', lambda config: mock_api)
 
-    result = runner.invoke(diagnose_app, ['lint', '--vault', str(fake_vault)], obj=mock_config)
+    result = runner.invoke(diagnose_app, ['findings', '--vault', str(fake_vault)], obj=mock_config)
     assert result.exit_code == 0, result.output
     parsed = json.loads(result.output)
     assert parsed['vault_id'] == str(fake_vault)

--- a/packages/cli/tests/test_memory_cli.py
+++ b/packages/cli/tests/test_memory_cli.py
@@ -122,21 +122,21 @@ def test_memory_search_risk_forwarded_to_api(runner, mock_api, mock_config, monk
 
 
 def test_memory_search_intent_invalid_rejected_locally(runner, mock_api, mock_config, monkeypatch):
-    """Bad --intent values must be rejected before the API roundtrip with exit code 1."""
+    """Bad --intent values must be rejected before the API roundtrip with exit code 2."""
     monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
 
     result = runner.invoke(app, ['search', 'q', '--intent', 'bogus'], obj=mock_config)
-    assert result.exit_code == 1
+    assert result.exit_code == 2
     assert 'Invalid --intent' in result.stdout
     mock_api.search.assert_not_called()
 
 
 def test_memory_search_risk_invalid_rejected_locally(runner, mock_api, mock_config, monkeypatch):
-    """Bad --risk values must be rejected before the API roundtrip with exit code 1."""
+    """Bad --risk values must be rejected before the API roundtrip with exit code 2."""
     monkeypatch.setattr('memex_cli.memory.get_api_context', lambda config: mock_api)
 
     result = runner.invoke(app, ['search', 'q', '--risk', 'bogus'], obj=mock_config)
-    assert result.exit_code == 1
+    assert result.exit_code == 2
     assert 'Invalid --risk' in result.stdout
     mock_api.search.assert_not_called()
 

--- a/packages/cli/tests/test_notes_cli.py
+++ b/packages/cli/tests/test_notes_cli.py
@@ -132,7 +132,7 @@ def test_note_page_index_invalid_uuid(runner, mock_api, monkeypatch):
     monkeypatch.setattr('memex_cli.notes.get_api_context', lambda config: mock_api)
 
     result = runner.invoke(note_app, ['page-index', 'not-a-uuid'])
-    assert result.exit_code == 1
+    assert result.exit_code == 2
     assert 'Invalid UUID' in result.stdout
 
 

--- a/packages/cli/tests/test_session_cli.py
+++ b/packages/cli/tests/test_session_cli.py
@@ -36,7 +36,7 @@ def test_briefing_success_writes_markdown_to_stdout(runner, mock_config, _patche
 def test_briefing_invalid_budget_exits_2_to_stderr(runner, mock_config, _patched_api):
     result = _invoke(runner, mock_config, ['--budget', '500'])
 
-    assert result.exit_code == 1
+    assert result.exit_code == 2
     assert '--budget must be one of' in result.output
 
 

--- a/packages/cli/tests/test_template_cli.py
+++ b/packages/cli/tests/test_template_cli.py
@@ -177,19 +177,21 @@ class TestTemplateDelete:
         _write_toml_template(templates_dir, 'standup')
         mock_config.server.file_store.root = str(tmp_path)
 
-        result = runner.invoke(app, ['template', 'delete', 'standup', '--yes'], obj=mock_config)
+        result = runner.invoke(app, ['template', 'delete', 'standup', '--force'], obj=mock_config)
         assert result.exit_code == 0
         assert 'Deleted' in result.stdout
 
     def test_delete_nonexistent(self, runner: CliRunner, mock_config) -> None:
-        result = runner.invoke(app, ['template', 'delete', 'nonexistent', '--yes'], obj=mock_config)
+        result = runner.invoke(
+            app, ['template', 'delete', 'nonexistent', '--force'], obj=mock_config
+        )
         assert result.exit_code == 1
         assert 'not found' in result.stdout
 
     def test_delete_builtin_rejected(self, runner: CliRunner, mock_config) -> None:
         """Cannot delete built-in templates (no 'builtin' scope accessible via --local or default)."""
         result = runner.invoke(
-            app, ['template', 'delete', 'general_note', '--yes'], obj=mock_config
+            app, ['template', 'delete', 'general_note', '--force'], obj=mock_config
         )
         # Will fail because general_note.toml doesn't exist in the global scope dir
         assert result.exit_code == 1

--- a/packages/cli/tests/test_vaults_cli.py
+++ b/packages/cli/tests/test_vaults_cli.py
@@ -97,10 +97,10 @@ def test_truncate_vault_with_force(runner, mock_api, strip_ansi, monkeypatch):
 
     monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
 
-    result = runner.invoke(app, ['truncate', vault_name, '--force'])
+    result = runner.invoke(app, ['clear', vault_name, '--force'])
     assert result.exit_code == 0
     clean = strip_ansi(result.stdout)
-    assert 'Vault truncated' in clean
+    assert 'Vault cleared' in clean
     mock_api.truncate_vault.assert_called_once_with(vault_uuid)
 
 
@@ -114,7 +114,7 @@ def test_truncate_vault_shows_stats(runner, mock_api, strip_ansi, monkeypatch):
 
     monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
 
-    result = runner.invoke(app, ['truncate', vault_name, '--force'])
+    result = runner.invoke(app, ['clear', vault_name, '--force'])
     assert result.exit_code == 0
     clean = strip_ansi(result.stdout)
     assert '12' in clean  # notes count shown
@@ -129,7 +129,7 @@ def test_truncate_vault_aborted_without_force(runner, mock_api, strip_ansi, monk
 
     monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
 
-    result = runner.invoke(app, ['truncate', 'test-vault'], input='n\n')
+    result = runner.invoke(app, ['clear', 'test-vault'], input='n\n')
     assert result.exit_code == 0
     clean = strip_ansi(result.stdout)
     assert 'Aborted' in clean
@@ -146,7 +146,7 @@ def test_truncate_empty_vault(runner, mock_api, strip_ansi, monkeypatch):
 
     monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
 
-    result = runner.invoke(app, ['truncate', 'empty-vault', '--force'])
+    result = runner.invoke(app, ['clear', 'empty-vault', '--force'])
     assert result.exit_code == 0
     clean = strip_ansi(result.stdout)
     assert 'already empty' in clean
@@ -163,7 +163,7 @@ def test_truncate_vault_not_found(runner, mock_api, strip_ansi, monkeypatch):
 
     monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
 
-    result = runner.invoke(app, ['truncate', vault_name, '--force'])
+    result = runner.invoke(app, ['clear', vault_name, '--force'])
     assert result.exit_code == 1
     clean = strip_ansi(result.stdout)
     assert f"Vault '{vault_name}' not found" in clean

--- a/tests/test_e2e_cli_memory.py
+++ b/tests/test_e2e_cli_memory.py
@@ -189,7 +189,7 @@ async def test_cli_memory_search(db_session: AsyncSession, setup_cli_e2e):
         mock_run_dspy.return_value = mock_prediction
         result = runner.invoke(
             app,
-            ['memory', 'search', 'Python', '--token-budget', '1000'],
+            ['memory', 'search', 'Python', '--budget', '1000'],
             env=os.environ,
         )
 


### PR DESCRIPTION
## What & why

Implements **V8** from the CLI/TUI UX overhaul: breaking command/option renames with **no deprecated aliases**, a CLI-wide short-flag/help/exit-code convention, and a CI fence that prevents future drift.

- **Backlog**: `BACKLOG.md` → `## V8 — CLI command-tree & naming overhaul`
- **Plan**: `~/.claude/plans/memex-cli-tui-ux-overhaul.md` §V8 (87/87 anchors verified `ok`)
- **Design doc**: N/A — `DESIGN_DOCUMENT.md` not present on this branch

> **Stacked on #215 (V9).** This PR targets `v9-cli-helpers-errors`, not the release branch — it consumes V9's `VaultOption` aliases. Merge after #215.

## Breaking changes (no aliases)

| Old | New |
|---|---|
| `memex system` | `memex stats` |
| `memex diagnostics lint` | `memex diagnostics findings` |
| `memex vault truncate` | `memex vault clear` |
| `memory search --token-budget` | `--budget` / `-b` |
| `diagnostics retrieval --top-n`, `entity scan-merges --top-n` | `--limit` / `-l` |
| `note template delete --yes` / `-y` | `--force` / `-f` |

HTTP/service-layer `api.truncate_vault`, the `token_budget`/`top_n` params, and `config show --format` are all intentionally unchanged.

## Conventions established + enforced

- **Short flags**: one long option carries the same shorthand everywhere (or none); unique within a command. Added `-l` to every `--limit` (incl. 6 bare `limit:int` params), `-t` to lint `--type`, `-d` to `--description` (freed from `note --date`), `-r` to note-search `--reason`, `-d` to agent-surface `--output-dir`. `-h` is a global `--help` alias.
- **Exit codes**: local usage/validation → `2` (aligns with Click); runtime/server → `1`.
- **Help text**: canonical strings for `--json`/`--force`/`--limit`; trailing period on every option/argument help.
- **New `packages/cli/tests/test_cli_conventions.py`** walks the whole lazy command tree and fences all of the above — new commands that drift fail CI.

## Consumers updated (repo-wide)

`docs/reference/cli-commands.md`, `docs/how-to/{diagnostics,note-templates,trace-lineage}.md`, `docs/tutorial/memory-worth-and-deprioritization.md`, both READMEs, and tests `test_{diagnose,vaults_cli,template_cli,memory_cli,notes_cli,session_cli}.py` + root `tests/test_e2e_cli_memory.py`.

## Validation

- Full CLI suite green (457); root e2e memory test green; conventions fence proven to fail on injected drift.
- Manually verified live: `memex stats`, `memex diagnostics findings`, `memex vault clear`, `memex -h`, `memory search --budget -b` all resolve; old `memex system` exits non-zero.
- Pre-PR self-assessment 99%; adversarial review loop run to a clean pass (2 rounds, fresh reviewer each, zero CRITICAL/HIGH/MEDIUM on the final).

🤖 Generated with [Claude Code](https://claude.com/claude-code)