### PR TITLE
fix: add missing 'procedure:' namespace to KV store validation

### DIFF
--- a/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
+++ b/packages/hermes-plugin/src/memex_hermes_plugin/memex/tools.py
@@ -1339,7 +1339,7 @@ _MAX_ADD_ASSETS_ITEMS = 20
 
 # Canonical KV key namespaces per RFC-012. Hermes is the ``key`` holder here;
 # ``_scope_from_key`` above derives these from stored entries.
-_VALID_KV_NAMESPACES = ('global:', 'user:', 'project:', 'app:')
+_VALID_KV_NAMESPACES = ('global:', 'user:', 'project:', 'app:', 'procedure:')
 
 
 def _serialize_memory_unit(unit: Any) -> dict[str, Any]:

--- a/packages/hermes-plugin/tests/test_tools.py
+++ b/packages/hermes-plugin/tests/test_tools.py
@@ -3045,7 +3045,7 @@ def test_kv_write_missing_required_params(config, vault_id):
     ['noscope', 'unknown:foo', 'Global:foo', 'usre:work:x', ':leading', '  user:foo'],
 )
 def test_kv_write_rejects_bad_namespace(config, vault_id, bad_key):
-    """Keys outside the four RFC-012 namespaces (global:/user:/project:/app:) → tool_error."""
+    """Keys outside the five RFC-012 namespaces (global:/user:/project:/app:/procedure:) → tool_error."""
     api = Mock()
     api.embed_text = AsyncMock()
     api.kv_put = AsyncMock()

--- a/packages/mcp/src/memex_mcp/server.py
+++ b/packages/mcp/src/memex_mcp/server.py
@@ -3013,10 +3013,12 @@ async def memex_find_note(
         '`memex_add_note`. '
         'Key MUST start with a namespace prefix: '
         '"global:" (always loaded), "user:" (personal prefs), '
-        '"project:<project-id>:" (project-scoped), or '
-        '"app:<app-id>:" (application-scoped). '
+        '"project:<project-id>:" (project-scoped), '
+        '"app:<app-id>:" (application-scoped), or '
+        '"procedure:<verb>:<context-tag>:" (procedural memory). '
         'Examples: "global:tool:python:pkg_mgr", "user:work:employer", '
-        '"project:github.com/user/repo:vault", "app:claude-code:theme".'
+        '"project:github.com/user/repo:vault", "app:claude-code:theme", '
+        '"procedure:store:mutable_user_facts".'
     ),
     tags={'storage'},
     annotations={'readOnlyHint': False, 'idempotentHint': True},
@@ -3032,9 +3034,10 @@ async def memex_kv_write(
         str,
         Field(
             description=(
-                'Namespaced key. Must start with global:, user:, project:, or app:. '
+                'Namespaced key. Must start with global:, user:, project:, app:, or procedure:. '
                 'Examples: "global:lang:python:version", '
-                '"project:github.com/user/repo:vault", "app:claude-code:theme".'
+                '"project:github.com/user/repo:vault", "app:claude-code:theme", '
+                '"procedure:store:mutable_user_facts".'
             ),
         ),
     ],


### PR DESCRIPTION
Closes #176

The KV store's validation tuple `_VALID_KV_NAMESPACES` was missing the `procedure:` namespace prefix, causing the documented `procedure:<verb>:<context-tag>` namespace to be rejected with a 400 error.

Changes:
- Add `'procedure:'` to `_VALID_KV_NAMESPACES` in hermes-plugin tools.py
- Update test docstring to reflect five valid namespaces (tested invalid names are unchanged — all existing tests pass)
- Update memex_kv_write MCP tool description and key parameter docs to include `procedure:` with examples

3 files, 10 insertions, 7 deletions.
