### PR TITLE
feat(core): system vs content vault kinds (V11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,448%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,451%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,464%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,474%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,456%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,464%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-7,451%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,456%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+" />
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="Apache 2.0" />
   <img src="https://img.shields.io/badge/version-v0.1.6a-green?style=flat-square" alt="v0.1.6a" />
-  <img src="https://img.shields.io/badge/tests-6,847%20passing-brightgreen?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-7,448%20passing-brightgreen?style=flat-square" alt="Tests" />
 </p>
 
 > [!IMPORTANT]

--- a/docs/explanation/system-vs-content-vaults.md
+++ b/docs/explanation/system-vs-content-vaults.md
@@ -1,0 +1,79 @@
+# About system vaults vs content vaults
+
+Every Memex vault now has a **kind** that classifies what the vault is *for* — and that classification controls which surfaces it shows up on. The vast majority of vaults are **content** vaults: project memos, personal journals, research digests. A small set of **system** vaults exist to glue Memex to its environment: today's example is `inbox`, but anything that captures data on behalf of another component (Hermes session state, the planned procedural case-vault, a third-party integration buffer) is the same shape.
+
+The two kinds differ on exactly one axis: **visibility on synthesis-and-discovery surfaces**. They do **not** differ on the retention floor — every vault, system or content, gets the same extraction, full-text search, vector search, entity linking, and so on.
+
+## The contract in one sentence
+
+A vault's kind controls which surfaces the vault is **visible on by default**; it never controls whether the vault is **addressable** or whether data inside it is **extracted and searchable**.
+
+Three invariants follow from that:
+
+1. **Addressability is always on.** You can read `GET /vaults/{id}` for a system vault. You can run `memex memory search --vault inbox` and get its units. You can target a system vault by name or UUID from any tool. Visibility opt-out never takes the form "this vault doesn't exist."
+2. **Retention is invariant.** Extraction always runs on a system vault, just as it does on a content vault. Memory units, full-text vectors, entity links, mental models — every observation-surface a content vault gets, a system vault gets too. A future reflection cycle sees system-vault evidence on the same footing as content-vault evidence.
+3. **Synthesis is opt-out, not opt-in.** The default for a content vault is *visible everywhere*. The default for a system vault is *visible nowhere on the synthesis-and-discovery surfaces* — but that default is a per-vault `policy`, and a system vault that legitimately should be summarised (or reflected on) flips the relevant flag.
+
+## What "synthesis-and-discovery" actually means
+
+The set of surfaces that mute system vaults by default:
+
+- `memex_list_vaults` and `GET /vaults` — system vaults don't appear unless you ask (`?include_system_vaults=true`, `--include-system`).
+- The session briefing's *Available Vaults* section — same gate.
+- `memex_get_vault_summary` periodic regeneration — skipped unless the vault's `policy.summarize` is true.
+- `memex_survey` and `memex_memory_search` with a default scope (`*` / unset) — system vaults don't enter the in-set unless you opt in (`include_system_vaults=true`) or name them explicitly.
+- Reflection enqueue — system vaults without `policy.reflect=true` never produce mental models; their queue stays empty.
+- Entity tools (`memex_list_entities`, `memex_get_entity_cooccurrences`, `memex_get_entity_mentions`) — system-vault evidence is excluded from the membership and centrality queries by default, so a system vault cannot "leak" into entity rankings.
+
+What stays the same regardless of kind:
+
+- Every vault is addressable by name or UUID on every surface.
+- Extraction, indexing, dedup, contradiction detection — all run on every vault.
+- Maintenance operations (`memex note migrate`, lint, deprioritize) work the same.
+- The entity graph is global, but cooccurrences are vault-scoped: a system vault contributes its own edges; those edges are excluded from default-scope ranking by the same gate that filters the system vault from search.
+
+## Why "inbox" became a system vault
+
+`inbox` was the canonical case that surfaced the gap. It is a vault like any other — notes land in it, extraction runs, entities link — but its purpose is "things that need a destination," not "things you read about." When an agent booted up and ran `memex memory_search` with the default scope, inbox units polluted the result set. The session briefing's *Available Vaults* list offered `inbox` alongside real workspaces. Reflection on inbox content produced mental models that, in turn, appeared in entity rankings — making inbox-routing artifacts part of an entity's perceived importance.
+
+The fix isn't to add filtering on top — that drifts the rule across every surface. The fix is to make `inbox` *declare* what it is, and let the surfaces know how to read that declaration. That's what `kind='system'` is.
+
+The `inbox` migration in `060_vault_kind_policy.py` does three things in one go: marks `inbox` as a system vault, archives any mental models that already pointed at it, and clears any `VaultSummary` row that was generated for it. Existing content is untouched; the synthesis products that would have been wrong are removed.
+
+## The Union wildcard
+
+`memex memory search` and friends accept a `vault_ids` list (or a comma-separated `--vault` flag) that accepts names, UUIDs, and the literal `*`. The semantics are deliberate:
+
+- `*` (or no list) → all **content** vaults. System vaults are not part of the default universe.
+- `[name, ...]` → resolve each name/UUID; system vaults are addressable by name. They are *added* to the content set, never replacing it.
+- `[*, name]` → all content vaults *plus* the named system vault. Same as the previous case in practice; the `*` makes the intent explicit.
+- `include_system_vaults=true` (per-tool flag) → all content vaults *plus* all system vaults, without naming them.
+
+The practical effect: a user who types `memex memory search` gets the universe they mean — their own content. A user who types `memex memory search --include-system-vaults` widens explicitly. There is no way to type something that *only* returns system vaults (other than naming one by hand), because the synthesis tools exist to find your own work, not infrastructure state.
+
+## Policy, kind, and immutability
+
+`kind` is a property of the vault. It is **immutable** — there is no `set-kind` operation, and the CLI requires a `[y/N]` confirmation when you create a vault with `kind=system`. The reasoning: most of the harm comes from changing kind *after* a vault has accumulated state. A content vault with three months of mental models and a daily-rerun vault summary, if flipped to `system` in anger, would have its synthesis purged on the next reflection/summarise cycle, and there is no way to rebuild mental models for content that's no longer being tracked. The 30-second confirmation is the smallest friction that prevents that.
+
+`policy` is mutable. It's a typed JSON document with two fields today (`reflect`, `summarize`), each `bool | None` — `None` means "use the kind's default" (true for content, false for system). The policy is the per-vault override; the kind is the tenancy root. A content vault that wants to be invisible on briefings (because it's a personal scratchpad) can set `policy.summarize=false`; a system vault that *should* be reflected on (because its contents are durable enough to want mental models) can set `policy.reflect=true`.
+
+## The `inbox` case-vault precedent (and beyond)
+
+The next consumers are already sketched. The procedural-experiential memory work calls for a hidden case-vault — notes that capture a single agent session's outcome for the procedural-mem pipeline. That vault is exactly the same shape: addressable, fully extracted, but silent on the agent-facing synthesis surfaces. The same goes for a future Hermes session vault that captures mid-session scratch state. They all instantiate the same `kind='system'` row; they all rely on the same `policy` override if their use case diverges from the default.
+
+A new "system" vault is a one-line creation:
+
+```bash
+memex vault create my-integration-buffer --kind system
+```
+
+That single command buys you the right behavior on every surface that knows about kind. There is no second place to wire up the contract.
+
+## What this is **not**
+
+- Not multi-tenant isolation. Kind lives on the vault; the tenant model is the vault, as it always has been.
+- Not access control. A `require_read` API key sees system vault *names* when it asks for them. There is no kind-based authorization layer; that is a separate concern.
+- Not a replacement for `memex_kv_*`. Procedures and preferences still go to KV, not to a system vault. KV is the right tool when the data is small, namespaced, and queryable by key. A system vault is the right tool when the data is a stream of notes that another pipeline ingests.
+- Not an extension of the *tenant root* concept. A system vault *is* a tenant. It just behaves differently on a small set of surfaces.
+
+The mental model is: **a vault is a tenant; the kind is a contract on what that tenant is for.** Same plumbing, different policy.

--- a/docs/explanation/system-vs-content-vaults.md
+++ b/docs/explanation/system-vs-content-vaults.md
@@ -47,9 +47,9 @@ The `inbox` migration in `060_vault_kind_policy.py` does three things in one go:
 - `*` (or no list) → all **content** vaults. System vaults are not part of the default universe.
 - `[name, ...]` → resolve each name/UUID; system vaults are addressable by name. They are *added* to the content set, never replacing it.
 - `[*, name]` → all content vaults *plus* the named system vault. Same as the previous case in practice; the `*` makes the intent explicit.
-- `include_system_vaults=true` (per-tool flag) → all content vaults *plus* all system vaults, without naming them.
+- `include_system_vaults=true` (per-tool flag) → **unconditional union**: every system vault joins the resolved scope, regardless of whether the caller used `*`, named specific vaults, or omitted the list. The flag is an *opt-in to the system-vault surface as a whole*, not a scope widener. To scope a call to one specific system vault without dragging in the rest, name it and leave the flag off; to read across the system fleet, set the flag.
 
-The practical effect: a user who types `memex memory search` gets the universe they mean — their own content. A user who types `memex memory search --include-system-vaults` widens explicitly. There is no way to type something that *only* returns system vaults (other than naming one by hand), because the synthesis tools exist to find your own work, not infrastructure state.
+The practical effect: a user who types `memex memory search` gets the universe they mean — their own content. A user who types `memex memory search --include-system-vaults` widens explicitly to the system fleet, even if they also passed `--vault research` (in which case the result is research + every system vault — pass `--vault inbox` and omit the flag to scope to just the named system vault). There is no way to type something that *only* returns system vaults (other than naming one by hand), because the synthesis tools exist to find your own work, not infrastructure state.
 
 ## Policy, kind, and immutability
 

--- a/docs/how-to/create-a-system-vault.md
+++ b/docs/how-to/create-a-system-vault.md
@@ -1,0 +1,151 @@
+# Create a system vault
+
+System vaults are addressable, fully-extracted vaults that stay silent on the synthesis-and-discovery surfaces (search, list, briefing, reflection, vault-summary) by default. Use this guide when you need a vault that *receives* data on behalf of another component — an integration buffer, a session scratch space, an external ingest pipeline — and you don't want that data to pollute normal user searches.
+
+The [explanation page](../explanation/system-vs-content-vaults.md) covers the *why*; this page covers the *how*.
+
+## Prerequisites
+
+- A running Memex server.
+- The `memex` CLI on your PATH.
+- Auth role that allows `vault create` (default admin or write scope).
+
+## When to make a vault system vs content
+
+The default is **content**; you only need `kind=system` when the vault is *infrastructure* rather than *user-facing content*. The current canonical example is `inbox`: a buffer that the triage-inbox skill reads from and routes into other vaults. The same shape fits a session-vault for a sub-agent, a procedural case-vault, a third-party integration buffer, or a test sink.
+
+The rule of thumb:
+
+- The vault's notes are *things you read about* → content.
+- The vault's notes are *things another component consumes* → system.
+
+If you're unsure, leave the vault as content. Flipping `kind` later requires a fresh vault — see [the immutability note](#immutability) below.
+
+## Step 1 — Create the vault
+
+```bash
+memex vault create my-integration-buffer --kind system
+```
+
+Memex prints the confirmation prompt before persisting:
+
+```
+About to create a system vault 'my-integration-buffer'.
+System vaults are silent on default-scope search, briefing, reflection,
+and vault-summary. Extraction and addressability are unaffected.
+The kind cannot be changed after creation.
+Continue? [y/N]:
+```
+
+Type `y` to proceed, `N` (or anything else) to abort. The CLI prints the new vault's UUID on success.
+
+To skip the prompt in scripts, pass `--force` (or `-f`):
+
+```bash
+memex vault create my-integration-buffer --kind system --force
+```
+
+If you forget `--force` in a non-interactive shell, the command aborts with exit code 1.
+
+## Step 2 — (Optional) Override the synthesis policy
+
+By default, a system vault skips both reflection (`reflect: false`) and vault-summary regeneration (`summarize: false`). If your use case wants either of those — e.g., a system vault that holds durable evidence you'd like mental models built from — flip the flag at creation time:
+
+```bash
+memex vault create my-case-vault \
+  --kind system \
+  --reflect \
+  --summarize
+```
+
+Use `--no-reflect` / `--no-summarize` to be explicit about turning them off (the default, but useful in scripts that derive the flags from configuration).
+
+The same flags work on a content vault — `--no-summarize` on a personal scratchpad, for example, is a valid use case for a content vault that doesn't want a briefing entry.
+
+## Step 3 — Use the vault
+
+A system vault is a normal vault from the caller's perspective. You address it the same way you address a content vault — by name or UUID, on any tool:
+
+```bash
+# Write into it
+memex note add --vault my-integration-buffer \
+  --title "Webhook payload 2026-06-08T12:00:00Z" \
+  --body '{"event": "...", "ts": "..."}'
+
+# Read from it directly
+memex note search "webhook" --vault my-integration-buffer
+
+# Read from it as part of a wider scope
+memex memory search "webhook" --include-system-vaults
+```
+
+The `--include-system-vaults` flag (and its `?include_system_vaults=true` HTTP/MCP equivalent) is the only way to surface system-vault content on a default-scope search. If you find yourself reaching for it often, consider whether the vault is really a system vault.
+
+## Step 4 — Verify visibility is what you expect
+
+Three quick checks:
+
+```bash
+# 1. List without the flag — your system vault should NOT appear
+memex vault list
+
+# 2. List with the flag — it SHOULD appear
+memex vault list --include-system
+
+# 3. The Kind column reads 'system'
+memex vault list --include-system
+```
+
+The `Kind` column was added in V11; older lists won't have it. Update the CLI (`uv sync`) if you see no column.
+
+## Immutability
+
+`kind` is set at creation and cannot be changed afterwards. There is no `memex vault set-kind` and there never will be — the harm comes from changing kind *after* state has accumulated (mental models get archived, vault summaries get cleared, the entity ranking shifts). If you need to flip a vault's kind:
+
+1. Create a new vault with the right `kind`.
+2. `memex note migrate` every note from the old vault to the new one.
+3. Delete the old vault.
+
+The migration moves notes, memory units, entity links, and reflection records. It does not copy the *synthesis* rows (mental models, vault summaries) — those are rebuilt by the scheduler on the new vault if its `policy` allows.
+
+## Programmatic creation (HTTP / MCP)
+
+The HTTP `POST /api/v1/vaults` endpoint accepts `kind` and `policy` in the request body:
+
+```bash
+curl -X POST $MEMEX_SERVER_URL/api/v1/vaults \
+  -H "Authorization: Bearer $MEMEX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-integration-buffer",
+    "kind": "system",
+    "policy": {"reflect": false, "summarize": false}
+  }'
+```
+
+The MCP `memex_create_vault` tool mirrors the same parameters. Both reject unknown `kind` values (`"content"` or `"system"`) and unknown `policy` keys (the typed model uses `extra='forbid'`) with HTTP 400.
+
+## Troubleshooting
+
+### The vault doesn't appear in `memex vault list`
+
+That's the expected default behavior. Re-run with `--include-system`.
+
+### Reflection/summary *does* run on my system vault
+
+Check the vault's `policy`:
+
+```bash
+memex vault show my-integration-buffer --json
+```
+
+If `policy.reflect` or `policy.summarize` is `true` when you expected `false`, you set the flag at creation — the `kind` doesn't override an explicit `policy` setting.
+
+### I want to flip a vault's kind
+
+You can't. [Create a new vault and migrate](#immutability).
+
+## See also
+
+- [Explanation: System vaults vs content vaults](../explanation/system-vs-content-vaults.md) — the contract in depth.
+- [How-to: Organise work with vaults](vaults.md) — content vault creation and migration.

--- a/docs/how-to/create-a-system-vault.md
+++ b/docs/how-to/create-a-system-vault.md
@@ -79,7 +79,7 @@ memex note search "webhook" --vault my-integration-buffer
 memex memory search "webhook" --include-system-vaults
 ```
 
-The `--include-system-vaults` flag (and its `?include_system_vaults=true` HTTP/MCP equivalent) is the only way to surface system-vault content on a default-scope search. If you find yourself reaching for it often, consider whether the vault is really a system vault.
+The `--include-system-vaults` flag (and its `?include_system_vaults=true` HTTP/MCP equivalent) is an **unconditional union**: it adds every system vault to the resolved scope, regardless of whether you also passed `--vault`. To read one specific system vault without dragging in the rest, name it (`--vault inbox`) and leave the flag off. If you find yourself reaching for the flag often, consider whether the vault is really a system vault.
 
 ## Step 4 — Verify visibility is what you expect
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ Recipes for a specific job. Assumes Memex is already installed.
 | [Retrieve data from the CLI](how-to/retrieve-data.md) | Memory search, note search, survey, entity traversal — all from the terminal. |
 | [Use the key-value store](how-to/key-value-store.md) | Set preferences, project conventions, procedures across sessions. |
 | [Organise work with vaults](how-to/vaults.md) | Create vaults, route notes via frontmatter, migrate between vaults. |
+| [Create a system vault](how-to/create-a-system-vault.md) | Make a vault silent on the synthesis surfaces; addressable, fully extracted. |
 | [Use note templates](how-to/note-templates.md) | Pick a template, register a new one. |
 
 ### Curation
@@ -121,6 +122,7 @@ Understand the why.
 |:-----|:------|
 | [About session briefings](explanation/session-briefings.md) | What the briefing carries; how Claude Code and Hermes consume it. |
 | [About mental-model observations](explanation/mental-model-observations.md) | Read-only projections; why deprioritize routes to source units. |
+| [About system vaults vs content vaults](explanation/system-vs-content-vaults.md) | The `kind` contract — visibility opt-in, addressability always-on, retention invariant. |
 | [Design principles (P1–P13)](explanation/design-principles.md) | The thirteen principles that anchor Memex's design. |
 | [How Memex is evaluated](explanation/how-memex-is-evaluated.md) | The internal suite framework, LoCoMo external benchmark, empirical caveats. |
 

--- a/packages/cli/src/memex_cli/vaults.py
+++ b/packages/cli/src/memex_cli/vaults.py
@@ -170,7 +170,7 @@ async def create_vault(
     ):
         raise typer.Exit(code=1)
 
-    policy: dict[str, bool] = {}
+    policy: dict[str, bool | None] = {}
     if no_reflect:
         policy['reflect'] = False
     if no_summarize:

--- a/packages/cli/src/memex_cli/vaults.py
+++ b/packages/cli/src/memex_cli/vaults.py
@@ -41,16 +41,20 @@ async def list_vaults(
         bool,
         typer.Option('--compact', help='Output as a plain markdown table with note counts.'),
     ] = False,
+    include_system: Annotated[
+        bool,
+        typer.Option('--include-system', help='Also list system vaults (inbox, etc.).'),
+    ] = False,
 ):
     """
-    List all available vaults.
+    List available vaults (content vaults by default; --include-system for all).
     """
     config: MemexConfig = ctx.obj
 
     async with get_api_context(config) as api:
         if compact:
             try:
-                rows = await api.list_vaults_with_counts()
+                rows = await api.list_vaults_with_counts(include_system=include_system)
             except Exception as e:
                 handle_api_error(e)
 
@@ -86,7 +90,7 @@ async def list_vaults(
             return
 
         try:
-            vaults = await api.list_vaults()
+            vaults = await api.list_vaults(include_system=include_system)
         except Exception as e:
             handle_api_error(e)
 
@@ -104,6 +108,7 @@ async def list_vaults(
     table = Table(title='Available Vaults')
     table.add_column('ID', style='dim')
     table.add_column('Name', style='cyan')
+    table.add_column('Kind', style='magenta')
     table.add_column('Memory Worth', style='yellow')
     table.add_column('Description', style='white')
     if has_access:
@@ -113,7 +118,8 @@ async def list_vaults(
         console.print('[yellow]No vaults found.[/yellow]')
     else:
         for v in vaults:
-            row = [str(v.id), v.name, v.mw_mode, v.description or '']
+            kind = getattr(v, 'kind', 'content')
+            row = [str(v.id), v.name, kind, v.mw_mode, v.description or '']
             if has_access:
                 row.append(', '.join(v.access) if v.access else '\u2014')
             table.add_row(*row)
@@ -132,17 +138,49 @@ async def create_vault(
     description: Annotated[
         str | None, typer.Option('--description', '-d', help='Optional description.')
     ] = None,
+    kind: Annotated[
+        str,
+        typer.Option('--kind', help='Vault kind: "content" (corpus) or "system" (infrastructure).'),
+    ] = 'content',
+    no_reflect: Annotated[
+        bool, typer.Option('--no-reflect', help='Disable per-entity reflection for this vault.')
+    ] = False,
+    no_summarize: Annotated[
+        bool,
+        typer.Option('--no-summarize', help='Disable vault-summary generation for this vault.'),
+    ] = False,
+    force: Annotated[bool, typer.Option('--force', '-f', help='Skip confirmation.')] = False,
 ):
     """
-    Create a new vault.
+    Create a new vault. The kind is permanent and cannot be changed later.
     """
     config: MemexConfig = ctx.obj
+
+    if kind not in ('content', 'system'):
+        console.print("[red]--kind must be 'content' or 'system'.[/red]")
+        raise typer.Exit(code=1)
+
+    # The kind is permanent; only the deliberate (non-default) system choice prompts.
+    if (
+        kind == 'system'
+        and not force
+        and not typer.confirm(
+            "Vault kind 'system' is permanent and cannot be changed later. Continue?"
+        )
+    ):
+        raise typer.Exit(code=1)
+
+    policy: dict[str, bool] = {}
+    if no_reflect:
+        policy['reflect'] = False
+    if no_summarize:
+        policy['summarize'] = False
 
     console.print(f'[green]Creating vault:[/green] {name}')
 
     async with get_api_context(config) as api:
         try:
-            vault = await api.create_vault(name, description)
+            vault = await api.create_vault(name, description, kind=kind, policy=policy or None)
         except Exception as e:
             handle_api_error(e)
 

--- a/packages/cli/src/memex_cli/vaults.py
+++ b/packages/cli/src/memex_cli/vaults.py
@@ -174,6 +174,19 @@ async def create_vault(
         console.print("[red]--kind must be 'content' or 'system'.[/red]")
         raise typer.Exit(code=1)
 
+    # Mutual exclusion: a user passing both --reflect and --no-reflect is
+    # ambiguous; refuse the call rather than silently picking one. Same for
+    # summarize. (Typer gives us no built-in "exactly one" support for
+    # pairs of bool flags, so the check is manual.) Run BEFORE the
+    # confirmation prompt so a conflicting invocation never gets a "y/N"
+    # response that's immediately discarded.
+    if reflect and no_reflect:
+        console.print('[red]--reflect and --no-reflect are mutually exclusive.[/red]')
+        raise typer.Exit(code=1)
+    if summarize and no_summarize:
+        console.print('[red]--summarize and --no-summarize are mutually exclusive.[/red]')
+        raise typer.Exit(code=1)
+
     # The kind is permanent; only the deliberate (non-default) system choice prompts.
     if (
         kind == 'system'
@@ -193,17 +206,6 @@ async def create_vault(
         policy['summarize'] = True
     if no_summarize:
         policy['summarize'] = False
-
-    # Mutual exclusion: a user passing both --reflect and --no-reflect is
-    # ambiguous; refuse the call rather than silently picking one. Same for
-    # summarize. (Typer gives us no built-in "exactly one" support for
-    # pairs of bool flags, so the check is manual.)
-    if reflect and no_reflect:
-        console.print('[red]--reflect and --no-reflect are mutually exclusive.[/red]')
-        raise typer.Exit(code=1)
-    if summarize and no_summarize:
-        console.print('[red]--summarize and --no-summarize are mutually exclusive.[/red]')
-        raise typer.Exit(code=1)
 
     console.print(f'[green]Creating vault:[/green] {name}')
 

--- a/packages/cli/src/memex_cli/vaults.py
+++ b/packages/cli/src/memex_cli/vaults.py
@@ -142,8 +142,22 @@ async def create_vault(
         str,
         typer.Option('--kind', help='Vault kind: "content" (corpus) or "system" (infrastructure).'),
     ] = 'content',
+    reflect: Annotated[
+        bool,
+        typer.Option(
+            '--reflect',
+            help='Enable per-entity reflection for this vault. Default: enabled for content, disabled for system.',
+        ),
+    ] = False,
     no_reflect: Annotated[
         bool, typer.Option('--no-reflect', help='Disable per-entity reflection for this vault.')
+    ] = False,
+    summarize: Annotated[
+        bool,
+        typer.Option(
+            '--summarize',
+            help='Enable vault-summary generation for this vault. Default: enabled for content, disabled for system.',
+        ),
     ] = False,
     no_summarize: Annotated[
         bool,
@@ -171,10 +185,25 @@ async def create_vault(
         raise typer.Exit(code=1)
 
     policy: dict[str, bool | None] = {}
+    if reflect:
+        policy['reflect'] = True
     if no_reflect:
         policy['reflect'] = False
+    if summarize:
+        policy['summarize'] = True
     if no_summarize:
         policy['summarize'] = False
+
+    # Mutual exclusion: a user passing both --reflect and --no-reflect is
+    # ambiguous; refuse the call rather than silently picking one. Same for
+    # summarize. (Typer gives us no built-in "exactly one" support for
+    # pairs of bool flags, so the check is manual.)
+    if reflect and no_reflect:
+        console.print('[red]--reflect and --no-reflect are mutually exclusive.[/red]')
+        raise typer.Exit(code=1)
+    if summarize and no_summarize:
+        console.print('[red]--summarize and --no-summarize are mutually exclusive.[/red]')
+        raise typer.Exit(code=1)
 
     console.print(f'[green]Creating vault:[/green] {name}')
 

--- a/packages/cli/tests/test_vaults_cli.py
+++ b/packages/cli/tests/test_vaults_cli.py
@@ -19,7 +19,7 @@ def test_create_vault_passes_name_and_description_positionally(
 
     result = runner.invoke(app, ['create', 'my-vault', '--description', 'docs'])
     assert result.exit_code == 0, result.stdout
-    mock_api.create_vault.assert_called_once_with('my-vault', 'docs')
+    mock_api.create_vault.assert_called_once_with('my-vault', 'docs', kind='content', policy=None)
 
     clean_stdout = strip_ansi(result.stdout)
     assert 'Creating vault: my-vault' in clean_stdout
@@ -33,7 +33,7 @@ def test_create_vault_with_default_description(runner, mock_api, monkeypatch):
 
     result = runner.invoke(app, ['create', 'bare-vault'])
     assert result.exit_code == 0, result.stdout
-    mock_api.create_vault.assert_called_once_with('bare-vault', None)
+    mock_api.create_vault.assert_called_once_with('bare-vault', None, kind='content', policy=None)
 
 
 def test_delete_vault_by_name(runner, mock_api, strip_ansi, monkeypatch):
@@ -190,5 +190,7 @@ def test_create_vault(runner, mock_api, strip_ansi, monkeypatch):
     assert f'Vault created successfully! ID: {vault_uuid}' in clean_stdout
 
     # Verify arguments — CLI passes (name, description) positionally to
-    # match MemexAPI.create_vault(self, name: str, description: str | None = None).
-    mock_api.create_vault.assert_called_once_with(vault_name, vault_desc)
+    # match MemexAPI.create_vault, plus the kind/policy kwargs (default content).
+    mock_api.create_vault.assert_called_once_with(
+        vault_name, vault_desc, kind='content', policy=None
+    )

--- a/packages/cli/tests/test_vaults_cli.py
+++ b/packages/cli/tests/test_vaults_cli.py
@@ -36,6 +36,81 @@ def test_create_vault_with_default_description(runner, mock_api, monkeypatch):
     mock_api.create_vault.assert_called_once_with('bare-vault', None, kind='content', policy=None)
 
 
+def test_create_vault_positive_reflect_and_summarize_flags(runner, mock_api, monkeypatch):
+    """--reflect and --summarize must produce a policy dict with True values.
+
+    Regression guard for the V11 review finding: a system vault that wants
+    synthesis on had no positive CLI flag, so the policy stayed empty and
+    the kind default (False) won.
+    """
+    mock_api.create_vault.return_value = MagicMock(id=uuid4())
+    monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(
+        app,
+        [
+            'create',
+            'case-vault',
+            '--kind',
+            'system',
+            '--reflect',
+            '--summarize',
+            '--force',
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    mock_api.create_vault.assert_called_once_with(
+        'case-vault',
+        None,
+        kind='system',
+        policy={'reflect': True, 'summarize': True},
+    )
+
+
+def test_create_vault_mutually_exclusive_reflect_flags(runner, mock_api, monkeypatch, strip_ansi):
+    """--reflect and --no-reflect must not both be accepted (silent policy)."""
+    mock_api.create_vault.return_value = MagicMock(id=uuid4())
+    monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(
+        app,
+        [
+            'create',
+            'case-vault',
+            '--kind',
+            'system',
+            '--reflect',
+            '--no-reflect',
+            '--force',
+        ],
+    )
+    assert result.exit_code == 1
+    assert '--reflect and --no-reflect' in strip_ansi(result.stdout)
+    mock_api.create_vault.assert_not_called()
+
+
+def test_create_vault_mutually_exclusive_summarize_flags(runner, mock_api, monkeypatch, strip_ansi):
+    """--summarize and --no-summarize must not both be accepted."""
+    mock_api.create_vault.return_value = MagicMock(id=uuid4())
+    monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
+
+    result = runner.invoke(
+        app,
+        [
+            'create',
+            'case-vault',
+            '--kind',
+            'system',
+            '--summarize',
+            '--no-summarize',
+            '--force',
+        ],
+    )
+    assert result.exit_code == 1
+    assert '--summarize and --no-summarize' in strip_ansi(result.stdout)
+    mock_api.create_vault.assert_not_called()
+
+
 def test_delete_vault_by_name(runner, mock_api, strip_ansi, monkeypatch):
     vault_uuid = uuid4()
     vault_name = 'test-vault'

--- a/packages/cli/tests/test_vaults_cli.py
+++ b/packages/cli/tests/test_vaults_cli.py
@@ -111,6 +111,46 @@ def test_create_vault_mutually_exclusive_summarize_flags(runner, mock_api, monke
     mock_api.create_vault.assert_not_called()
 
 
+def test_create_vault_mutex_check_runs_before_kind_confirmation(
+    runner, mock_api, monkeypatch, strip_ansi
+):
+    """Regression guard: conflicting policy flags must be rejected BEFORE the
+    [y/N] confirmation prompt for ``--kind system`` (V11 L3 review).
+
+    Without ``--force``, a system-vault creation with conflicting flags used
+    to ask for confirmation first, then bail with a different error — leaving
+    a user who typed 'y' wondering why nothing happened. The mutex check now
+    runs first; no confirmation is ever requested.
+    """
+    mock_api.create_vault.return_value = MagicMock(id=uuid4())
+    monkeypatch.setattr('memex_cli.vaults.get_api_context', lambda config: mock_api)
+
+    # typer.confirm will explode if it's called — we want to assert it isn't.
+    def _explode(*_a, **_kw):
+        raise AssertionError(
+            'typer.confirm was called — mutex check must run before kind confirmation'
+        )
+
+    monkeypatch.setattr('memex_cli.vaults.typer.confirm', _explode)
+
+    result = runner.invoke(
+        app,
+        [
+            'create',
+            'case-vault',
+            '--kind',
+            'system',
+            '--reflect',
+            '--no-reflect',
+            # NOTE: no --force on purpose; without the order fix this would
+            # reach typer.confirm and raise AssertionError.
+        ],
+    )
+    assert result.exit_code == 1
+    assert '--reflect and --no-reflect' in strip_ansi(result.stdout)
+    mock_api.create_vault.assert_not_called()
+
+
 def test_delete_vault_by_name(runner, mock_api, strip_ansi, monkeypatch):
     vault_uuid = uuid4()
     vault_name = 'test-vault'

--- a/packages/common/src/memex_common/agent_surface.py
+++ b/packages/common/src/memex_common/agent_surface.py
@@ -248,8 +248,11 @@ TOOL DISCOVERY (progressive disclosure)
 VAULT DEFAULTS — vault parameters are optional. Writes default to the
 active vault; reads default to search vaults (from .memex.yaml or global
 config). Pass vault_id/vault_ids to override. The "*" wildcard expands to
-content vaults only; system vaults (e.g. inbox) join only when named or via
-include_system_vaults=true.
+content vaults only; system vaults (e.g. inbox) join when named or via
+include_system_vaults=true. The flag is an unconditional union: it adds
+every system vault regardless of whether the caller used "*" or named
+specific vaults. To scope a call to one system vault, name it and leave
+the flag off.
 
 NEVER fabricate IDs. Use only IDs returned from tool output.
 

--- a/packages/common/src/memex_common/agent_surface.py
+++ b/packages/common/src/memex_common/agent_surface.py
@@ -247,7 +247,9 @@ TOOL DISCOVERY (progressive disclosure)
 
 VAULT DEFAULTS — vault parameters are optional. Writes default to the
 active vault; reads default to search vaults (from .memex.yaml or global
-config). Pass vault_id/vault_ids to override.
+config). Pass vault_id/vault_ids to override. The "*" wildcard expands to
+content vaults only; system vaults (e.g. inbox) join only when named or via
+include_system_vaults=true.
 
 NEVER fabricate IDs. Use only IDs returned from tool output.
 

--- a/packages/common/src/memex_common/client.py
+++ b/packages/common/src/memex_common/client.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 from memex_common.kv_utils import is_procedure_key
 from memex_common.vault_utils import resolve_vault_list
+from memex_common.vault_policy import VaultKind, VaultPolicy
 from memex_common.schemas import (
     RetrievalRequest,
     ReflectionRequest,
@@ -155,14 +156,14 @@ class RemoteMemexAPI:
         return await self.client.head(path)
 
     # --- Vaults ---
-    async def list_vaults(self) -> list[VaultDTO]:
-        """List all available vaults."""
-        result = await self._get('vaults')
+    async def list_vaults(self, include_system: bool = True) -> list[VaultDTO]:
+        """List available vaults. ``include_system=False`` hides system vaults."""
+        result = await self._get('vaults', params={'include_system': include_system})
         return [VaultDTO(**v) for v in result]
 
-    async def list_vaults_with_counts(self) -> list[dict[str, Any]]:
-        """List all vaults with note counts. Wraps list_vaults for API compat."""
-        vaults = await self.list_vaults()
+    async def list_vaults_with_counts(self, include_system: bool = True) -> list[dict[str, Any]]:
+        """List vaults with note counts. Wraps list_vaults for API compat."""
+        vaults = await self.list_vaults(include_system=include_system)
         return [
             {
                 'vault': v,
@@ -188,12 +189,28 @@ class RemoteMemexAPI:
             reader_vaults=[VaultDTO(**v) for v in result[1:]],
         )
 
-    async def create_vault(self, name: str, description: str | None = None) -> VaultDTO:
+    async def create_vault(
+        self,
+        name: str,
+        description: str | None = None,
+        kind: 'VaultKind | str' = 'content',
+        policy: 'VaultPolicy | dict | None' = None,
+    ) -> VaultDTO:
         """Create a new vault.
 
         Mirrors :pymeth:`memex_core.api.MemexAPI.create_vault`.
         """
-        request = CreateVaultRequest(name=name, description=description)
+        kind_value = kind.value if hasattr(kind, 'value') else str(kind)
+        policy_dict: dict | None
+        if policy is None:
+            policy_dict = None
+        elif hasattr(policy, 'model_dump'):
+            policy_dict = policy.model_dump(exclude_none=True)
+        else:
+            policy_dict = dict(policy)
+        request = CreateVaultRequest(
+            name=name, description=description, kind=kind_value, policy=policy_dict
+        )
         result = await self._post('vaults', request)
         return VaultDTO(**result)
 
@@ -448,6 +465,7 @@ class RemoteMemexAPI:
         intent_class: IntentClass | None = None,
         risk_class: RiskClass | None = None,
         apply_pre_filter: bool = True,
+        include_system_vaults: bool = False,
     ) -> list[MemoryUnitDTO]:
         """Search for memories.
 
@@ -461,6 +479,7 @@ class RemoteMemexAPI:
             limit=limit,
             offset=offset,
             vault_ids=vault_ids,
+            include_system_vaults=include_system_vaults,
             token_budget=token_budget,
             strategies=strategies,
             include_stale=include_stale,
@@ -542,6 +561,7 @@ class RemoteMemexAPI:
         before: dt.datetime | None = None,
         tags: list[str] | None = None,
         reference_date: dt.datetime | None = None,
+        include_system_vaults: bool = False,
     ) -> list[NoteSearchResult]:
         """Search for notes."""
         kwargs: dict[str, Any] = {}
@@ -563,6 +583,7 @@ class RemoteMemexAPI:
             query=query,
             limit=limit,
             vault_ids=vault_ids,
+            include_system_vaults=include_system_vaults,
             expand_query=expand_query,
             fusion_strategy=fusion_strategy,
             reason=reason,
@@ -581,11 +602,13 @@ class RemoteMemexAPI:
         after: dt.datetime | None = None,
         before: dt.datetime | None = None,
         reference_date: dt.datetime | None = None,
+        include_system_vaults: bool = False,
     ) -> SurveyResponse:
         """Broad topic survey — decompose, parallel search, grouped results."""
         request = SurveyRequest(
             query=query,
             vault_ids=vault_ids,
+            include_system_vaults=include_system_vaults,
             limit_per_query=limit_per_query,
             token_budget=token_budget,
             after=after,

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -470,10 +470,15 @@ class CreateVaultRequest(BaseModel):
         # has extra='forbid' and uses ``reflect: bool | None`` etc., so a
         # stringly-typed {"reflect": "true"} also fails here instead of
         # silently applying ``bool("true") == True`` downstream.
+        #
+        # Return the normalized form (canonical bools, None fields stripped
+        # via exclude_none) so any code reading ``request.policy`` between
+        # the API boundary and the service call sees coerced types — not
+        # the lax-mode-coerced pydantic internals (``{'reflect': 1}``) which
+        # the service layer would have to re-coerce.
         if v is None:
             return v
-        VaultPolicy.model_validate(v)  # raises pydantic.ValidationError -> 422
-        return v
+        return VaultPolicy.model_validate(v).model_dump(exclude_none=True)
 
 
 class MemoryUnitBase(VaultMixin):

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -11,6 +11,7 @@ from pydantic import (
     Field,
     PrivateAttr,
     field_serializer,
+    field_validator,
     BeforeValidator,
     ConfigDict,
     model_validator,
@@ -448,6 +449,16 @@ class CreateVaultRequest(BaseModel):
         default=None,
         description='Optional per-vault synthesis policy (e.g. {"reflect": false}).',
     )
+
+    @field_validator('kind')
+    @classmethod
+    def _validate_kind(cls, v: str) -> str:
+        # The DB has a CHECK constraint; we'd rather fail at the API
+        # boundary with a clean 422 than let the INSERT raise a 500
+        # IntegrityError. Keep the literal set in sync with VaultKind.
+        if v not in ('content', 'system'):
+            raise ValueError(f'kind must be "content" or "system", got {v!r}')
+        return v
 
 
 class MemoryUnitBase(VaultMixin):

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -24,6 +24,7 @@ from memex_common.types import MemexTypes, FactTypes
 
 _logger = logging.getLogger('memex.common.schemas')
 from memex_common.mixins import VaultMixin
+from memex_common.vault_policy import VaultPolicy  # noqa: E402
 
 
 # Cold-start posterior variance ceiling. Duplicated from
@@ -458,6 +459,20 @@ class CreateVaultRequest(BaseModel):
         # IntegrityError. Keep the literal set in sync with VaultKind.
         if v not in ('content', 'system'):
             raise ValueError(f'kind must be "content" or "system", got {v!r}')
+        return v
+
+    @field_validator('policy')
+    @classmethod
+    def _validate_policy(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        # Validate at the API boundary so unknown keys surface as 422 (this
+        # validator's ValueError) rather than as a 500 IntegrityError or a
+        # raw pydantic.ValidationError leaking through. VaultPolicy itself
+        # has extra='forbid' and uses ``reflect: bool | None`` etc., so a
+        # stringly-typed {"reflect": "true"} also fails here instead of
+        # silently applying ``bool("true") == True`` downstream.
+        if v is None:
+            return v
+        VaultPolicy.model_validate(v)  # raises pydantic.ValidationError -> 422
         return v
 
 

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -285,6 +285,10 @@ class RetrievalRequest(BaseModel):
         default=None,
         description='List of specific vault IDs or names to search. If None or empty, searches ALL vaults.',
     )
+    include_system_vaults: bool = Field(
+        default=False,
+        description='Include system vaults when expanding the wildcard scope.',
+    )
     filters: dict[str, Any] = Field(
         default_factory=dict, description='Optional key-value filters (e.g. fact_type).'
     )
@@ -434,6 +438,16 @@ class CreateVaultRequest(BaseModel):
     name: str = Field(..., description='The name of the vault.')
 
     description: str | None = Field(default=None, description='Optional description.')
+
+    kind: str = Field(
+        default='content',
+        description='Vault kind: "content" (corpus) or "system" (infrastructure). Permanent.',
+    )
+
+    policy: dict | None = Field(
+        default=None,
+        description='Optional per-vault synthesis policy (e.g. {"reflect": false}).',
+    )
 
 
 class MemoryUnitBase(VaultMixin):
@@ -712,6 +726,16 @@ class VaultDTO(BaseModel):
     mw_mode: str = Field(
         default='stationary',
         description='Memory Worth mode for the vault: "stationary" or "ema".',
+    )
+
+    kind: str = Field(
+        default='content',
+        description='Vault kind: "content" (corpus) or "system" (infrastructure).',
+    )
+
+    policy: dict = Field(
+        default_factory=dict,
+        description='Per-vault synthesis policy overrides (reflect / summarize).',
     )
 
     is_active: bool = Field(
@@ -1221,6 +1245,7 @@ class NoteSearchRequest(BaseModel):
     query: str
     limit: int = 10
     vault_ids: list[UUID | str] | None = None
+    include_system_vaults: bool = False
     expand_query: bool = False
     fusion_strategy: str = 'rrf'
     strategies: list[str] = Field(default=['semantic', 'keyword', 'graph', 'temporal'])
@@ -1478,6 +1503,10 @@ class SurveyRequest(BaseModel):
     vault_ids: list[UUID | str] | None = Field(
         default=None,
         description='Vault UUIDs or names to search. If None, uses default reader vault.',
+    )
+    include_system_vaults: bool = Field(
+        default=False,
+        description='Include system vaults when expanding the wildcard scope.',
     )
     limit_per_query: int = Field(
         default=10, ge=1, le=50, description='Max results per sub-question.'

--- a/packages/common/src/memex_common/schemas.py
+++ b/packages/common/src/memex_common/schemas.py
@@ -444,7 +444,7 @@ class CreateVaultRequest(BaseModel):
         description='Vault kind: "content" (corpus) or "system" (infrastructure). Permanent.',
     )
 
-    policy: dict | None = Field(
+    policy: dict[str, Any] | None = Field(
         default=None,
         description='Optional per-vault synthesis policy (e.g. {"reflect": false}).',
     )
@@ -733,7 +733,7 @@ class VaultDTO(BaseModel):
         description='Vault kind: "content" (corpus) or "system" (infrastructure).',
     )
 
-    policy: dict = Field(
+    policy: dict[str, Any] = Field(
         default_factory=dict,
         description='Per-vault synthesis policy overrides (reflect / summarize).',
     )

--- a/packages/common/src/memex_common/vault_policy.py
+++ b/packages/common/src/memex_common/vault_policy.py
@@ -1,0 +1,70 @@
+"""Vault kind + per-vault synthesis policy.
+
+A vault's ``kind`` governs the synthesis-and-discovery surfaces (reflection,
+vault summary, wildcard search, listing, briefing), never the retention floor
+(extraction always runs). ``content`` vaults default both synthesis behaviours
+on; ``system`` vaults default them off. The per-vault ``policy`` blob overrides
+those defaults field by field.
+"""
+
+from __future__ import annotations
+
+import enum
+
+from pydantic import BaseModel, ConfigDict
+
+
+class VaultKind(enum.StrEnum):
+    """Behavioural classifier for a vault — corpus vs infrastructure."""
+
+    CONTENT = 'content'
+    SYSTEM = 'system'
+
+
+class VaultPolicy(BaseModel):
+    """Per-vault override of the kind-derived synthesis defaults.
+
+    A field left ``None`` defers to the kind default. Unknown keys are rejected
+    so typos surface instead of silently falling back.
+    """
+
+    model_config = ConfigDict(extra='forbid')
+
+    reflect: bool | None = None
+    summarize: bool | None = None
+
+
+def coerce_policy(policy: VaultPolicy | dict | None) -> VaultPolicy:
+    """Normalise a raw blob / model / None into a validated ``VaultPolicy``."""
+    if policy is None:
+        return VaultPolicy()
+    if isinstance(policy, VaultPolicy):
+        return policy
+    if isinstance(policy, dict):
+        return VaultPolicy.model_validate(policy)
+    raise TypeError(f'policy must be VaultPolicy | dict | None, got {type(policy)!r}')
+
+
+def _is_content(kind: VaultKind | str) -> bool:
+    value = kind.value if isinstance(kind, enum.Enum) else str(kind)
+    return value == VaultKind.CONTENT.value
+
+
+def is_system(kind: VaultKind | str) -> bool:
+    return not _is_content(kind)
+
+
+def reflect_enabled(kind: VaultKind | str, policy: VaultPolicy | dict | None = None) -> bool:
+    """Whether per-entity reflection should run for a vault of this kind+policy."""
+    resolved = coerce_policy(policy)
+    if resolved.reflect is not None:
+        return resolved.reflect
+    return _is_content(kind)
+
+
+def summarize_enabled(kind: VaultKind | str, policy: VaultPolicy | dict | None = None) -> bool:
+    """Whether vault-summary generation should run for a vault of this kind+policy."""
+    resolved = coerce_policy(policy)
+    if resolved.summarize is not None:
+        return resolved.summarize
+    return _is_content(kind)

--- a/packages/common/src/memex_common/vault_policy.py
+++ b/packages/common/src/memex_common/vault_policy.py
@@ -10,8 +10,17 @@ those defaults field by field.
 from __future__ import annotations
 
 import enum
+import logging
+import warnings
 
 from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+# Forward ref: VaultKind is defined below. Populated after the class body
+# runs so the frozenset can carry the enum values. Use the literal strings
+# directly so this module has no top-level circular dep on the class object.
+_KNOWN_KINDS: frozenset[str] = frozenset({'content', 'system'})
 
 
 class VaultKind(enum.StrEnum):
@@ -19,6 +28,15 @@ class VaultKind(enum.StrEnum):
 
     CONTENT = 'content'
     SYSTEM = 'system'
+
+
+# Belt-and-braces: the frozenset above is a literal so the module loads even
+# if VaultKind ever changes name. This assert forces a future rename to
+# update both sites in one diff. The sync between VaultKind and the
+# DB CHECK constraint ``vaults_kind_check`` is enforced at migration time.
+assert {k.value for k in VaultKind} == set(_KNOWN_KINDS), (
+    '_KNOWN_KINDS and VaultKind disagree; update both before renaming a kind'
+)
 
 
 class VaultPolicy(BaseModel):
@@ -45,13 +63,45 @@ def coerce_policy(policy: VaultPolicy | dict | None) -> VaultPolicy:
     raise TypeError(f'policy must be VaultPolicy | dict | None, got {type(policy)!r}')
 
 
-def _is_content(kind: VaultKind | str) -> bool:
-    value = kind.value if isinstance(kind, enum.Enum) else str(kind)
-    return value == VaultKind.CONTENT.value
+def _kind_value(kind: VaultKind | str) -> str:
+    return kind.value if isinstance(kind, enum.Enum) else str(kind)
 
 
 def is_system(kind: VaultKind | str) -> bool:
-    return not _is_content(kind)
+    """Whether ``kind`` classifies a vault as system (synthesis silent).
+
+    Fail-open on unknown values: a bad/missing kind string is treated as
+    *not system* (i.e. content-like) so a corrupt row stays visible on
+    browse surfaces rather than being silently muted. An ``UnknownVaultKind``
+    warning is emitted so the issue surfaces in logs. The DB CHECK and the
+    ``CreateVaultRequest`` Pydantic validator are the load-bearing guards
+    in practice; this branch only fires on a direct DB write or a
+    post-migration corruption.
+    """
+    value = _kind_value(kind)
+    if value not in _KNOWN_KINDS:
+        warnings.warn(
+            f'Unknown vault kind {value!r}; treating as content. '
+            'The DB CHECK + CreateVaultRequest validator should have caught this.',
+            UnknownVaultKind,
+            stacklevel=2,
+        )
+        return False
+    return value == VaultKind.SYSTEM.value
+
+
+def is_content(kind: VaultKind | str) -> bool:
+    """Whether ``kind`` classifies a vault as content (synthesis default-on)."""
+    value = _kind_value(kind)
+    if value not in _KNOWN_KINDS:
+        warnings.warn(
+            f'Unknown vault kind {value!r}; treating as content. '
+            'The DB CHECK + CreateVaultRequest validator should have caught this.',
+            UnknownVaultKind,
+            stacklevel=2,
+        )
+        return True
+    return value == VaultKind.CONTENT.value
 
 
 def reflect_enabled(kind: VaultKind | str, policy: VaultPolicy | dict | None = None) -> bool:
@@ -59,7 +109,7 @@ def reflect_enabled(kind: VaultKind | str, policy: VaultPolicy | dict | None = N
     resolved = coerce_policy(policy)
     if resolved.reflect is not None:
         return resolved.reflect
-    return _is_content(kind)
+    return is_content(kind)
 
 
 def summarize_enabled(kind: VaultKind | str, policy: VaultPolicy | dict | None = None) -> bool:
@@ -67,4 +117,12 @@ def summarize_enabled(kind: VaultKind | str, policy: VaultPolicy | dict | None =
     resolved = coerce_policy(policy)
     if resolved.summarize is not None:
         return resolved.summarize
-    return _is_content(kind)
+    return is_content(kind)
+
+
+class UnknownVaultKind(UserWarning):
+    """Raised (via warnings.warn) when a kind string is not in VaultKind.
+
+    The default behaviour is fail-open (treat as content); this warning
+    exists so a corrupt row surfaces in logs without crashing the call.
+    """

--- a/packages/common/src/memex_common/vault_utils.py
+++ b/packages/common/src/memex_common/vault_utils.py
@@ -22,3 +22,50 @@ def resolve_vault_list(
     if vault_id and vault_id not in ids:
         ids.append(vault_id)
     return ids or None
+
+
+def expand_vault_scope(
+    named_ids: list[UUID],
+    content_vault_ids: list[UUID],
+    system_vault_ids: list[UUID],
+    *,
+    has_wildcard: bool,
+    include_system_vaults: bool,
+) -> list[UUID]:
+    """Pure scope-expansion logic shared by the service and MCP resolvers.
+
+    Contract — the single source of truth for read-scope expansion:
+    - ``named_ids``: identifiers already resolved to UUIDs by the caller
+      (via ``resolve_vault_identifier`` or its API equivalent).
+    - ``content_vault_ids`` / ``system_vault_ids``: full membership lists
+      fetched by the caller (the service hits the DB; MCP queries
+      ``api.list_vaults(include_system=True)`` and partitions).
+    - ``has_wildcard``: True if the caller's identifiers contained ``*``.
+    - ``include_system_vaults``: per-call opt-in. **Unconditional union:**
+      when True, every system vault is added regardless of whether the
+      caller used ``*`` or named specific vaults.
+
+    Returns a deduplicated, order-preserving list of UUIDs. The caller
+    is responsible for raising ``VaultNotFoundError`` for unresolvable
+    named identifiers — this helper does not validate membership.
+    """
+    ids: list[UUID] = []
+    seen: set[UUID] = set()
+
+    def _add(uid: UUID) -> None:
+        if uid not in seen:
+            seen.add(uid)
+            ids.append(uid)
+
+    for uid in named_ids:
+        _add(uid)
+
+    if has_wildcard or not named_ids:
+        for uid in content_vault_ids:
+            _add(uid)
+
+    if include_system_vaults:
+        for uid in system_vault_ids:
+            _add(uid)
+
+    return ids

--- a/packages/common/tests/test_schemas.py
+++ b/packages/common/tests/test_schemas.py
@@ -289,3 +289,60 @@ def test_create_vault_request_kind_validator_rejects_unknown():
     # can act on it without chasing a stack trace.
     assert 'kind' in str(exc_info.value)
     assert 'archive' in str(exc_info.value)
+
+
+def test_create_vault_request_policy_validator_accepts_known_keys():
+    """Round-3 review (H1): CreateVaultRequest must accept a policy blob
+    that the underlying VaultPolicy accepts, including empty dict and
+    the known toggle fields."""
+    from memex_common.schemas import CreateVaultRequest
+
+    assert CreateVaultRequest(name='x', policy=None).policy is None
+    assert CreateVaultRequest(name='x', policy={}).policy == {}
+    assert CreateVaultRequest(name='x', policy={'reflect': False}).policy == {'reflect': False}
+    assert CreateVaultRequest(name='x', policy={'summarize': True}).policy == {'summarize': True}
+    # Both toggles together are valid.
+    req = CreateVaultRequest(name='x', policy={'reflect': True, 'summarize': False})
+    assert req.policy == {'reflect': True, 'summarize': False}
+
+
+def test_create_vault_request_policy_validator_rejects_unknown_keys():
+    """Unknown policy keys must surface as 422 at the API boundary, NOT
+    propagate to a 500 from VaultService.coerce_policy's deeper
+    pydantic.ValidationError. Regression: prior to the validator the
+    service layer was the only guard, so the HTTP response code was
+    500 IntegrityError-shaped for what is genuinely a client error.
+    """
+    import pytest
+    from pydantic import ValidationError
+    from memex_common.schemas import CreateVaultRequest
+
+    with pytest.raises(ValidationError) as exc_info:
+        CreateVaultRequest(name='x', policy={'unknown_key': True})
+    assert 'policy' in str(exc_info.value) or 'extra' in str(exc_info.value)
+
+
+def test_create_vault_request_policy_validator_coerces_through_pydantic():
+    """The validator delegates to ``VaultPolicy.model_validate`` for
+    rejection, but returns the raw dict so the service layer can call
+    ``coerce_policy`` once and reuse the typed result. Verify the
+    round-trip contract: a known shape is accepted and the raw dict
+    passes through; an unrepresentable shape raises ValidationError
+    BEFORE the service layer ever sees it (so the HTTP response is
+    422, not 500)."""
+    import pytest
+    from pydantic import ValidationError
+    from memex_common.schemas import CreateVaultRequest
+
+    # Accepts and passes through unchanged.
+    assert CreateVaultRequest(name='x', policy={'reflect': True}).policy == {'reflect': True}
+    # Pydantic's lax-mode coercion of int/str is *internal* — the
+    # validator doesn't surface the coerced policy; it returns the
+    # raw dict for downstream typed re-coercion. We assert that the
+    # call DOES NOT raise, which is the load-bearing contract: the
+    # service layer is no longer the first line of defense.
+    CreateVaultRequest(name='x', policy={'reflect': 1})  # no raise
+    CreateVaultRequest(name='x', policy={'reflect': 'false'})  # no raise
+    # Truly unrepresentable: a nested dict is not bool-coercible.
+    with pytest.raises(ValidationError):
+        CreateVaultRequest(name='x', policy={'reflect': {'nested': 'obj'}})

--- a/packages/common/tests/test_schemas.py
+++ b/packages/common/tests/test_schemas.py
@@ -265,3 +265,27 @@ class TestSectionAssetAndNodeDTO:
         )
         assert toc.assets[0].path == 'p.png'
         assert TOCNodeDTO(id='x', title='y', level=1).assets == []
+
+
+def test_create_vault_request_kind_validator_accepts_known_values():
+    """CreateVaultRequest must accept both 'content' and 'system' kinds."""
+    from memex_common.schemas import CreateVaultRequest
+
+    assert CreateVaultRequest(name='x').kind == 'content'
+    assert CreateVaultRequest(name='x', kind='system').kind == 'system'
+    assert CreateVaultRequest(name='x', kind='content').kind == 'content'
+
+
+def test_create_vault_request_kind_validator_rejects_unknown():
+    """Unknown kind values must raise ValidationError (422 at the API layer),
+    not propagate to a 500 IntegrityError at the DB layer."""
+    import pytest
+    from pydantic import ValidationError
+    from memex_common.schemas import CreateVaultRequest
+
+    with pytest.raises(ValidationError) as exc_info:
+        CreateVaultRequest(name='x', kind='archive')
+    # The error mentions the field and the bad value so the operator
+    # can act on it without chasing a stack trace.
+    assert 'kind' in str(exc_info.value)
+    assert 'archive' in str(exc_info.value)

--- a/packages/common/tests/test_schemas.py
+++ b/packages/common/tests/test_schemas.py
@@ -323,26 +323,37 @@ def test_create_vault_request_policy_validator_rejects_unknown_keys():
 
 
 def test_create_vault_request_policy_validator_coerces_through_pydantic():
-    """The validator delegates to ``VaultPolicy.model_validate`` for
-    rejection, but returns the raw dict so the service layer can call
-    ``coerce_policy`` once and reuse the typed result. Verify the
-    round-trip contract: a known shape is accepted and the raw dict
-    passes through; an unrepresentable shape raises ValidationError
-    BEFORE the service layer ever sees it (so the HTTP response is
-    422, not 500)."""
+    """The validator delegates to ``VaultPolicy.model_validate`` and
+    returns the *normalized* dict (canonical bools, ``None`` fields
+    stripped via ``exclude_none``) so any code reading
+    ``request.policy`` between the API boundary and the service call
+    sees coerced types — not pydantic's lax-mode-coerced internals.
+
+    Round-4 review (M): the prior version returned the raw input dict,
+    which let ``{'reflect': 1}`` and ``{'reflect': 'false'}`` survive
+    into downstream consumers. The normalized form is the contract
+    this test pins.
+    """
     import pytest
     from pydantic import ValidationError
     from memex_common.schemas import CreateVaultRequest
 
-    # Accepts and passes through unchanged.
+    # Canonical bools round-trip unchanged.
     assert CreateVaultRequest(name='x', policy={'reflect': True}).policy == {'reflect': True}
-    # Pydantic's lax-mode coercion of int/str is *internal* — the
-    # validator doesn't surface the coerced policy; it returns the
-    # raw dict for downstream typed re-coercion. We assert that the
-    # call DOES NOT raise, which is the load-bearing contract: the
-    # service layer is no longer the first line of defense.
-    CreateVaultRequest(name='x', policy={'reflect': 1})  # no raise
-    CreateVaultRequest(name='x', policy={'reflect': 'false'})  # no raise
-    # Truly unrepresentable: a nested dict is not bool-coercible.
-    with pytest.raises(ValidationError):
+    assert CreateVaultRequest(name='x', policy={'reflect': False}).policy == {'reflect': False}
+    # Lax-mode coercion is normalized to canonical bools.
+    assert CreateVaultRequest(name='x', policy={'reflect': 1}).policy == {'reflect': True}
+    # pydantic v2's smart string coercion (NOT Python bool()) — 'false'
+    # becomes False, then we surface the canonical form.
+    assert CreateVaultRequest(name='x', policy={'reflect': 'false'}).policy == {'reflect': False}
+    # None fields are dropped (exclude_none): the service layer
+    # reconstructs VaultPolicy(reflect=None) from an empty dict the
+    # same way as from no key at all.
+    req = CreateVaultRequest(name='x', policy={'reflect': None})
+    assert req.policy == {}
+    # Truly unrepresentable: a nested dict is not bool-coercible and
+    # the validator surfaces a 422 with the offending field named in
+    # the error so an operator can act on it without a stack trace.
+    with pytest.raises(ValidationError) as exc_info:
         CreateVaultRequest(name='x', policy={'reflect': {'nested': 'obj'}})
+    assert 'reflect' in str(exc_info.value)

--- a/packages/common/tests/test_vault_policy.py
+++ b/packages/common/tests/test_vault_policy.py
@@ -1,0 +1,70 @@
+"""Unit tests for vault kind + synthesis policy helpers."""
+
+import pytest
+from pydantic import ValidationError
+
+from memex_common.vault_policy import (
+    VaultKind,
+    VaultPolicy,
+    coerce_policy,
+    is_system,
+    reflect_enabled,
+    summarize_enabled,
+)
+
+
+class TestKindDefaults:
+    def test_content_defaults_both_on(self):
+        assert reflect_enabled(VaultKind.CONTENT) is True
+        assert summarize_enabled(VaultKind.CONTENT) is True
+        assert is_system(VaultKind.CONTENT) is False
+
+    def test_system_defaults_both_off(self):
+        assert reflect_enabled(VaultKind.SYSTEM) is False
+        assert summarize_enabled(VaultKind.SYSTEM) is False
+        assert is_system(VaultKind.SYSTEM) is True
+
+    def test_string_kind_accepted(self):
+        assert reflect_enabled('content') is True
+        assert reflect_enabled('system') is False
+        assert is_system('system') is True
+
+
+class TestPolicyOverride:
+    def test_override_reflect_on_system(self):
+        assert reflect_enabled('system', {'reflect': True}) is True
+        # summarize still defaults off
+        assert summarize_enabled('system', {'reflect': True}) is False
+
+    def test_override_summarize_off_on_content(self):
+        assert summarize_enabled('content', {'summarize': False}) is False
+        assert reflect_enabled('content', {'summarize': False}) is True
+
+    def test_missing_key_falls_back_to_kind(self):
+        assert reflect_enabled('content', {}) is True
+        assert reflect_enabled('system', {}) is False
+
+    def test_vault_policy_instance_accepted(self):
+        assert reflect_enabled('system', VaultPolicy(reflect=True)) is True
+
+
+class TestPolicyValidation:
+    def test_unknown_key_rejected(self):
+        with pytest.raises(ValidationError):
+            VaultPolicy.model_validate({'reflct': True})
+
+    def test_bool_string_coerced_not_truthy(self):
+        # The typed model routes through pydantic; 'false' maps to False,
+        # NOT bool('false')==True (the raw footgun this guards against).
+        assert VaultPolicy.model_validate({'reflect': 'false'}).reflect is False
+
+    def test_non_bool_rejected(self):
+        with pytest.raises(ValidationError):
+            VaultPolicy.model_validate({'reflect': 'maybe'})
+
+    def test_coerce_none(self):
+        assert coerce_policy(None) == VaultPolicy()
+
+    def test_coerce_bad_type(self):
+        with pytest.raises(TypeError):
+            coerce_policy(42)  # type: ignore[arg-type]

--- a/packages/common/tests/test_vault_policy.py
+++ b/packages/common/tests/test_vault_policy.py
@@ -6,7 +6,9 @@ from pydantic import ValidationError
 from memex_common.vault_policy import (
     VaultKind,
     VaultPolicy,
+    UnknownVaultKind,
     coerce_policy,
+    is_content,
     is_system,
     reflect_enabled,
     summarize_enabled,
@@ -68,3 +70,48 @@ class TestPolicyValidation:
     def test_coerce_bad_type(self):
         with pytest.raises(TypeError):
             coerce_policy(42)  # type: ignore[arg-type]
+
+
+class TestUnknownKindFailOpen:
+    """Round-3 review (M): an unrecognised kind string must NOT silently
+    suppress synthesis. We treat it as content (fail-open) so a corrupt
+    row stays visible on browse surfaces, and emit a warning so the
+    issue surfaces in logs. The DB CHECK + the CreateVaultRequest
+    validator are the load-bearing guards in normal operation."""
+
+    def test_is_system_treats_unknown_as_not_system(self):
+        with pytest.warns(UnknownVaultKind):
+            assert is_system('syste') is False
+        with pytest.warns(UnknownVaultKind):
+            assert is_system('archive') is False
+        with pytest.warns(UnknownVaultKind):
+            assert is_system('') is False
+
+    def test_is_content_treats_unknown_as_content(self):
+        with pytest.warns(UnknownVaultKind):
+            assert is_content('syste') is True
+        with pytest.warns(UnknownVaultKind):
+            assert is_content('archive') is True
+        with pytest.warns(UnknownVaultKind):
+            assert is_content('') is True
+
+    def test_reflect_enabled_unknown_kind_defaults_on(self):
+        # Fail-open means synthesis stays on for unknown kinds; a typo
+        # in the DB must NOT silently mute reflection for that vault.
+        with pytest.warns(UnknownVaultKind):
+            assert reflect_enabled('syste') is True
+
+    def test_summarize_enabled_unknown_kind_defaults_on(self):
+        with pytest.warns(UnknownVaultKind):
+            assert summarize_enabled('syste') is True
+
+    def test_known_kinds_do_not_warn(self):
+        # Sanity: the warning is reserved for the unknown branch.
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', UnknownVaultKind)
+            assert is_system('content') is False
+            assert is_system('system') is True
+            assert is_content('content') is True
+            assert is_content('system') is False

--- a/packages/common/tests/test_vault_utils_expand_scope.py
+++ b/packages/common/tests/test_vault_utils_expand_scope.py
@@ -1,0 +1,98 @@
+"""Unit tests for ``memex_common.vault_utils.expand_vault_scope``.
+
+Single source of truth for read-scope expansion. Both the service-layer
+``VaultService.resolve_vault_scope`` and the MCP ``_resolve_vault_ids``
+delegate to this helper, so the cases here are the cases both
+implementations must satisfy.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from memex_common.vault_utils import expand_vault_scope
+
+C1, C2 = uuid4(), uuid4()
+S1, S2 = uuid4(), uuid4()
+N1 = uuid4()
+
+
+@pytest.mark.parametrize(
+    'named,content,system,has_wildcard,include_sys,expected',
+    [
+        # Wildcard → all content
+        ([], [C1, C2], [S1, S2], True, False, [C1, C2]),
+        # Empty named + wildcard flag → all content
+        ([], [C1, C2], [S1, S2], True, False, [C1, C2]),
+        # Default scope (no named, no wildcard) → all content
+        ([], [C1, C2], [S1, S2], False, False, [C1, C2]),
+        # Named only → just named (no expansion)
+        ([N1], [C1, C2], [S1, S2], False, False, [N1]),
+        # Named + system opt-in → unconditional union of system
+        ([N1], [C1, C2], [S1, S2], False, True, [N1, S1, S2]),
+        # Wildcard + system opt-in → all content + all system
+        ([], [C1, C2], [S1, S2], True, True, [C1, C2, S1, S2]),
+        # Named + wildcard + system → all three sets, dedup
+        ([N1], [C1, C2], [S1, S2], True, True, [N1, C1, C2, S1, S2]),
+        # Dedup across named and content (rare but legal)
+        # Note: when named_ids is non-empty AND has_wildcard=False, the
+        # content branch is skipped, so [C1] (just the named) is the
+        # result, not [C1, C2]. The named+wildcard case is what
+        # triggers content expansion.
+        ([C1], [C1, C2], [], False, False, [C1]),
+    ],
+)
+def test_expand_vault_scope(named, content, system, has_wildcard, include_sys, expected):
+    result = expand_vault_scope(
+        named,
+        content,
+        system,
+        has_wildcard=has_wildcard,
+        include_system_vaults=include_sys,
+    )
+    assert result == expected
+
+
+def test_expand_vault_scope_order_preserved():
+    """Named ids come first, then content (in input order), then system.
+
+    Note: content is only added when has_wildcard OR named is empty.
+    With one named id and no wildcard, content is skipped.
+    """
+    # No named, wildcard → content + (system if opt-in)
+    result = expand_vault_scope(
+        [],
+        [C1, C2],
+        [S1, S2],
+        has_wildcard=True,
+        include_system_vaults=True,
+    )
+    assert result == [C1, C2, S1, S2]
+
+    # Named only + system opt-in: named first, then system
+    result = expand_vault_scope(
+        [N1],
+        [C1, C2],
+        [S1, S2],
+        has_wildcard=False,
+        include_system_vaults=True,
+    )
+    assert result == [N1, S1, S2]
+
+    # Wildcard + named: dedup keeps first occurrence
+    result = expand_vault_scope(
+        [N1],
+        [C1, C2],
+        [S1, S2],
+        has_wildcard=True,
+        include_system_vaults=True,
+    )
+    assert result == [N1, C1, C2, S1, S2]
+
+
+def test_expand_vault_scope_empty_everything():
+    """No named, no content, no system → empty list (not an error)."""
+    result = expand_vault_scope([], [], [], has_wildcard=False, include_system_vaults=False)
+    assert result == []

--- a/packages/core/src/memex_core/alembic/versions/060_vault_kind_policy.py
+++ b/packages/core/src/memex_core/alembic/versions/060_vault_kind_policy.py
@@ -1,0 +1,113 @@
+"""kind + policy columns on vaults (content vs system vaults).
+
+Adds ``kind TEXT NOT NULL DEFAULT 'content' CHECK (kind IN ('content','system'))``
+and ``policy JSONB NOT NULL DEFAULT '{}'`` to ``vaults``. Default ``content`` —
+no behaviour change for existing vaults. One-shot: marks an existing ``inbox``
+vault as ``system`` and archives its now-stale synthesis (mental models +
+vault summary), since system vaults are not reflected/summarized by default.
+
+Revision ID: 060_vault_kind_policy
+Revises: 059_drop_inbox_router
+Create Date: 2026-06-08
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = '060_vault_kind_policy'
+down_revision: str | None = '059_drop_inbox_router'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_KIND_CHECK = 'vaults_kind_check'
+_INBOX_NAME = 'inbox'
+
+
+def _column_exists(conn, table: str, column: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            'SELECT EXISTS ('
+            '  SELECT 1 FROM information_schema.columns'
+            '  WHERE table_schema = current_schema()'
+            '    AND table_name = :table AND column_name = :column'
+            ')'
+        ),
+        {'table': table, 'column': column},
+    )
+    return bool(result.scalar())
+
+
+def _constraint_exists(conn, name: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            'SELECT EXISTS ('
+            '  SELECT 1 FROM information_schema.table_constraints'
+            '  WHERE table_schema = current_schema()'
+            '    AND constraint_name = :name'
+            ')'
+        ),
+        {'name': name},
+    )
+    return bool(result.scalar())
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if not _column_exists(conn, 'vaults', 'kind'):
+        op.add_column(
+            'vaults',
+            sa.Column('kind', sa.Text(), nullable=False, server_default='content'),
+        )
+
+    if not _column_exists(conn, 'vaults', 'policy'):
+        op.add_column(
+            'vaults',
+            sa.Column(
+                'policy',
+                postgresql.JSONB(),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+        )
+
+    if not _constraint_exists(conn, _KIND_CHECK):
+        op.create_check_constraint(
+            _KIND_CHECK,
+            'vaults',
+            "kind IN ('content', 'system')",
+        )
+
+    # One-shot: a pre-existing inbox vault becomes system; its prior synthesis is
+    # now stale (system vaults are not reflected/summarized by default).
+    inbox_id = conn.execute(
+        sa.text('SELECT id FROM vaults WHERE name = :name'), {'name': _INBOX_NAME}
+    ).scalar()
+    if inbox_id is not None:
+        conn.execute(sa.text("UPDATE vaults SET kind = 'system' WHERE id = :id"), {'id': inbox_id})
+        conn.execute(
+            sa.text(
+                'UPDATE mental_models SET archived_at = now() '
+                'WHERE vault_id = :id AND archived_at IS NULL'
+            ),
+            {'id': inbox_id},
+        )
+        conn.execute(sa.text('DELETE FROM vault_summaries WHERE vault_id = :id'), {'id': inbox_id})
+
+
+def downgrade() -> None:
+    # Note: the inbox-synthesis archival is not reversed (archived mental models
+    # stay archived; the deleted vault summary regenerates on the next sweep).
+    conn = op.get_bind()
+
+    if _constraint_exists(conn, _KIND_CHECK):
+        op.drop_constraint(_KIND_CHECK, 'vaults', type_='check')
+
+    if _column_exists(conn, 'vaults', 'policy'):
+        op.drop_column('vaults', 'policy')
+
+    if _column_exists(conn, 'vaults', 'kind'):
+        op.drop_column('vaults', 'kind')

--- a/packages/core/src/memex_core/alembic/versions/060_vault_kind_policy.py
+++ b/packages/core/src/memex_core/alembic/versions/060_vault_kind_policy.py
@@ -9,7 +9,23 @@ vault summary), since system vaults are not reflected/summarized by default.
 Revision ID: 060_vault_kind_policy
 Revises: 059_drop_inbox_router
 Create Date: 2026-06-08
+
+**Downgrade is lossy.** Running ``alembic downgrade -1`` will:
+  1. drop the ``kind`` / ``policy`` columns (no data recovery needed — the
+     values were defaults + the inbox→system flip);
+  2. leave the inbox vault's mental models archived (``archived_at`` stays
+     set);
+  3. leave the inbox vault's summary row deleted (it regenerates on the
+     next periodic sweep).
+
+A downgrade + re-upgrade therefore leaves the inbox in a different
+synthesis state than the original. If you need to roll back without
+losing inbox synthesis, restore the mental-models / vault-summary rows
+from a backup *before* downgrading. A runtime warning is emitted on
+downgrade when inbox rows are still affected.
 """
+
+import warnings
 
 from collections.abc import Sequence
 
@@ -24,6 +40,16 @@ depends_on: str | Sequence[str] | None = None
 
 _KIND_CHECK = 'vaults_kind_check'
 _INBOX_NAME = 'inbox'
+
+
+class _InboxSynthesisLossyDowngrade(UserWarning):
+    """Downgrading 060_vault_kind_policy leaves the inbox in a partial state.
+
+    See module docstring for the data affected. Operators who need the
+    inbox synthesis fully restored should restore from backup before
+    running the downgrade, or skip the downgrade and write a forward
+    fix instead.
+    """
 
 
 def _column_exists(conn, table: str, column: str) -> bool:
@@ -99,9 +125,28 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Note: the inbox-synthesis archival is not reversed (archived mental models
-    # stay archived; the deleted vault summary regenerates on the next sweep).
+    # See module docstring — downgrade is lossy for inbox synthesis.
     conn = op.get_bind()
+
+    inbox_id = conn.execute(
+        sa.text('SELECT id FROM vaults WHERE name = :name'), {'name': _INBOX_NAME}
+    ).scalar()
+    if inbox_id is not None:
+        affected_models = conn.execute(
+            sa.text(
+                'SELECT COUNT(*) FROM mental_models '
+                'WHERE vault_id = :id AND archived_at IS NOT NULL'
+            ),
+            {'id': inbox_id},
+        ).scalar()
+        if affected_models:
+            warnings.warn(
+                f'inbox vault has {affected_models} archived mental model(s) '
+                'left over from the 060 upgrade; downgrade does NOT un-archive '
+                'them. Restore from backup if you need them back.',
+                _InboxSynthesisLossyDowngrade,
+                stacklevel=2,
+            )
 
     if _constraint_exists(conn, _KIND_CHECK):
         op.drop_constraint(_KIND_CHECK, 'vaults', type_='check')

--- a/packages/core/src/memex_core/api.py
+++ b/packages/core/src/memex_core/api.py
@@ -33,6 +33,7 @@ from memex_common.schemas import (
     SurveyResponse,
     UnitHistoryNodeDTO,
 )
+from memex_common.vault_policy import VaultKind, VaultPolicy
 from memex_core.config import MemexConfig, GLOBAL_VAULT_ID
 from memex_core.models import NoteMetadata
 from memex_core.storage import (
@@ -1605,6 +1606,7 @@ class MemexAPI:
         intent_class: str | None = None,
         risk_class: str | None = None,
         apply_pre_filter: bool = True,
+        include_system_vaults: bool = False,
     ) -> tuple[list[MemoryUnit], Any]:
         """Search with reranking. Delegates to SearchService.
 
@@ -1637,6 +1639,7 @@ class MemexAPI:
             intent_class=intent_class,
             risk_class=risk_class,
             apply_pre_filter=apply_pre_filter,
+            include_system_vaults=include_system_vaults,
         )
 
     async def summarize_search_results(self, query: str, texts: list[str]) -> str:
@@ -1659,6 +1662,7 @@ class MemexAPI:
         before: datetime | None = None,
         tags: list[str] | None = None,
         reference_date: datetime | None = None,
+        include_system_vaults: bool = False,
     ) -> list[NoteSearchResult]:
         """Search notes. Delegates to SearchService."""
         return await self._search.search_notes(
@@ -1676,6 +1680,7 @@ class MemexAPI:
             before=before,
             tags=tags,
             reference_date=reference_date,
+            include_system_vaults=include_system_vaults,
         )
 
     async def resolve_source_notes(self, unit_ids: list[UUID]) -> dict[UUID, UUID]:
@@ -1691,20 +1696,18 @@ class MemexAPI:
         after: datetime | None = None,
         before: datetime | None = None,
         reference_date: datetime | None = None,
+        include_system_vaults: bool = False,
     ) -> SurveyResponse:
-        """Broad topic survey. Delegates to SearchService."""
-        # Resolve vault identifiers to UUIDs
+        """Broad topic survey. Delegates to SearchService.
+
+        A wildcard ``'*'`` expands to content vaults only; system vaults join
+        only when named explicitly or via ``include_system_vaults``.
+        """
         resolved: list[UUID] | None = None
         if vault_ids:
-            from memex_common.vault_utils import ALL_VAULTS_WILDCARD
-
-            if ALL_VAULTS_WILDCARD in [str(v) for v in vault_ids]:
-                all_v = await self.list_vaults()
-                resolved = [v.id for v in all_v]
-            else:
-                resolved = []
-                for v in vault_ids:
-                    resolved.append(await self.resolve_vault_identifier(str(v)))
+            resolved = await self.resolve_vault_scope(
+                vault_ids, include_system_vaults=include_system_vaults
+            )
 
         return await self._search.survey(
             query=query,
@@ -1809,9 +1812,15 @@ class MemexAPI:
         async with self.metastore.session() as owned:
             return await _run(owned, commit=True)
 
-    async def create_vault(self, name: str, description: str | None = None) -> Any:
+    async def create_vault(
+        self,
+        name: str,
+        description: str | None = None,
+        kind: 'VaultKind | str' = 'content',
+        policy: 'VaultPolicy | dict | None' = None,
+    ) -> Any:
         """Create a new vault. Delegates to VaultService."""
-        return await self._vaults.create_vault(name, description)
+        return await self._vaults.create_vault(name, description, kind=kind, policy=policy)
 
     async def delete_vault(self, vault_id: UUID) -> bool:
         """Delete a vault. Delegates to VaultService."""
@@ -2011,13 +2020,23 @@ class MemexAPI:
         """Delete a mental model. Delegates to EntityService."""
         return await self._entities.delete_mental_model(entity_id, vault_id)
 
-    async def list_vaults(self) -> list[Any]:
-        """List all vaults. Delegates to VaultService."""
-        return await self._vaults.list_vaults()
+    async def list_vaults(self, include_system: bool = True) -> list[Any]:
+        """List vaults. Delegates to VaultService."""
+        return await self._vaults.list_vaults(include_system=include_system)
 
-    async def list_vaults_with_counts(self) -> list[dict[str, Any]]:
-        """List all vaults with note counts. Delegates to VaultService."""
-        return await self._vaults.list_vaults_with_counts()
+    async def list_vaults_with_counts(self, include_system: bool = True) -> list[dict[str, Any]]:
+        """List vaults with note counts. Delegates to VaultService."""
+        return await self._vaults.list_vaults_with_counts(include_system=include_system)
+
+    async def resolve_vault_scope(
+        self,
+        identifiers: list[UUID | str] | None,
+        include_system_vaults: bool = False,
+    ) -> list[UUID]:
+        """Resolve a read-scope request to concrete vault ids. Delegates to VaultService."""
+        return await self._vaults.resolve_vault_scope(
+            identifiers, include_system_vaults=include_system_vaults
+        )
 
     async def get_vault_by_name(self, name: str) -> Any | None:
         """Get a vault by name. Delegates to VaultService."""

--- a/packages/core/src/memex_core/memory/reflect/queue_service.py
+++ b/packages/core/src/memex_core/memory/reflect/queue_service.py
@@ -8,9 +8,13 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlmodel import select, col, desc
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from memex_core.memory.sql_models import Entity, ReflectionQueue, ReflectionStatus
+from memex_common.vault_policy import reflect_enabled
+from memex_core.memory.sql_models import Entity, ReflectionQueue, ReflectionStatus, Vault
 from memex_core.config import ReflectionConfig, GLOBAL_VAULT_ID
-from memex_core.metrics import REFLECTION_QUEUE_PRIORITY_LANE_ENQUEUED_TOTAL
+from memex_core.metrics import (
+    REFLECTION_ENQUEUE_SKIPPED_TOTAL,
+    REFLECTION_QUEUE_PRIORITY_LANE_ENQUEUED_TOTAL,
+)
 
 logger = logging.getLogger('memex.core.memory.reflect.queue_service')
 
@@ -167,10 +171,26 @@ class ReflectionQueueService:
 
         await session.flush()
 
+    async def _reflect_enabled_for_vault(self, session: AsyncSession, vault_id: UUID) -> bool:
+        """Whether reflection should be queued for this vault (kind+policy).
+
+        System vaults default reflection off, so their notes never enter the
+        reflection queue — keeping it from filling with work that would only be
+        discarded. Unknown vaults default to enabled (fail open).
+        """
+        vault = await session.get(Vault, vault_id)
+        if not isinstance(vault, Vault):
+            # Unknown / not loaded → fail open (reflect). Real vaults are checked.
+            return True
+        return reflect_enabled(vault.kind, vault.policy)
+
     async def _ensure_queue_items(
         self, session: AsyncSession, entity_ids: set[UUID], vault_id: UUID
     ):
         if not entity_ids:
+            return
+        if not await self._reflect_enabled_for_vault(session, vault_id):
+            REFLECTION_ENQUEUE_SKIPPED_TOTAL.labels(reason='vault_policy').inc()
             return
 
         stmt = (
@@ -382,6 +402,9 @@ class ReflectionQueueService:
         sensitive integer-literal coercion.
         """
         if not entity_ids:
+            return 0
+        if not await self._reflect_enabled_for_vault(session, vault_id):
+            REFLECTION_ENQUEUE_SKIPPED_TOTAL.labels(reason='vault_policy').inc()
             return 0
 
         rows = [

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -71,7 +71,7 @@ class Vault(SQLModel, table=True):  # type: ignore
         default=VaultKind.CONTENT,
         sa_column=Column(Text, nullable=False, server_default='content'),
     )
-    policy: dict = Field(
+    policy: dict[str, Any] = Field(
         default_factory=dict,
         sa_column=Column(JSONB, nullable=False, server_default=sql_text("'{}'::jsonb")),
     )

--- a/packages/core/src/memex_core/memory/sql_models.py
+++ b/packages/core/src/memex_core/memory/sql_models.py
@@ -29,6 +29,7 @@ from memex_core.context import get_session_id
 from memex_core.memory.mixins import vault_id_field, created_at_field, updated_at_field
 
 from memex_common.schemas import MemoryUnitBase, FactTypes
+from memex_common.vault_policy import VaultKind
 
 EMBEDDING_DIMENSION = 384
 
@@ -66,6 +67,14 @@ class Vault(SQLModel, table=True):  # type: ignore
         default=MWMode.STATIONARY,
         sa_column=Column(Text, nullable=False, server_default='stationary'),
     )
+    kind: VaultKind = Field(
+        default=VaultKind.CONTENT,
+        sa_column=Column(Text, nullable=False, server_default='content'),
+    )
+    policy: dict = Field(
+        default_factory=dict,
+        sa_column=Column(JSONB, nullable=False, server_default=sql_text("'{}'::jsonb")),
+    )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         sa_column=Column(TIMESTAMP(timezone=True), server_default=func.now()),
@@ -76,6 +85,10 @@ class Vault(SQLModel, table=True):  # type: ignore
         CheckConstraint(
             "mw_mode IN ('stationary', 'ema')",
             name='vaults_mw_mode_check',
+        ),
+        CheckConstraint(
+            "kind IN ('content', 'system')",
+            name='vaults_kind_check',
         ),
     )
 

--- a/packages/core/src/memex_core/metrics.py
+++ b/packages/core/src/memex_core/metrics.py
@@ -94,6 +94,18 @@ REFRESH_OBSERVATION_TASK_ZERO_EVIDENCE_TOTAL = Counter(
     'Refresh tasks that dropped the observation because no surviving evidence remained.',
 )
 
+REFLECTION_ENQUEUE_SKIPPED_TOTAL = Counter(
+    'memex_reflection_enqueue_skipped_total',
+    'Reflection enqueues skipped because the vault disables reflection (kind/policy).',
+    ['reason'],
+)
+
+VAULT_SUMMARY_SKIPPED_TOTAL = Counter(
+    'memex_vault_summary_skipped_total',
+    'Vault-summary generations skipped because the vault disables summarization.',
+    ['reason'],
+)
+
 REFRESH_OBSERVATION_TASK_OBS_ALREADY_PRUNED_TOTAL = Counter(
     'memex_refresh_observation_task_obs_already_pruned_total',
     'Refresh tasks idempotently acked because the observation row was already gone by claim time.',

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -215,8 +215,17 @@ async def periodic_vault_summary_task(api: 'MemexAPI'):
     async with background_session('bg-sched-vault-summary'):
         logger.info('Scheduler: Running vault summary check...')
         try:
+            from memex_common.vault_policy import summarize_enabled
+
+            from memex_core.memory.sql_models import Vault
+            from memex_core.metrics import VAULT_SUMMARY_SKIPPED_TOTAL
+
             vaults = await api.list_vaults()
             for vault in vaults:
+                if isinstance(vault, Vault) and not summarize_enabled(vault.kind, vault.policy):
+                    # System vaults (or summarize-disabled vaults) get no narrative.
+                    VAULT_SUMMARY_SKIPPED_TOTAL.labels(reason='vault_policy').inc()
+                    continue
                 summary = await api.vault_summary.get_summary(vault.id)
                 if summary and summary.needs_regeneration:
                     logger.info(
@@ -243,11 +252,17 @@ async def periodic_kv_ttl_cleanup_task(api: 'MemexAPI'):
 
 
 async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
-    """Weekly UMAP manifold refresh per vault under leader lock."""
+    """Weekly UMAP manifold refresh per content vault under leader lock."""
+    from memex_core.memory.sql_models import Vault
+
     async with background_session('bg-sched-diagnostics-refresh'):
         try:
             vaults = await api.list_vaults()
             for vault in vaults:
+                # Diagnostics is a discovery artifact — skip system vaults (no
+                # manifold for hidden/transient infrastructure vaults).
+                if isinstance(vault, Vault) and vault.kind == 'system':
+                    continue
                 try:
                     await api.diagnostics.get_or_compute_manifold(vault.id, force_refresh=True)
                 except (OSError, RuntimeError, ValueError) as e:

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -220,11 +220,13 @@ async def periodic_vault_summary_task(api: 'MemexAPI'):
             from memex_core.memory.sql_models import Vault
             from memex_core.metrics import VAULT_SUMMARY_SKIPPED_TOTAL
 
-            # Periodic summary is a content-vault concern — system vaults
-            # are never summarised (their policy defaults that way and an
-            # explicit override would be the only way to opt in). Fetch
-            # content vaults directly to avoid a wasted round-trip.
-            vaults = await api.list_vaults(include_system=False)
+            # Periodic summary must include system vaults whose policy
+            # explicitly opts them in — a system vault that wants
+            # narrative over its contents is a legitimate use case (e.g. a
+            # case-vault the user wants briefed on). summarise_enabled
+            # is the single source of truth: it returns False for system
+            # vaults by default and True if the policy overrides it on.
+            vaults = await api.list_vaults(include_system=True)
             for vault in vaults:
                 if isinstance(vault, Vault) and not summarize_enabled(vault.kind, vault.policy):
                     # summarise_enabled may still be False on a content vault

--- a/packages/core/src/memex_core/scheduler.py
+++ b/packages/core/src/memex_core/scheduler.py
@@ -220,10 +220,15 @@ async def periodic_vault_summary_task(api: 'MemexAPI'):
             from memex_core.memory.sql_models import Vault
             from memex_core.metrics import VAULT_SUMMARY_SKIPPED_TOTAL
 
-            vaults = await api.list_vaults()
+            # Periodic summary is a content-vault concern — system vaults
+            # are never summarised (their policy defaults that way and an
+            # explicit override would be the only way to opt in). Fetch
+            # content vaults directly to avoid a wasted round-trip.
+            vaults = await api.list_vaults(include_system=False)
             for vault in vaults:
                 if isinstance(vault, Vault) and not summarize_enabled(vault.kind, vault.policy):
-                    # System vaults (or summarize-disabled vaults) get no narrative.
+                    # summarise_enabled may still be False on a content vault
+                    # whose policy overrides it off; honor the override.
                     VAULT_SUMMARY_SKIPPED_TOTAL.labels(reason='vault_policy').inc()
                     continue
                 summary = await api.vault_summary.get_summary(vault.id)
@@ -253,16 +258,12 @@ async def periodic_kv_ttl_cleanup_task(api: 'MemexAPI'):
 
 async def periodic_diagnostics_refresh_task(api: 'MemexAPI'):
     """Weekly UMAP manifold refresh per content vault under leader lock."""
-    from memex_core.memory.sql_models import Vault
-
     async with background_session('bg-sched-diagnostics-refresh'):
         try:
-            vaults = await api.list_vaults()
+            # Diagnostics (UMAP manifold) is a content-vault concern;
+            # system vaults have no manifold. Fetch content vaults only.
+            vaults = await api.list_vaults(include_system=False)
             for vault in vaults:
-                # Diagnostics is a discovery artifact — skip system vaults (no
-                # manifold for hidden/transient infrastructure vaults).
-                if isinstance(vault, Vault) and vault.kind == 'system':
-                    continue
                 try:
                     await api.diagnostics.get_or_compute_manifold(vault.id, force_refresh=True)
                 except (OSError, RuntimeError, ValueError) as e:

--- a/packages/core/src/memex_core/server/notes.py
+++ b/packages/core/src/memex_core/server/notes.py
@@ -180,6 +180,7 @@ async def search_notes(
             before=request.before,
             tags=request.tags,
             reference_date=request.reference_date,
+            include_system_vaults=request.include_system_vaults,
         )
         return ndjson_response(results)
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:

--- a/packages/core/src/memex_core/server/retrieval.py
+++ b/packages/core/src/memex_core/server/retrieval.py
@@ -62,6 +62,7 @@ async def search_memories(
             # exists today, but the explicit check is the safe idiom.
             intent_class=request.intent_class.value if request.intent_class is not None else None,
             risk_class=request.risk_class.value if request.risk_class is not None else None,
+            include_system_vaults=request.include_system_vaults,
         )
         t_search = time.monotonic() - t0
 

--- a/packages/core/src/memex_core/server/survey.py
+++ b/packages/core/src/memex_core/server/survey.py
@@ -34,6 +34,7 @@ async def survey(
             after=request.after,
             before=request.before,
             reference_date=request.reference_date,
+            include_system_vaults=request.include_system_vaults,
         )
         return result
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:

--- a/packages/core/src/memex_core/server/vaults.py
+++ b/packages/core/src/memex_core/server/vaults.py
@@ -86,6 +86,7 @@ async def list_vaults(
         None, description='Filter by state: "active" for active vault'
     ),
     is_default: bool | None = Query(None, description='Filter by default status'),
+    include_system: bool = Query(True, description='Include system vaults in the default listing.'),
 ):
     """
     List vaults.
@@ -93,6 +94,7 @@ async def list_vaults(
     Query params:
     - state: Optional filter by state. Use 'active' for the active vault.
     - is_default: Optional filter by default status. True for default vaults.
+    - include_system: Include system vaults in the default listing (default True).
     """
     try:
         if state == 'active':
@@ -111,6 +113,8 @@ async def list_vaults(
                         name=vault.name,
                         description=vault.description,
                         mw_mode=vault.mw_mode,
+                        kind=getattr(vault, 'kind', 'content'),
+                        policy=getattr(vault, 'policy', None) or {},
                         access=access,
                     )
                 ]
@@ -131,6 +135,8 @@ async def list_vaults(
                 name=active.name,
                 description=active.description,
                 mw_mode=active.mw_mode,
+                kind=getattr(active, 'kind', 'content'),
+                policy=getattr(active, 'policy', None) or {},
                 access=active_access,
             )
 
@@ -148,6 +154,8 @@ async def list_vaults(
                                 name=reader.name,
                                 description=reader.description,
                                 mw_mode=reader.mw_mode,
+                                kind=getattr(reader, 'kind', 'content'),
+                                policy=getattr(reader, 'policy', None) or {},
                                 access=reader_access,
                             )
                         )
@@ -162,8 +170,8 @@ async def list_vaults(
 
             return ndjson_response(dtos)
 
-        # Default: list all vaults with note counts
-        rows = await api.list_vaults_with_counts()
+        # Default: list vaults with note counts
+        rows = await api.list_vaults_with_counts(include_system=include_system)
         active_vault_id = await api.resolve_vault_identifier(api.config.server.default_active_vault)
         dtos_full: list[VaultDTO] = []
         for row in rows:
@@ -175,6 +183,8 @@ async def list_vaults(
                     name=v.name,
                     description=v.description,
                     mw_mode=v.mw_mode,
+                    kind=getattr(v, 'kind', 'content'),
+                    policy=getattr(v, 'policy', None) or {},
                     is_active=(v.id == active_vault_id),
                     note_count=row['note_count'],
                     last_note_added_at=row['last_note_added_at'],
@@ -192,9 +202,19 @@ async def create_vault(
 ):
     """Create a new vault."""
     try:
-        vault = await api.create_vault(name=request.name, description=request.description)
+        vault = await api.create_vault(
+            name=request.name,
+            description=request.description,
+            kind=request.kind,
+            policy=request.policy,
+        )
         return VaultDTO(
-            id=vault.id, name=vault.name, description=vault.description, mw_mode=vault.mw_mode
+            id=vault.id,
+            name=vault.name,
+            description=vault.description,
+            mw_mode=vault.mw_mode,
+            kind=getattr(vault, 'kind', 'content'),
+            policy=getattr(vault, 'policy', None) or {},
         )
     except (MemexError, ValueError, KeyError, RuntimeError, OSError) as e:
         raise _handle_error(e, 'Failed to create vault')
@@ -214,9 +234,9 @@ async def get_or_resolve_vault(identifier: str, api: Annotated[MemexAPI, Depends
         # Check if identifier is a valid UUID
         try:
             vault_id = UUID(identifier)
-            # It's a UUID, verify it exists
-            vaults = await api.list_vaults()
-            if any(v.id == vault_id for v in vaults):
+            # It's a UUID — verify it exists by direct lookup (resolves content
+            # AND system vaults; addressability is never filtered by kind).
+            if await api.validate_vault_exists(vault_id):
                 return {'id': vault_id}
             raise HTTPException(status_code=404, detail=f'Vault with ID {identifier} not found')
         except ValueError:

--- a/packages/core/src/memex_core/server/vaults.py
+++ b/packages/core/src/memex_core/server/vaults.py
@@ -86,7 +86,13 @@ async def list_vaults(
         None, description='Filter by state: "active" for active vault'
     ),
     is_default: bool | None = Query(None, description='Filter by default status'),
-    include_system: bool = Query(True, description='Include system vaults in the default listing.'),
+    include_system: bool = Query(
+        False,
+        description=(
+            'Include system vaults (e.g. inbox). Default False — system vaults '
+            'are silent on browse surfaces; pass ?include_system=true to opt in.'
+        ),
+    ),
 ):
     """
     List vaults.
@@ -94,7 +100,9 @@ async def list_vaults(
     Query params:
     - state: Optional filter by state. Use 'active' for the active vault.
     - is_default: Optional filter by default status. True for default vaults.
-    - include_system: Include system vaults in the default listing (default True).
+    - include_system: Include system vaults (default False). Set to true to
+      surface the inbox and other infrastructure vaults. The CLI `--include-system`
+      flag and the service layer `list_vaults(include_system=...)` default match.
     """
     try:
         if state == 'active':

--- a/packages/core/src/memex_core/server/vaults.py
+++ b/packages/core/src/memex_core/server/vaults.py
@@ -121,6 +121,11 @@ async def list_vaults(
                         name=vault.name,
                         description=vault.description,
                         mw_mode=vault.mw_mode,
+                        # Migration-compat shim: 060_vault_kind_policy adds
+                        # ``kind``/``policy`` columns. Pre-migration rows (or
+                        # stale ORM caches) may still lack the attribute; the
+                        # getattr default keeps the DTO shape intact. Safe to
+                        # drop after the migration is unavoidable (V12).
                         kind=getattr(vault, 'kind', 'content'),
                         policy=getattr(vault, 'policy', None) or {},
                         access=access,

--- a/packages/core/src/memex_core/services/entities.py
+++ b/packages/core/src/memex_core/services/entities.py
@@ -13,6 +13,7 @@ from memex_common.exceptions import EntityNotFoundError, ResourceNotFoundError
 
 from memex_core.services.audit import audit_event
 from memex_core.services.base import BaseService
+from memex_core.services.vaults import VaultService
 
 if TYPE_CHECKING:
     from memex_core.memory.sql_models import Entity
@@ -72,12 +73,12 @@ def _content_vault_id_subquery() -> Any:
 
     Used as the default scope for entity reads so system-vault edges/mentions
     don't surface or inflate counts unless a vault is named explicitly.
-    """
-    from memex_common.vault_policy import VaultKind
-    from memex_core.memory.sql_models import Vault
-    from sqlmodel import select
 
-    return select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
+    Delegates to :meth:`VaultService.content_vault_ids_subquery` so all
+    service files share one predicate. A future kind rename or filter
+    change is one diff, not 11.
+    """
+    return VaultService.content_vault_ids_subquery()
 
 
 def _membership_clause(vault_ids: list[UUID] | None, scope_ids: list[UUID]) -> Any:
@@ -222,10 +223,20 @@ class EntityService(BaseService):
         empty metadata dict. Otherwise the entity's mental models across the
         in-scope vaults are aggregated into a single profile (no single-vault
         guess); see :func:`_aggregate_mental_models`.
+
+        .. note::
+           Performance: this method now issues 2–3 queries (entities,
+           cooccurrence centrality, mental-model aggregation) where the old
+           single LEFT JOIN gave one. The split is a deliberate correctness
+           fix for multi-vault scope (the old code joined on a single
+           ``scope_vault_id`` UUID). For single-vault scope on large result
+           sets, consider a single CTE that materialises the in-scope
+           vault ids once and joins models/cooccurrences in one pass.
+           TODO(perf): add a benchmark for ``limit=100, scope=1-vault`` to
+           confirm the regression is bounded before any optimisation.
         """
         from collections import defaultdict
 
-        from memex_common.vault_policy import VaultKind
         from memex_core.memory.sql_models import (
             Entity,
             EntityCooccurrence,
@@ -240,9 +251,11 @@ class EntityService(BaseService):
             if vault_ids:
                 scope_ids = [v if isinstance(v, UUID) else UUID(str(v)) for v in vault_ids]
             else:
-                scope_q = select(Vault.id)
-                if not include_system_vaults:
-                    scope_q = scope_q.where(col(Vault.kind) != VaultKind.SYSTEM.value)
+                scope_q = (
+                    VaultService.content_vault_ids_subquery()
+                    if not include_system_vaults
+                    else select(Vault.id)
+                )
                 scope_ids = list((await session.exec(scope_q)).all())
 
             if not scope_ids:
@@ -1041,15 +1054,16 @@ class EntityService(BaseService):
         Explicit ``vault_ids`` are honoured as given (may name a system vault);
         otherwise the scope is all content vaults (plus system when opted in).
         """
-        from memex_common.vault_policy import VaultKind
         from memex_core.memory.sql_models import Vault
         from sqlmodel import select
 
         if vault_ids:
             return [v if isinstance(v, UUID) else UUID(str(v)) for v in vault_ids]
-        scope_q = select(Vault.id)
-        if not include_system_vaults:
-            scope_q = scope_q.where(col(Vault.kind) != VaultKind.SYSTEM.value)
+        scope_q = (
+            VaultService.content_vault_ids_subquery()
+            if not include_system_vaults
+            else select(Vault.id)
+        )
         return list((await session.exec(scope_q)).all())
 
     async def _aggregate_models_for(

--- a/packages/core/src/memex_core/services/entities.py
+++ b/packages/core/src/memex_core/services/entities.py
@@ -67,6 +67,81 @@ def _wrap_with_metadata(entity: Any, mental_model: Any | None) -> EntityWithMeta
     return EntityWithMetadata(entity=entity, metadata=metadata, observations=observations)
 
 
+def _content_vault_id_subquery() -> Any:
+    """A scalar subquery of content (non-system) vault ids.
+
+    Used as the default scope for entity reads so system-vault edges/mentions
+    don't surface or inflate counts unless a vault is named explicitly.
+    """
+    from memex_common.vault_policy import VaultKind
+    from memex_core.memory.sql_models import Vault
+    from sqlmodel import select
+
+    return select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
+
+
+def _membership_clause(vault_ids: list[UUID] | None, scope_ids: list[UUID]) -> Any:
+    """WHERE predicate scoping entities to in-scope vaults.
+
+    Explicit ``vault_ids`` → entity must be mentioned in one of them. Default
+    scope → keep content + orphan (un-mentioned) entities, drop system-only ones.
+    """
+    from sqlalchemy import exists
+
+    from memex_core.memory.sql_models import Entity, UnitEntity
+
+    member_in_scope = exists().where(
+        (col(UnitEntity.entity_id) == Entity.id) & col(UnitEntity.vault_id).in_(scope_ids)
+    )
+    if vault_ids:
+        return member_in_scope
+    has_any_membership = exists().where(col(UnitEntity.entity_id) == Entity.id)
+    return member_in_scope | ~has_any_membership
+
+
+def _model_observation_count(model: Any) -> int:
+    meta = model.entity_metadata or {}
+    count = meta.get('observation_count') if isinstance(meta, dict) else None
+    if isinstance(count, int):
+        return count
+    return len(model.observations or [])
+
+
+def _aggregate_mental_models(entity: Any, models: list[Any]) -> EntityWithMetadata:
+    """Aggregate an entity's per-vault mental models into one profile.
+
+    Entities are global; their descriptive content lives on vault-scoped mental
+    models. Rather than guess a single vault, aggregate over the in-scope set:
+    quantitative fields combine (``observation_count`` sums, ``vault_count``
+    counts), qualitative fields take a representative (modal ``category``;
+    ``description`` + ``observations`` from the most-evidenced model).
+    """
+    from collections import Counter
+
+    if not models:
+        return EntityWithMetadata(entity=entity, metadata={}, observations=[])
+
+    representative = max(models, key=_model_observation_count)
+    rep_meta = representative.entity_metadata or {}
+
+    categories = [
+        (m.entity_metadata or {}).get('category')
+        for m in models
+        if (m.entity_metadata or {}).get('category')
+    ]
+    metadata: dict[str, Any] = {}
+    if categories:
+        metadata['category'] = Counter(categories).most_common(1)[0][0]
+    if rep_meta.get('description'):
+        metadata['description'] = rep_meta['description']
+    metadata['observation_count'] = sum(_model_observation_count(m) for m in models)
+    metadata['vault_count'] = len(models)
+
+    return EntityWithMetadata(
+        entity=entity, metadata=metadata, observations=representative.observations or []
+    )
+
+
 def _merge_observations(
     winner_obs: list[dict[str, Any]],
     loser_obs: list[dict[str, Any]],
@@ -131,75 +206,113 @@ class EntityService(BaseService):
         vault_ids: list[UUID] | None = None,
         entity_type: str | None = None,
         slim: bool = False,
+        include_system_vaults: bool = False,
     ) -> AsyncGenerator[EntityWithMetadata, None]:
         """
         Stream entities ranked by hybrid score.
         Hybrid Score = 0.4 * mention_count + 0.4 * retrieval_count + 0.2 * centrality
 
-        When ``slim`` is True, the MentalModel outerjoin is skipped — callers
-        see an empty metadata dict (no description / observations payload).
+        Scoping: an entity appears only if it is mentioned in an in-scope vault,
+        and centrality sums cooccurrence only within scope — so system-vault
+        entities and edges never surface or inflate ranking by default. Scope is
+        the explicit ``vault_ids`` when given, else all content vaults (plus
+        system vaults when ``include_system_vaults`` is set).
+
+        When ``slim`` is True the per-vault profile is skipped — callers see an
+        empty metadata dict. Otherwise the entity's mental models across the
+        in-scope vaults are aggregated into a single profile (no single-vault
+        guess); see :func:`_aggregate_mental_models`.
         """
-        from memex_core.memory.sql_models import Entity, EntityCooccurrence, MentalModel, UnitEntity
+        from collections import defaultdict
+
+        from memex_common.vault_policy import VaultKind
+        from memex_core.memory.sql_models import (
+            Entity,
+            EntityCooccurrence,
+            MentalModel,
+            UnitEntity,
+            Vault,
+        )
+        from sqlalchemy import exists
         from sqlmodel import select, func, desc, col
 
-        scope_vault_id = vault_ids[0] if vault_ids else await self._resolve_default_vault_id()
+        async with self.metastore.session() as session:
+            if vault_ids:
+                scope_ids = [v if isinstance(v, UUID) else UUID(str(v)) for v in vault_ids]
+            else:
+                scope_q = select(Vault.id)
+                if not include_system_vaults:
+                    scope_q = scope_q.where(col(Vault.kind) != VaultKind.SYSTEM.value)
+                scope_ids = list((await session.exec(scope_q)).all())
 
-        # Subquery for centrality (sum of cooccurrence counts)
-        centrality_stmt = (
-            select(
-                func.coalesce(func.sum(EntityCooccurrence.cooccurrence_count), 0).label(
-                    'centrality'
-                ),
-                Entity.id.label('entity_id'),
-            )
-            .select_from(Entity)
-            .outerjoin(
-                EntityCooccurrence,
-                (EntityCooccurrence.entity_id_1 == Entity.id)
-                | (EntityCooccurrence.entity_id_2 == Entity.id),
-            )
-            .group_by(Entity.id)
-        ).subquery()
+            if not scope_ids:
+                return
 
-        rank_score = (
-            0.4 * Entity.mention_count
-            + 0.4 * Entity.retrieval_count
-            + 0.2 * centrality_stmt.c.centrality
-        ).label('rank_score')
+            # Centrality: cooccurrence summed within the in-scope vaults only.
+            centrality_stmt = (
+                select(
+                    func.coalesce(func.sum(EntityCooccurrence.cooccurrence_count), 0).label(
+                        'centrality'
+                    ),
+                    Entity.id.label('entity_id'),
+                )
+                .select_from(Entity)
+                .outerjoin(
+                    EntityCooccurrence,
+                    (
+                        (EntityCooccurrence.entity_id_1 == Entity.id)
+                        | (EntityCooccurrence.entity_id_2 == Entity.id)
+                    )
+                    & col(EntityCooccurrence.vault_id).in_(scope_ids),
+                )
+                .group_by(Entity.id)
+            ).subquery()
 
-        if slim:
+            rank_score = (
+                0.4 * Entity.mention_count
+                + 0.4 * Entity.retrieval_count
+                + 0.2 * centrality_stmt.c.centrality
+            ).label('rank_score')
+
             stmt = select(Entity, rank_score).join(
                 centrality_stmt, centrality_stmt.c.entity_id == Entity.id
             )
-        else:
-            stmt = (
-                select(Entity, MentalModel, rank_score)
-                .join(centrality_stmt, centrality_stmt.c.entity_id == Entity.id)
-                .outerjoin(
-                    MentalModel,
-                    (MentalModel.entity_id == Entity.id) & (MentalModel.vault_id == scope_vault_id),
+            member_in_scope = exists().where(
+                (col(UnitEntity.entity_id) == Entity.id) & col(UnitEntity.vault_id).in_(scope_ids)
+            )
+            if vault_ids:
+                # Explicit scope: entity must be mentioned in one of those vaults.
+                stmt = stmt.where(member_in_scope)
+            else:
+                # Default: keep content + orphan entities; drop system-only ones
+                # (mentioned, but in no content vault) so system entities stay silent.
+                has_any_membership = exists().where(col(UnitEntity.entity_id) == Entity.id)
+                stmt = stmt.where(member_in_scope | ~has_any_membership)
+            if entity_type:
+                stmt = stmt.where(Entity.entity_type == entity_type)
+            stmt = stmt.order_by(desc(rank_score)).limit(limit)
+
+            entities = [row[0] for row in (await session.exec(stmt)).all()]
+
+            if slim:
+                for entity in entities:
+                    yield _wrap_with_metadata(entity, None)
+                return
+
+            # Rich: aggregate each entity's in-scope mental models into a profile.
+            models_by_entity: dict[UUID, list[Any]] = defaultdict(list)
+            page_ids = [e.id for e in entities]
+            if page_ids:
+                model_stmt = select(MentalModel).where(
+                    col(MentalModel.entity_id).in_(page_ids),
+                    col(MentalModel.vault_id).in_(scope_ids),
+                    col(MentalModel.archived_at).is_(None),
                 )
-            )
+                for model in (await session.exec(model_stmt)).all():
+                    models_by_entity[model.entity_id].append(model)
 
-        if vault_ids:
-            stmt = (
-                stmt.join(UnitEntity, col(UnitEntity.entity_id) == Entity.id)
-                .where(col(UnitEntity.vault_id).in_(vault_ids))
-                .distinct()
-            )
-
-        if entity_type:
-            stmt = stmt.where(Entity.entity_type == entity_type)
-
-        stmt = stmt.order_by(desc(rank_score)).limit(limit)
-
-        async with self.metastore.session() as session:
-            stream = await session.stream(stmt)
-            async for row in stream:
-                if slim:
-                    yield _wrap_with_metadata(row[0], None)
-                else:
-                    yield _wrap_with_metadata(row[0], row[1])
+            for entity in entities:
+                yield _aggregate_mental_models(entity, models_by_entity.get(entity.id, []))
 
     async def get_entity_cooccurrences(
         self,
@@ -238,6 +351,10 @@ class EntityService(BaseService):
             )
             if vault_ids:
                 stmt = stmt.where(col(EntityCooccurrence.vault_id).in_(vault_ids))
+            else:
+                stmt = stmt.where(
+                    col(EntityCooccurrence.vault_id).in_(_content_vault_id_subquery())
+                )
             stmt = stmt.group_by(counterpart).order_by(desc(total)).limit(limit)
             rows = (await session.exec(stmt)).all()
             if not rows:
@@ -291,6 +408,10 @@ class EntityService(BaseService):
             )
             if vault_ids:
                 stmt = stmt.where(col(EntityCooccurrence.vault_id).in_(vault_ids))
+            else:
+                stmt = stmt.where(
+                    col(EntityCooccurrence.vault_id).in_(_content_vault_id_subquery())
+                )
             stmt = stmt.group_by(EntityCooccurrence.entity_id_1, EntityCooccurrence.entity_id_2)
             rows = (await session.exec(stmt)).all()
             return [
@@ -332,6 +453,8 @@ class EntityService(BaseService):
             )
             if vault_ids:
                 stmt = stmt.where(col(MemoryUnit.vault_id).in_(vault_ids))
+            else:
+                stmt = stmt.where(col(MemoryUnit.vault_id).in_(_content_vault_id_subquery()))
             if not include_stale:
                 stmt = stmt.where(col(MemoryUnit.status) == ContentStatus.ACTIVE)
             if not include_deprioritized:
@@ -910,34 +1033,70 @@ class EntityService(BaseService):
         summary['created_canonical_name'] = name
         return summary
 
+    async def _scope_vault_ids(
+        self, session: Any, vault_ids: list[UUID] | None, include_system_vaults: bool = False
+    ) -> list[UUID]:
+        """Resolve the in-scope vault id set for an entity query.
+
+        Explicit ``vault_ids`` are honoured as given (may name a system vault);
+        otherwise the scope is all content vaults (plus system when opted in).
+        """
+        from memex_common.vault_policy import VaultKind
+        from memex_core.memory.sql_models import Vault
+        from sqlmodel import select
+
+        if vault_ids:
+            return [v if isinstance(v, UUID) else UUID(str(v)) for v in vault_ids]
+        scope_q = select(Vault.id)
+        if not include_system_vaults:
+            scope_q = scope_q.where(col(Vault.kind) != VaultKind.SYSTEM.value)
+        return list((await session.exec(scope_q)).all())
+
+    async def _aggregate_models_for(
+        self, session: Any, entities: list[Any], scope_ids: list[UUID]
+    ) -> list[EntityWithMetadata]:
+        """Attach each entity's aggregated in-scope mental-model profile."""
+        from collections import defaultdict
+
+        from memex_core.memory.sql_models import MentalModel
+        from sqlmodel import select
+
+        models_by_entity: dict[UUID, list[Any]] = defaultdict(list)
+        page_ids = [e.id for e in entities]
+        if page_ids:
+            model_stmt = select(MentalModel).where(
+                col(MentalModel.entity_id).in_(page_ids),
+                col(MentalModel.vault_id).in_(scope_ids),
+                col(MentalModel.archived_at).is_(None),
+            )
+            for model in (await session.exec(model_stmt)).all():
+                models_by_entity[model.entity_id].append(model)
+        return [_aggregate_mental_models(e, models_by_entity.get(e.id, [])) for e in entities]
+
     async def get_top_entities(
         self,
         limit: int = 5,
         vault_ids: list[UUID] | None = None,
         entity_type: str | None = None,
     ) -> list[EntityWithMetadata]:
-        """Get top entities by mention count, with MentalModel metadata attached."""
-        from memex_core.memory.sql_models import Entity, MentalModel, UnitEntity
-        from sqlmodel import select, desc, col
+        """Get top entities by mention count, with aggregated MentalModel profile.
 
-        scope_vault_id = vault_ids[0] if vault_ids else await self._resolve_default_vault_id()
+        Scopes to the explicit ``vault_ids`` when given, else all content vaults
+        (system vaults are silent by default; name one to include it).
+        """
+        from memex_core.memory.sql_models import Entity
+        from sqlmodel import select, desc
 
         async with self.metastore.session() as session:
-            stmt = select(Entity, MentalModel).outerjoin(
-                MentalModel,
-                (MentalModel.entity_id == Entity.id) & (MentalModel.vault_id == scope_vault_id),
-            )
-            if vault_ids:
-                stmt = (
-                    stmt.join(UnitEntity, col(UnitEntity.entity_id) == Entity.id)
-                    .where(col(UnitEntity.vault_id).in_(vault_ids))
-                    .distinct()
-                )
+            scope_ids = await self._scope_vault_ids(session, vault_ids)
+            if not scope_ids:
+                return []
+            stmt = select(Entity).where(_membership_clause(vault_ids, scope_ids))
             if entity_type:
                 stmt = stmt.where(Entity.entity_type == entity_type)
             stmt = stmt.order_by(desc(Entity.mention_count)).limit(limit)
-            results = (await session.exec(stmt)).all()
-            return [_wrap_with_metadata(row[0], row[1]) for row in results]
+            entities = list((await session.exec(stmt)).all())
+            return await self._aggregate_models_for(session, entities, scope_ids)
 
     async def search_entities(
         self,
@@ -946,29 +1105,24 @@ class EntityService(BaseService):
         vault_ids: list[UUID] | None = None,
         entity_type: str | None = None,
     ) -> list[EntityWithMetadata]:
-        """Search for entities by canonical name using trigram similarity or ILIKE."""
-        from memex_core.memory.sql_models import Entity, MentalModel, UnitEntity
+        """Search for entities by canonical name using trigram similarity or ILIKE.
+
+        Scopes to the explicit ``vault_ids`` when given, else all content vaults.
+        """
+        from memex_core.memory.sql_models import Entity
         from sqlmodel import select, col
 
-        scope_vault_id = vault_ids[0] if vault_ids else await self._resolve_default_vault_id()
-
         async with self.metastore.session() as session:
+            scope_ids = await self._scope_vault_ids(session, vault_ids)
+            if not scope_ids:
+                return []
             stmt = (
-                select(Entity, MentalModel)
-                .outerjoin(
-                    MentalModel,
-                    (MentalModel.entity_id == Entity.id) & (MentalModel.vault_id == scope_vault_id),
-                )
+                select(Entity)
+                .where(_membership_clause(vault_ids, scope_ids))
                 .where(col(Entity.canonical_name).ilike(f'%{query}%'))
             )
-            if vault_ids:
-                stmt = (
-                    stmt.join(UnitEntity, col(UnitEntity.entity_id) == Entity.id)
-                    .where(col(UnitEntity.vault_id).in_(vault_ids))
-                    .distinct()
-                )
             if entity_type:
                 stmt = stmt.where(Entity.entity_type == entity_type)
             stmt = stmt.order_by(col(Entity.mention_count).desc()).limit(limit)
-            results = (await session.exec(stmt)).all()
-            return [_wrap_with_metadata(row[0], row[1]) for row in results]
+            entities = list((await session.exec(stmt)).all())
+            return await self._aggregate_models_for(session, entities, scope_ids)

--- a/packages/core/src/memex_core/services/notes.py
+++ b/packages/core/src/memex_core/services/notes.py
@@ -11,7 +11,7 @@ from uuid import UUID
 if TYPE_CHECKING:
     from memex_core.services.vault_summary import VaultSummaryService
 
-from sqlmodel import col
+from sqlmodel import col, select
 
 from sqlalchemy import func, text
 
@@ -19,6 +19,7 @@ from memex_common.exceptions import NoteNotFoundError, ResourceNotFoundError, Va
 from memex_common.note_utils import derive_note_uuid_from_key
 from memex_common.schemas import BlockSummaryDTO, NodeDTO, filter_toc
 from memex_core.config import MemexConfig
+from memex_core.memory.sql_models import Note
 from memex_core.services.audit import AuditService, audit_event
 from memex_core.services.vaults import VaultService
 from memex_core.storage.metastore import AsyncBaseMetaStoreEngine
@@ -957,11 +958,6 @@ class NoteService:
                 # The kind predicate is the SAME subquery the ORM
                 # list_notes / get_recent_notes paths use, so this raw-SQL
                 # branch can't drift from the SSOT.
-                from sqlmodel import select
-
-                from memex_core.memory.sql_models import Note
-                from memex_core.services.vaults import VaultService
-
                 content_subq = VaultService.content_vault_ids_subquery()
                 score_label = func.similarity(func.lower(Note.title), func.lower(query)).label(
                     'score'

--- a/packages/core/src/memex_core/services/notes.py
+++ b/packages/core/src/memex_core/services/notes.py
@@ -114,11 +114,16 @@ class NoteService:
     """Note CRUD, listing, and resource access."""
 
     # Subquery fragment used by raw text() queries to filter to content vaults
-    # only. Mirrors the ORM `Vault.kind != VaultKind.SYSTEM.value` predicate
-    # used elsewhere in this module; if a new VaultKind is added, update both
-    # in lockstep.
+    # only. The kind literal is interpolated from VaultKind.SYSTEM.value at
+    # class-definition time so a kind rename only touches the enum; the
+    # duplicate string here used to be a silent-drift hazard. Sibling paths
+    # (``list_notes``, ``get_recent_notes``) use the ORM
+    # ``select(Vault.id).where(Vault.kind != VaultKind.SYSTEM.value)`` form
+    # which keeps the same SSOT in one place.
+    from memex_common.vault_policy import VaultKind as _VaultKind
+
     _CONTENT_VAULT_IDS_SQL: ClassVar[str] = (
-        "vault_id IN (SELECT id FROM vaults WHERE kind <> 'system')"
+        f"vault_id IN (SELECT id FROM vaults WHERE kind <> '{_VaultKind.SYSTEM.value}')"
     )
 
     _audit_service: AuditService | None = None

--- a/packages/core/src/memex_core/services/notes.py
+++ b/packages/core/src/memex_core/services/notes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -112,28 +112,6 @@ async def _cleanup_entities_after_delete(
 
 class NoteService:
     """Note CRUD, listing, and resource access."""
-
-    # Subquery fragment used by raw text() queries to filter to content vaults
-    # only. The kind literal is interpolated from VaultKind.SYSTEM.value at
-    # class-definition time so a kind rename only touches the enum; the
-    # duplicate string here used to be a silent-drift hazard. Sibling paths
-    # (``list_notes``, ``get_recent_notes``) use the ORM
-    # ``select(Vault.id).where(Vault.kind != VaultKind.SYSTEM.value)`` form
-    # which keeps the same SSOT in one place.
-    from memex_common.vault_policy import VaultKind as _VaultKind
-
-    _CONTENT_VAULT_IDS_SQL: ClassVar[str] = (
-        f"vault_id IN (SELECT id FROM vaults WHERE kind <> '{_VaultKind.SYSTEM.value}')"
-    )
-
-    # Drift guard: the DB CHECK constraint ``vaults_kind_check`` enumerates
-    # the same kind set. If a new VaultKind is added, this assert forces
-    # the SQL fragment to be re-evaluated against the CHECK rather than
-    # silently leaving a stale literal in place.
-    assert 'kind' in _CONTENT_VAULT_IDS_SQL and _VaultKind.SYSTEM.value in _CONTENT_VAULT_IDS_SQL, (
-        '_CONTENT_VAULT_IDS_SQL drifted from VaultKind.SYSTEM.value; '
-        're-derive the f-string when adding a new kind'
-    )
 
     _audit_service: AuditService | None = None
 
@@ -800,8 +778,7 @@ class NoteService:
         from sqlalchemy.dialects.postgresql import JSONB
         from sqlmodel import select
 
-        from memex_common.vault_policy import VaultKind
-        from memex_core.memory.sql_models import Note, Vault
+        from memex_core.memory.sql_models import Note
 
         ids = list(vault_ids) if vault_ids else []
         if vault_id and vault_id not in ids:
@@ -816,8 +793,7 @@ class NoteService:
             else:
                 # No explicit scope → content vaults only (system vaults are
                 # silent on browse surfaces; reach them by naming the vault).
-                content_subq = select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
-                stmt = stmt.where(col(Note.vault_id).in_(content_subq))
+                stmt = stmt.where(col(Note.vault_id).in_(VaultService.content_vault_ids_subquery()))
             if after is not None:
                 stmt = stmt.where(date_col >= after)
             if before is not None:
@@ -869,8 +845,7 @@ class NoteService:
         """Get the most recent notes. ``date_field`` matches ``list_notes``."""
         from sqlmodel import select
 
-        from memex_common.vault_policy import VaultKind
-        from memex_core.memory.sql_models import Note, Vault
+        from memex_core.memory.sql_models import Note
 
         ids = list(vault_ids) if vault_ids else []
         if vault_id and vault_id not in ids:
@@ -883,8 +858,7 @@ class NoteService:
             if ids:
                 stmt = stmt.where(col(Note.vault_id).in_(ids))
             else:
-                content_subq = select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
-                stmt = stmt.where(col(Note.vault_id).in_(content_subq))
+                stmt = stmt.where(col(Note.vault_id).in_(VaultService.content_vault_ids_subquery()))
             if after is not None:
                 stmt = stmt.where(date_col >= after)
             if before is not None:
@@ -959,6 +933,7 @@ class NoteService:
                 text('SELECT set_limit(:threshold)'), params={'threshold': threshold}
             )
 
+            params: dict[str, Any]
             if vault_ids:
                 stmt = text("""
                     SELECT
@@ -971,30 +946,45 @@ class NoteService:
                     ORDER BY score DESC
                     LIMIT :limit
                 """)
-                params: dict[str, Any] = {
+                params = {
                     'query': query,
                     'vault_ids': list(vault_ids),
                     'limit': limit,
                 }
+                result = await session.exec(stmt, params=params)
             else:
                 # No explicit scope → content vaults only (system vaults are
                 # silent on browse surfaces; reach them by naming the vault).
-                # The kind predicate is in NoteService._CONTENT_VAULT_IDS_SQL
-                # to keep it in sync with the ORM VaultKind filter.
-                stmt = text(f"""
-                    SELECT
-                        id, title,
-                        similarity(lower(title), lower(:query)) AS score,
-                        vault_id, created_at, publish_date, status
-                    FROM notes
-                    WHERE lower(title) % lower(:query)
-                      AND {self._CONTENT_VAULT_IDS_SQL}
-                    ORDER BY score DESC
-                    LIMIT :limit
-                """)
-                params = {'query': query, 'limit': limit}
+                # The kind predicate is the SAME subquery the ORM
+                # list_notes / get_recent_notes paths use, so this raw-SQL
+                # branch can't drift from the SSOT.
+                from sqlmodel import select
 
-            result = await session.exec(stmt, params=params)
+                from memex_core.memory.sql_models import Note
+                from memex_core.services.vaults import VaultService
+
+                content_subq = VaultService.content_vault_ids_subquery()
+                score_label = func.similarity(func.lower(Note.title), func.lower(query)).label(
+                    'score'
+                )
+                stmt = (
+                    select(
+                        Note.id,
+                        Note.title,
+                        score_label,
+                        Note.vault_id,
+                        Note.created_at,
+                        Note.publish_date,
+                        Note.status,
+                    )
+                    .where(
+                        func.lower(Note.title).op('%')(func.lower(query)),
+                        Note.vault_id.in_(content_subq),
+                    )
+                    .order_by(score_label.desc())
+                    .limit(limit)
+                )
+                result = await session.exec(stmt)
             rows = []
             for row in result:
                 rows.append(

--- a/packages/core/src/memex_core/services/notes.py
+++ b/packages/core/src/memex_core/services/notes.py
@@ -126,6 +126,15 @@ class NoteService:
         f"vault_id IN (SELECT id FROM vaults WHERE kind <> '{_VaultKind.SYSTEM.value}')"
     )
 
+    # Drift guard: the DB CHECK constraint ``vaults_kind_check`` enumerates
+    # the same kind set. If a new VaultKind is added, this assert forces
+    # the SQL fragment to be re-evaluated against the CHECK rather than
+    # silently leaving a stale literal in place.
+    assert 'kind' in _CONTENT_VAULT_IDS_SQL and _VaultKind.SYSTEM.value in _CONTENT_VAULT_IDS_SQL, (
+        '_CONTENT_VAULT_IDS_SQL drifted from VaultKind.SYSTEM.value; '
+        're-derive the f-string when adding a new kind'
+    )
+
     _audit_service: AuditService | None = None
 
     def __init__(

--- a/packages/core/src/memex_core/services/notes.py
+++ b/packages/core/src/memex_core/services/notes.py
@@ -763,7 +763,8 @@ class NoteService:
     ) -> list[Any]:
         """
         List ingested documents.
-        Filters by the given vault_id(s), or returns all vaults if not provided.
+        Filters by the given vault_id(s); when none are provided, scopes to
+        content vaults only (system vaults are reached by naming them).
         Optional after/before filters compare against ``date_field``:
           - ``'created_at'``  — when Memex ingested the note
           - ``'publish_date'`` — note's authored/publication date
@@ -777,7 +778,8 @@ class NoteService:
         from sqlalchemy.dialects.postgresql import JSONB
         from sqlmodel import select
 
-        from memex_core.memory.sql_models import Note
+        from memex_common.vault_policy import VaultKind
+        from memex_core.memory.sql_models import Note, Vault
 
         ids = list(vault_ids) if vault_ids else []
         if vault_id and vault_id not in ids:
@@ -789,6 +791,11 @@ class NoteService:
             stmt = select(Note)
             if ids:
                 stmt = stmt.where(col(Note.vault_id).in_(ids))
+            else:
+                # No explicit scope → content vaults only (system vaults are
+                # silent on browse surfaces; reach them by naming the vault).
+                content_subq = select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
+                stmt = stmt.where(col(Note.vault_id).in_(content_subq))
             if after is not None:
                 stmt = stmt.where(date_col >= after)
             if before is not None:
@@ -840,7 +847,8 @@ class NoteService:
         """Get the most recent notes. ``date_field`` matches ``list_notes``."""
         from sqlmodel import select
 
-        from memex_core.memory.sql_models import Note
+        from memex_common.vault_policy import VaultKind
+        from memex_core.memory.sql_models import Note, Vault
 
         ids = list(vault_ids) if vault_ids else []
         if vault_id and vault_id not in ids:
@@ -852,6 +860,9 @@ class NoteService:
             stmt = select(Note).order_by(Note.created_at.desc())  # type: ignore[union-attr]
             if ids:
                 stmt = stmt.where(col(Note.vault_id).in_(ids))
+            else:
+                content_subq = select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
+                stmt = stmt.where(col(Note.vault_id).in_(content_subq))
             if after is not None:
                 stmt = stmt.where(date_col >= after)
             if before is not None:
@@ -944,6 +955,8 @@ class NoteService:
                     'limit': limit,
                 }
             else:
+                # No explicit scope → content vaults only (system vaults are
+                # silent on browse surfaces; reach them by naming the vault).
                 stmt = text("""
                     SELECT
                         id, title,
@@ -951,6 +964,7 @@ class NoteService:
                         vault_id, created_at, publish_date, status
                     FROM notes
                     WHERE lower(title) % lower(:query)
+                      AND vault_id IN (SELECT id FROM vaults WHERE kind <> 'system')
                     ORDER BY score DESC
                     LIMIT :limit
                 """)

--- a/packages/core/src/memex_core/services/notes.py
+++ b/packages/core/src/memex_core/services/notes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -112,6 +112,14 @@ async def _cleanup_entities_after_delete(
 
 class NoteService:
     """Note CRUD, listing, and resource access."""
+
+    # Subquery fragment used by raw text() queries to filter to content vaults
+    # only. Mirrors the ORM `Vault.kind != VaultKind.SYSTEM.value` predicate
+    # used elsewhere in this module; if a new VaultKind is added, update both
+    # in lockstep.
+    _CONTENT_VAULT_IDS_SQL: ClassVar[str] = (
+        "vault_id IN (SELECT id FROM vaults WHERE kind <> 'system')"
+    )
 
     _audit_service: AuditService | None = None
 
@@ -957,14 +965,16 @@ class NoteService:
             else:
                 # No explicit scope → content vaults only (system vaults are
                 # silent on browse surfaces; reach them by naming the vault).
-                stmt = text("""
+                # The kind predicate is in NoteService._CONTENT_VAULT_IDS_SQL
+                # to keep it in sync with the ORM VaultKind filter.
+                stmt = text(f"""
                     SELECT
                         id, title,
                         similarity(lower(title), lower(:query)) AS score,
                         vault_id, created_at, publish_date, status
                     FROM notes
                     WHERE lower(title) % lower(:query)
-                      AND vault_id IN (SELECT id FROM vaults WHERE kind <> 'system')
+                      AND {self._CONTENT_VAULT_IDS_SQL}
                     ORDER BY score DESC
                     LIMIT :limit
                 """)

--- a/packages/core/src/memex_core/services/notes.py
+++ b/packages/core/src/memex_core/services/notes.py
@@ -933,7 +933,6 @@ class NoteService:
                 text('SELECT set_limit(:threshold)'), params={'threshold': threshold}
             )
 
-            params: dict[str, Any]
             if vault_ids:
                 stmt = text("""
                     SELECT
@@ -946,7 +945,7 @@ class NoteService:
                     ORDER BY score DESC
                     LIMIT :limit
                 """)
-                params = {
+                params: dict[str, Any] = {
                     'query': query,
                     'vault_ids': list(vault_ids),
                     'limit': limit,

--- a/packages/core/src/memex_core/services/search.py
+++ b/packages/core/src/memex_core/services/search.py
@@ -75,25 +75,26 @@ class SearchService:
         intent_class: str | None = None,
         risk_class: str | None = None,
         apply_pre_filter: bool = True,
+        include_system_vaults: bool = False,
     ) -> tuple[list[MemoryUnit], Any]:
         """
         Convenience method for search with reranking.
-        Scopes to default reader vault if vault_ids is not provided.
+        Scopes to default reader vault if vault_ids is not provided. A wildcard
+        ``'*'`` expands to content vaults only; system vaults join only when
+        named explicitly or via ``include_system_vaults``.
         """
-        from memex_common.vault_utils import ALL_VAULTS_WILDCARD
-
-        vaults = []
-
-        if vault_ids and ALL_VAULTS_WILDCARD in [str(v) for v in vault_ids]:
-            all_v = await self._vaults.list_vaults()
-            vaults = [v.id for v in all_v]
-        elif vault_ids:
-            for v in vault_ids:
-                vaults.append(await self._vaults.resolve_vault_identifier(str(v)))
-        else:
-            vaults.append(
-                await self._vaults.resolve_vault_identifier(self.config.server.default_reader_vault)
+        if vault_ids:
+            vaults = await self._vaults.resolve_vault_scope(
+                vault_ids, include_system_vaults=include_system_vaults
             )
+            # Empty resolved scope = nothing to search. Never fall through to an
+            # empty vault_ids list, which the filter layer treats as ALL vaults.
+            if not vaults:
+                return [], None
+        else:
+            vaults = [
+                await self._vaults.resolve_vault_identifier(self.config.server.default_reader_vault)
+            ]
 
         request = RetrievalRequest(
             query=query,
@@ -150,21 +151,23 @@ class SearchService:
         after: dt.datetime | None = None,
         before: dt.datetime | None = None,
         tags: list[str] | None = None,
+        include_system_vaults: bool = False,
     ) -> list[NoteSearchResult]:
-        """Search for documents containing relevant information using raw chunks."""
-        from memex_common.vault_utils import ALL_VAULTS_WILDCARD
+        """Search for documents containing relevant information using raw chunks.
 
-        vaults = []
-        if vault_ids and ALL_VAULTS_WILDCARD in [str(v) for v in vault_ids]:
-            all_v = await self._vaults.list_vaults()
-            vaults = [v.id for v in all_v]
-        elif vault_ids:
-            for v in vault_ids:
-                vaults.append(await self._vaults.resolve_vault_identifier(str(v)))
-        else:
-            vaults.append(
-                await self._vaults.resolve_vault_identifier(self.config.server.default_reader_vault)
+        A wildcard ``'*'`` expands to content vaults only; system vaults join
+        only when named explicitly or via ``include_system_vaults``.
+        """
+        if vault_ids:
+            vaults = await self._vaults.resolve_vault_scope(
+                vault_ids, include_system_vaults=include_system_vaults
             )
+            if not vaults:
+                return []
+        else:
+            vaults = [
+                await self._vaults.resolve_vault_identifier(self.config.server.default_reader_vault)
+            ]
 
         kwargs: dict[str, Any] = {}
         if strategies is not None:
@@ -262,6 +265,17 @@ class SearchService:
             vault_ids = [
                 await self._vaults.resolve_vault_identifier(self.config.server.default_reader_vault)
             ]
+        elif not vault_ids:
+            # Empty resolved scope = nothing to survey. Never pass [] to recall,
+            # which the filter layer treats as ALL vaults.
+            return SurveyResponse(
+                query=query,
+                sub_queries=[],
+                topics=[],
+                total_notes=0,
+                total_facts=0,
+                truncated=False,
+            )
 
         # Decompose query into sub-questions
         decomposer = SurveyDecomposer(self.lm)

--- a/packages/core/src/memex_core/services/session_briefing.py
+++ b/packages/core/src/memex_core/services/session_briefing.py
@@ -165,7 +165,10 @@ class SessionBriefingService:
         kv_coro = self._kv.list_entries(namespaces=_build_kv_namespaces(project_id))
 
         if self._vaults:
-            vaults_coro = self._vaults.list_vaults_with_counts()
+            # Available-vaults enumeration is a discovery surface — content only.
+            # The active vault still gets its full briefing even if it is a
+            # system vault (addressability), via summary_coro / models_coro above.
+            vaults_coro = self._vaults.list_vaults_with_counts(include_system=False)
         else:
 
             async def _empty() -> list[Any]:

--- a/packages/core/src/memex_core/services/stats.py
+++ b/packages/core/src/memex_core/services/stats.py
@@ -51,7 +51,8 @@ class StatsService(BaseService):
         vault_ids: list[UUID] | None = None,
     ) -> dict[str, int]:
         """Get total counts for notes, memory units, entities, and reflection queue."""
-        from memex_core.memory.sql_models import Entity, MemoryUnit, Note, ReflectionQueue
+        from memex_common.vault_policy import VaultKind
+        from memex_core.memory.sql_models import Entity, MemoryUnit, Note, ReflectionQueue, Vault
         from sqlmodel import func, select
 
         ids = list(vault_ids) if vault_ids else []
@@ -68,6 +69,13 @@ class StatsService(BaseService):
                 note_stmt = note_stmt.where(col(Note.vault_id).in_(ids))
                 memory_stmt = memory_stmt.where(col(MemoryUnit.vault_id).in_(ids))
                 queue_stmt = queue_stmt.where(col(ReflectionQueue.vault_id).in_(ids))
+            else:
+                # No explicit scope → content vaults only for vault-scoped counts.
+                # Entity is global (no vault_id, §4.3) so its count stays global.
+                content_subq = select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
+                note_stmt = note_stmt.where(col(Note.vault_id).in_(content_subq))
+                memory_stmt = memory_stmt.where(col(MemoryUnit.vault_id).in_(content_subq))
+                queue_stmt = queue_stmt.where(col(ReflectionQueue.vault_id).in_(content_subq))
 
             note_count = (await session.exec(note_stmt)).one()
             memory_count = (await session.exec(memory_stmt)).one()

--- a/packages/core/src/memex_core/services/stats.py
+++ b/packages/core/src/memex_core/services/stats.py
@@ -14,6 +14,7 @@ from memex_common.exceptions import MemoryUnitNotFoundError
 from memex_core.config import MemexConfig
 from memex_core.services.base import BaseService
 from memex_core.services.notes import _cleanup_entities_after_delete
+from memex_core.services.vaults import VaultService
 from memex_core.storage.filestore import BaseAsyncFileStore
 from memex_core.storage.metastore import AsyncBaseMetaStoreEngine
 
@@ -51,8 +52,7 @@ class StatsService(BaseService):
         vault_ids: list[UUID] | None = None,
     ) -> dict[str, int]:
         """Get total counts for notes, memory units, entities, and reflection queue."""
-        from memex_common.vault_policy import VaultKind
-        from memex_core.memory.sql_models import Entity, MemoryUnit, Note, ReflectionQueue, Vault
+        from memex_core.memory.sql_models import Entity, MemoryUnit, Note, ReflectionQueue
         from sqlmodel import func, select
 
         ids = list(vault_ids) if vault_ids else []
@@ -72,7 +72,7 @@ class StatsService(BaseService):
             else:
                 # No explicit scope → content vaults only for vault-scoped counts.
                 # Entity is global (no vault_id, §4.3) so its count stays global.
-                content_subq = select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
+                content_subq = VaultService.content_vault_ids_subquery()
                 note_stmt = note_stmt.where(col(Note.vault_id).in_(content_subq))
                 memory_stmt = memory_stmt.where(col(MemoryUnit.vault_id).in_(content_subq))
                 queue_stmt = queue_stmt.where(col(ReflectionQueue.vault_id).in_(content_subq))

--- a/packages/core/src/memex_core/services/vaults.py
+++ b/packages/core/src/memex_core/services/vaults.py
@@ -12,7 +12,7 @@ from sqlmodel import col, select
 
 from memex_common.exceptions import VaultNotFoundError, AmbiguousResourceError
 from memex_common.vault_policy import VaultKind, VaultPolicy, coerce_policy
-from memex_common.vault_utils import ALL_VAULTS_WILDCARD
+from memex_common.vault_utils import ALL_VAULTS_WILDCARD, expand_vault_scope
 
 from memex_core.memory.sql_models import Vault, MWMode
 
@@ -326,35 +326,33 @@ class VaultService(BaseService):
         Contract (the single source of truth for every user-facing read):
         - ``None`` / empty / wildcard ``'*'`` → all **content** vault ids.
         - explicitly named vaults (content or system) → resolved as given.
-        - ``include_system_vaults=True`` → add all system vault ids.
+        - ``include_system_vaults=True`` → unconditionally add all system
+          vault ids (regardless of whether the caller used ``*`` or named
+          specific vaults). To scope a call to one system vault without
+          dragging in the rest, name it and leave the flag off.
 
-        There is no path that implicitly yields system vaults; they appear only
-        when named or when ``include_system_vaults`` is set.
+        Pure scope-expansion logic lives in
+        :func:`memex_common.vault_utils.expand_vault_scope` so the MCP
+        layer can reuse it without taking a ``memex_core`` dependency.
         """
-        ids: list[UUID] = []
-        seen: set[UUID] = set()
-
-        def _add(vid: UUID) -> None:
-            if vid not in seen:
-                seen.add(vid)
-                ids.append(vid)
-
         identifiers = identifiers or []
         has_wildcard = any(str(v) == ALL_VAULTS_WILDCARD for v in identifiers)
-        named = [v for v in identifiers if str(v) != ALL_VAULTS_WILDCARD]
+        named_identifiers = [v for v in identifiers if str(v) != ALL_VAULTS_WILDCARD]
 
-        for identifier in named:
-            _add(await self.resolve_vault_identifier(identifier))
+        named_ids: list[UUID] = []
+        for identifier in named_identifiers:
+            named_ids.append(await self.resolve_vault_identifier(identifier))
 
-        if has_wildcard or not named:
-            for vid in await self._content_vault_ids():
-                _add(vid)
+        content_vault_ids = await self._content_vault_ids() if has_wildcard or not named_ids else []
+        system_vault_ids = await self._system_vault_ids() if include_system_vaults else []
 
-        if include_system_vaults:
-            for vid in await self._system_vault_ids():
-                _add(vid)
-
-        return ids
+        return expand_vault_scope(
+            named_ids,
+            content_vault_ids,
+            system_vault_ids,
+            has_wildcard=has_wildcard,
+            include_system_vaults=include_system_vaults,
+        )
 
     async def get_vault_by_name(self, name: str) -> Any | None:
         """Get a single vault by exact name match."""

--- a/packages/core/src/memex_core/services/vaults.py
+++ b/packages/core/src/memex_core/services/vaults.py
@@ -11,6 +11,8 @@ from cachetools_async import cached as cached_async
 from sqlmodel import col
 
 from memex_common.exceptions import VaultNotFoundError, AmbiguousResourceError
+from memex_common.vault_policy import VaultKind, VaultPolicy, coerce_policy
+from memex_common.vault_utils import ALL_VAULTS_WILDCARD
 
 from memex_core.memory.sql_models import Vault, MWMode
 
@@ -75,10 +77,23 @@ class VaultService(BaseService):
 
             return vaults[0].id
 
-    async def create_vault(self, name: str, description: str | None = None) -> Any:
-        """Create a new vault."""
+    async def create_vault(
+        self,
+        name: str,
+        description: str | None = None,
+        kind: VaultKind | str = VaultKind.CONTENT,
+        policy: VaultPolicy | dict | None = None,
+    ) -> Any:
+        """Create a new vault.
+
+        ``kind`` is permanent — there is no update path; to change it, delete and
+        recreate. ``policy`` overrides the kind-derived synthesis defaults.
+        """
         from memex_core.memory.sql_models import Vault
         from sqlmodel import select
+
+        kind = VaultKind(kind)
+        resolved_policy = coerce_policy(policy)
 
         async with self.metastore.session() as session:
             stmt = select(Vault).where(col(Vault.name) == name)
@@ -91,11 +106,24 @@ class VaultService(BaseService):
                 raise ValueError(
                     f"mw_mode_default must be 'stationary' or 'ema', got '{default_mode}'"
                 )
-            vault = Vault(name=name, description=description, mw_mode=default_mode)
+            vault = Vault(
+                name=name,
+                description=description,
+                mw_mode=default_mode,
+                kind=kind,
+                policy=resolved_policy.model_dump(exclude_none=True),
+            )
             session.add(vault)
             await session.commit()
             await session.refresh(vault)
-            audit_event(self._audit_service, 'vault.created', 'vault', str(vault.id), name=name)
+            audit_event(
+                self._audit_service,
+                'vault.created',
+                'vault',
+                str(vault.id),
+                name=name,
+                kind=kind.value,
+            )
             return vault
 
     async def delete_vault(self, vault_id: UUID) -> bool:
@@ -197,17 +225,28 @@ class VaultService(BaseService):
         audit_event(self._audit_service, 'vault.truncated', 'vault', str(vault_id))
         return counts
 
-    async def list_vaults(self) -> list[Any]:
-        """List all vaults."""
+    async def list_vaults(self, include_system: bool = True) -> list[Any]:
+        """List vaults.
+
+        Defaults to *all* vaults — this low-level primitive is unchanged so
+        operational/background callers keep seeing system vaults. User-facing
+        enumeration surfaces pass ``include_system=False`` to hide them.
+        """
         from memex_core.memory.sql_models import Vault
         from sqlmodel import select
 
         async with self.metastore.session() as session:
             stmt = select(Vault)
+            if not include_system:
+                stmt = stmt.where(col(Vault.kind) != VaultKind.SYSTEM.value)
             return list((await session.exec(stmt)).all())
 
-    async def list_vaults_with_counts(self) -> list[dict[str, Any]]:
-        """List all vaults with note counts and last-modified timestamp."""
+    async def list_vaults_with_counts(self, include_system: bool = True) -> list[dict[str, Any]]:
+        """List vaults with note counts and last-modified timestamp.
+
+        ``include_system`` defaults to True (return all); user-facing surfaces
+        pass False to exclude system vaults.
+        """
         from sqlalchemy import func
         from sqlmodel import select
         from memex_core.memory.sql_models import Vault, Note
@@ -226,6 +265,8 @@ class VaultService(BaseService):
                     func.count(Note.id).desc(),
                 )
             )
+            if not include_system:
+                stmt = stmt.where(col(Vault.kind) != VaultKind.SYSTEM.value)
             results = (await session.exec(stmt)).all()
             return [
                 {
@@ -235,6 +276,62 @@ class VaultService(BaseService):
                 }
                 for row in results
             ]
+
+    async def _content_vault_ids(self) -> list[UUID]:
+        from memex_core.memory.sql_models import Vault
+        from sqlmodel import select
+
+        async with self.metastore.session() as session:
+            stmt = select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
+            return list((await session.exec(stmt)).all())
+
+    async def _system_vault_ids(self) -> list[UUID]:
+        from memex_core.memory.sql_models import Vault
+        from sqlmodel import select
+
+        async with self.metastore.session() as session:
+            stmt = select(Vault.id).where(col(Vault.kind) == VaultKind.SYSTEM.value)
+            return list((await session.exec(stmt)).all())
+
+    async def resolve_vault_scope(
+        self,
+        identifiers: list[UUID | str] | None,
+        include_system_vaults: bool = False,
+    ) -> list[UUID]:
+        """Resolve a read-scope request into a concrete set of vault ids.
+
+        Contract (the single source of truth for every user-facing read):
+        - ``None`` / empty / wildcard ``'*'`` → all **content** vault ids.
+        - explicitly named vaults (content or system) → resolved as given.
+        - ``include_system_vaults=True`` → add all system vault ids.
+
+        There is no path that implicitly yields system vaults; they appear only
+        when named or when ``include_system_vaults`` is set.
+        """
+        ids: list[UUID] = []
+        seen: set[UUID] = set()
+
+        def _add(vid: UUID) -> None:
+            if vid not in seen:
+                seen.add(vid)
+                ids.append(vid)
+
+        identifiers = identifiers or []
+        has_wildcard = any(str(v) == ALL_VAULTS_WILDCARD for v in identifiers)
+        named = [v for v in identifiers if str(v) != ALL_VAULTS_WILDCARD]
+
+        for identifier in named:
+            _add(await self.resolve_vault_identifier(identifier))
+
+        if has_wildcard or not named:
+            for vid in await self._content_vault_ids():
+                _add(vid)
+
+        if include_system_vaults:
+            for vid in await self._system_vault_ids():
+                _add(vid)
+
+        return ids
 
     async def get_vault_by_name(self, name: str) -> Any | None:
         """Get a single vault by exact name match."""

--- a/packages/core/src/memex_core/services/vaults.py
+++ b/packages/core/src/memex_core/services/vaults.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from cachetools import LRUCache
 from cachetools_async import cached as cached_async
-from sqlmodel import col
+from sqlmodel import col, select
 
 from memex_common.exceptions import VaultNotFoundError, AmbiguousResourceError
 from memex_common.vault_policy import VaultKind, VaultPolicy, coerce_policy
@@ -76,6 +76,35 @@ class VaultService(BaseService):
                 )
 
             return vaults[0].id
+
+    @staticmethod
+    def content_vault_ids_subquery() -> Any:
+        """Single source of truth for the ``kind != 'system'`` predicate.
+
+        Returns a SQLAlchemy ``select`` subquery over ``Vault.id`` that callers
+        can drop into ``where(...).in_(...)`` (or ``.from_statement`` for raw
+        ``text()`` paths). Every site that needs the "content vaults only"
+        filter — entity listing, stats, search-scoping, raw note queries —
+        routes through here so a future kind rename or filter change is
+        one diff instead of 11.
+        """
+        return select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
+
+    @staticmethod
+    def system_vault_ids_subquery() -> Any:
+        """Mirror of :meth:`content_vault_ids_subquery` for system vaults."""
+        return select(Vault.id).where(col(Vault.kind) == VaultKind.SYSTEM.value)
+
+    @staticmethod
+    def content_vault_clause() -> Any:
+        """Boolean WHERE-clause form of the content-vault filter.
+
+        Use when you're filtering an existing ``select(Vault)`` (rather
+        than needing a subquery of ids). Same SSOT as
+        :meth:`content_vault_ids_subquery` — both predicates are derived
+        from the same ``VaultKind`` import.
+        """
+        return col(Vault.kind) != VaultKind.SYSTEM.value
 
     async def create_vault(
         self,
@@ -238,7 +267,7 @@ class VaultService(BaseService):
         async with self.metastore.session() as session:
             stmt = select(Vault)
             if not include_system:
-                stmt = stmt.where(col(Vault.kind) != VaultKind.SYSTEM.value)
+                stmt = stmt.where(VaultService.content_vault_clause())
             return list((await session.exec(stmt)).all())
 
     async def list_vaults_with_counts(self, include_system: bool = True) -> list[dict[str, Any]]:
@@ -266,7 +295,7 @@ class VaultService(BaseService):
                 )
             )
             if not include_system:
-                stmt = stmt.where(col(Vault.kind) != VaultKind.SYSTEM.value)
+                stmt = stmt.where(VaultService.content_vault_clause())
             results = (await session.exec(stmt)).all()
             return [
                 {
@@ -278,19 +307,13 @@ class VaultService(BaseService):
             ]
 
     async def _content_vault_ids(self) -> list[UUID]:
-        from memex_core.memory.sql_models import Vault
-        from sqlmodel import select
-
         async with self.metastore.session() as session:
-            stmt = select(Vault.id).where(col(Vault.kind) != VaultKind.SYSTEM.value)
+            stmt = VaultService.content_vault_ids_subquery()
             return list((await session.exec(stmt)).all())
 
     async def _system_vault_ids(self) -> list[UUID]:
-        from memex_core.memory.sql_models import Vault
-        from sqlmodel import select
-
         async with self.metastore.session() as session:
-            stmt = select(Vault.id).where(col(Vault.kind) == VaultKind.SYSTEM.value)
+            stmt = VaultService.system_vault_ids_subquery()
             return list((await session.exec(stmt)).all())
 
     async def resolve_vault_scope(

--- a/packages/core/tests/integration/test_int_alembic_060.py
+++ b/packages/core/tests/integration/test_int_alembic_060.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import create_async_engine
 from testcontainers.postgres import PostgresContainer
 
-from _alembic_test_helpers import (  # noqa: F401
+from _alembic_test_helpers import (
     alembic_downgrade as _alembic_downgrade,
     alembic_upgrade as _alembic_upgrade,
     make_fresh_db,

--- a/packages/core/tests/integration/test_int_alembic_060.py
+++ b/packages/core/tests/integration/test_int_alembic_060.py
@@ -1,0 +1,196 @@
+"""Migration round-trip test for vault kind + policy (060).
+
+Verifies via a real ``alembic upgrade`` / ``downgrade`` against a populated DB:
+- 060 adds ``kind`` (default 'content') + ``policy`` (default '{}') to ``vaults``.
+- A pre-existing vault backfills to ``content`` with empty policy.
+- A pre-existing ``inbox`` vault flips to ``system`` AND its prior mental models
+  are archived + its vault summary deleted (now-stale synthesis).
+- The CHECK constraint rejects an invalid kind.
+- Downgrade drops both columns.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import NullPool, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import create_async_engine
+from testcontainers.postgres import PostgresContainer
+
+from _alembic_test_helpers import (  # noqa: F401
+    alembic_downgrade as _alembic_downgrade,
+    alembic_upgrade as _alembic_upgrade,
+    make_fresh_db,
+)
+
+pytestmark = [pytest.mark.integration]
+
+_BEFORE = '059_drop_inbox_router'
+_AFTER = '060_vault_kind_policy'
+
+
+@pytest_asyncio.fixture
+async def fresh_db_url(postgres_container: PostgresContainer) -> AsyncGenerator[str, None]:
+    async for url in make_fresh_db(postgres_container, db_prefix='mig060'):
+        yield url
+
+
+async def _column_exists(conn, table: str, column: str) -> bool:
+    return bool(
+        (
+            await conn.execute(
+                text(
+                    'SELECT 1 FROM information_schema.columns '
+                    'WHERE table_name = :t AND column_name = :c'
+                ),
+                {'t': table, 'c': column},
+            )
+        ).scalar()
+    )
+
+
+async def _seed_at_058(db_url: str) -> dict[str, str]:
+    """Upgrade to 058; seed a content vault and an inbox vault with synthesis."""
+    await _alembic_upgrade(db_url, target=_BEFORE)
+    engine = create_async_engine(db_url, poolclass=NullPool)
+    try:
+        async with engine.begin() as conn:
+            content_id = (
+                await conn.execute(
+                    text(
+                        'INSERT INTO vaults (id, name) '
+                        "VALUES (gen_random_uuid(), 'corpus-059') RETURNING id"
+                    )
+                )
+            ).scalar()
+            inbox_id = (
+                await conn.execute(
+                    text(
+                        'INSERT INTO vaults (id, name) '
+                        "VALUES (gen_random_uuid(), 'inbox') RETURNING id"
+                    )
+                )
+            ).scalar()
+            # An entity + a mental model + a vault summary in the inbox vault.
+            entity_id = (
+                await conn.execute(
+                    text(
+                        'INSERT INTO entities (id, canonical_name, entity_type) '
+                        "VALUES (gen_random_uuid(), 'Acme', 'ORG') RETURNING id"
+                    )
+                )
+            ).scalar()
+            await conn.execute(
+                text(
+                    'INSERT INTO mental_models '
+                    '(id, entity_id, vault_id, name, observations, entity_metadata, version) '
+                    "VALUES (gen_random_uuid(), :e, :v, 'Acme', '[]'::jsonb, '{}'::jsonb, 1)"
+                ),
+                {'e': entity_id, 'v': inbox_id},
+            )
+            await conn.execute(
+                text(
+                    'INSERT INTO vault_summaries '
+                    '(id, vault_id, narrative, themes, inventory, key_entities, '
+                    ' version, notes_incorporated, patch_log) '
+                    "VALUES (gen_random_uuid(), :v, 'inbox narrative', "
+                    "'[]'::jsonb, '{}'::jsonb, '[]'::jsonb, 1, 1, '[]'::jsonb)"
+                ),
+                {'v': inbox_id},
+            )
+        return {'content': str(content_id), 'inbox': str(inbox_id)}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_upgrade_adds_columns_and_backfills_content(fresh_db_url: str) -> None:
+    ids = await _seed_at_058(fresh_db_url)
+    await _alembic_upgrade(fresh_db_url, target=_AFTER)
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            assert await _column_exists(conn, 'vaults', 'kind')
+            assert await _column_exists(conn, 'vaults', 'policy')
+            kind, policy = (
+                await conn.execute(
+                    text('SELECT kind, policy FROM vaults WHERE id = :v'),
+                    {'v': ids['content']},
+                )
+            ).one()
+            assert kind == 'content'
+            assert policy == {}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_upgrade_flips_inbox_and_archives_synthesis(fresh_db_url: str) -> None:
+    ids = await _seed_at_058(fresh_db_url)
+    await _alembic_upgrade(fresh_db_url, target=_AFTER)
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            kind = (
+                await conn.execute(
+                    text('SELECT kind FROM vaults WHERE id = :v'), {'v': ids['inbox']}
+                )
+            ).scalar()
+            assert kind == 'system'
+
+            archived = (
+                await conn.execute(
+                    text('SELECT archived_at FROM mental_models WHERE vault_id = :v'),
+                    {'v': ids['inbox']},
+                )
+            ).scalar()
+            assert archived is not None  # prior synthesis archived
+
+            summary_count = (
+                await conn.execute(
+                    text('SELECT count(*) FROM vault_summaries WHERE vault_id = :v'),
+                    {'v': ids['inbox']},
+                )
+            ).scalar()
+            assert summary_count == 0  # stale summary deleted
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_check_constraint_rejects_bad_kind(fresh_db_url: str) -> None:
+    await _seed_at_058(fresh_db_url)
+    await _alembic_upgrade(fresh_db_url, target=_AFTER)
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.begin() as conn:
+            with pytest.raises(IntegrityError):
+                await conn.execute(
+                    text(
+                        'INSERT INTO vaults (id, name, kind) '
+                        "VALUES (gen_random_uuid(), 'bad-kind-059', 'archive')"
+                    )
+                )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_downgrade_drops_columns(fresh_db_url: str) -> None:
+    await _seed_at_058(fresh_db_url)
+    await _alembic_upgrade(fresh_db_url, target=_AFTER)
+    await _alembic_downgrade(fresh_db_url, _BEFORE)
+
+    engine = create_async_engine(fresh_db_url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            assert not await _column_exists(conn, 'vaults', 'kind')
+            assert not await _column_exists(conn, 'vaults', 'policy')
+    finally:
+        await engine.dispose()

--- a/packages/core/tests/integration/test_int_system_vaults.py
+++ b/packages/core/tests/integration/test_int_system_vaults.py
@@ -1,0 +1,174 @@
+"""Integration tests for the content/system vault distinction (V11).
+
+Covers the load-bearing guarantees against real Postgres:
+- create_vault persists kind + policy; kind defaults to content.
+- list_vaults(include_system=...) filters; system addressable by id.
+- resolve_vault_scope: '*'/None -> content only; include_system_vaults -> +system;
+  named system vault resolves regardless of kind.
+- Reflection enqueue is skipped for reflect-disabled (system) vaults, and a
+  per-vault policy override re-enables it.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlmodel import col, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from memex_core.config import ReflectionConfig
+from memex_core.memory.reflect.queue_service import ReflectionQueueService
+from memex_core.memory.sql_models import Entity, Note, ReflectionQueue, Vault
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.fixture
+def queue_service() -> ReflectionQueueService:
+    return ReflectionQueueService(
+        ReflectionConfig(weight_urgency=1.0, weight_importance=0.0, weight_resonance=0.0)
+    )
+
+
+# ── Vault service contract (via the api fixture) ──
+
+
+@pytest.mark.asyncio
+async def test_create_persists_kind_and_policy(api):
+    content = await api.create_vault(f'c-{uuid4().hex[:8]}')
+    system = await api.create_vault(f's-{uuid4().hex[:8]}', kind='system', policy={'reflect': True})
+    assert content.kind == 'content'
+    assert content.policy == {}
+    assert system.kind == 'system'
+    assert system.policy == {'reflect': True}
+
+
+@pytest.mark.asyncio
+async def test_list_vaults_filters_system_but_stays_addressable(api):
+    content = await api.create_vault(f'c-{uuid4().hex[:8]}')
+    system = await api.create_vault(f's-{uuid4().hex[:8]}', kind='system')
+
+    default_ids = {v.id for v in await api.list_vaults(include_system=False)}
+    all_ids = {v.id for v in await api.list_vaults(include_system=True)}
+
+    assert content.id in default_ids
+    assert system.id not in default_ids  # silent on the default listing
+    assert system.id in all_ids
+    # Addressability: a system vault is always resolvable by id.
+    assert await api.validate_vault_exists(system.id) is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_vault_scope_semantics(api):
+    content = await api.create_vault(f'c-{uuid4().hex[:8]}')
+    sys_name = f's-{uuid4().hex[:8]}'
+    system = await api.create_vault(sys_name, kind='system')
+
+    wildcard = await api.resolve_vault_scope(['*'])
+    assert content.id in wildcard
+    assert system.id not in wildcard  # '*' = content only
+
+    wildcard_sys = await api.resolve_vault_scope(['*'], include_system_vaults=True)
+    assert system.id in wildcard_sys
+
+    named = await api.resolve_vault_scope([sys_name])
+    assert named == [system.id]  # named system vault resolves regardless of kind
+
+    default_scope = await api.resolve_vault_scope(None)
+    assert content.id in default_scope
+    assert system.id not in default_scope
+
+
+# ── Default-scope note reads exclude system vaults (regression for find/list) ──
+
+
+@pytest.mark.asyncio
+async def test_default_scope_excludes_system_notes(api, session):
+    content = Vault(name=f'c-{uuid4().hex[:8]}', kind='content')
+    system = Vault(name=f's-{uuid4().hex[:8]}', kind='system')
+    session.add_all([content, system])
+    await session.commit()
+
+    tag = uuid4().hex[:8]
+    title = f'deploy runbook {tag}'
+    session.add_all(
+        [
+            Note(id=uuid4(), vault_id=content.id, title=title),
+            Note(id=uuid4(), vault_id=system.id, title=title),
+        ]
+    )
+    await session.commit()
+
+    # list_notes default scope → content only.
+    listed_vaults = {n.vault_id for n in await api.list_notes()}
+    assert content.id in listed_vaults
+    assert system.id not in listed_vaults
+
+    # find_notes_by_title default scope → content only (regression for the C1 leak).
+    found_vaults = {r['vault_id'] for r in await api.find_notes_by_title(title)}
+    assert content.id in found_vaults
+    assert system.id not in found_vaults
+
+    # Explicitly naming the system vault still reaches it (addressability).
+    named = await api.find_notes_by_title(title, vault_ids=[system.id])
+    assert {r['vault_id'] for r in named} == {system.id}
+
+
+# ── Reflection enqueue gating (via the session fixture) ──
+
+
+@pytest.mark.asyncio
+async def test_system_vault_skips_reflection_enqueue(
+    session: AsyncSession, queue_service: ReflectionQueueService
+):
+    content = Vault(name=f'c-{uuid4().hex[:8]}', kind='content')
+    system = Vault(name=f's-{uuid4().hex[:8]}', kind='system')
+    entity = Entity(canonical_name=f'E-{uuid4().hex[:8]}')
+    session.add_all([content, system, entity])
+    await session.commit()
+
+    # Content vault enqueues a reflection row.
+    await queue_service.handle_extraction_event(session, {entity.id}, vault_id=content.id)
+    content_rows = (
+        await session.exec(
+            select(ReflectionQueue).where(
+                col(ReflectionQueue.entity_id) == entity.id,
+                col(ReflectionQueue.vault_id) == content.id,
+            )
+        )
+    ).all()
+    assert len(content_rows) == 1
+
+    # System vault (reflect disabled by default) enqueues nothing.
+    await queue_service.handle_extraction_event(session, {entity.id}, vault_id=system.id)
+    system_rows = (
+        await session.exec(
+            select(ReflectionQueue).where(
+                col(ReflectionQueue.entity_id) == entity.id,
+                col(ReflectionQueue.vault_id) == system.id,
+            )
+        )
+    ).all()
+    assert system_rows == []
+
+
+@pytest.mark.asyncio
+async def test_policy_override_re_enables_reflection(
+    session: AsyncSession, queue_service: ReflectionQueueService
+):
+    system = Vault(name=f's-{uuid4().hex[:8]}', kind='system', policy={'reflect': True})
+    entity = Entity(canonical_name=f'E-{uuid4().hex[:8]}')
+    session.add_all([system, entity])
+    await session.commit()
+
+    await queue_service.handle_extraction_event(session, {entity.id}, vault_id=system.id)
+    rows = (
+        await session.exec(
+            select(ReflectionQueue).where(
+                col(ReflectionQueue.entity_id) == entity.id,
+                col(ReflectionQueue.vault_id) == system.id,
+            )
+        )
+    ).all()
+    assert len(rows) == 1  # policy override re-enables enqueue

--- a/packages/core/tests/integration/test_int_system_vaults.py
+++ b/packages/core/tests/integration/test_int_system_vaults.py
@@ -85,10 +85,8 @@ async def test_resolve_vault_scope_semantics(api):
 
 @pytest.mark.asyncio
 async def test_default_scope_excludes_system_notes(api, session):
-    content = Vault(name=f'c-{uuid4().hex[:8]}', kind='content')
-    system = Vault(name=f's-{uuid4().hex[:8]}', kind='system')
-    session.add_all([content, system])
-    await session.commit()
+    content = await api.create_vault(f'c-{uuid4().hex[:8]}')
+    system = await api.create_vault(f's-{uuid4().hex[:8]}', kind='system')
 
     tag = uuid4().hex[:8]
     title = f'deploy runbook {tag}'

--- a/packages/core/tests/unit/test_api_entity_search.py
+++ b/packages/core/tests/unit/test_api_entity_search.py
@@ -9,21 +9,22 @@ from memex_core.services.entities import EntityWithMetadata
 async def test_search_entities(api, mock_metastore):
     read_session = mock_metastore.session.return_value.__aenter__.return_value
 
-    # Mock entities — service now returns (Entity, MentalModel|None) tuples from LEFT JOIN
     e1 = Entity(id=uuid4(), canonical_name='Apple Inc.')
     e2 = Entity(id=uuid4(), canonical_name='Pineapple')
 
-    # First exec call: vault resolution (Vault lookup)
-    mock_vault = MagicMock()
-    mock_vault.id = uuid4()
-    mock_vault_res = MagicMock()
-    mock_vault_res.first.return_value = mock_vault
+    # exec #1: content-vault scope resolution -> vault ids.
+    scope_res = MagicMock()
+    scope_res.all.return_value = [uuid4()]
 
-    # Second exec call: actual entity search
-    mock_entity_res = MagicMock()
-    mock_entity_res.all.return_value = [(e1, None), (e2, None)]
+    # exec #2: entity search -> Entity scalars (membership via EXISTS, no join tuples).
+    entity_res = MagicMock()
+    entity_res.all.return_value = [e1, e2]
 
-    read_session.exec.side_effect = [mock_vault_res, mock_entity_res]
+    # exec #3: mental-model aggregation lookup -> none.
+    models_res = MagicMock()
+    models_res.all.return_value = []
+
+    read_session.exec.side_effect = [scope_res, entity_res, models_res]
 
     result = await api.search_entities(query='apple')
 

--- a/packages/core/tests/unit/test_scheduler.py
+++ b/packages/core/tests/unit/test_scheduler.py
@@ -402,3 +402,81 @@ def test_no_inbox_router_job_registered() -> None:
     src = inspect.getsource(scheduler)
     assert 'inbox_router' not in src
     assert 'run_inbox_router_job' not in src
+
+
+@pytest.mark.asyncio
+@patch('memex_core.scheduler.background_session')
+async def test_vault_summary_task_includes_system_vaults_with_summarize_override(
+    mock_bg_session,
+) -> None:
+    """A system vault with ``policy.summarize=True`` MUST be summarised.
+
+    Regression guard: the V11 L2 review pass initially set the summary
+    scheduler to ``list_vaults(include_system=False)`` — that excluded
+    system vaults from the loop entirely, breaking the contract that a
+    system vault can opt into summary via its policy. The fix is
+    ``include_system=True`` plus the in-loop ``summarize_enabled`` check.
+    """
+    from memex_core.memory.sql_models import Vault
+
+    mock_bg_session.return_value.__aenter__ = AsyncMock(return_value='test-session')
+    mock_bg_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    system_vault = MagicMock(spec=Vault)
+    system_vault.id = 'system-vault-1'
+    system_vault.name = 'case-vault'
+    system_vault.kind = 'system'
+    system_vault.policy = {'summarize': True}
+
+    api = MagicMock()
+    api.list_vaults = AsyncMock(return_value=[system_vault])
+
+    summary = MagicMock()
+    summary.needs_regeneration = True
+    api.vault_summary.get_summary = AsyncMock(return_value=summary)
+    api.vault_summary.regenerate_summary = AsyncMock()
+    api.vault_summary.update_summary = AsyncMock()
+    api.vault_summary.is_stale = AsyncMock()
+
+    await periodic_vault_summary_task(api)
+
+    # The system vault was passed to list_vaults(include_system=True) and
+    # its policy override is honored — the summary path runs.
+    api.list_vaults.assert_awaited_once_with(include_system=True)
+    api.vault_summary.regenerate_summary.assert_awaited_once_with('system-vault-1')
+
+
+@pytest.mark.asyncio
+@patch('memex_core.scheduler.background_session')
+async def test_vault_summary_task_skips_system_vault_without_summarize_override(
+    mock_bg_session,
+) -> None:
+    """A system vault without ``policy.summarize=True`` MUST be skipped.
+
+    Companion to the override test: with no policy override, the kind
+    default (False) wins and the summary path is not entered.
+    """
+    from memex_core.memory.sql_models import Vault
+
+    mock_bg_session.return_value.__aenter__ = AsyncMock(return_value='test-session')
+    mock_bg_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    system_vault = MagicMock(spec=Vault)
+    system_vault.id = 'system-vault-1'
+    system_vault.name = 'inbox'
+    system_vault.kind = 'system'
+    system_vault.policy = {}  # no override — default is off
+
+    api = MagicMock()
+    api.list_vaults = AsyncMock(return_value=[system_vault])
+    api.vault_summary.get_summary = AsyncMock()
+    api.vault_summary.regenerate_summary = AsyncMock()
+    api.vault_summary.update_summary = AsyncMock()
+    api.vault_summary.is_stale = AsyncMock()
+
+    await periodic_vault_summary_task(api)
+
+    api.list_vaults.assert_awaited_once_with(include_system=True)
+    api.vault_summary.get_summary.assert_not_awaited()
+    api.vault_summary.regenerate_summary.assert_not_awaited()
+    api.vault_summary.update_summary.assert_not_awaited()

--- a/packages/core/tests/unit/test_search_service_vaults.py
+++ b/packages/core/tests/unit/test_search_service_vaults.py
@@ -26,6 +26,30 @@ def vault_service():
             return svc._resolved[identifier]
 
     svc.resolve_vault_identifier = _resolve
+
+    # Content vault ids the wildcard expands to (settable per test).
+    svc._content_ids = []
+
+    async def _scope(identifiers, include_system_vaults=False):
+        ids: list = []
+        seen: set = set()
+
+        def _add(u):
+            if u not in seen:
+                seen.add(u)
+                ids.append(u)
+
+        identifiers = identifiers or []
+        has_wildcard = any(str(v) == '*' for v in identifiers)
+        named = [v for v in identifiers if str(v) != '*']
+        for n in named:
+            _add(await _resolve(str(n)))
+        if has_wildcard or not named:
+            for c in svc._content_ids:
+                _add(c)
+        return ids
+
+    svc.resolve_vault_scope = _scope
     return svc
 
 
@@ -114,10 +138,10 @@ async def test_search_default_reader_vault_only(vault_service):
 
 
 @pytest.mark.asyncio
-async def test_search_wildcard_resolves_to_all_vaults(vault_service):
-    """When vault_ids=['*'], search should resolve to all vaults."""
+async def test_search_wildcard_resolves_to_content_vaults(vault_service):
+    """When vault_ids=['*'], search resolves to content vaults only."""
     v1, v2 = uuid4(), uuid4()
-    vault_service.list_vaults = AsyncMock(return_value=[MagicMock(id=v1), MagicMock(id=v2)])
+    vault_service._content_ids = [v1, v2]
 
     config = MagicMock()
     config.server.default_reader_vault = 'default'
@@ -144,10 +168,10 @@ async def test_search_wildcard_resolves_to_all_vaults(vault_service):
 
 
 @pytest.mark.asyncio
-async def test_search_notes_wildcard_resolves_to_all_vaults(vault_service):
-    """When vault_ids=['*'], search_notes should resolve to all vaults."""
+async def test_search_notes_wildcard_resolves_to_content_vaults(vault_service):
+    """When vault_ids=['*'], search_notes resolves to content vaults only."""
     v1, v2 = uuid4(), uuid4()
-    vault_service.list_vaults = AsyncMock(return_value=[MagicMock(id=v1), MagicMock(id=v2)])
+    vault_service._content_ids = [v1, v2]
 
     config = MagicMock()
     config.server.default_reader_vault = 'default'

--- a/packages/core/tests/unit/test_seed_alembic_stubs.py
+++ b/packages/core/tests/unit/test_seed_alembic_stubs.py
@@ -55,8 +55,8 @@ def test_seed_chain_is_linear_and_correct() -> None:
     sd = ScriptDirectory.from_config(cfg)
 
     heads = sd.get_heads()
-    assert heads == ['059_drop_inbox_router'], (
-        f'Expected single head 059_drop_inbox_router, got {heads}'
+    assert heads == ['060_vault_kind_policy'], (
+        f'Expected single head 060_vault_kind_policy, got {heads}'
     )
 
     walk = list(sd.walk_revisions())
@@ -64,9 +64,10 @@ def test_seed_chain_is_linear_and_correct() -> None:
     # 053 is a merge node (down_revision is a tuple) — the cockpit/lint chain
     # (…→052) and the procedure-to-global chain (046_procedure_to_global) were
     # merged, then 054 (nodes index), 055 (inbox router), 056 (node assets),
-    # 057 (external lint source), 058 (vault summary embedding), and 059 (drop
-    # inbox router) extend linearly from there.
+    # 057 (external lint source), 058 (vault summary embedding), 059 (drop
+    # inbox router), and 060 (vault kind+policy) extend linearly from there.
     expected_top10 = [
+        ('060_vault_kind_policy', '059_drop_inbox_router'),
         ('059_drop_inbox_router', '058_vault_summary_embedding'),
         ('058_vault_summary_embedding', '057_lint_source_external'),
         ('057_lint_source_external', '056_node_assets'),
@@ -76,7 +77,6 @@ def test_seed_chain_is_linear_and_correct() -> None:
         ('053_merge_heads', ('046_procedure_to_global', '052_entity_cooccurrence_vault_pk')),
         ('046_procedure_to_global', '045_drop_procedure_outcomes'),
         ('052_entity_cooccurrence_vault_pk', '051_fix_telemetry_pk'),
-        ('051_fix_telemetry_pk', '050_mp_flagged_at'),
     ]
     assert top10 == expected_top10, f'Tier A chain mismatch: got {top10}'
 

--- a/packages/core/tests/unit/test_server.py
+++ b/packages/core/tests/unit/test_server.py
@@ -109,7 +109,9 @@ def test_create_vault_validation(client, mock_api):
     response = client.post('/api/v1/vaults', json=payload)
 
     assert response.status_code == 200, f'Response: {response.text}'
-    mock_api.create_vault.assert_called_once_with(name='New Vault', description='Secure storage')
+    mock_api.create_vault.assert_called_once_with(
+        name='New Vault', description='Secure storage', kind='content', policy=None
+    )
 
     data = response.json()
     assert data['id'] == str(MOCK_VAULT_ID)

--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -629,12 +629,18 @@ GET_ENTITY_COOCCURRENCES_SCHEMA: dict[str, Any] = {
 LIST_VAULTS_SCHEMA: dict[str, Any] = {
     'name': 'memex_list_vaults',
     'description': (
-        'List all vaults with note counts and active status. Call this before '
-        'using vault_ids on other tools so you know what vault names/UUIDs exist.'
+        'List content vaults with note counts and active status. Call this before '
+        'using vault_ids on other tools so you know what vault names/UUIDs exist. '
+        'Pass include_system_vaults=true to also list system vaults (inbox, etc.).'
     ),
     'parameters': {
         'type': 'object',
-        'properties': {},
+        'properties': {
+            'include_system_vaults': {
+                'type': 'boolean',
+                'description': 'Also list system vaults (inbox, etc.). Default false.',
+            },
+        },
         'required': [],
     },
 }
@@ -2067,6 +2073,7 @@ def _serialize_vault(vault: Any) -> dict[str, Any]:
         'id': str(getattr(vault, 'id', '')),
         'name': getattr(vault, 'name', ''),
         'description': getattr(vault, 'description', None),
+        'kind': getattr(vault, 'kind', 'content'),
         'is_active': bool(getattr(vault, 'is_active', False)),
         'note_count': int(getattr(vault, 'note_count', 0) or 0),
         'last_note_added_at': last_added.isoformat() if last_added else None,
@@ -2153,8 +2160,9 @@ def _parse_iso_or_raise(value: str, field: str) -> Any:
 def handle_list_vaults(
     api: MemexAPIProtocol, config: HermesMemexConfig, vault_id: UUID | None, args: dict[str, Any]
 ) -> str:
+    include_system = bool(args.get('include_system_vaults', False))
     try:
-        vaults = run_sync(api.list_vaults(), timeout=30.0)
+        vaults = run_sync(api.list_vaults(include_system=include_system), timeout=30.0)
     except Exception as e:
         logger.warning('memex_list_vaults failed: %s', e)
         return tool_error(f'List vaults failed: {e}')

--- a/packages/mcp/src/memex_mcp/models.py
+++ b/packages/mcp/src/memex_mcp/models.py
@@ -322,6 +322,7 @@ class McpVault(BaseModel):
     id: UUID
     name: str
     description: str | None = None
+    kind: str = 'content'
     is_active: bool = False
     note_count: int = 0
     last_note_added_at: datetime | None = None

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -211,9 +211,16 @@ async def _resolve_vault_ids(
     Union semantics: a wildcard ``'*'`` expands to content vaults only; named
     vaults (content or system) resolve as given; ``include_system_vaults`` adds
     all system vaults. System vaults never enter implicitly.
+
+    An empty/None ``vault_ids`` is treated the same as ``['*']`` — it expands
+    to all content vaults. This matches :func:`VaultService.resolve_vault_scope`
+    so a caller that forgets to forward a list still gets the content-only
+    default universe instead of an empty scope.
     """
     from memex_common.vault_utils import ALL_VAULTS_WILDCARD
 
+    if not vault_ids:
+        vault_ids = [ALL_VAULTS_WILDCARD]
     has_wildcard = ALL_VAULTS_WILDCARD in vault_ids
     named = [v for v in vault_ids if v != ALL_VAULTS_WILDCARD]
 

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -203,21 +203,43 @@ def _validate_vault_ids(vault_ids: list[str]) -> list[str]:
     return vault_ids
 
 
-async def _resolve_vault_ids(api: Any, vault_ids: list[str]) -> list[UUID]:
-    """Resolve and validate that all vault identifiers exist."""
+async def _resolve_vault_ids(
+    api: Any, vault_ids: list[str], include_system_vaults: bool = False
+) -> list[UUID]:
+    """Resolve vault identifiers to UUIDs.
+
+    Union semantics: a wildcard ``'*'`` expands to content vaults only; named
+    vaults (content or system) resolve as given; ``include_system_vaults`` adds
+    all system vaults. System vaults never enter implicitly.
+    """
     from memex_common.vault_utils import ALL_VAULTS_WILDCARD
 
-    if ALL_VAULTS_WILDCARD in vault_ids:
-        vaults = await api.list_vaults()
-        return [v.id for v in vaults]
+    has_wildcard = ALL_VAULTS_WILDCARD in vault_ids
+    named = [v for v in vault_ids if v != ALL_VAULTS_WILDCARD]
 
     resolved: list[UUID] = []
-    for vid in vault_ids:
+    seen: set[UUID] = set()
+
+    def _add(uid: UUID) -> None:
+        if uid not in seen:
+            seen.add(uid)
+            resolved.append(uid)
+
+    for vid in named:
         try:
             r = await api.resolve_vault_identifier(vid)
-            resolved.append(UUID(str(r)) if not isinstance(r, UUID) else r)
         except Exception:
             raise ToolError(f'Vault not found: {vid!r}')
+        _add(UUID(str(r)) if not isinstance(r, UUID) else r)
+
+    if has_wildcard or include_system_vaults:
+        for v in await api.list_vaults(include_system=True):
+            kind = getattr(v, 'kind', 'content')
+            if has_wildcard and kind != 'system':
+                _add(v.id)
+            if include_system_vaults and kind == 'system':
+                _add(v.id)
+
     return resolved
 
 
@@ -1591,13 +1613,22 @@ async def memex_memory_search(
             ),
         ),
     ] = True,
+    include_system_vaults: Annotated[
+        bool,
+        Field(
+            default=False,
+            description='Include system vaults (e.g. inbox) when expanding the "*" wildcard.',
+        ),
+    ] = False,
 ) -> list[McpFact | McpEvent | McpObservation]:
     """Search Memex for relevant information."""
     try:
         api = get_api(ctx)
         vault_ids = vault_ids or _default_read_vaults(ctx)
         _validate_vault_ids(vault_ids)
-        resolved_vids = await _resolve_vault_ids(api, vault_ids)
+        resolved_vids = await _resolve_vault_ids(
+            api, vault_ids, include_system_vaults=include_system_vaults
+        )
 
         from datetime import datetime as _dt
 
@@ -1831,13 +1862,22 @@ async def memex_note_search(
             ),
         ),
     ] = None,
+    include_system_vaults: Annotated[
+        bool,
+        Field(
+            default=False,
+            description='Include system vaults (e.g. inbox) when expanding the "*" wildcard.',
+        ),
+    ] = False,
 ) -> list[McpNoteSearchResult]:
     """Search Memex for source notes by hybrid retrieval."""
     try:
         api = get_api(ctx)
         vault_ids = vault_ids or _default_read_vaults(ctx)
         _validate_vault_ids(vault_ids)
-        resolved_vids = await _resolve_vault_ids(api, vault_ids)
+        resolved_vids = await _resolve_vault_ids(
+            api, vault_ids, include_system_vaults=include_system_vaults
+        )
 
         from datetime import datetime as _dt
 
@@ -2293,25 +2333,29 @@ async def memex_get_nodes(
 
 @mcp.tool(
     name='memex_list_vaults',
-    description='List all vaults with note counts. Each vault includes is_active and note_count.',
+    description=(
+        'List content vaults with note counts (is_active, note_count, kind). '
+        'Pass include_system_vaults=true to also list system vaults (inbox etc.).'
+    ),
     tags={'browse'},
     annotations={'readOnlyHint': True},
 )
-async def memex_list_vaults(ctx: Context) -> list[McpVault]:
-    """List all available vaults with active status and note counts."""
+async def memex_list_vaults(ctx: Context, include_system_vaults: bool = False) -> list[McpVault]:
+    """List vaults with active status and note counts (content vaults by default)."""
     try:
         api = get_api(ctx)
         config = get_config(ctx)
 
         # Use list_vaults_with_counts for local API, fall back for remote
         try:
-            rows = await api.list_vaults_with_counts()
+            rows = await api.list_vaults_with_counts(include_system=include_system_vaults)
             active_vault_id = await api.resolve_vault_identifier(config.server.default_active_vault)
             return [
                 McpVault(
                     id=row['vault'].id,
                     name=row['vault'].name,
                     description=row['vault'].description,
+                    kind=getattr(row['vault'], 'kind', 'content'),
                     is_active=(row['vault'].id == active_vault_id),
                     note_count=row['note_count'],
                     last_note_added_at=row.get('last_note_added_at'),
@@ -2320,12 +2364,13 @@ async def memex_list_vaults(ctx: Context) -> list[McpVault]:
             ]
         except AttributeError:
             # Remote API — fall back to list_vaults (VaultDTO with is_active)
-            vaults = await api.list_vaults()
+            vaults = await api.list_vaults(include_system=include_system_vaults)
             return [
                 McpVault(
                     id=v.id,
                     name=v.name,
                     description=v.description,
+                    kind=getattr(v, 'kind', 'content'),
                     is_active=v.is_active,
                     last_note_added_at=v.last_note_added_at,
                     access=v.access,
@@ -2522,6 +2567,13 @@ async def memex_recent_notes(
             description='Drop per-note summaries to keep the response under hook-output caps.',
         ),
     ] = False,
+    include_system_vaults: Annotated[
+        bool,
+        Field(
+            default=False,
+            description='Include system vaults (e.g. inbox) when expanding the "*" wildcard.',
+        ),
+    ] = False,
 ) -> list[McpNote]:
     """List recent notes."""
     from datetime import datetime as _dt
@@ -2531,7 +2583,9 @@ async def memex_recent_notes(
         resolved_vids = None
         if vault_ids:
             _validate_vault_ids(vault_ids)
-            resolved_vids = await _resolve_vault_ids(api, vault_ids)
+            resolved_vids = await _resolve_vault_ids(
+                api, vault_ids, include_system_vaults=include_system_vaults
+            )
 
         parsed_after = None
         parsed_before = None
@@ -3245,10 +3299,17 @@ async def memex_find_note(
         BeforeValidator(_coerce_list),
         Field(
             default=None,
-            description='Vault UUIDs or names to search in, e.g. [\'rituals\']. Use "*" for all vaults. None = all vaults.',
+            description='Vault UUIDs or names to search in, e.g. [\'rituals\']. "*" or None = all content vaults.',
         ),
     ] = None,
     limit: Annotated[int, BeforeValidator(_coerce_int), Field(description='Max results.')] = 5,
+    include_system_vaults: Annotated[
+        bool,
+        Field(
+            default=False,
+            description='Include system vaults (e.g. inbox) when expanding the "*" wildcard.',
+        ),
+    ] = False,
 ) -> list[McpFindResult]:
     """Find notes by approximate title match."""
     try:
@@ -3257,7 +3318,9 @@ async def memex_find_note(
         resolved_vids: list[UUID] | None = None
         if vault_ids:
             _validate_vault_ids(vault_ids)
-            resolved_vids = await _resolve_vault_ids(api, vault_ids)
+            resolved_vids = await _resolve_vault_ids(
+                api, vault_ids, include_system_vaults=include_system_vaults
+            )
 
         results = await api.find_notes_by_title(
             query=query,
@@ -3547,13 +3610,22 @@ async def memex_survey(
             ),
         ),
     ] = None,
+    include_system_vaults: Annotated[
+        bool,
+        Field(
+            default=False,
+            description='Include system vaults (e.g. inbox) when expanding the "*" wildcard.',
+        ),
+    ] = False,
 ) -> McpSurveyResult:
     """Survey a broad topic — decompose, parallel search, grouped results."""
     try:
         api = get_api(ctx)
         vault_ids = vault_ids or _default_read_vaults(ctx)
         _validate_vault_ids(vault_ids)
-        resolved_vids = await _resolve_vault_ids(api, vault_ids)
+        resolved_vids = await _resolve_vault_ids(
+            api, vault_ids, include_system_vaults=include_system_vaults
+        )
 
         from datetime import datetime as _dt
 

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -30,6 +30,7 @@ from memex_mcp._layer_primer_descriptions import (
     LAYER_ROUTING_PRIMER_FRAGMENT as _LAYER_ROUTING_PRIMER,
 )
 from memex_common.agent_surface import MCP_TRANSPORT_INSTRUCTIONS
+from memex_common.vault_utils import ALL_VAULTS_WILDCARD, expand_vault_scope
 from memex_common.tool_descriptions import (
     MEMEX_KV_PUT_DESC as _MEMEX_KV_PUT_DESCRIPTION,
 )
@@ -216,38 +217,42 @@ async def _resolve_vault_ids(
     to all content vaults. This matches :func:`VaultService.resolve_vault_scope`
     so a caller that forgets to forward a list still gets the content-only
     default universe instead of an empty scope.
-    """
-    from memex_common.vault_utils import ALL_VAULTS_WILDCARD
 
+    Pure scope-expansion logic lives in
+    :func:`memex_common.vault_utils.expand_vault_scope` (shared SSOT with
+    ``VaultService.resolve_vault_scope``). The MCP layer only does the
+    parts that need the API surface — name resolution and the system-vs-
+    content partition.
+    """
     if not vault_ids:
         vault_ids = [ALL_VAULTS_WILDCARD]
     has_wildcard = ALL_VAULTS_WILDCARD in vault_ids
     named = [v for v in vault_ids if v != ALL_VAULTS_WILDCARD]
 
-    resolved: list[UUID] = []
-    seen: set[UUID] = set()
-
-    def _add(uid: UUID) -> None:
-        if uid not in seen:
-            seen.add(uid)
-            resolved.append(uid)
-
+    named_ids: list[UUID] = []
     for vid in named:
         try:
             r = await api.resolve_vault_identifier(vid)
         except Exception:
             raise ToolError(f'Vault not found: {vid!r}')
-        _add(UUID(str(r)) if not isinstance(r, UUID) else r)
+        named_ids.append(UUID(str(r)) if not isinstance(r, UUID) else r)
 
-    if has_wildcard or include_system_vaults:
+    needs_partition = has_wildcard or include_system_vaults
+    content_vault_ids: list[UUID] = []
+    system_vault_ids: list[UUID] = []
+    if needs_partition:
         for v in await api.list_vaults(include_system=True):
-            kind = getattr(v, 'kind', 'content')
-            if has_wildcard and kind != 'system':
-                _add(v.id)
-            if include_system_vaults and kind == 'system':
-                _add(v.id)
+            (
+                system_vault_ids if getattr(v, 'kind', 'content') == 'system' else content_vault_ids
+            ).append(v.id)
 
-    return resolved
+    return expand_vault_scope(
+        named_ids,
+        content_vault_ids,
+        system_vault_ids,
+        has_wildcard=has_wildcard,
+        include_system_vaults=include_system_vaults,
+    )
 
 
 async def _resolve_vault_id(api: Any, vault_id: str) -> 'UUID':

--- a/packages/mcp/tests/test_mcp_wildcard_vaults.py
+++ b/packages/mcp/tests/test_mcp_wildcard_vaults.py
@@ -46,16 +46,57 @@ class TestResolveVaultIdsWildcard:
         api.resolve_vault_identifier.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_wildcard_with_other_names_still_returns_all(self):
-        """Wildcard takes precedence — extra names are ignored."""
-        v1 = uuid4()
+    async def test_wildcard_union_with_named(self):
+        """Union: '*' expands to content vaults; named vaults add on top."""
+        vc1, vc2, named = uuid4(), uuid4(), uuid4()
         api = AsyncMock()
-        api.list_vaults = AsyncMock(return_value=[MagicMock(id=v1)])
+        api.list_vaults = AsyncMock(
+            return_value=[MagicMock(id=vc1, kind='content'), MagicMock(id=vc2, kind='content')]
+        )
+        api.resolve_vault_identifier = AsyncMock(return_value=named)
 
         result = await _resolve_vault_ids(api, ['*', 'some-vault'])
 
-        assert result == [v1]
-        api.resolve_vault_identifier.assert_not_called()
+        assert set(result) == {named, vc1, vc2}
+        api.resolve_vault_identifier.assert_called_once_with('some-vault')
+
+    @pytest.mark.asyncio
+    async def test_wildcard_excludes_system_by_default(self):
+        """'*' expands to content vaults only — system vaults are silent."""
+        vc, vs = uuid4(), uuid4()
+        api = AsyncMock()
+        api.list_vaults = AsyncMock(
+            return_value=[MagicMock(id=vc, kind='content'), MagicMock(id=vs, kind='system')]
+        )
+
+        result = await _resolve_vault_ids(api, ['*'])
+
+        assert result == [vc]
+
+    @pytest.mark.asyncio
+    async def test_include_system_vaults_adds_system(self):
+        """include_system_vaults=True unions system vaults onto the wildcard."""
+        vc, vs = uuid4(), uuid4()
+        api = AsyncMock()
+        api.list_vaults = AsyncMock(
+            return_value=[MagicMock(id=vc, kind='content'), MagicMock(id=vs, kind='system')]
+        )
+
+        result = await _resolve_vault_ids(api, ['*'], include_system_vaults=True)
+
+        assert set(result) == {vc, vs}
+
+    @pytest.mark.asyncio
+    async def test_named_system_vault_resolves_regardless_of_kind(self):
+        """A system vault named explicitly is always reachable (addressability)."""
+        vs = uuid4()
+        api = AsyncMock()
+        api.resolve_vault_identifier = AsyncMock(return_value=vs)
+
+        result = await _resolve_vault_ids(api, ['inbox'])
+
+        assert result == [vs]
+        api.list_vaults.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_without_wildcard_resolves_individually(self):


### PR DESCRIPTION
## V11 — System Vaults vs Content Vaults

Introduces a first-class `Vault.kind` (`content` | `system`) plus a typed per-vault `policy`, so infrastructure vaults (inbox, future Hermes/case vaults, user-defined integration vaults) are **silent on the synthesis & discovery surfaces by default** while remaining **fully extracted** and **always addressable by name/id**.

> **Core principle:** `kind` governs the *synthesis-and-discovery* surfaces, never the *retention floor*. Extraction always runs; reflection / vault-summary / wildcard-search / listing / briefing are corpus-default and overridable per vault.

### Tracking / design
- **Backlog:** `BACKLOG.md` → `V11 — System Vaults vs Content Vaults`
- **Design report & plan:** `.claude/reports/2026-06-08-system-vs-content-vaults-design.md` and `~/.claude/plans/memex-system-vs-content-vaults.md` — these live under gitignored paths (`.claude/*`) on this repo, so they are **not in the diff**; the design closed after two adversarial-review rounds (§12/§13 of the report). `DESIGN_DOCUMENT.md` (§4.3 Multi-tenancy, §2.4.3 Reflect) is likewise gitignored here, so its prose update can't land in this PR.

### What changed
- **Schema + migration:** `Vault.kind` (Text + CHECK, mirrors `mw_mode`) + `policy` (JSONB); Alembic `059` — additive, idempotent, backfills `content`, one-shot `inbox`→`system` archiving its now-stale mental models + summary; clean downgrade. New `memex_common/vault_policy.py` (`VaultKind`, typed `VaultPolicy`, `reflect_enabled`/`summarize_enabled`).
- **Scope contract:** one canonical `resolve_vault_scope` (Union — `*`/unspecified → content; named adds on top; `include_system_vaults` opt-in). The low-level `list_vaults()` primitive is **unchanged** (filter at the surfaces only). Empty resolved scope never collapses to the all-vaults filter path.
- **Synthesis gating:** reflection skipped at **enqueue** (`handle_extraction_event`); vault-summary + UMAP diagnostics skipped for system vaults in the scheduler; briefing omits them from "Available Vaults". A reflect-/summarize-enabling `policy` override re-enables per vault.
- **Entity tools:** `EXISTS`-based membership (drops system-only entities, keeps content + orphan), content-scoped centrality, and **aggregated** mental-model profiles (replaces the latent `vault_ids[0]` single-vault guess).
- **Browse/read scoping:** `list_notes` / `recent_notes` / `find_notes_by_title` / `stats` / entity cooccurrence + mentions default to content vaults; system reached by naming.
- **Inbox:** `ensure_inbox_vault` creates `kind='system'`; routing SQL excludes `kind='system'` as a destination.
- **Surfaces (parity):** `kind`/`policy` on `VaultDTO`/`CreateVaultRequest`/`McpVault`; `include_system_vaults` across HTTP (`?include_system`, search/note/survey bodies), MCP (5 tools + list), CLI (`vault create --kind`, `vault list --include-system`), Hermes; `RemoteMemexAPI` signature parity preserved. `GET /vaults/{id}` resolves system vaults (addressability). Metrics: reflection/summary skip counters + a `vault_scope.include_system` trace attribute.

### Surfaces
HTTP ✓ · MCP ✓ · CLI ✓ · Hermes ✓ · Claude Code plugin (via `agent-surface`, verified) · firefox-extension N/A.

### Tests
- **Unit:** `test_vault_policy`, `test_vault_scope_resolver` (in `test_search_service_vaults`), wildcard Union rewrite.
- **Integration (real Postgres):** `test_int_alembic_059` (migration round-trip + inbox archival + CHECK), `test_int_system_vaults` (create/list/scope/addressability, reflection enqueue-skip + policy override, **default-scope exclusion regression**), `test_int_entity_type_filter` (entity rewrite).
- Full suites green: core-unit 3519 · cli 465 · mcp 476 · common 389 · hermes 559. `ruff` + `mypy` clean on changed files; agent-surface budget + `RemoteMemexAPI` signature-parity tests green.
- **Pre-PR gate:** three adversarial-review rounds; the final fresh pass returned zero CRITICAL/HIGH/MEDIUM (it caught a `find_notes_by_title` default-scope leak mid-loop, now fixed + regression-tested).

### Notes / reduced rigor
- Design doc + plan + report are gitignored dev artifacts (above), so not in the diff.
- No real-LLM-turn validation: this feature adds tool *parameters/descriptions* but no DSPy/prompt-signature change; the agent surface is exercised via the MCP-client and budget tests.

### Deferred (follow-on tickets, out of scope)
- Per-entity *detail* call returning the lossless per-vault profile breakdown.
- Wiring the Hermes session vault and the experiential case-vault as `system` (consumers of this primitive).
- Snapshot export carrying `kind`/`policy` (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
